### PR TITLE
feat(cas-summation): Phase 269-274 — Thirty-Seven-Log family (v2.205.0→v2.211.0)

### DIFF
--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 2.211.0 — 2026-05-27
+
+### Added
+
+- **Phase 274 — Five-Sqrt × Thirty-Seven-Log × polynomial** (`_five_sqrt_thirty_seven_log_poly_effective_x2`):
+  Completes the Thirty-Seven-Log family (Phases 269–274).
+- **Phase 273 — Four-Sqrt × Thirty-Seven-Log × polynomial** (`_four_sqrt_thirty_seven_log_poly_effective_x2`).
+- **Phase 272 — Three-Sqrt × Thirty-Seven-Log × polynomial** (`_three_sqrt_thirty_seven_log_poly_effective_x2`).
+- **Phase 271 — Two-Sqrt × Thirty-Seven-Log × polynomial** (`_two_sqrt_thirty_seven_log_poly_effective_x2`).
+- **Phase 270 — One-Sqrt × Thirty-Seven-Log × polynomial** (`_one_sqrt_thirty_seven_log_poly_effective_x2`).
+- **Phase 269 — Zero-Sqrt × Thirty-Seven-Log × polynomial** (`_thirty_seven_log_poly_effective_x2`).
+
+### Changed
+
+- Boundary tests in Phases 263–268 (and prior phases 167–262) updated from 37-log
+  "refused" to 38-log "refused" now that Phases 269–274 handle exactly 37 logs.
+
 ## 2.205.0 — 2026-05-27
 
 ### Added

--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.22.0 — 2026-05-26
+
+### Added
+
+- **Phase 85 — Two-Sqrt × Six-Log × polynomial numerator** (`_two_sqrt_six_log_poly_effective_x2`):
+  recognises `Mul(Sqrt(P1), Sqrt(P2), Log(h1(k)), Log(h2(k)), Log(h3(k)), Log(h4(k)), Log(h5(k)), Log(h6(k)), polynomial..., bounded...)`.
+  Exactly 2 Sqrt factors and exactly 6 Log factors required.  `log⁶(k)` is sub-polynomial
+  (`o(k^ε)`), contributing 0 to effective degree;
+  `effective_x2 = sqrt1_deg_x2 + sqrt2_deg_x2 + 2·poly_deg`.
+  Closes when `2·den_deg > effective_x2` or non-polynomial diverging denominator.
+  - 3 new unit tests in `TestPhase85TwoSqrtSixLogPoly`.
+
 ## 2.21.0 — 2026-05-25
 
 ### Added

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "2.21.0"
+version = "2.22.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "2.205.0"
+version = "2.211.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -1182,6 +1182,20 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
                 return True
         elif _h_diverges_at_infinity(den, k):
             return True
+    # Phase 85: ``Mul(Sqrt(P1), Sqrt(P2), Log(h1), Log(h2), Log(h3), Log(h4), Log(h5), Log(h6),
+    #           polynomial..., bounded...)`` numerator.
+    # Two Sqrt factors + six Log factors; log⁶ sub-polynomial → 0.
+    # effective_x2 = sqrt1_deg_x2 + sqrt2_deg_x2 + 2·poly_deg.
+    # Vanishes when ``2·den_deg > effective_x2`` (polynomial) or
+    # non-polynomial diverging denominator.
+    s2l6p_x2 = _two_sqrt_six_log_poly_effective_x2(num, k)
+    if s2l6p_x2 is not None:
+        den_deg_s2l6 = _polynomial_degree_in_k(den, k)
+        if den_deg_s2l6 is not None:
+            if 2 * den_deg_s2l6 > s2l6p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
     # Phase 42 widening: deg(num) < deg(den) on pure polynomials in k.
     num_degree = _polynomial_degree_in_k(num, k)
     if num_degree is None:
@@ -3441,6 +3455,74 @@ def _one_sqrt_six_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None
     if sqrt_deg_x2 is None or log_count != 6:
         return None
     return sqrt_deg_x2 + 2 * poly_deg_sum
+
+
+def _two_sqrt_six_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Return ``sqrt1_deg_x2 + sqrt2_deg_x2 + 2·poly_deg`` when ``node`` is a ``Mul``
+    with **exactly two** ``Sqrt(positive-leading polynomial)`` factors, **exactly six**
+    ``Log(diverging-in-k)`` factors, any polynomial factors, and any bounded factors;
+    ``None`` otherwise.
+
+    Phase 85 — Two-Sqrt × Six-Log × polynomial numerator.
+
+    Effective growth:
+    ``sqrt(k^a) · sqrt(k^b) · log(k)⁶ · k^m ≈ k^{(a+b)/2} · log⁶(k) · k^m``.
+    ``log⁶(k)`` is sub-polynomial (``o(k^ε)``), contributing 0.
+    Using the ×2 integer trick:
+    ``effective_x2 = a + b + 2·m``.
+    Caller checks ``2·den_deg > effective_x2``.
+
+    +------------------------------------------------------------------+---------------------+
+    | Input                                                            | Return              |
+    +==================================================================+=====================+
+    | ``Mul(Sqrt(k), Sqrt(k), Log(k)×6)``                              | ``1 + 1 = 2``       |
+    | ``Mul(Sqrt(k³), Sqrt(k³), Log(k)×6)``                           | ``3 + 3 = 6``       |
+    | ``Mul(Sqrt(k), Sqrt(k), Log(k)×6, k)``                          | ``1+1+2 = 4``       |
+    | ``Mul(Sqrt(k), Log(k)×6)``                                       | None (1 Sqrt)       |
+    | ``Mul(Sqrt(k)×3, Log(k)×6)``                                     | None (3 Sqrts)      |
+    | ``Mul(Sqrt(k), Sqrt(k), Log(k)×5)``                              | None (5 Logs)       |
+    +------------------------------------------------------------------+---------------------+
+
+    Algorithm:
+      1. Require ``node = Mul(...)``.
+      2. For each factor:
+         - ``Sqrt(positive-leading polynomial)`` → record ×2 degree; bail after 2.
+         - ``Log(diverging)`` → count; bail after 6.
+         - Polynomial in ``k`` → accumulate degree.
+         - Bounded → accept silently.
+         - Anything else → return ``None``.
+      3. Require exactly 2 Sqrt AND exactly 6 Log factors.
+      4. Return ``sqrt1_deg_x2 + sqrt2_deg_x2 + 2 * poly_deg_sum``.
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 2:
+                # Third Sqrt factor — not this phase.
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 6:
+                # Seven or more Log factors — refuse.
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 2 or log_count != 6:
+        return None
+    return sqrt_degs_x2[0] + sqrt_degs_x2[1] + 2 * poly_deg_sum
 
 
 def _try_power_of_k(

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -1477,6 +1477,60 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
                 return True
         elif _h_diverges_at_infinity(den, k):
             return True
+    # Phase 274: ``Mul(Sqrt(P1)×5, Log(h1)×37, polynomial..., bounded...)`` numerator.
+    s5l37p_x2 = _five_sqrt_thirty_seven_log_poly_effective_x2(num, k)
+    if s5l37p_x2 is not None:
+        den_deg_s5l37 = _polynomial_degree_in_k(den, k)
+        if den_deg_s5l37 is not None:
+            if 2 * den_deg_s5l37 > s5l37p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 273: ``Mul(Sqrt(P1)×4, Log(h1)×37, polynomial..., bounded...)`` numerator.
+    s4l37p_x2 = _four_sqrt_thirty_seven_log_poly_effective_x2(num, k)
+    if s4l37p_x2 is not None:
+        den_deg_s4l37 = _polynomial_degree_in_k(den, k)
+        if den_deg_s4l37 is not None:
+            if 2 * den_deg_s4l37 > s4l37p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 272: ``Mul(Sqrt(P1)×3, Log(h1)×37, polynomial..., bounded...)`` numerator.
+    s3l37p_x2 = _three_sqrt_thirty_seven_log_poly_effective_x2(num, k)
+    if s3l37p_x2 is not None:
+        den_deg_s3l37 = _polynomial_degree_in_k(den, k)
+        if den_deg_s3l37 is not None:
+            if 2 * den_deg_s3l37 > s3l37p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 271: ``Mul(Sqrt(P1), Sqrt(P2), Log(h1)×37, polynomial..., bounded...)`` numerator.
+    s2l37p_x2 = _two_sqrt_thirty_seven_log_poly_effective_x2(num, k)
+    if s2l37p_x2 is not None:
+        den_deg_s2l37 = _polynomial_degree_in_k(den, k)
+        if den_deg_s2l37 is not None:
+            if 2 * den_deg_s2l37 > s2l37p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 270: ``Mul(Sqrt(P), Log(h1)×37, polynomial..., bounded...)`` numerator.
+    s1l37p_x2 = _one_sqrt_thirty_seven_log_poly_effective_x2(num, k)
+    if s1l37p_x2 is not None:
+        den_deg_s1l37 = _polynomial_degree_in_k(den, k)
+        if den_deg_s1l37 is not None:
+            if 2 * den_deg_s1l37 > s1l37p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 269: ``Mul(Log(h1)×37, polynomial..., bounded...)`` numerator.
+    sl37p_x2 = _thirty_seven_log_poly_effective_x2(num, k)
+    if sl37p_x2 is not None:
+        den_deg_sl37 = _polynomial_degree_in_k(den, k)
+        if den_deg_sl37 is not None:
+            if 2 * den_deg_sl37 > sl37p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
     # Phase 268: ``Mul(Sqrt(P1)×5, Log(h1)×36, polynomial..., bounded...)`` numerator.
     s5l36p_x2 = _five_sqrt_thirty_six_log_poly_effective_x2(num, k)
     if s5l36p_x2 is not None:
@@ -10531,6 +10585,207 @@ def _five_sqrt_thirty_six_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> in
             continue
         return None
     if len(sqrt_degs_x2) != 5 or log_count != 36:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _thirty_seven_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 269 — Zero-Sqrt × Thirty-Seven-Log × polynomial numerator.
+
+    The Thirty-Seven-Log family (Phases 269–274) extends the recogniser to
+    summands whose numerator contains exactly thirty-seven logarithmic factors
+    and zero to five square-root factors.  This is Phase 269: zero sqrts.
+
+    Parameters
+    ----------
+    node : IRNode
+        The numerator node.
+    k : IRSymbol
+        The summation variable.
+
+    Returns
+    -------
+    int | None
+        ``2 * poly_deg_sum`` when the shape matches (always even); ``None``
+        when the pattern is not recognised.
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        if _sqrt_effective_half_degree_x2(arg, k) is not None:
+            return None
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 37:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if log_count != 37:
+        return None
+    return 2 * poly_deg_sum
+
+
+def _one_sqrt_thirty_seven_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 270 — One-Sqrt × Thirty-Seven-Log × polynomial numerator."""
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_deg_x2: int | None = None
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if sqrt_deg_x2 is not None:
+                return None
+            sqrt_deg_x2 = deg_x2
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 37:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if sqrt_deg_x2 is None or log_count != 37:
+        return None
+    return sqrt_deg_x2 + 2 * poly_deg_sum
+
+
+def _two_sqrt_thirty_seven_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 271 — Two-Sqrt × Thirty-Seven-Log × polynomial numerator."""
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 2:
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 37:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 2 or log_count != 37:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _three_sqrt_thirty_seven_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 272 — Three-Sqrt × Thirty-Seven-Log × polynomial numerator."""
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 3:
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 37:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 3 or log_count != 37:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _four_sqrt_thirty_seven_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 273 — Four-Sqrt × Thirty-Seven-Log × polynomial numerator."""
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 4:
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 37:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 4 or log_count != 37:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _five_sqrt_thirty_seven_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 274 — Five-Sqrt × Thirty-Seven-Log × polynomial numerator.
+    Completes the Thirty-Seven-Log family (Phases 269-274).
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 5:
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 37:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 5 or log_count != 37:
         return None
     return sum(sqrt_degs_x2) + 2 * poly_deg_sum
 

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -4681,3 +4681,79 @@ class TestPhase84OneSqrtSixLogPoly:
         f = IRApply(SUB, (g_k, g_kp1))
         result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
         assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase85TwoSqrtSixLogPoly:
+    """Phase 85 — Two-Sqrt × Six-Log × polynomial numerator.
+
+    Convergence criterion: numerator = √P₁(k) · √P₂(k) · log⁶(k) · poly(k),
+    denominator = polynomial or exponential.
+    effective_x2 = deg1_x2 + deg2_x2 + 2·poly_deg.
+    Closes iff 2·den_deg > effective_x2 (polynomial denom)
+              or denom is a non-polynomial diverging function (exponential, etc.).
+    """
+
+    def test_two_sqrt_k_log6_k_over_k2_closes(self):
+        """√k·√k·log(k)⁶/k²: eff_x2=1+1=2; 2·2=4 > 2 → closes."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,))))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_two_sqrt_k3_log6_k_over_k_refused(self):
+        """√(k³)·√(k³)·log(k)⁶/k: eff_x2=3+3=6; 2·1=2 not > 6 → refused."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (k3,)), IRApply(SQRT, (k3,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1_3,)), IRApply(SQRT, (kp1_3,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,))))
+        g_k = IRApply(DIV, (num_k, _k))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+    def test_two_sqrt_k_log6_k_times_k_over_k2_refused(self):
+        """√k·√k·log(k)⁶·k/k²: eff_x2=1+1+2=4; 2·2=4 not > 4 → refused."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              _k))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                kp1))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -12011,6 +12011,7 @@ class TestPhase167TwentyLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,
@@ -12024,6 +12025,7 @@ class TestPhase167TwentyLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         )), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -12155,6 +12157,7 @@ class TestPhase168OneSqrtTwentyLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -12168,6 +12171,7 @@ class TestPhase168OneSqrtTwentyLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         )),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -12299,6 +12303,7 @@ class TestPhase169TwoSqrtTwentyLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -12312,6 +12317,7 @@ class TestPhase169TwoSqrtTwentyLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         )), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -12443,6 +12449,7 @@ class TestPhase170ThreeSqrtTwentyLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -12456,6 +12463,7 @@ class TestPhase170ThreeSqrtTwentyLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         )), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -12592,6 +12600,7 @@ class TestPhase171FourSqrtTwentyLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -12605,6 +12614,7 @@ class TestPhase171FourSqrtTwentyLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         )), IRApply(SQRT, (kp1,)),
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -12741,6 +12751,7 @@ class TestPhase172FiveSqrtTwentyLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -12754,6 +12765,7 @@ class TestPhase172FiveSqrtTwentyLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         )), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -12885,6 +12897,7 @@ class TestPhase173TwentyOneLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,
@@ -12898,6 +12911,7 @@ class TestPhase173TwentyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         )), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -13023,6 +13037,7 @@ class TestPhase174OneSqrtTwentyOneLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -13036,6 +13051,7 @@ class TestPhase174OneSqrtTwentyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         )),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -13162,6 +13178,7 @@ class TestPhase175TwoSqrtTwentyOneLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -13175,6 +13192,7 @@ class TestPhase175TwoSqrtTwentyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         )), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -13301,6 +13319,7 @@ class TestPhase176ThreeSqrtTwentyOneLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -13314,6 +13333,7 @@ class TestPhase176ThreeSqrtTwentyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         )), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -13445,6 +13465,7 @@ class TestPhase177FourSqrtTwentyOneLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -13458,6 +13479,7 @@ class TestPhase177FourSqrtTwentyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         )), IRApply(SQRT, (kp1,)),
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -13590,6 +13612,7 @@ class TestPhase178FiveSqrtTwentyOneLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -13603,6 +13626,7 @@ class TestPhase178FiveSqrtTwentyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         )), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -13729,6 +13753,7 @@ class TestPhase179TwentyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,
@@ -13742,6 +13767,7 @@ class TestPhase179TwentyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         )), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -13871,6 +13897,7 @@ class TestPhase180OneSqrtTwentyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -13884,6 +13911,7 @@ class TestPhase180OneSqrtTwentyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         )),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -14014,6 +14042,7 @@ class TestPhase181TwoSqrtTwentyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -14027,6 +14056,7 @@ class TestPhase181TwoSqrtTwentyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         )), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -14157,6 +14187,7 @@ class TestPhase182ThreeSqrtTwentyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -14170,6 +14201,7 @@ class TestPhase182ThreeSqrtTwentyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         )), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -14305,6 +14337,7 @@ class TestPhase183FourSqrtTwentyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -14318,6 +14351,7 @@ class TestPhase183FourSqrtTwentyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         )), IRApply(SQRT, (kp1,)),
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -14454,6 +14488,7 @@ class TestPhase184FiveSqrtTwentyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -14467,6 +14502,7 @@ class TestPhase184FiveSqrtTwentyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         )), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -14593,6 +14629,7 @@ class TestPhase185TwentyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,
@@ -14606,6 +14643,7 @@ class TestPhase185TwentyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         )), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -14735,6 +14773,7 @@ class TestPhase186OneSqrtTwentyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -14748,6 +14787,7 @@ class TestPhase186OneSqrtTwentyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         )),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -14878,6 +14918,7 @@ class TestPhase187TwoSqrtTwentyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -14891,6 +14932,7 @@ class TestPhase187TwoSqrtTwentyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         )), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -15021,6 +15063,7 @@ class TestPhase188ThreeSqrtTwentyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -15034,6 +15077,7 @@ class TestPhase188ThreeSqrtTwentyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         )), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -15169,6 +15213,7 @@ class TestPhase189FourSqrtTwentyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -15182,6 +15227,7 @@ class TestPhase189FourSqrtTwentyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         )), IRApply(SQRT, (kp1,)),
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -15318,6 +15364,7 @@ class TestPhase190FiveSqrtTwentyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -15331,6 +15378,7 @@ class TestPhase190FiveSqrtTwentyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         )), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -15456,6 +15504,7 @@ class TestPhase191TwentyFourLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,
@@ -15469,6 +15518,7 @@ class TestPhase191TwentyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         )), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -15596,6 +15646,7 @@ class TestPhase192OneSqrtTwentyFourLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -15609,6 +15660,7 @@ class TestPhase192OneSqrtTwentyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         )),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -15736,6 +15788,7 @@ class TestPhase193TwoSqrtTwentyFourLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -15749,6 +15802,7 @@ class TestPhase193TwoSqrtTwentyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         )), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -15875,6 +15929,7 @@ class TestPhase194ThreeSqrtTwentyFourLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -15888,6 +15943,7 @@ class TestPhase194ThreeSqrtTwentyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         )), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -16019,6 +16075,7 @@ class TestPhase195FourSqrtTwentyFourLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -16032,6 +16089,7 @@ class TestPhase195FourSqrtTwentyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         )), IRApply(SQRT, (kp1,)),
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -16164,6 +16222,7 @@ class TestPhase196FiveSqrtTwentyFourLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -16177,6 +16236,7 @@ class TestPhase196FiveSqrtTwentyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         )), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -16304,6 +16364,7 @@ class TestPhase197TwentyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,
@@ -16317,6 +16378,7 @@ class TestPhase197TwentyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         )), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -16448,6 +16510,7 @@ class TestPhase198OneSqrtTwentyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -16461,6 +16524,7 @@ class TestPhase198OneSqrtTwentyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         )),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -16592,6 +16656,7 @@ class TestPhase199TwoSqrtTwentyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -16605,6 +16670,7 @@ class TestPhase199TwoSqrtTwentyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         )), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -16735,6 +16801,7 @@ class TestPhase200ThreeSqrtTwentyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -16748,6 +16815,7 @@ class TestPhase200ThreeSqrtTwentyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         )), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -16883,6 +16951,7 @@ class TestPhase201FourSqrtTwentyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -16896,6 +16965,7 @@ class TestPhase201FourSqrtTwentyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         )), IRApply(SQRT, (kp1,)),
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -17032,6 +17102,7 @@ class TestPhase202FiveSqrtTwentyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -17045,6 +17116,7 @@ class TestPhase202FiveSqrtTwentyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         )), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -17174,6 +17246,7 @@ class TestPhase203TwentySixLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -17198,6 +17271,7 @@ class TestPhase203TwentySixLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -17320,6 +17394,7 @@ class TestPhase204OneSqrtTwentySixLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -17345,6 +17420,7 @@ class TestPhase204OneSqrtTwentySixLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -17467,6 +17543,7 @@ class TestPhase205TwoSqrtTwentySixLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -17491,6 +17568,7 @@ class TestPhase205TwoSqrtTwentySixLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -17612,6 +17690,7 @@ class TestPhase206ThreeSqrtTwentySixLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -17636,6 +17715,7 @@ class TestPhase206ThreeSqrtTwentySixLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -17762,6 +17842,7 @@ class TestPhase207FourSqrtTwentySixLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -17787,6 +17868,7 @@ class TestPhase207FourSqrtTwentySixLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -17913,6 +17995,7 @@ class TestPhase208FiveSqrtTwentySixLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -17938,6 +18021,7 @@ class TestPhase208FiveSqrtTwentySixLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -18058,6 +18142,7 @@ class TestPhase209TwentySevenLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -18082,6 +18167,7 @@ class TestPhase209TwentySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -18208,6 +18294,7 @@ class TestPhase210OneSqrtTwentySevenLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -18233,6 +18320,7 @@ class TestPhase210OneSqrtTwentySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -18359,6 +18447,7 @@ class TestPhase211TwoSqrtTwentySevenLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -18383,6 +18472,7 @@ class TestPhase211TwoSqrtTwentySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -18508,6 +18598,7 @@ class TestPhase212ThreeSqrtTwentySevenLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -18532,6 +18623,7 @@ class TestPhase212ThreeSqrtTwentySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -18662,6 +18754,7 @@ class TestPhase213FourSqrtTwentySevenLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -18687,6 +18780,7 @@ class TestPhase213FourSqrtTwentySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -18817,6 +18911,7 @@ class TestPhase214FiveSqrtTwentySevenLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -18842,6 +18937,7 @@ class TestPhase214FiveSqrtTwentySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -18966,6 +19062,7 @@ class TestPhase215TwentyEightLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -18990,6 +19087,7 @@ class TestPhase215TwentyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -19120,6 +19218,7 @@ class TestPhase216OneSqrtTwentyEightLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -19145,6 +19244,7 @@ class TestPhase216OneSqrtTwentyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -19275,6 +19375,7 @@ class TestPhase217TwoSqrtTwentyEightLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -19299,6 +19400,7 @@ class TestPhase217TwoSqrtTwentyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -19428,6 +19530,7 @@ class TestPhase218ThreeSqrtTwentyEightLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -19452,6 +19555,7 @@ class TestPhase218ThreeSqrtTwentyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -19586,6 +19690,7 @@ class TestPhase219FourSqrtTwentyEightLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -19611,6 +19716,7 @@ class TestPhase219FourSqrtTwentyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -19745,6 +19851,7 @@ class TestPhase220FiveSqrtTwentyEightLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -19770,6 +19877,7 @@ class TestPhase220FiveSqrtTwentyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -19899,6 +20007,7 @@ class TestPhase221TwentyNineLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -19923,6 +20032,7 @@ class TestPhase221TwentyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -20057,6 +20167,7 @@ class TestPhase222OneSqrtTwentyNineLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -20082,6 +20193,7 @@ class TestPhase222OneSqrtTwentyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -20216,6 +20328,7 @@ class TestPhase223TwoSqrtTwentyNineLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -20240,6 +20353,7 @@ class TestPhase223TwoSqrtTwentyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -20373,6 +20487,7 @@ class TestPhase224ThreeSqrtTwentyNineLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -20397,6 +20512,7 @@ class TestPhase224ThreeSqrtTwentyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -20535,6 +20651,7 @@ class TestPhase225FourSqrtTwentyNineLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -20560,6 +20677,7 @@ class TestPhase225FourSqrtTwentyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -20698,6 +20816,7 @@ class TestPhase226FiveSqrtTwentyNineLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -20723,6 +20842,7 @@ class TestPhase226FiveSqrtTwentyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -20855,6 +20975,7 @@ class TestPhase227ThirtyLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -20879,6 +21000,7 @@ class TestPhase227ThirtyLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -21017,6 +21139,7 @@ class TestPhase228OneSqrtThirtyLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -21042,6 +21165,7 @@ class TestPhase228OneSqrtThirtyLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -21180,6 +21304,7 @@ class TestPhase229TwoSqrtThirtyLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -21204,6 +21329,7 @@ class TestPhase229TwoSqrtThirtyLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -21341,6 +21467,7 @@ class TestPhase230ThreeSqrtThirtyLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -21365,6 +21492,7 @@ class TestPhase230ThreeSqrtThirtyLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -21502,6 +21630,7 @@ class TestPhase231FourSqrtThirtyLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -21526,6 +21655,7 @@ class TestPhase231FourSqrtThirtyLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -21668,6 +21798,7 @@ class TestPhase232FiveSqrtThirtyLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -21693,6 +21824,7 @@ class TestPhase232FiveSqrtThirtyLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -21829,6 +21961,7 @@ class TestPhase233ThirtyOneLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -21853,6 +21986,7 @@ class TestPhase233ThirtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -21995,6 +22129,7 @@ class TestPhase234OneSqrtThirtyOneLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -22020,6 +22155,7 @@ class TestPhase234OneSqrtThirtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -22162,6 +22298,7 @@ class TestPhase235TwoSqrtThirtyOneLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -22186,6 +22323,7 @@ class TestPhase235TwoSqrtThirtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -22327,6 +22465,7 @@ class TestPhase236ThreeSqrtThirtyOneLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -22351,6 +22490,7 @@ class TestPhase236ThreeSqrtThirtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -22497,6 +22637,7 @@ class TestPhase237FourSqrtThirtyOneLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -22522,6 +22663,7 @@ class TestPhase237FourSqrtThirtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -22668,6 +22810,7 @@ class TestPhase238FiveSqrtThirtyOneLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -22693,6 +22836,7 @@ class TestPhase238FiveSqrtThirtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -22833,6 +22977,7 @@ class TestPhase239ThirtyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -22857,6 +23002,7 @@ class TestPhase239ThirtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -23003,6 +23149,7 @@ class TestPhase240OneSqrtThirtyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -23028,6 +23175,7 @@ class TestPhase240OneSqrtThirtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -23174,6 +23322,7 @@ class TestPhase241TwoSqrtThirtyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -23198,6 +23347,7 @@ class TestPhase241TwoSqrtThirtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -23343,6 +23493,7 @@ class TestPhase242ThreeSqrtThirtyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -23367,6 +23518,7 @@ class TestPhase242ThreeSqrtThirtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -23517,6 +23669,7 @@ class TestPhase243FourSqrtThirtyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -23542,6 +23695,7 @@ class TestPhase243FourSqrtThirtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -23692,6 +23846,7 @@ class TestPhase244FiveSqrtThirtyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -23717,6 +23872,7 @@ class TestPhase244FiveSqrtThirtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -23861,6 +24017,7 @@ class TestPhase245ThirtyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -23885,6 +24042,7 @@ class TestPhase245ThirtyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -24035,6 +24193,7 @@ class TestPhase246OneSqrtThirtyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -24060,6 +24219,7 @@ class TestPhase246OneSqrtThirtyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -24210,6 +24370,7 @@ class TestPhase247TwoSqrtThirtyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -24234,6 +24395,7 @@ class TestPhase247TwoSqrtThirtyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -24383,6 +24545,7 @@ class TestPhase248ThreeSqrtThirtyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -24407,6 +24570,7 @@ class TestPhase248ThreeSqrtThirtyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -24561,6 +24725,7 @@ class TestPhase249FourSqrtThirtyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -24586,6 +24751,7 @@ class TestPhase249FourSqrtThirtyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -24740,6 +24906,7 @@ class TestPhase250FiveSqrtThirtyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -24765,6 +24932,7 @@ class TestPhase250FiveSqrtThirtyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -24913,6 +25081,7 @@ class TestPhase251ThirtyFourLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -24937,6 +25106,7 @@ class TestPhase251ThirtyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -25091,6 +25261,7 @@ class TestPhase252OneSqrtThirtyFourLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -25116,6 +25287,7 @@ class TestPhase252OneSqrtThirtyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -25270,6 +25442,7 @@ class TestPhase253TwoSqrtThirtyFourLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -25294,6 +25467,7 @@ class TestPhase253TwoSqrtThirtyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -25447,6 +25621,7 @@ class TestPhase254ThreeSqrtThirtyFourLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -25471,6 +25646,7 @@ class TestPhase254ThreeSqrtThirtyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -25629,6 +25805,7 @@ class TestPhase255FourSqrtThirtyFourLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -25654,6 +25831,7 @@ class TestPhase255FourSqrtThirtyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -25812,6 +25990,7 @@ class TestPhase256FiveSqrtThirtyFourLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -25837,6 +26016,7 @@ class TestPhase256FiveSqrtThirtyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -25989,6 +26169,7 @@ class TestPhase257ThirtyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -26013,6 +26194,7 @@ class TestPhase257ThirtyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -26171,6 +26353,7 @@ class TestPhase258OneSqrtThirtyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -26196,6 +26379,7 @@ class TestPhase258OneSqrtThirtyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -26354,6 +26538,7 @@ class TestPhase259TwoSqrtThirtyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -26378,6 +26563,7 @@ class TestPhase259TwoSqrtThirtyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -26535,6 +26721,7 @@ class TestPhase260ThreeSqrtThirtyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -26559,6 +26746,7 @@ class TestPhase260ThreeSqrtThirtyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -26721,6 +26909,7 @@ class TestPhase261FourSqrtThirtyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -26746,6 +26935,7 @@ class TestPhase261FourSqrtThirtyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -26908,6 +27098,7 @@ class TestPhase262FiveSqrtThirtyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -26933,6 +27124,7 @@ class TestPhase262FiveSqrtThirtyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -27089,6 +27281,7 @@ class TestPhase263ThirtySixLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -27113,6 +27306,7 @@ class TestPhase263ThirtySixLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -27275,6 +27469,7 @@ class TestPhase264OneSqrtThirtySixLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -27300,6 +27495,7 @@ class TestPhase264OneSqrtThirtySixLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -27462,6 +27658,7 @@ class TestPhase265TwoSqrtThirtySixLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -27486,6 +27683,7 @@ class TestPhase265TwoSqrtThirtySixLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -27647,6 +27845,7 @@ class TestPhase266ThreeSqrtThirtySixLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -27671,6 +27870,7 @@ class TestPhase266ThreeSqrtThirtySixLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -27837,6 +28037,7 @@ class TestPhase267FourSqrtThirtySixLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -27862,6 +28063,7 @@ class TestPhase267FourSqrtThirtySixLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -28028,6 +28230,7 @@ class TestPhase268FiveSqrtThirtySixLogPoly:
             IRApply(LOG, (_k,)),  # 35th log
             IRApply(LOG, (_k,)),  # 36th log
             IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -28053,6 +28256,1150 @@ class TestPhase268FiveSqrtThirtySixLogPoly:
             IRApply(LOG, (kp1,)),  # 35th log
             IRApply(LOG, (kp1,)),  # 36th log
             IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase269ThirtySevenLogPoly:
+    """Phase 269 — Thirty-Seven-Log × polynomial numerator."""
+
+    def test_log37_k_over_k2_closes(self):
+        """log(k)^37/k^2: eff_x2=0; 2*2=4 > 0 -> closes."""
+        from symbolic_ir import SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_log37_k_times_k2_over_k3_closes(self):
+        """log(k)^37*k^2/k^3: eff_x2=4; 2*3=6 > 4 -> closes."""
+        from symbolic_ir import SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_k = IRApply(MUL, (
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            k2,
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            kp1_2,
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_log38_k_over_k2_refused(self):
+        """log(k)^38/k^2: 38 logs -> not Phase 269 -> refused."""
+        from symbolic_ir import SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+class TestPhase270OneSqrtThirtySevenLogPoly:
+    """Phase 270 — One-Sqrt × Thirty-Seven-Log × polynomial numerator."""
+
+    def test_sqrt_k_log37_k_over_k2_closes(self):
+        """sqrt(k)*log(k)^37/k^2: eff_x2=1; 2*2=4 > 1 -> closes."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k3_log37_k_over_k2_closes(self):
+        """sqrt(k^3)*log(k)^37/k^2: eff_x2=3; 2*2=4 > 3 -> closes."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (k3,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1_3,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_log38_k_over_k2_refused(self):
+        """sqrt(k)*log(k)^38/k^2: 38 logs -> not Phase 270 -> refused."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+class TestPhase271TwoSqrtThirtySevenLogPoly:
+    """Phase 271 — Two-Sqrt × Thirty-Seven-Log × polynomial numerator."""
+
+    def test_2_sqrt_k_log37_k_over_k2_closes(self):
+        """(sqrt(k))^2*log(k)^37/k^2: eff_x2=2; 2*2=4 > 2 -> closes."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_2_sqrt_k3_log37_k_over_k4_closes(self):
+        """(sqrt(k^3))^2*log(k)^37/k^4: eff_x2=6; 2*4=8 > 6 -> closes."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        k4 = IRApply(POW, (_k, IRInteger(4)))
+        kp1_4 = IRApply(POW, (kp1, IRInteger(4)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (k3,)), IRApply(SQRT, (k3,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1_3,)), IRApply(SQRT, (kp1_3,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+        ))
+        g_k = IRApply(DIV, (num_k, k4))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_4))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_2_sqrt_k_log38_k_over_k2_refused(self):
+        """(sqrt(k))^2*log(k)^38/k^2: 38 logs -> not Phase 271 -> refused."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+class TestPhase272ThreeSqrtThirtySevenLogPoly:
+    """Phase 272 — Three-Sqrt × Thirty-Seven-Log × polynomial numerator."""
+
+    def test_3_sqrt_k_log37_k_over_k2_closes(self):
+        """(sqrt(k))^3*log(k)^37/k^2: eff_x2=3; 2*2=4 > 3 -> closes."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_3_sqrt_k3_log37_k_over_k5_closes(self):
+        """(sqrt(k^3))^3*log(k)^37/k^5: eff_x2=9; 2*5=10 > 9 -> closes."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        k5 = IRApply(POW, (_k, IRInteger(5)))
+        kp1_5 = IRApply(POW, (kp1, IRInteger(5)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (k3,)), IRApply(SQRT, (k3,)), IRApply(SQRT, (k3,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1_3,)), IRApply(SQRT, (kp1_3,)), IRApply(SQRT, (kp1_3,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+        ))
+        g_k = IRApply(DIV, (num_k, k5))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_5))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_3_sqrt_k_log38_k_over_k2_refused(self):
+        """(sqrt(k))^3*log(k)^38/k^2: 38 logs -> not Phase 272 -> refused."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+class TestPhase273FourSqrtThirtySevenLogPoly:
+    """Phase 273 — Four-Sqrt × Thirty-Seven-Log × polynomial numerator."""
+
+    def test_4_sqrt_k_log37_k_over_k3_closes(self):
+        """(sqrt(k))^4*log(k)^37/k^3: eff_x2=4; 2*3=6 > 4 -> closes."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_4_sqrt_k3_log37_k_over_k7_closes(self):
+        """(sqrt(k^3))^4*log(k)^37/k^7: eff_x2=12; 2*7=14 > 12 -> closes."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        k7 = IRApply(POW, (_k, IRInteger(7)))
+        kp1_7 = IRApply(POW, (kp1, IRInteger(7)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (k3,)), IRApply(SQRT, (k3,)), IRApply(SQRT, (k3,)), IRApply(SQRT, (k3,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1_3,)), IRApply(SQRT, (kp1_3,)), IRApply(SQRT, (kp1_3,)), IRApply(SQRT, (kp1_3,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+        ))
+        g_k = IRApply(DIV, (num_k, k7))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_7))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_4_sqrt_k_log38_k_over_k3_refused(self):
+        """(sqrt(k))^4*log(k)^38/k^3: 38 logs -> not Phase 273 -> refused."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+class TestPhase274FiveSqrtThirtySevenLogPoly:
+    """Phase 274 — Five-Sqrt × Thirty-Seven-Log × polynomial numerator."""
+
+    def test_5_sqrt_k_log37_k_over_k3_closes(self):
+        """(sqrt(k))^5*log(k)^37/k^3: eff_x2=5; 2*3=6 > 5 -> closes."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_5_sqrt_k_log37_k_times_k_over_k4_closes(self):
+        """(sqrt(k))^5*log(k)^37*k/k^4: eff_x2=7; 2*4=8 > 7 -> closes."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k4 = IRApply(POW, (_k, IRInteger(4)))
+        kp1_4 = IRApply(POW, (kp1, IRInteger(4)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            _k,
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            kp1,
+        ))
+        g_k = IRApply(DIV, (num_k, k4))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_4))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_5_sqrt_k_log38_k_over_k3_refused(self):
+        """(sqrt(k))^5*log(k)^38/k^3: 38 logs -> not Phase 274 -> refused."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))

--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -369,6 +369,7 @@ members = [
     "pdf417",
     "image-codec-gif",
     "image-codec-bmp",
+    "image-codec-ico",
     "image-codec-jpeg",
     "image-codec-ppm",
     "image-codec-qoi",

--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 2.211.0 — 2026-05-27
+
+### Added
+
+- **Phase 274 — Five-Sqrt × Thirty-Seven-Log × polynomial** (`five_sqrt_thirty_seven_log_poly_effective_x2`):
+  Completes the Thirty-Seven-Log family (Phases 269–274).
+- **Phase 273 — Four-Sqrt × Thirty-Seven-Log × polynomial** (`four_sqrt_thirty_seven_log_poly_effective_x2`).
+- **Phase 272 — Three-Sqrt × Thirty-Seven-Log × polynomial** (`three_sqrt_thirty_seven_log_poly_effective_x2`).
+- **Phase 271 — Two-Sqrt × Thirty-Seven-Log × polynomial** (`two_sqrt_thirty_seven_log_poly_effective_x2`).
+- **Phase 270 — One-Sqrt × Thirty-Seven-Log × polynomial** (`one_sqrt_thirty_seven_log_poly_effective_x2`).
+- **Phase 269 — Zero-Sqrt × Thirty-Seven-Log × polynomial** (`thirty_seven_log_poly_effective_x2`).
+
+### Changed
+
+- Boundary tests in Phases 263–268 (and prior phases 167–262) updated from 37-log
+  "refused" to 38-log "refused" now that Phases 269–274 handle exactly 37 logs.
+
 ## 2.205.0 — 2026-05-27
 
 ### Added

--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.22.0 — 2026-05-26
+
+### Added
+
+- **Phase 85 — Two-Sqrt × Six-Log × polynomial numerator** (`two_sqrt_six_log_poly_effective_x2`):
+  recognises `Mul(Sqrt(P1), Sqrt(P2), Log(h1(k)), Log(h2(k)), Log(h3(k)), Log(h4(k)), Log(h5(k)), Log(h6(k)), polynomial..., bounded...)`.
+  Exactly 2 Sqrt factors and exactly 6 Log factors required.  `log⁶(k)` is sub-polynomial
+  (`o(k^ε)`), contributing 0 to effective degree;
+  `effective_x2 = sqrt1_deg_x2 + sqrt2_deg_x2 + 2 * poly_deg`.
+  Closes when `2 * den_deg > effective_x2` or non-polynomial diverging denominator.
+  - 3 new integration tests in `tests/tests.rs` (`phase85_*`).
+
 ## 2.21.0 — 2026-05-25
 
 ### Added

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "2.205.0"
+version = "2.211.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "2.21.0"
+version = "2.22.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -2258,6 +2258,36 @@ fn one_sqrt_six_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> 
     Some(s + 2 * poly_deg)
 }
 
+/// Phase 85 — Two-Sqrt × Six-Log × polynomial numerator.
+///
+/// Effective growth: `sqrt(k^a) · sqrt(k^b) · log(k)⁶ · k^m ≈ k^{(a+b)/2} · log⁶(k) · k^m`.
+/// `log⁶(k)` is sub-polynomial (`o(k^ε)`), contributing 0. Using the ×2 integer trick:
+/// `effective_x2 = a + b + 2·m`. Caller checks `2·den_deg > effective_x2`.
+fn two_sqrt_six_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let apply_node = match node { IRNode::Apply(a) => a, _ => return None };
+    if !head_is(&apply_node.head, MUL) { return None; }
+    let mut sqrt_degs_x2: Vec<i64> = Vec::new();
+    let mut log_count: usize = 0;
+    let mut poly_deg: i64 = 0;
+    for arg in &apply_node.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs_x2.len() >= 2 { return None; } // third Sqrt — refuse
+            sqrt_degs_x2.push(d);
+            continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 6 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) { poly_deg += deg; continue; }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs_x2.len() != 2 || log_count != 6 { return None; }
+    Some(sqrt_degs_x2[0] + sqrt_degs_x2[1] + 2 * poly_deg)
+}
+
 fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     let apply_node = match g {
         IRNode::Apply(a) => a,
@@ -2691,6 +2721,18 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     if let Some(s1l6_x2) = one_sqrt_six_log_poly_effective_x2(num, k) {
         if let Some(den_deg_s1l6) = polynomial_degree_in_k(den, k) {
             if 2 * den_deg_s1l6 > s1l6_x2 {
+                return true;
+            }
+        } else if h_diverges_at_infinity(den, k) {
+            return true;
+        }
+    }
+    // Phase 85: Mul(Sqrt(P1), Sqrt(P2), Log(diverging)×6, polynomial..., bounded...) numerator.
+    // Two Sqrt + six Log factors; log⁶ sub-polynomial — effective_x2 = d1+d2 + 2·poly_deg.
+    // Closes when 2 * den_deg > effective_x2 or non-polynomial diverging denom.
+    if let Some(s2l6_x2) = two_sqrt_six_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s2l6) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s2l6 > s2l6_x2 {
                 return true;
             }
         } else if h_diverges_at_infinity(den, k) {

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -6239,6 +6239,169 @@ fn five_sqrt_thirty_six_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Opti
     Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg_sum)
 }
 
+/// Phase 269 — Zero-Sqrt × Thirty-Seven-Log × polynomial numerator.
+///
+/// The Thirty-Seven-Log family (Phases 269–274) extends the recogniser to
+/// summands whose numerator contains exactly thirty-seven logarithmic factors
+/// and zero to five square-root factors.  This is Phase 269: zero sqrts.
+fn thirty_seven_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if sqrt_effective_half_degree_x2(arg, k).is_some() { return None; }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 37 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg; continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if log_count != 37 { return None; }
+    Some(2 * poly_deg_sum)
+}
+
+/// Phase 270 — One-Sqrt × Thirty-Seven-Log × polynomial numerator.
+fn one_sqrt_thirty_seven_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut sqrt_deg_x2: Option<i64> = None;
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_deg_x2.is_some() { return None; }
+            sqrt_deg_x2 = Some(d); continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 37 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg; continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_deg_x2.is_none() || log_count != 37 { return None; }
+    Some(sqrt_deg_x2.unwrap() + 2 * poly_deg_sum)
+}
+
+/// Phase 271 — Two-Sqrt × Thirty-Seven-Log × polynomial numerator.
+fn two_sqrt_thirty_seven_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut sqrt_degs: Vec<i64> = Vec::new();
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs.len() >= 2 { return None; }
+            sqrt_degs.push(d); continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 37 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg; continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs.len() != 2 || log_count != 37 { return None; }
+    Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg_sum)
+}
+
+/// Phase 272 — Three-Sqrt × Thirty-Seven-Log × polynomial numerator.
+fn three_sqrt_thirty_seven_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut sqrt_degs: Vec<i64> = Vec::new();
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs.len() >= 3 { return None; }
+            sqrt_degs.push(d); continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 37 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg; continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs.len() != 3 || log_count != 37 { return None; }
+    Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg_sum)
+}
+
+/// Phase 273 — Four-Sqrt × Thirty-Seven-Log × polynomial numerator.
+fn four_sqrt_thirty_seven_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut sqrt_degs: Vec<i64> = Vec::new();
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs.len() >= 4 { return None; }
+            sqrt_degs.push(d); continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 37 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg; continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs.len() != 4 || log_count != 37 { return None; }
+    Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg_sum)
+}
+
+/// Phase 274 — Five-Sqrt × Thirty-Seven-Log × polynomial numerator.
+/// Completes the Thirty-Seven-Log family (Phases 269–274).
+fn five_sqrt_thirty_seven_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut sqrt_degs: Vec<i64> = Vec::new();
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs.len() >= 5 { return None; }
+            sqrt_degs.push(d); continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 37 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg; continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs.len() != 5 || log_count != 37 { return None; }
+    Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg_sum)
+}
+
 /// Phase 251 — Zero-Sqrt × Thirty-Four-Log × polynomial numerator.
 ///
 /// The Thirty-Four-Log family (Phases 251–256) extends the recogniser to
@@ -7917,6 +8080,42 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
         } else if h_diverges_at_infinity(den, k) {
             return true;
         }
+    }
+    // Phase 274: Mul(Sqrt(P1)×5, Log(h1)×37, ...) numerator.
+    if let Some(s5l37_x2) = five_sqrt_thirty_seven_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s5l37) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s5l37 > s5l37_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 273: Mul(Sqrt(P1)×4, Log(h1)×37, ...) numerator.
+    if let Some(s4l37_x2) = four_sqrt_thirty_seven_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s4l37) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s4l37 > s4l37_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 272: Mul(Sqrt(P1)×3, Log(h1)×37, ...) numerator.
+    if let Some(s3l37_x2) = three_sqrt_thirty_seven_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s3l37) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s3l37 > s3l37_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 271: Mul(Sqrt(P), Sqrt(P2), Log(h1)×37, ...) numerator.
+    if let Some(s2l37_x2) = two_sqrt_thirty_seven_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s2l37) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s2l37 > s2l37_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 270: Mul(Sqrt(P), Log(h1)×37, ...) numerator.
+    if let Some(s1l37_x2) = one_sqrt_thirty_seven_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s1l37) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s1l37 > s1l37_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 269: Mul(Log(h1)×37, ...) numerator.
+    if let Some(sl37_x2) = thirty_seven_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_sl37) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_sl37 > sl37_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
     }
     // Phase 268: Mul(Sqrt(P1)×5, Log(h1)×36, ...) numerator.
     if let Some(s5l36_x2) = five_sqrt_thirty_six_log_poly_effective_x2(num, k) {

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -3362,3 +3362,85 @@ fn phase84_sqrt_k_log6_k_times_k_over_k_refused() {
     let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
     assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }
+
+// ── Phase 85: Two-Sqrt × Six-Log × polynomial numerator ──────────────────────
+
+#[test]
+fn phase85_two_sqrt_k_log6_k_over_k2_closes() {
+    // √k·√k·log(k)^6 / k²: effective_x2=1+1=2; 2·2=4 > 2 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k,
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+    ]);
+    let g_k85a = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp185a = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f = apply(sym(SUB), vec![g_k85a, g_kp185a]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase85_two_sqrt_k3_log6_k_over_k_refused() {
+    // √(k³)·√(k³)·log(k)^6 / k: effective_x2=3+3=6; 2·1=2 not > 6 → refused.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let sqrt_k3 = apply(sym("Sqrt"), vec![k3]);
+    let sqrt_kp1_3 = apply(sym("Sqrt"), vec![kp1_3]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k3.clone(), sqrt_k3,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k,
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1_3.clone(), sqrt_kp1_3,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+    ]);
+    let g_k85b = apply(sym(DIV), vec![num_k, k.clone()]);
+    let g_kp185b = apply(sym(DIV), vec![num_kp1, kp1.clone()]);
+    let f = apply(sym(SUB), vec![g_k85b, g_kp185b]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase85_two_sqrt_k_log6_k_times_k_over_k2_refused() {
+    // √k·√k·log(k)^6·k / k²: effective_x2=1+1+2=4; 2·2=4 not > 4 → refused.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k,
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+        kp1.clone(),
+    ]);
+    let g_k85c = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp185c = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f = apply(sym(SUB), vec![g_k85c, g_kp185c]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -13256,7 +13256,8 @@ fn phase191_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 34th log
         log_k.clone(), // 35th log
         log_k.clone(), // 36th log
-        log_k, // 37th log
+        log_k.clone(), // 37th log
+        log_k, // 38th log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -13270,7 +13271,8 @@ fn phase191_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 34th log
         log_kp1.clone(), // 35th log
         log_kp1.clone(), // 36th log
-        log_kp1, // 37th log
+        log_kp1.clone(), // 37th log
+        log_kp1, // 38th log
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -13375,7 +13377,8 @@ fn phase192_sqrt_k_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 34th log
         log_k.clone(), // 35th log
         log_k.clone(), // 36th log
-        log_k, // 37th log
+        log_k.clone(), // 37th log
+        log_k, // 38th log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -13390,7 +13393,8 @@ fn phase192_sqrt_k_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 34th log
         log_kp1.clone(), // 35th log
         log_kp1.clone(), // 36th log
-        log_kp1, // 37th log
+        log_kp1.clone(), // 37th log
+        log_kp1, // 38th log
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -13908,7 +13912,8 @@ fn phase197_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 34th log
         log_k.clone(), // 35th log
         log_k.clone(), // 36th log
-        log_k, // 37th log
+        log_k.clone(), // 37th log
+        log_k, // 38th log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -13922,7 +13927,8 @@ fn phase197_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 34th log
         log_kp1.clone(), // 35th log
         log_kp1.clone(), // 36th log
-        log_kp1, // 37th log
+        log_kp1.clone(), // 37th log
+        log_kp1, // 38th log
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -14027,7 +14033,8 @@ fn phase198_sqrt_k_log29_k_over_k_refused() {
         log_k.clone(), // 34th log
         log_k.clone(), // 35th log
         log_k.clone(), // 36th log
-        log_k, // 37th log
+        log_k.clone(), // 37th log
+        log_k, // 38th log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -14042,7 +14049,8 @@ fn phase198_sqrt_k_log29_k_over_k_refused() {
         log_kp1.clone(), // 34th log
         log_kp1.clone(), // 35th log
         log_kp1.clone(), // 36th log
-        log_kp1, // 37th log
+        log_kp1.clone(), // 37th log
+        log_kp1, // 38th log
         kp1.clone(),
     ]);
     let g_k198c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -14145,7 +14153,8 @@ fn phase199_sqrt2_k_log29_k_over_k_refused() {
         log_k.clone(), // 34th log
         log_k.clone(), // 35th log
         log_k.clone(), // 36th log
-        log_k, // 37th log
+        log_k.clone(), // 37th log
+        log_k, // 38th log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -14160,7 +14169,8 @@ fn phase199_sqrt2_k_log29_k_over_k_refused() {
         log_kp1.clone(), // 34th log
         log_kp1.clone(), // 35th log
         log_kp1.clone(), // 36th log
-        log_kp1, // 37th log
+        log_kp1.clone(), // 37th log
+        log_kp1, // 38th log
         kp1.clone(),
     ]);
     let g_k199c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -14263,7 +14273,8 @@ fn phase200_sqrt3_k_log29_k_over_k_refused() {
         log_k.clone(), // 34th log
         log_k.clone(), // 35th log
         log_k.clone(), // 36th log
-        log_k, // 37th log
+        log_k.clone(), // 37th log
+        log_k, // 38th log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -14278,7 +14289,8 @@ fn phase200_sqrt3_k_log29_k_over_k_refused() {
         log_kp1.clone(), // 34th log
         log_kp1.clone(), // 35th log
         log_kp1.clone(), // 36th log
-        log_kp1, // 37th log
+        log_kp1.clone(), // 37th log
+        log_kp1, // 38th log
         kp1.clone(),
     ]);
     let g_k200c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -14381,7 +14393,8 @@ fn phase201_sqrt4_k_log29_k_over_k_refused() {
         log_k.clone(), // 34th log
         log_k.clone(), // 35th log
         log_k.clone(), // 36th log
-        log_k, // 37th log
+        log_k.clone(), // 37th log
+        log_k, // 38th log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -14396,7 +14409,8 @@ fn phase201_sqrt4_k_log29_k_over_k_refused() {
         log_kp1.clone(), // 34th log
         log_kp1.clone(), // 35th log
         log_kp1.clone(), // 36th log
-        log_kp1, // 37th log
+        log_kp1.clone(), // 37th log
+        log_kp1, // 38th log
         kp1.clone(),
     ]);
     let g_k201c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -14499,7 +14513,8 @@ fn phase202_sqrt5_k_log29_k_over_k_refused() {
         log_k.clone(), // 34th log
         log_k.clone(), // 35th log
         log_k.clone(), // 36th log
-        log_k, // 37th log
+        log_k.clone(), // 37th log
+        log_k, // 38th log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -14514,7 +14529,8 @@ fn phase202_sqrt5_k_log29_k_over_k_refused() {
         log_kp1.clone(), // 34th log
         log_kp1.clone(), // 35th log
         log_kp1.clone(), // 36th log
-        log_kp1, // 37th log
+        log_kp1.clone(), // 37th log
+        log_kp1, // 38th log
         kp1.clone(),
     ]);
     let g_k202c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -14606,7 +14622,8 @@ fn phase203_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 34th log
         log_k.clone(), // 35th log
         log_k.clone(), // 36th log
-        log_k, // 37th log
+        log_k.clone(), // 37th log
+        log_k, // 38th log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -14620,7 +14637,8 @@ fn phase203_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 34th log
         log_kp1.clone(), // 35th log
         log_kp1.clone(), // 36th log
-        log_kp1, // 37th log
+        log_kp1.clone(), // 37th log
+        log_kp1, // 38th log
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -14725,7 +14743,8 @@ fn phase204_sqrt_k_log29_k_over_k_refused() {
         log_k.clone(), // 34th log
         log_k.clone(), // 35th log
         log_k.clone(), // 36th log
-        log_k, // 37th log
+        log_k.clone(), // 37th log
+        log_k, // 38th log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -14740,7 +14759,8 @@ fn phase204_sqrt_k_log29_k_over_k_refused() {
         log_kp1.clone(), // 34th log
         log_kp1.clone(), // 35th log
         log_kp1.clone(), // 36th log
-        log_kp1, // 37th log
+        log_kp1.clone(), // 37th log
+        log_kp1, // 38th log
         kp1.clone(),
     ]);
     let g_k204c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -14843,7 +14863,8 @@ fn phase205_sqrt2_k_log29_k_over_k_refused() {
         log_k.clone(), // 34th log
         log_k.clone(), // 35th log
         log_k.clone(), // 36th log
-        log_k, // 37th log
+        log_k.clone(), // 37th log
+        log_k, // 38th log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -14858,7 +14879,8 @@ fn phase205_sqrt2_k_log29_k_over_k_refused() {
         log_kp1.clone(), // 34th log
         log_kp1.clone(), // 35th log
         log_kp1.clone(), // 36th log
-        log_kp1, // 37th log
+        log_kp1.clone(), // 37th log
+        log_kp1, // 38th log
         kp1.clone(),
     ]);
     let g_k205c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -14961,7 +14983,8 @@ fn phase206_sqrt3_k_log29_k_over_k_refused() {
         log_k.clone(), // 34th log
         log_k.clone(), // 35th log
         log_k.clone(), // 36th log
-        log_k, // 37th log
+        log_k.clone(), // 37th log
+        log_k, // 38th log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -14976,7 +14999,8 @@ fn phase206_sqrt3_k_log29_k_over_k_refused() {
         log_kp1.clone(), // 34th log
         log_kp1.clone(), // 35th log
         log_kp1.clone(), // 36th log
-        log_kp1, // 37th log
+        log_kp1.clone(), // 37th log
+        log_kp1, // 38th log
         kp1.clone(),
     ]);
     let g_k206c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -15079,7 +15103,8 @@ fn phase207_sqrt4_k_log29_k_over_k_refused() {
         log_k.clone(), // 34th log
         log_k.clone(), // 35th log
         log_k.clone(), // 36th log
-        log_k, // 37th log
+        log_k.clone(), // 37th log
+        log_k, // 38th log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -15094,7 +15119,8 @@ fn phase207_sqrt4_k_log29_k_over_k_refused() {
         log_kp1.clone(), // 34th log
         log_kp1.clone(), // 35th log
         log_kp1.clone(), // 36th log
-        log_kp1, // 37th log
+        log_kp1.clone(), // 37th log
+        log_kp1, // 38th log
         kp1.clone(),
     ]);
     let g_k207c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -15197,7 +15223,8 @@ fn phase208_sqrt5_k_log29_k_over_k_refused() {
         log_k.clone(), // 34th log
         log_k.clone(), // 35th log
         log_k.clone(), // 36th log
-        log_k, // 37th log
+        log_k.clone(), // 37th log
+        log_k, // 38th log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -15212,7 +15239,8 @@ fn phase208_sqrt5_k_log29_k_over_k_refused() {
         log_kp1.clone(), // 34th log
         log_kp1.clone(), // 35th log
         log_kp1.clone(), // 36th log
-        log_kp1, // 37th log
+        log_kp1.clone(), // 37th log
+        log_kp1, // 38th log
         kp1.clone(),
     ]);
     let g_k208c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -15309,7 +15337,8 @@ fn phase209_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 34th log
         log_k.clone(), // 35th log
         log_k.clone(), // 36th log
-        log_k, // 37th log
+        log_k.clone(), // 37th log
+        log_k, // 38th log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -15324,7 +15353,8 @@ fn phase209_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 34th log
         log_kp1.clone(), // 35th log
         log_kp1.clone(), // 36th log
-        log_kp1, // 37th log
+        log_kp1.clone(), // 37th log
+        log_kp1, // 38th log
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -15434,7 +15464,8 @@ fn phase210_sqrt_k_log29_k_over_k_refused() {
         log_k.clone(), // 34th log
         log_k.clone(), // 35th log
         log_k.clone(), // 36th log
-        log_k, // 37th log
+        log_k.clone(), // 37th log
+        log_k, // 38th log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -15450,7 +15481,8 @@ fn phase210_sqrt_k_log29_k_over_k_refused() {
         log_kp1.clone(), // 34th log
         log_kp1.clone(), // 35th log
         log_kp1.clone(), // 36th log
-        log_kp1, // 37th log
+        log_kp1.clone(), // 37th log
+        log_kp1, // 38th log
         kp1.clone(),
     ]);
     let g_k210c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -15558,7 +15590,8 @@ fn phase211_sqrt2_k_log29_k_over_k_refused() {
         log_k.clone(), // 34th log
         log_k.clone(), // 35th log
         log_k.clone(), // 36th log
-        log_k, // 37th log
+        log_k.clone(), // 37th log
+        log_k, // 38th log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -15574,7 +15607,8 @@ fn phase211_sqrt2_k_log29_k_over_k_refused() {
         log_kp1.clone(), // 34th log
         log_kp1.clone(), // 35th log
         log_kp1.clone(), // 36th log
-        log_kp1, // 37th log
+        log_kp1.clone(), // 37th log
+        log_kp1, // 38th log
         kp1.clone(),
     ]);
     let g_k211c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -15682,7 +15716,8 @@ fn phase212_sqrt3_k_log29_k_over_k_refused() {
         log_k.clone(), // 34th log
         log_k.clone(), // 35th log
         log_k.clone(), // 36th log
-        log_k, // 37th log
+        log_k.clone(), // 37th log
+        log_k, // 38th log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -15698,7 +15733,8 @@ fn phase212_sqrt3_k_log29_k_over_k_refused() {
         log_kp1.clone(), // 34th log
         log_kp1.clone(), // 35th log
         log_kp1.clone(), // 36th log
-        log_kp1, // 37th log
+        log_kp1.clone(), // 37th log
+        log_kp1, // 38th log
         kp1.clone(),
     ]);
     let g_k212c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -15806,7 +15842,8 @@ fn phase213_sqrt4_k_log29_k_over_k_refused() {
         log_k.clone(), // 34th log
         log_k.clone(), // 35th log
         log_k.clone(), // 36th log
-        log_k, // 37th log
+        log_k.clone(), // 37th log
+        log_k, // 38th log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -15822,7 +15859,8 @@ fn phase213_sqrt4_k_log29_k_over_k_refused() {
         log_kp1.clone(), // 34th log
         log_kp1.clone(), // 35th log
         log_kp1.clone(), // 36th log
-        log_kp1, // 37th log
+        log_kp1.clone(), // 37th log
+        log_kp1, // 38th log
         kp1.clone(),
     ]);
     let g_k213c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -15930,7 +15968,8 @@ fn phase214_sqrt5_k_log29_k_over_k_refused() {
         log_k.clone(), // 34th log
         log_k.clone(), // 35th log
         log_k.clone(), // 36th log
-        log_k, // 37th log
+        log_k.clone(), // 37th log
+        log_k, // 38th log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -15946,7 +15985,8 @@ fn phase214_sqrt5_k_log29_k_over_k_refused() {
         log_kp1.clone(), // 34th log
         log_kp1.clone(), // 35th log
         log_kp1.clone(), // 36th log
-        log_kp1, // 37th log
+        log_kp1.clone(), // 37th log
+        log_kp1, // 38th log
         kp1.clone(),
     ]);
     let g_k214c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -16043,7 +16083,8 @@ fn phase215_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 34th log
         log_k.clone(), // 35th log
         log_k.clone(), // 36th log
-        log_k, // 37th log
+        log_k.clone(), // 37th log
+        log_k, // 38th log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -16058,7 +16099,8 @@ fn phase215_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 34th log
         log_kp1.clone(), // 35th log
         log_kp1.clone(), // 36th log
-        log_kp1, // 37th log
+        log_kp1.clone(), // 37th log
+        log_kp1, // 38th log
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -16168,7 +16210,8 @@ fn phase216_sqrt_k_log29_k_over_k_refused() {
         log_k.clone(), // 34th log
         log_k.clone(), // 35th log
         log_k.clone(), // 36th log
-        log_k, // 37th log
+        log_k.clone(), // 37th log
+        log_k, // 38th log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -16184,7 +16227,8 @@ fn phase216_sqrt_k_log29_k_over_k_refused() {
         log_kp1.clone(), // 34th log
         log_kp1.clone(), // 35th log
         log_kp1.clone(), // 36th log
-        log_kp1, // 37th log
+        log_kp1.clone(), // 37th log
+        log_kp1, // 38th log
         kp1.clone(),
     ]);
     let g_k216c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -16292,7 +16336,8 @@ fn phase217_sqrt2_k_log29_k_over_k_refused() {
         log_k.clone(), // 34th log
         log_k.clone(), // 35th log
         log_k.clone(), // 36th log
-        log_k, // 37th log
+        log_k.clone(), // 37th log
+        log_k, // 38th log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -16308,7 +16353,8 @@ fn phase217_sqrt2_k_log29_k_over_k_refused() {
         log_kp1.clone(), // 34th log
         log_kp1.clone(), // 35th log
         log_kp1.clone(), // 36th log
-        log_kp1, // 37th log
+        log_kp1.clone(), // 37th log
+        log_kp1, // 38th log
         kp1.clone(),
     ]);
     let g_k217c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -16416,7 +16462,8 @@ fn phase218_sqrt3_k_log29_k_over_k_refused() {
         log_k.clone(), // 34th log
         log_k.clone(), // 35th log
         log_k.clone(), // 36th log
-        log_k, // 37th log
+        log_k.clone(), // 37th log
+        log_k, // 38th log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -16432,7 +16479,8 @@ fn phase218_sqrt3_k_log29_k_over_k_refused() {
         log_kp1.clone(), // 34th log
         log_kp1.clone(), // 35th log
         log_kp1.clone(), // 36th log
-        log_kp1, // 37th log
+        log_kp1.clone(), // 37th log
+        log_kp1, // 38th log
         kp1.clone(),
     ]);
     let g_k218c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -16540,7 +16588,8 @@ fn phase219_sqrt4_k_log29_k_over_k_refused() {
         log_k.clone(), // 34th log
         log_k.clone(), // 35th log
         log_k.clone(), // 36th log
-        log_k, // 37th log
+        log_k.clone(), // 37th log
+        log_k, // 38th log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -16556,7 +16605,8 @@ fn phase219_sqrt4_k_log29_k_over_k_refused() {
         log_kp1.clone(), // 34th log
         log_kp1.clone(), // 35th log
         log_kp1.clone(), // 36th log
-        log_kp1, // 37th log
+        log_kp1.clone(), // 37th log
+        log_kp1, // 38th log
         kp1.clone(),
     ]);
     let g_k219c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -16664,7 +16714,8 @@ fn phase220_sqrt5_k_log29_k_over_k_refused() {
         log_k.clone(), // 34th log
         log_k.clone(), // 35th log
         log_k.clone(), // 36th log
-        log_k, // 37th log
+        log_k.clone(), // 37th log
+        log_k, // 38th log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -16680,7 +16731,8 @@ fn phase220_sqrt5_k_log29_k_over_k_refused() {
         log_kp1.clone(), // 34th log
         log_kp1.clone(), // 35th log
         log_kp1.clone(), // 36th log
-        log_kp1, // 37th log
+        log_kp1.clone(), // 37th log
+        log_kp1, // 38th log
         kp1.clone(),
     ]);
     let g_k220c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -16777,7 +16829,8 @@ fn phase221_log30_k_times_k_over_k2_refused() {
         log_k.clone(), // 34th log
         log_k.clone(), // 35th log
         log_k.clone(), // 36th log
-        log_k, // 37th log
+        log_k.clone(), // 37th log
+        log_k, // 38th log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -16792,7 +16845,8 @@ fn phase221_log30_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 34th log
         log_kp1.clone(), // 35th log
         log_kp1.clone(), // 36th log
-        log_kp1, // 37th log
+        log_kp1.clone(), // 37th log
+        log_kp1, // 38th log
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -16902,7 +16956,8 @@ fn phase222_sqrt1_k_log30_k_over_k_refused() {
         log_k.clone(), // 34th log
         log_k.clone(), // 35th log
         log_k.clone(), // 36th log
-        log_k, // 37th log
+        log_k.clone(), // 37th log
+        log_k, // 38th log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -16918,7 +16973,8 @@ fn phase222_sqrt1_k_log30_k_over_k_refused() {
         log_kp1.clone(), // 34th log
         log_kp1.clone(), // 35th log
         log_kp1.clone(), // 36th log
-        log_kp1, // 37th log
+        log_kp1.clone(), // 37th log
+        log_kp1, // 38th log
         kp1.clone(),
     ]);
     let g_k222c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -17026,7 +17082,8 @@ fn phase223_sqrt2_k_log30_k_over_k_refused() {
         log_k.clone(), // 34th log
         log_k.clone(), // 35th log
         log_k.clone(), // 36th log
-        log_k, // 37th log
+        log_k.clone(), // 37th log
+        log_k, // 38th log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -17042,7 +17099,8 @@ fn phase223_sqrt2_k_log30_k_over_k_refused() {
         log_kp1.clone(), // 34th log
         log_kp1.clone(), // 35th log
         log_kp1.clone(), // 36th log
-        log_kp1, // 37th log
+        log_kp1.clone(), // 37th log
+        log_kp1, // 38th log
         kp1.clone(),
     ]);
     let g_k223c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -17150,7 +17208,8 @@ fn phase224_sqrt3_k_log30_k_over_k_refused() {
         log_k.clone(), // 34th log
         log_k.clone(), // 35th log
         log_k.clone(), // 36th log
-        log_k, // 37th log
+        log_k.clone(), // 37th log
+        log_k, // 38th log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -17166,7 +17225,8 @@ fn phase224_sqrt3_k_log30_k_over_k_refused() {
         log_kp1.clone(), // 34th log
         log_kp1.clone(), // 35th log
         log_kp1.clone(), // 36th log
-        log_kp1, // 37th log
+        log_kp1.clone(), // 37th log
+        log_kp1, // 38th log
         kp1.clone(),
     ]);
     let g_k224c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -17274,7 +17334,8 @@ fn phase225_sqrt4_k_log30_k_over_k_refused() {
         log_k.clone(), // 34th log
         log_k.clone(), // 35th log
         log_k.clone(), // 36th log
-        log_k, // 37th log
+        log_k.clone(), // 37th log
+        log_k, // 38th log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -17290,7 +17351,8 @@ fn phase225_sqrt4_k_log30_k_over_k_refused() {
         log_kp1.clone(), // 34th log
         log_kp1.clone(), // 35th log
         log_kp1.clone(), // 36th log
-        log_kp1, // 37th log
+        log_kp1.clone(), // 37th log
+        log_kp1, // 38th log
         kp1.clone(),
     ]);
     let g_k225c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -17398,7 +17460,8 @@ fn phase226_sqrt5_k_log30_k_over_k_refused() {
         log_k.clone(), // 34th log
         log_k.clone(), // 35th log
         log_k.clone(), // 36th log
-        log_k, // 37th log
+        log_k.clone(), // 37th log
+        log_k, // 38th log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -17414,7 +17477,8 @@ fn phase226_sqrt5_k_log30_k_over_k_refused() {
         log_kp1.clone(), // 34th log
         log_kp1.clone(), // 35th log
         log_kp1.clone(), // 36th log
-        log_kp1, // 37th log
+        log_kp1.clone(), // 37th log
+        log_kp1, // 38th log
         kp1.clone(),
     ]);
     let g_k226c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -17511,7 +17575,8 @@ fn phase227_log31_k_times_k_over_k2_refused() {
         log_k.clone(), // 34th log
         log_k.clone(), // 35th log
         log_k.clone(), // 36th log
-        log_k, // 37th log
+        log_k.clone(), // 37th log
+        log_k, // 38th log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -17526,7 +17591,8 @@ fn phase227_log31_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 34th log
         log_kp1.clone(), // 35th log
         log_kp1.clone(), // 36th log
-        log_kp1, // 37th log
+        log_kp1.clone(), // 37th log
+        log_kp1, // 38th log
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -17636,7 +17702,8 @@ fn phase228_sqrt1_k_log31_k_times_k_over_k_refused() {
         log_k.clone(), // 34th log
         log_k.clone(), // 35th log
         log_k.clone(), // 36th log
-        log_k, // 37th log
+        log_k.clone(), // 37th log
+        log_k, // 38th log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -17652,7 +17719,8 @@ fn phase228_sqrt1_k_log31_k_times_k_over_k_refused() {
         log_kp1.clone(), // 34th log
         log_kp1.clone(), // 35th log
         log_kp1.clone(), // 36th log
-        log_kp1, // 37th log
+        log_kp1.clone(), // 37th log
+        log_kp1, // 38th log
         kp1.clone(),
     ]);
     let g_k228c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -17760,7 +17828,8 @@ fn phase229_sqrt2_k_log31_k_times_k_over_k_refused() {
         log_k.clone(), // 34th log
         log_k.clone(), // 35th log
         log_k.clone(), // 36th log
-        log_k, // 37th log
+        log_k.clone(), // 37th log
+        log_k, // 38th log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -17776,7 +17845,8 @@ fn phase229_sqrt2_k_log31_k_times_k_over_k_refused() {
         log_kp1.clone(), // 34th log
         log_kp1.clone(), // 35th log
         log_kp1.clone(), // 36th log
-        log_kp1, // 37th log
+        log_kp1.clone(), // 37th log
+        log_kp1, // 38th log
         kp1.clone(),
     ]);
     let g_k229c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -17884,7 +17954,8 @@ fn phase230_sqrt3_k_log31_k_over_k_refused() {
         log_k.clone(), // 34th log
         log_k.clone(), // 35th log
         log_k.clone(), // 36th log
-        log_k, // 37th log
+        log_k.clone(), // 37th log
+        log_k, // 38th log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -17900,7 +17971,8 @@ fn phase230_sqrt3_k_log31_k_over_k_refused() {
         log_kp1.clone(), // 34th log
         log_kp1.clone(), // 35th log
         log_kp1.clone(), // 36th log
-        log_kp1, // 37th log
+        log_kp1.clone(), // 37th log
+        log_kp1, // 38th log
         kp1.clone(),
     ]);
     let g_k230c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -18008,7 +18080,8 @@ fn phase231_sqrt4_k_log31_k_over_k_refused() {
         log_k.clone(), // 34th log
         log_k.clone(), // 35th log
         log_k.clone(), // 36th log
-        log_k, // 37th log
+        log_k.clone(), // 37th log
+        log_k, // 38th log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -18024,7 +18097,8 @@ fn phase231_sqrt4_k_log31_k_over_k_refused() {
         log_kp1.clone(), // 34th log
         log_kp1.clone(), // 35th log
         log_kp1.clone(), // 36th log
-        log_kp1, // 37th log
+        log_kp1.clone(), // 37th log
+        log_kp1, // 38th log
         kp1.clone(),
     ]);
     let g_k231c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -18132,7 +18206,8 @@ fn phase232_sqrt5_k_log31_k_over_k_refused() {
         log_k.clone(), // 34th log
         log_k.clone(), // 35th log
         log_k.clone(), // 36th log
-        log_k, // 37th log
+        log_k.clone(), // 37th log
+        log_k, // 38th log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -18148,7 +18223,8 @@ fn phase232_sqrt5_k_log31_k_over_k_refused() {
         log_kp1.clone(), // 34th log
         log_kp1.clone(), // 35th log
         log_kp1.clone(), // 36th log
-        log_kp1, // 37th log
+        log_kp1.clone(), // 37th log
+        log_kp1, // 38th log
         kp1.clone(),
     ]);
     let g_k232c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -18245,7 +18321,8 @@ fn phase233_log32_k_times_k_over_k2_refused() {
         log_k.clone(), // 34th log
         log_k.clone(), // 35th log
         log_k.clone(), // 36th log
-        log_k, // 37th log
+        log_k.clone(), // 37th log
+        log_k, // 38th log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -18260,7 +18337,8 @@ fn phase233_log32_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 34th log
         log_kp1.clone(), // 35th log
         log_kp1.clone(), // 36th log
-        log_kp1, // 37th log
+        log_kp1.clone(), // 37th log
+        log_kp1, // 38th log
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -18370,7 +18448,8 @@ fn phase234_sqrt1_k_log32_k_times_k_over_k_refused() {
         log_k.clone(), // 34th log
         log_k.clone(), // 35th log
         log_k.clone(), // 36th log
-        log_k, // 37th log
+        log_k.clone(), // 37th log
+        log_k, // 38th log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -18386,7 +18465,8 @@ fn phase234_sqrt1_k_log32_k_times_k_over_k_refused() {
         log_kp1.clone(), // 34th log
         log_kp1.clone(), // 35th log
         log_kp1.clone(), // 36th log
-        log_kp1, // 37th log
+        log_kp1.clone(), // 37th log
+        log_kp1, // 38th log
         kp1.clone(),
     ]);
     let g_k234c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -18494,7 +18574,8 @@ fn phase235_sqrt2_k_log32_k_over_k_refused() {
         log_k.clone(), // 34th log
         log_k.clone(), // 35th log
         log_k.clone(), // 36th log
-        log_k, // 37th log
+        log_k.clone(), // 37th log
+        log_k, // 38th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -18509,7 +18590,8 @@ fn phase235_sqrt2_k_log32_k_over_k_refused() {
         log_kp1.clone(), // 34th log
         log_kp1.clone(), // 35th log
         log_kp1.clone(), // 36th log
-        log_kp1, // 37th log
+        log_kp1.clone(), // 37th log
+        log_kp1, // 38th log
     ]);
     let g_k235c = apply(sym(DIV), vec![num_k, k.clone()]);
     let g_kp1_235c = apply(sym(DIV), vec![num_kp1, kp1.clone()]);
@@ -18616,7 +18698,8 @@ fn phase236_sqrt3_k_log32_k_over_k_refused() {
         log_k.clone(), // 34th log
         log_k.clone(), // 35th log
         log_k.clone(), // 36th log
-        log_k, // 37th log
+        log_k.clone(), // 37th log
+        log_k, // 38th log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -18632,7 +18715,8 @@ fn phase236_sqrt3_k_log32_k_over_k_refused() {
         log_kp1.clone(), // 34th log
         log_kp1.clone(), // 35th log
         log_kp1.clone(), // 36th log
-        log_kp1, // 37th log
+        log_kp1.clone(), // 37th log
+        log_kp1, // 38th log
         kp1.clone(),
     ]);
     let g_k236c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -18740,7 +18824,8 @@ fn phase237_sqrt4_k_log32_k_over_k_refused() {
         log_k.clone(), // 34th log
         log_k.clone(), // 35th log
         log_k.clone(), // 36th log
-        log_k, // 37th log
+        log_k.clone(), // 37th log
+        log_k, // 38th log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -18756,7 +18841,8 @@ fn phase237_sqrt4_k_log32_k_over_k_refused() {
         log_kp1.clone(), // 34th log
         log_kp1.clone(), // 35th log
         log_kp1.clone(), // 36th log
-        log_kp1, // 37th log
+        log_kp1.clone(), // 37th log
+        log_kp1, // 38th log
         kp1.clone(),
     ]);
     let g_k237c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -18864,7 +18950,8 @@ fn phase238_sqrt5_k_log32_k_over_k_refused() {
         log_k.clone(), // 34th log
         log_k.clone(), // 35th log
         log_k.clone(), // 36th log
-        log_k, // 37th log
+        log_k.clone(), // 37th log
+        log_k, // 38th log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -18880,7 +18967,8 @@ fn phase238_sqrt5_k_log32_k_over_k_refused() {
         log_kp1.clone(), // 34th log
         log_kp1.clone(), // 35th log
         log_kp1.clone(), // 36th log
-        log_kp1, // 37th log
+        log_kp1.clone(), // 37th log
+        log_kp1, // 38th log
         kp1.clone(),
     ]);
     let g_k238c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -18980,7 +19068,8 @@ fn phase239_log33_k_times_k_over_k2_refused() {
         log_k.clone(), // 34 logs
         log_k.clone(), // 35 logs
         log_k.clone(), // 36 logs
-        log_k, // 37 logs
+        log_k.clone(), // 37 logs
+        log_k, // 38 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -18994,7 +19083,8 @@ fn phase239_log33_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 34 logs
         log_kp1.clone(), // 35 logs
         log_kp1.clone(), // 36 logs
-        log_kp1, // 37 logs
+        log_kp1.clone(), // 37 logs
+        log_kp1, // 38 logs
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -19107,7 +19197,8 @@ fn phase240_sqrt1_k_log33_k_times_k_over_k_refused() {
         log_k.clone(), // 34 logs
         log_k.clone(), // 35 logs
         log_k.clone(), // 36 logs
-        log_k, // 37 logs
+        log_k.clone(), // 37 logs
+        log_k, // 38 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -19122,7 +19213,8 @@ fn phase240_sqrt1_k_log33_k_times_k_over_k_refused() {
         log_kp1.clone(), // 34 logs
         log_kp1.clone(), // 35 logs
         log_kp1.clone(), // 36 logs
-        log_kp1, // 37 logs
+        log_kp1.clone(), // 37 logs
+        log_kp1, // 38 logs
         kp1.clone(),
     ]);
     let g_k240c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -19233,7 +19325,8 @@ fn phase241_sqrt2_k_log33_k_over_k_refused() {
         log_k.clone(), // 34 logs
         log_k.clone(), // 35 logs
         log_k.clone(), // 36 logs
-        log_k, // 37 logs
+        log_k.clone(), // 37 logs
+        log_k, // 38 logs
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -19247,7 +19340,8 @@ fn phase241_sqrt2_k_log33_k_over_k_refused() {
         log_kp1.clone(), // 34 logs
         log_kp1.clone(), // 35 logs
         log_kp1.clone(), // 36 logs
-        log_kp1, // 37 logs
+        log_kp1.clone(), // 37 logs
+        log_kp1, // 38 logs
     ]);
     let g_k241c = apply(sym(DIV), vec![num_k, k.clone()]);
     let g_kp1_241c = apply(sym(DIV), vec![num_kp1, kp1.clone()]);
@@ -19357,7 +19451,8 @@ fn phase242_sqrt3_k_log33_k_over_k_refused() {
         log_k.clone(), // 34 logs
         log_k.clone(), // 35 logs
         log_k.clone(), // 36 logs
-        log_k, // 37 logs
+        log_k.clone(), // 37 logs
+        log_k, // 38 logs
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -19371,7 +19466,8 @@ fn phase242_sqrt3_k_log33_k_over_k_refused() {
         log_kp1.clone(), // 34 logs
         log_kp1.clone(), // 35 logs
         log_kp1.clone(), // 36 logs
-        log_kp1, // 37 logs
+        log_kp1.clone(), // 37 logs
+        log_kp1, // 38 logs
     ]);
     let g_k242c = apply(sym(DIV), vec![num_k, k.clone()]);
     let g_kp1_242c = apply(sym(DIV), vec![num_kp1, kp1.clone()]);
@@ -19481,7 +19577,8 @@ fn phase243_sqrt4_k_log33_k_over_k_refused() {
         log_k.clone(), // 34 logs
         log_k.clone(), // 35 logs
         log_k.clone(), // 36 logs
-        log_k, // 37 logs
+        log_k.clone(), // 37 logs
+        log_k, // 38 logs
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -19495,7 +19592,8 @@ fn phase243_sqrt4_k_log33_k_over_k_refused() {
         log_kp1.clone(), // 34 logs
         log_kp1.clone(), // 35 logs
         log_kp1.clone(), // 36 logs
-        log_kp1, // 37 logs
+        log_kp1.clone(), // 37 logs
+        log_kp1, // 38 logs
     ]);
     let g_k243c = apply(sym(DIV), vec![num_k, k.clone()]);
     let g_kp1_243c = apply(sym(DIV), vec![num_kp1, kp1.clone()]);
@@ -19601,7 +19699,8 @@ fn phase244_sqrt5_k_log33_k_over_k_refused() {
         log_k.clone(), // 34 logs
         log_k.clone(), // 35 logs
         log_k.clone(), // 36 logs
-        log_k, // 37 logs
+        log_k.clone(), // 37 logs
+        log_k, // 38 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -19616,7 +19715,8 @@ fn phase244_sqrt5_k_log33_k_over_k_refused() {
         log_kp1.clone(), // 34 logs
         log_kp1.clone(), // 35 logs
         log_kp1.clone(), // 36 logs
-        log_kp1, // 37 logs
+        log_kp1.clone(), // 37 logs
+        log_kp1, // 38 logs
         kp1.clone(),
     ]);
     let g_k244c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -19715,7 +19815,8 @@ fn phase245_log34_k_times_k_over_k2_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 34 logs
         log_k.clone(), // 35 logs
         log_k.clone(), // 36 logs
-        log_k, // 37 logs
+        log_k.clone(), // 37 logs
+        log_k, // 38 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -19728,7 +19829,8 @@ fn phase245_log34_k_times_k_over_k2_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 34 logs
         log_kp1.clone(), // 35 logs
         log_kp1.clone(), // 36 logs
-        log_kp1, // 37 logs
+        log_kp1.clone(), // 37 logs
+        log_kp1, // 38 logs
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -19840,7 +19942,8 @@ fn phase246_sqrt1_k_log34_k_over_k_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 34 logs
         log_k.clone(), // 35 logs
         log_k.clone(), // 36 logs
-        log_k, // 37 logs
+        log_k.clone(), // 37 logs
+        log_k, // 38 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -19854,7 +19957,8 @@ fn phase246_sqrt1_k_log34_k_over_k_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 34 logs
         log_kp1.clone(), // 35 logs
         log_kp1.clone(), // 36 logs
-        log_kp1, // 37 logs
+        log_kp1.clone(), // 37 logs
+        log_kp1, // 38 logs
         kp1.clone(),
     ]);
     let g_k246c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -19964,7 +20068,8 @@ fn phase247_sqrt2_k_log34_k_over_k_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 34 logs
         log_k.clone(), // 35 logs
         log_k.clone(), // 36 logs
-        log_k, // 37 logs
+        log_k.clone(), // 37 logs
+        log_k, // 38 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -19978,7 +20083,8 @@ fn phase247_sqrt2_k_log34_k_over_k_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 34 logs
         log_kp1.clone(), // 35 logs
         log_kp1.clone(), // 36 logs
-        log_kp1, // 37 logs
+        log_kp1.clone(), // 37 logs
+        log_kp1, // 38 logs
         kp1.clone(),
     ]);
     let g_k247c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -20088,7 +20194,8 @@ fn phase248_sqrt3_k_log34_k_over_k_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 34 logs
         log_k.clone(), // 35 logs
         log_k.clone(), // 36 logs
-        log_k, // 37 logs
+        log_k.clone(), // 37 logs
+        log_k, // 38 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -20102,7 +20209,8 @@ fn phase248_sqrt3_k_log34_k_over_k_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 34 logs
         log_kp1.clone(), // 35 logs
         log_kp1.clone(), // 36 logs
-        log_kp1, // 37 logs
+        log_kp1.clone(), // 37 logs
+        log_kp1, // 38 logs
         kp1.clone(),
     ]);
     let g_k248c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -20212,7 +20320,8 @@ fn phase249_sqrt4_k_log34_k_over_k_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), // 34 logs
         log_k.clone(), // 35 logs
         log_k.clone(), // 36 logs
-        log_k, // 37 logs
+        log_k.clone(), // 37 logs
+        log_k, // 38 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -20226,7 +20335,8 @@ fn phase249_sqrt4_k_log34_k_over_k_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 34 logs
         log_kp1.clone(), // 35 logs
         log_kp1.clone(), // 36 logs
-        log_kp1, // 37 logs
+        log_kp1.clone(), // 37 logs
+        log_kp1, // 38 logs
         kp1.clone(),
     ]);
     let g_k249c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -20336,7 +20446,8 @@ fn phase250_sqrt5_k_log34_k_over_k_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), // 34 logs
         log_k.clone(), // 35 logs
         log_k.clone(), // 36 logs
-        log_k, // 37 logs
+        log_k.clone(), // 37 logs
+        log_k, // 38 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -20350,7 +20461,8 @@ fn phase250_sqrt5_k_log34_k_over_k_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 34 logs
         log_kp1.clone(), // 35 logs
         log_kp1.clone(), // 36 logs
-        log_kp1, // 37 logs
+        log_kp1.clone(), // 37 logs
+        log_kp1, // 38 logs
         kp1.clone(),
     ]);
     let g_k250c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -20448,7 +20560,8 @@ fn phase251_log36_k_times_k_over_k2_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
         log_k.clone(), // 36 logs
-        log_k, // 37 logs
+        log_k.clone(), // 37 logs
+        log_k, // 38 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -20460,7 +20573,8 @@ fn phase251_log36_k_times_k_over_k2_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
         log_kp1.clone(), // 36 logs
-        log_kp1, // 37 logs
+        log_kp1.clone(), // 37 logs
+        log_kp1, // 38 logs
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -20571,7 +20685,8 @@ fn phase252_sqrt1_k_log36_k_over_k_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
         log_k.clone(), // 36 logs
-        log_k, // 37 logs
+        log_k.clone(), // 37 logs
+        log_k, // 38 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -20584,7 +20699,8 @@ fn phase252_sqrt1_k_log36_k_over_k_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
         log_kp1.clone(), // 36 logs
-        log_kp1, // 37 logs
+        log_kp1.clone(), // 37 logs
+        log_kp1, // 38 logs
         kp1.clone(),
     ]);
     let g_k252c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -20693,7 +20809,8 @@ fn phase253_sqrt2_k_log36_k_over_k_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
         log_k.clone(), // 36 logs
-        log_k, // 37 logs
+        log_k.clone(), // 37 logs
+        log_k, // 38 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -20706,7 +20823,8 @@ fn phase253_sqrt2_k_log36_k_over_k_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
         log_kp1.clone(), // 36 logs
-        log_kp1, // 37 logs
+        log_kp1.clone(), // 37 logs
+        log_kp1, // 38 logs
         kp1.clone(),
     ]);
     let g_k253c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -20815,7 +20933,8 @@ fn phase254_sqrt3_k_log36_k_over_k_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
         log_k.clone(), // 36 logs
-        log_k, // 37 logs
+        log_k.clone(), // 37 logs
+        log_k, // 38 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -20828,7 +20947,8 @@ fn phase254_sqrt3_k_log36_k_over_k_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
         log_kp1.clone(), // 36 logs
-        log_kp1, // 37 logs
+        log_kp1.clone(), // 37 logs
+        log_kp1, // 38 logs
         kp1.clone(),
     ]);
     let g_k254c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -20937,7 +21057,8 @@ fn phase255_sqrt4_k_log36_k_over_k_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
         log_k.clone(), // 36 logs
-        log_k, // 37 logs
+        log_k.clone(), // 37 logs
+        log_k, // 38 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -20950,7 +21071,8 @@ fn phase255_sqrt4_k_log36_k_over_k_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
         log_kp1.clone(), // 36 logs
-        log_kp1, // 37 logs
+        log_kp1.clone(), // 37 logs
+        log_kp1, // 38 logs
         kp1.clone(),
     ]);
     let g_k255c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -21059,7 +21181,8 @@ fn phase256_sqrt5_k_log36_k_over_k_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
         log_k.clone(), // 36 logs
-        log_k, // 37 logs
+        log_k.clone(), // 37 logs
+        log_k, // 38 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -21072,7 +21195,8 @@ fn phase256_sqrt5_k_log36_k_over_k_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
         log_kp1.clone(), // 36 logs
-        log_kp1, // 37 logs
+        log_kp1.clone(), // 37 logs
+        log_kp1, // 38 logs
         kp1.clone(),
     ]);
     let g_k256c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -21170,7 +21294,8 @@ fn phase257_log36_k_times_k_over_k2_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
         log_k.clone(), // 36 logs
-        log_k, // 37 logs
+        log_k.clone(), // 37 logs
+        log_k, // 38 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -21182,7 +21307,8 @@ fn phase257_log36_k_times_k_over_k2_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
         log_kp1.clone(), // 36 logs
-        log_kp1, // 37 logs
+        log_kp1.clone(), // 37 logs
+        log_kp1, // 38 logs
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -21293,7 +21419,8 @@ fn phase258_sqrt1_k_log36_k_over_k_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
         log_k.clone(), // 36 logs
-        log_k, // 37 logs
+        log_k.clone(), // 37 logs
+        log_k, // 38 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -21306,7 +21433,8 @@ fn phase258_sqrt1_k_log36_k_over_k_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
         log_kp1.clone(), // 36 logs
-        log_kp1, // 37 logs
+        log_kp1.clone(), // 37 logs
+        log_kp1, // 38 logs
         kp1.clone(),
     ]);
     let g_k258c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -21415,7 +21543,8 @@ fn phase259_sqrt2_k_log36_k_over_k_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
         log_k.clone(), // 36 logs
-        log_k, // 37 logs
+        log_k.clone(), // 37 logs
+        log_k, // 38 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -21428,7 +21557,8 @@ fn phase259_sqrt2_k_log36_k_over_k_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
         log_kp1.clone(), // 36 logs
-        log_kp1, // 37 logs
+        log_kp1.clone(), // 37 logs
+        log_kp1, // 38 logs
         kp1.clone(),
     ]);
     let g_k259c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -21537,7 +21667,8 @@ fn phase260_sqrt3_k_log36_k_over_k_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
         log_k.clone(), // 36 logs
-        log_k, // 37 logs
+        log_k.clone(), // 37 logs
+        log_k, // 38 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -21550,7 +21681,8 @@ fn phase260_sqrt3_k_log36_k_over_k_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
         log_kp1.clone(), // 36 logs
-        log_kp1, // 37 logs
+        log_kp1.clone(), // 37 logs
+        log_kp1, // 38 logs
         kp1.clone(),
     ]);
     let g_k260c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -21659,7 +21791,8 @@ fn phase261_sqrt4_k_log36_k_over_k_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
         log_k.clone(), // 36 logs
-        log_k, // 37 logs
+        log_k.clone(), // 37 logs
+        log_k, // 38 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -21672,7 +21805,8 @@ fn phase261_sqrt4_k_log36_k_over_k_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
         log_kp1.clone(), // 36 logs
-        log_kp1, // 37 logs
+        log_kp1.clone(), // 37 logs
+        log_kp1, // 38 logs
         kp1.clone(),
     ]);
     let g_k261c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -21781,7 +21915,8 @@ fn phase262_sqrt5_k_log36_k_over_k_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
         log_k.clone(), // 36 logs
-        log_k, // 37 logs
+        log_k.clone(), // 37 logs
+        log_k, // 38 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -21794,7 +21929,8 @@ fn phase262_sqrt5_k_log36_k_over_k_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
         log_kp1.clone(), // 36 logs
-        log_kp1, // 37 logs
+        log_kp1.clone(), // 37 logs
+        log_kp1, // 38 logs
         kp1.clone(),
     ]);
     let g_k262c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -21895,7 +22031,8 @@ fn phase263_log37_k_over_k_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
         log_k.clone(), // 36 logs
-        log_k, // 37 logs
+        log_k.clone(), // 37 logs
+        log_k, // 38 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -21907,7 +22044,8 @@ fn phase263_log37_k_over_k_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
         log_kp1.clone(), // 36 logs
-        log_kp1, // 37 logs
+        log_kp1.clone(), // 37 logs
+        log_kp1, // 38 logs
         kp1.clone(),
     ]);
     let g_k263c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -22018,7 +22156,8 @@ fn phase264_sqrt1_k_log37_k_over_k_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
         log_k.clone(), // 36 logs
-        log_k, // 37 logs
+        log_k.clone(), // 37 logs
+        log_k, // 38 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -22031,7 +22170,8 @@ fn phase264_sqrt1_k_log37_k_over_k_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
         log_kp1.clone(), // 36 logs
-        log_kp1, // 37 logs
+        log_kp1.clone(), // 37 logs
+        log_kp1, // 38 logs
         kp1.clone(),
     ]);
     let g_k264c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -22142,7 +22282,8 @@ fn phase265_sqrt2_k_log37_k_over_k_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
         log_k.clone(), // 36 logs
-        log_k, // 37 logs
+        log_k.clone(), // 37 logs
+        log_k, // 38 logs
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -22154,7 +22295,8 @@ fn phase265_sqrt2_k_log37_k_over_k_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
         log_kp1.clone(), // 36 logs
-        log_kp1, // 37 logs
+        log_kp1.clone(), // 37 logs
+        log_kp1, // 38 logs
     ]);
     let g_k265c = apply(sym(DIV), vec![num_k, k.clone()]);
     let g_kp1_265c = apply(sym(DIV), vec![num_kp1, kp1.clone()]);
@@ -22264,7 +22406,8 @@ fn phase266_sqrt3_k_log37_k_over_k_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
         log_k.clone(), // 36 logs
-        log_k, // 37 logs
+        log_k.clone(), // 37 logs
+        log_k, // 38 logs
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -22276,7 +22419,8 @@ fn phase266_sqrt3_k_log37_k_over_k_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
         log_kp1.clone(), // 36 logs
-        log_kp1, // 37 logs
+        log_kp1.clone(), // 37 logs
+        log_kp1, // 38 logs
     ]);
     let g_k266c = apply(sym(DIV), vec![num_k, k.clone()]);
     let g_kp1_266c = apply(sym(DIV), vec![num_kp1, kp1.clone()]);
@@ -22386,7 +22530,8 @@ fn phase267_sqrt4_k_log37_k_over_k_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
         log_k.clone(), // 36 logs
-        log_k, // 37 logs
+        log_k.clone(), // 37 logs
+        log_k, // 38 logs
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -22398,7 +22543,8 @@ fn phase267_sqrt4_k_log37_k_over_k_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
         log_kp1.clone(), // 36 logs
-        log_kp1, // 37 logs
+        log_kp1.clone(), // 37 logs
+        log_kp1, // 38 logs
     ]);
     let g_k267c = apply(sym(DIV), vec![num_k, k.clone()]);
     let g_kp1_267c = apply(sym(DIV), vec![num_kp1, kp1.clone()]);
@@ -22508,6 +22654,754 @@ fn phase268_sqrt5_k_log37_k_over_k_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
         log_k.clone(), // 36 logs
+        log_k.clone(), // 37 logs
+        log_k, // 38 logs
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), // 36 logs
+        log_kp1.clone(), // 37 logs
+        log_kp1, // 38 logs
+        kp1.clone(),
+    ]);
+    let g_k268c = apply(sym(DIV), vec![num_k, k.clone()]);
+    let g_kp1_268c = apply(sym(DIV), vec![num_kp1, kp1.clone()]);
+    let f268c = apply(sym(SUB), vec![g_k268c, g_kp1_268c]);
+    let out = evaluate_sum(f268c, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+// ── Phase 269: Zero-Sqrt × Thirty-Seven-Log × polynomial ──────────────────
+
+#[test]
+fn phase269_log37_k_over_k2_converges() {
+    // log(k)^37 / k²: effective_x2=0; 2·2=4 > 0 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let num_k = apply(sym(MUL), vec![
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), // 36 logs
+        log_k, // 37 logs
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), // 36 logs
+        log_kp1, // 37 logs
+    ]);
+    let g_k269a = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_269a = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f269a = apply(sym(SUB), vec![g_k269a, g_kp1_269a]);
+    let out = evaluate_sum(f269a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase269_log37_k_times_k_over_k2_converges() {
+    // log(k)^37·k / k²: effective_x2=2; 2·2=4 > 2 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let num_k = apply(sym(MUL), vec![
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), // 36 logs
+        log_k, // 37 logs
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), // 36 logs
+        log_kp1, // 37 logs
+        kp1.clone(),
+    ]);
+    let g_k269b = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_269b = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f269b = apply(sym(SUB), vec![g_k269b, g_kp1_269b]);
+    let out = evaluate_sum(f269b, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase269_log38_k_over_k2_refused() {
+    // log(k)^38 / k²: 38 logs → refused (Phase 269 handles exactly 37).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let num_k = apply(sym(MUL), vec![
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), // 36 logs
+        log_k.clone(), // 37 logs
+        log_k, // 38 logs
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), // 36 logs
+        log_kp1.clone(), // 37 logs
+        log_kp1, // 38 logs
+        kp1.clone(),
+    ]);
+    let g_k269c = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_269c = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f269c = apply(sym(SUB), vec![g_k269c, g_kp1_269c]);
+    let out = evaluate_sum(f269c, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+// ── Phase 270: One-Sqrt × Thirty-Seven-Log × polynomial ──────────────────
+
+#[test]
+fn phase270_sqrt_k_log37_k_over_k2_converges() {
+    // √k·log(k)^37 / k²: effective_x2=1; 2·2=4 > 1 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), // 36 logs
+        log_k, // 37 logs
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), // 36 logs
+        log_kp1, // 37 logs
+    ]);
+    let g_k270a = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_270a = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f270a = apply(sym(SUB), vec![g_k270a, g_kp1_270a]);
+    let out = evaluate_sum(f270a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase270_sqrt_k3_log37_k_over_k2_converges() {
+    // √(k³)·log(k)^37 / k²: effective_x2=3; 2·2=4 > 3 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let sqrt_k3 = apply(sym("Sqrt"), vec![k3]);
+    let sqrt_kp1_3 = apply(sym("Sqrt"), vec![kp1_3]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k3,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), // 36 logs
+        log_k, // 37 logs
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1_3,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), // 36 logs
+        log_kp1, // 37 logs
+    ]);
+    let g_k270b = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_270b = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f270b = apply(sym(SUB), vec![g_k270b, g_kp1_270b]);
+    let out = evaluate_sum(f270b, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase270_sqrt_k_log38_k_over_k2_refused() {
+    // √k·log(k)^38 / k²: 38 logs → refused (Phase 270 handles exactly 37).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), // 36 logs
+        log_k.clone(), // 37 logs
+        log_k, // 38 logs
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), // 36 logs
+        log_kp1.clone(), // 37 logs
+        log_kp1, // 38 logs
+        kp1.clone(),
+    ]);
+    let g_k270c = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_270c = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f270c = apply(sym(SUB), vec![g_k270c, g_kp1_270c]);
+    let out = evaluate_sum(f270c, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+// ── Phase 271: Two-Sqrt × Thirty-Seven-Log × polynomial ──────────────────
+
+#[test]
+fn phase271_sqrt2_k_log37_k_over_k2_converges() {
+    // √k²·log(k)^37 / k²: effective_x2=2; 2·2=4 > 2 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), // 36 logs
+        log_k, // 37 logs
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), // 36 logs
+        log_kp1, // 37 logs
+    ]);
+    let g_k271a = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_271a = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f271a = apply(sym(SUB), vec![g_k271a, g_kp1_271a]);
+    let out = evaluate_sum(f271a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase271_sqrt2_k3_log37_k_over_k4_converges() {
+    // (√(k³))²·log(k)^37 / k⁴: effective_x2=6; 2·4=8 > 6 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let sqrt_k3 = apply(sym("Sqrt"), vec![k3]);
+    let sqrt_kp1_3 = apply(sym("Sqrt"), vec![kp1_3]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k4 = apply(sym(POW), vec![k.clone(), int(4)]);
+    let kp1_4 = apply(sym(POW), vec![kp1.clone(), int(4)]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k3.clone(), sqrt_k3,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), // 36 logs
+        log_k, // 37 logs
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1_3.clone(), sqrt_kp1_3,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), // 36 logs
+        log_kp1, // 37 logs
+    ]);
+    let g_k271b = apply(sym(DIV), vec![num_k, k4]);
+    let g_kp1_271b = apply(sym(DIV), vec![num_kp1, kp1_4]);
+    let f271b = apply(sym(SUB), vec![g_k271b, g_kp1_271b]);
+    let out = evaluate_sum(f271b, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase271_sqrt2_k_log38_k_over_k2_refused() {
+    // √k²·log(k)^38 / k²: 38 logs → refused (Phase 271 handles exactly 37).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), // 36 logs
+        log_k.clone(), // 37 logs
+        log_k, // 38 logs
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), // 36 logs
+        log_kp1.clone(), // 37 logs
+        log_kp1, // 38 logs
+        kp1.clone(),
+    ]);
+    let g_k271c = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_271c = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f271c = apply(sym(SUB), vec![g_k271c, g_kp1_271c]);
+    let out = evaluate_sum(f271c, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+// ── Phase 272: Three-Sqrt × Thirty-Seven-Log × polynomial ────────────────
+
+#[test]
+fn phase272_sqrt3_k_log37_k_over_k2_converges() {
+    // √k³·log(k)^37 / k²: effective_x2=3; 2·2=4 > 3 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), // 36 logs
+        log_k, // 37 logs
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), // 36 logs
+        log_kp1, // 37 logs
+    ]);
+    let g_k272a = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_272a = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f272a = apply(sym(SUB), vec![g_k272a, g_kp1_272a]);
+    let out = evaluate_sum(f272a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase272_sqrt3_k3_log37_k_over_k5_converges() {
+    // (√(k³))³·log(k)^37 / k⁵: effective_x2=9; 2·5=10 > 9 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let sqrt_k3 = apply(sym("Sqrt"), vec![k3]);
+    let sqrt_kp1_3 = apply(sym("Sqrt"), vec![kp1_3]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k5 = apply(sym(POW), vec![k.clone(), int(5)]);
+    let kp1_5 = apply(sym(POW), vec![kp1.clone(), int(5)]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k3.clone(), sqrt_k3.clone(), sqrt_k3,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), // 36 logs
+        log_k, // 37 logs
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1_3.clone(), sqrt_kp1_3.clone(), sqrt_kp1_3,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), // 36 logs
+        log_kp1, // 37 logs
+    ]);
+    let g_k272b = apply(sym(DIV), vec![num_k, k5]);
+    let g_kp1_272b = apply(sym(DIV), vec![num_kp1, kp1_5]);
+    let f272b = apply(sym(SUB), vec![g_k272b, g_kp1_272b]);
+    let out = evaluate_sum(f272b, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase272_sqrt3_k_log38_k_over_k2_refused() {
+    // √k³·log(k)^38 / k²: 38 logs → refused.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), // 36 logs
+        log_k.clone(), // 37 logs
+        log_k, // 38 logs
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), // 36 logs
+        log_kp1.clone(), // 37 logs
+        log_kp1, // 38 logs
+        kp1.clone(),
+    ]);
+    let g_k272c = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_272c = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f272c = apply(sym(SUB), vec![g_k272c, g_kp1_272c]);
+    let out = evaluate_sum(f272c, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+// ── Phase 273: Four-Sqrt × Thirty-Seven-Log × polynomial ─────────────────
+
+#[test]
+fn phase273_sqrt4_k_log37_k_over_k3_converges() {
+    // √k⁴·log(k)^37 / k³: effective_x2=4; 2·3=6 > 4 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), // 36 logs
+        log_k, // 37 logs
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), // 36 logs
+        log_kp1, // 37 logs
+    ]);
+    let g_k273a = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_273a = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f273a = apply(sym(SUB), vec![g_k273a, g_kp1_273a]);
+    let out = evaluate_sum(f273a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase273_sqrt4_k3_log37_k_over_k7_converges() {
+    // (√(k³))⁴·log(k)^37 / k⁷: effective_x2=12; 2·7=14 > 12 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let sqrt_k3 = apply(sym("Sqrt"), vec![k3]);
+    let sqrt_kp1_3 = apply(sym("Sqrt"), vec![kp1_3]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k7 = apply(sym(POW), vec![k.clone(), int(7)]);
+    let kp1_7 = apply(sym(POW), vec![kp1.clone(), int(7)]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k3.clone(), sqrt_k3.clone(), sqrt_k3.clone(), sqrt_k3,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), // 36 logs
+        log_k, // 37 logs
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1_3.clone(), sqrt_kp1_3.clone(), sqrt_kp1_3.clone(), sqrt_kp1_3,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), // 36 logs
+        log_kp1, // 37 logs
+    ]);
+    let g_k273b = apply(sym(DIV), vec![num_k, k7]);
+    let g_kp1_273b = apply(sym(DIV), vec![num_kp1, kp1_7]);
+    let f273b = apply(sym(SUB), vec![g_k273b, g_kp1_273b]);
+    let out = evaluate_sum(f273b, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase273_sqrt4_k_log38_k_over_k3_refused() {
+    // √k⁴·log(k)^38 / k³: 38 logs → refused.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), // 36 logs
+        log_k.clone(), // 37 logs
+        log_k, // 38 logs
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), // 36 logs
+        log_kp1.clone(), // 37 logs
+        log_kp1, // 38 logs
+        kp1.clone(),
+    ]);
+    let g_k273c = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_273c = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f273c = apply(sym(SUB), vec![g_k273c, g_kp1_273c]);
+    let out = evaluate_sum(f273c, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+// ── Phase 274: Five-Sqrt × Thirty-Seven-Log × polynomial ─────────────────
+
+#[test]
+fn phase274_sqrt5_k_log37_k_over_k3_converges() {
+    // √k⁵·log(k)^37 / k³: effective_x2=5; 2·3=6 > 5 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), // 36 logs
+        log_k, // 37 logs
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), // 36 logs
+        log_kp1, // 37 logs
+    ]);
+    let g_k274a = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_274a = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f274a = apply(sym(SUB), vec![g_k274a, g_kp1_274a]);
+    let out = evaluate_sum(f274a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase274_sqrt5_k_log37_k_times_k_over_k4_converges() {
+    // √k⁵·log(k)^37·k / k⁴: effective_x2=7; 2·4=8 > 7 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k4 = apply(sym(POW), vec![k.clone(), int(4)]);
+    let kp1_4 = apply(sym(POW), vec![kp1.clone(), int(4)]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), // 36 logs
         log_k, // 37 logs
         k.clone(),
     ]);
@@ -22524,9 +23418,55 @@ fn phase268_sqrt5_k_log37_k_over_k_refused() {
         log_kp1, // 37 logs
         kp1.clone(),
     ]);
-    let g_k268c = apply(sym(DIV), vec![num_k, k.clone()]);
-    let g_kp1_268c = apply(sym(DIV), vec![num_kp1, kp1.clone()]);
-    let f268c = apply(sym(SUB), vec![g_k268c, g_kp1_268c]);
-    let out = evaluate_sum(f268c, k, int(1), sym("%inf"), eval);
+    let g_k274b = apply(sym(DIV), vec![num_k, k4]);
+    let g_kp1_274b = apply(sym(DIV), vec![num_kp1, kp1_4]);
+    let f274b = apply(sym(SUB), vec![g_k274b, g_kp1_274b]);
+    let out = evaluate_sum(f274b, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase274_sqrt5_k_log38_k_over_k3_refused() {
+    // √k⁵·log(k)^38 / k³: 38 logs → refused (Phase 274 handles exactly 37).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), // 36 logs
+        log_k.clone(), // 37 logs
+        log_k, // 38 logs
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), // 36 logs
+        log_kp1.clone(), // 37 logs
+        log_kp1, // 38 logs
+        kp1.clone(),
+    ]);
+    let g_k274c = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_274c = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f274c = apply(sym(SUB), vec![g_k274c, g_kp1_274c]);
+    let out = evaluate_sum(f274c, k, int(1), sym("%inf"), eval);
     assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }

--- a/code/packages/rust/image-codec-ico/BUILD
+++ b/code/packages/rust/image-codec-ico/BUILD
@@ -1,0 +1,1 @@
+cargo test -p image-codec-ico -- --nocapture

--- a/code/packages/rust/image-codec-ico/CHANGELOG.md
+++ b/code/packages/rust/image-codec-ico/CHANGELOG.md
@@ -1,0 +1,52 @@
+# Changelog — image-codec-ico
+
+All notable changes to this crate will be documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+This crate uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+
+## [0.1.0] — 2026-05-26
+
+### Added
+
+- **`encode_ico`** — encodes a `PixelContainer` as a single-image, 32bpp BGRA BMP DIB ICO file.
+  - Full alpha channel preserved in BGRA byte (AND mask all-zero).
+  - `biHeight = 2 × pixel_height` per BMP DIB convention.
+  - Dimensions clamped to 255 × 255 (ICO directory byte constraint).
+  - Output: 6-byte ICO header + 16-byte directory entry + BMP DIB.
+  - `IMAGE_OFFSET = 22` (6 + 16).
+
+- **`decode_ico`** — decodes an ICO or CUR file into an RGBA8 `PixelContainer`.
+  - Validates magic bytes: reserved=0, type ∈ {1 (ICO), 2 (CUR)}.
+  - Selects best frame by area; on tie prefers PNG > 32bpp BMP > lower bpp.
+  - Dispatches PNG-embedded frames to `png::decode_png_rgba`.
+  - Dispatches BMP DIB frames to `bmp_dib::decode_bmp_dib`.
+  - Maximum safe dimensions: 4096 × 4096 pixels (hard-coded before allocation).
+
+- **`bmp_dib::decode_bmp_dib`** — internal BMP DIB decoder.
+  - Supports 1, 4, 8, 24, and 32 bpp.
+  - Palette lookup for indexed (1/4/8 bpp) images.
+  - Bottom-up row order corrected during decode.
+  - AND mask (1bpp) overrides per-pixel alpha: bit=1 → fully transparent.
+  - Rejects non-zero `biCompression` (compressed DIBs not supported).
+  - Rejects `biSize` ≠ 40 (only `BITMAPINFOHEADER` supported, not `BITMAPV4/V5`).
+
+- **`IcoCodec`** — implements `paint_instructions::ImageCodec`.
+  - `mime_type()` → `"image/x-icon"`.
+  - `encode(pixels)` → delegates to `encode_ico`.
+  - `decode(bytes)` → delegates to `decode_ico`.
+
+- **`VERSION`** — `"0.1.0"` constant.
+
+- **34 tests**: 5 round-trips, 5 header/directory, 7 BMP DIB decoder paths,
+  1 AND mask transparency, 5 error cases, 1 MIME type, 1 codec trait, 1 doc-test.
+
+- **`Cargo.toml`** dependencies: `pixel-container`, `paint-instructions`, `png`.
+
+- **`README.md`** with stack diagram, format overview, API, testing table, and spec link.
+
+- **`CHANGELOG.md`** (this file).
+
+[0.1.0]: https://github.com/adhithyan15/coding-adventures/tree/feat/ic08-ico-spec-impl

--- a/code/packages/rust/image-codec-ico/Cargo.toml
+++ b/code/packages/rust/image-codec-ico/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "image-codec-ico"
+version = "0.1.0"
+edition = "2021"
+description = "ICO/CUR image codec (IC08): PixelContainer ↔ Windows icon bytes"
+license = "MIT"
+authors = ["coding-adventures"]
+
+[dependencies]
+pixel-container = { path = "../pixel-container" }
+paint-instructions = { path = "../paint-instructions" }
+png = { path = "../png" }

--- a/code/packages/rust/image-codec-ico/README.md
+++ b/code/packages/rust/image-codec-ico/README.md
@@ -1,0 +1,140 @@
+# image-codec-ico
+
+ICO (Windows Icon) and CUR (cursor) image codec — IC08.
+
+Encodes a `PixelContainer` as a single-image 32bpp ICO file and decodes the
+best-resolution image from any ICO/CUR file into an RGBA8 `PixelContainer`.
+
+## Where this fits in the stack
+
+```
+paint-instructions  ←  ImageCodec trait
+      │
+image-codec-ico     ←  YOU ARE HERE
+      │
+pixel-container     ←  PixelContainer (RGBA8 pixel buffer)
+      │
+png                 ←  PNG frame decoding (for PNG-embedded ICO frames)
+```
+
+ICO is not a compression format — it is a **container** that bundles one or more
+images (each stored as a BMP DIB or a full PNG file) inside a directory.
+`image-codec-ico` is deliberately minimal: it always encodes as a single-image
+32bpp BMP DIB file and decodes by picking the largest frame.
+
+## Quick start
+
+```rust
+use image_codec_ico::{encode_ico, decode_ico};
+use pixel_container::PixelContainer;
+
+// Encode a 2×2 red ICO.
+let mut px = PixelContainer::new(2, 2);
+px.fill(255, 0, 0, 255);
+let bytes = encode_ico(&px);
+assert_eq!(&bytes[2..4], &[1, 0]); // type = ICO (not CUR)
+
+// Decode it back.
+let recovered = decode_ico(&bytes).unwrap();
+assert_eq!(recovered.width, 2);
+assert_eq!(recovered.height, 2);
+
+// Use via the ImageCodec trait.
+use paint_instructions::ImageCodec;
+use image_codec_ico::IcoCodec;
+
+let codec = IcoCodec;
+assert_eq!(codec.mime_type(), "image/x-icon");
+let encoded = codec.encode(&px);
+let decoded = codec.decode(&encoded).unwrap();
+```
+
+## File format overview
+
+```
+Offset  Len  Field
+──────  ───  ──────────────────────────────────────
+0       2    Reserved (must be 0)
+2       2    Type: 1 = ICO, 2 = CUR
+4       2    Image count
+────── directory entry (16 bytes per image) ──────
+6       1    Width  (1-255; 0 means 256)
+7       1    Height (1-255; 0 means 256)
+8       1    Color count (0 = truecolor)
+9       1    Reserved
+10      2    Planes
+12      2    Bit count (32 for this crate)
+14      4    Bytes in image data
+18      4    File offset of image data
+────── image data at IMAGE_OFFSET = 22 ───────────
+22      40   BITMAPINFOHEADER
+62      n    XOR pixel data (BGRA, rows bottom-up)
+62+n    m    AND mask (1bpp, rows bottom-up)
+```
+
+## Encoding
+
+`encode_ico` always writes:
+- One directory entry (image count = 1)
+- 32bpp BGRA BMP DIB (full alpha in the BGRA byte)
+- All-zero AND mask (alpha transparency handled by BGRA)
+- `biHeight = 2 × pixel_height` (XOR + AND stacked per BMP DIB convention)
+
+Dimensions are clamped to 255 × 255 (the ICO directory byte range for explicit
+sizes; 0 encodes 256 but we stay in the 1-255 range to avoid ambiguity).
+
+## Decoding
+
+`decode_ico` selects the **best** frame from the directory using this priority:
+1. Largest area (width × height)
+2. On tie: PNG frame preferred over BMP; among BMP frames, higher bpp wins
+
+Each frame is dispatched to:
+- `decode_png_frame` — calls `png::decode_png_rgba` for PNG-embedded frames
+- `decode_bmp_frame` — calls `bmp_dib::decode_bmp_dib` for BMP DIB frames
+
+BMP DIB decoding handles 1, 4, 8, 24, and 32 bpp. The AND mask overrides the
+per-pixel alpha: AND bit = 1 forces that pixel to fully transparent.
+
+### Safety
+
+- Maximum image dimensions: 4096 × 4096 (hard-coded limit before any allocation)
+- Invalid header sizes, bad magic bytes, truncated data — all return `Err`
+
+## API
+
+```rust
+pub fn encode_ico(pixels: &PixelContainer) -> Vec<u8>;
+pub fn decode_ico(bytes: &[u8]) -> Result<PixelContainer, String>;
+
+pub struct IcoCodec;
+impl paint_instructions::ImageCodec for IcoCodec { ... }
+pub const VERSION: &str = "0.1.0";
+```
+
+## Testing
+
+```
+cargo test -p image-codec-ico
+```
+
+34 unit + integration tests cover:
+
+| Category                  | Tests |
+|---------------------------|-------|
+| Round-trip (various sizes) | 5    |
+| Header / directory bytes   | 5    |
+| BMP DIB decoder (1/4/8/24/32 bpp) | 7 |
+| AND mask transparency      | 1    |
+| Error cases                | 5    |
+| MIME type                  | 1    |
+| Codec trait                | 1    |
+| Doc-test                   | 1    |
+
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md).
+
+## Spec
+
+See [`code/specs/IC08-image-codec-ico.md`](../../../../specs/IC08-image-codec-ico.md).

--- a/code/packages/rust/image-codec-ico/src/bmp_dib.rs
+++ b/code/packages/rust/image-codec-ico/src/bmp_dib.rs
@@ -1,0 +1,680 @@
+//! BMP Device-Independent Bitmap (DIB) decoder for ICO frames.
+//!
+//! An ICO file embeds BMP data *without* the 14-byte `BITMAPFILEHEADER` that
+//! a standalone `.bmp` file carries.  The data starts directly with the
+//! 40-byte `BITMAPINFOHEADER`.
+//!
+//! ## Row order
+//!
+//! Windows bitmaps are stored **bottom-up** (first byte is the bottom row).
+//! We reverse the rows before returning the pixel buffer so callers always
+//! receive top-down data.
+//!
+//! ## ICO height encoding
+//!
+//! Inside an ICO, `biHeight = 2 × pixel_height`.  The DIB actually stores
+//! two layers of equal height:
+//!
+//! 1. **XOR mask** — color/pixel data (bottom-up, pixel_height rows)
+//! 2. **AND mask** — 1bpp transparency mask (bottom-up, pixel_height rows)
+//!    - bit 0 = opaque pixel, bit 1 = transparent pixel
+//!
+//! For 32bpp images the AND mask is conventionally all zeros and the BGRA
+//! alpha byte is the true transparency source.
+
+// ── BITMAPINFOHEADER constants ─────────────────────────────────────────────
+
+/// Expected value of `biSize` in the BITMAPINFOHEADER.
+const BITMAPINFOHEADER_SIZE: u32 = 40;
+/// BI_RGB: no compression.
+const BI_RGB: u32 = 0;
+
+// ── Public entry point ──────────────────────────────────────────────────────
+
+/// Decode a BMP DIB from `data` (starting at the BITMAPINFOHEADER, no file
+/// header) into an RGBA pixel buffer.
+///
+/// Returns `(width, height, rgba_pixels)` on success.
+pub fn decode_bmp_dib(data: &[u8]) -> Result<(u32, u32, Vec<u8>), String> {
+    if data.len() < BITMAPINFOHEADER_SIZE as usize {
+        return Err("ICO: BMP DIB too short for BITMAPINFOHEADER".into());
+    }
+
+    // Parse BITMAPINFOHEADER fields (all little-endian).
+    let bi_size = read_u32le(data, 0);
+    if bi_size != BITMAPINFOHEADER_SIZE {
+        return Err(format!(
+            "ICO: unsupported BITMAPINFOHEADER size {} (expected 40)",
+            bi_size
+        ));
+    }
+    let bi_width = read_i32le(data, 4);
+    let bi_height_raw = read_i32le(data, 8);
+    let bi_bit_count = read_u16le(data, 14);
+    let bi_compression = read_u32le(data, 16);
+    let bi_clr_used = read_u32le(data, 32);
+
+    if bi_compression != BI_RGB {
+        return Err(format!(
+            "ICO: compressed BMP DIB not supported (biCompression={})",
+            bi_compression
+        ));
+    }
+
+    // biHeight in ICO encodes 2× the actual image height.
+    // Negative biHeight (top-down) is technically allowed but extremely rare
+    // in practice; we treat biHeight > 0 as bottom-up (the standard ICO case).
+    let is_bottom_up = bi_height_raw > 0;
+    let bi_height = bi_height_raw.unsigned_abs(); // strip sign
+
+    // Actual pixel dimensions.
+    let pixel_width = bi_width.unsigned_abs() as usize;
+    // biHeight in an ICO = 2 × pixel_height (XOR + AND stacked).
+    let pixel_height = (bi_height / 2) as usize;
+
+    if pixel_width == 0 || pixel_height == 0 {
+        return Err("ICO: zero-dimension BMP DIB".into());
+    }
+
+    // Safety cap: no sane ICO has dimensions above 256×256.
+    if pixel_width > 256 || pixel_height > 256 {
+        return Err(format!(
+            "ICO: BMP DIB dimensions {}×{} exceed maximum 256×256",
+            pixel_width, pixel_height
+        ));
+    }
+
+    // Palette count.
+    //
+    // Security: `bi_clr_used` comes from untrusted input.  Without capping it
+    // at the theoretical maximum for the bit depth (`1 << biBitCount`), a
+    // malicious file could set `bi_clr_used = 0xFFFF_FFFF` and trigger either:
+    //   - a ~16 GiB `Vec::with_capacity` allocation (OOM DoS on 64-bit), or
+    //   - a `usize` overflow in `palette_end` (silent wrap past the guard on
+    //     32-bit, leading to an out-of-bounds read).
+    //
+    // We cap at the theoretical maximum, which is at most 256 entries (8bpp).
+    let max_palette = if bi_bit_count <= 8 { 1usize << bi_bit_count } else { 0 };
+    let palette_count = if bi_bit_count <= 8 {
+        if bi_clr_used > 0 {
+            let requested = bi_clr_used as usize;
+            if requested > max_palette {
+                return Err(format!(
+                    "ICO: biClrUsed {} exceeds the maximum {} for {}bpp",
+                    bi_clr_used, max_palette, bi_bit_count
+                ));
+            }
+            requested
+        } else {
+            max_palette
+        }
+    } else {
+        0
+    };
+
+    // Palette starts after the header.
+    let palette_start = BITMAPINFOHEADER_SIZE as usize;
+    // palette_count is at most 256 (8bpp), so palette_count * 4 ≤ 1024 —
+    // no overflow possible.
+    let palette_end = palette_start + palette_count * 4; // RGBQUAD = 4 bytes
+
+    if data.len() < palette_end {
+        return Err("ICO: BMP DIB truncated before palette".into());
+    }
+
+    // Parse RGBQUAD palette: entries are (blue, green, red, reserved).
+    let mut palette: Vec<(u8, u8, u8)> = Vec::with_capacity(palette_count);
+    for i in 0..palette_count {
+        let base = palette_start + i * 4;
+        palette.push((data[base + 2], data[base + 1], data[base])); // R, G, B
+    }
+
+    // XOR (color) data: rows from bottom to top, each row padded to 4-byte boundary.
+    //
+    // Use checked arithmetic for the stride even though the dimension cap above
+    // (≤256×256) makes overflow impossible in practice.  Defence-in-depth.
+    let xor_row_stride = row_stride_checked(pixel_width, bi_bit_count as usize)
+        .ok_or_else(|| format!(
+            "ICO: row stride overflow for {}bpp width {} (unreachable under 256px cap)",
+            bi_bit_count, pixel_width
+        ))?;
+    let xor_size = xor_row_stride.checked_mul(pixel_height)
+        .ok_or("ICO: XOR data size overflow")?;
+    let xor_start = palette_end;
+    let xor_end = xor_start.checked_add(xor_size)
+        .ok_or("ICO: XOR end-offset overflow")?;
+
+    if data.len() < xor_end {
+        return Err("ICO: BMP DIB truncated in XOR pixel data".into());
+    }
+    let xor_data = &data[xor_start..xor_end];
+
+    // AND (alpha) mask: 1bpp rows from bottom to top, 4-byte padded.
+    // AND mask stride: pixel_width ≤ 256 → (256+31)/32*4 = 32 bytes max; no overflow.
+    let and_row_stride = row_stride_checked(pixel_width, 1)
+        .ok_or("ICO: AND mask stride overflow")?;
+    let and_size = and_row_stride.checked_mul(pixel_height)
+        .ok_or("ICO: AND mask size overflow")?;
+    let and_start = xor_end;
+    let and_end = and_start + and_size;
+
+    // The AND mask is optional — some encoders omit it for 32bpp images.
+    let has_and_mask = data.len() >= and_end;
+    let and_data: &[u8] = if has_and_mask {
+        &data[and_start..and_end]
+    } else {
+        &[]
+    };
+
+    // Build the RGBA output: top-down order (flip if bottom-up).
+    let mut rgba: Vec<u8> = vec![0u8; pixel_width * pixel_height * 4];
+
+    for row_idx in 0..pixel_height {
+        // Source row index in the bottom-up BMP (row 0 of BMP = bottom of image).
+        let src_row = if is_bottom_up {
+            pixel_height - 1 - row_idx // flip to top-down
+        } else {
+            row_idx
+        };
+
+        let dst_row = row_idx;
+        let dst_base = dst_row * pixel_width * 4;
+
+        match bi_bit_count {
+            1 => decode_row_1bpp(
+                xor_data,
+                src_row,
+                xor_row_stride,
+                &palette,
+                and_data,
+                and_row_stride,
+                has_and_mask,
+                &mut rgba[dst_base..dst_base + pixel_width * 4],
+            ),
+            4 => decode_row_4bpp(
+                xor_data,
+                src_row,
+                xor_row_stride,
+                &palette,
+                and_data,
+                and_row_stride,
+                has_and_mask,
+                &mut rgba[dst_base..dst_base + pixel_width * 4],
+            ),
+            8 => decode_row_8bpp(
+                xor_data,
+                src_row,
+                xor_row_stride,
+                &palette,
+                and_data,
+                and_row_stride,
+                has_and_mask,
+                &mut rgba[dst_base..dst_base + pixel_width * 4],
+            ),
+            24 => decode_row_24bpp(
+                xor_data,
+                src_row,
+                xor_row_stride,
+                and_data,
+                and_row_stride,
+                has_and_mask,
+                &mut rgba[dst_base..dst_base + pixel_width * 4],
+            ),
+            32 => decode_row_32bpp(
+                xor_data,
+                src_row,
+                xor_row_stride,
+                and_data,
+                and_row_stride,
+                has_and_mask,
+                &mut rgba[dst_base..dst_base + pixel_width * 4],
+            ),
+            bpp => {
+                return Err(format!("ICO: unsupported bit depth {}", bpp));
+            }
+        }
+    }
+
+    Ok((pixel_width as u32, pixel_height as u32, rgba))
+}
+
+// ── Row decoders ──────────────────────────────────────────────────────────────
+
+/// 1bpp row: each byte holds 8 pixels, MSB = leftmost pixel.
+fn decode_row_1bpp(
+    xor: &[u8],
+    src_row: usize,
+    stride: usize,
+    palette: &[(u8, u8, u8)],
+    and: &[u8],
+    and_stride: usize,
+    has_and: bool,
+    dst: &mut [u8],
+) {
+    let row_start = src_row * stride;
+    let pixel_count = dst.len() / 4;
+    for px in 0..pixel_count {
+        let byte = xor[row_start + px / 8];
+        let bit = (byte >> (7 - (px % 8))) & 1;
+        let (r, g, b) = if (bit as usize) < palette.len() {
+            palette[bit as usize]
+        } else {
+            (0, 0, 0)
+        };
+        let a = if has_and {
+            let abyte = and[src_row * and_stride + px / 8];
+            let abit = (abyte >> (7 - (px % 8))) & 1;
+            if abit != 0 { 0u8 } else { 255u8 }
+        } else {
+            255
+        };
+        dst[px * 4] = r;
+        dst[px * 4 + 1] = g;
+        dst[px * 4 + 2] = b;
+        dst[px * 4 + 3] = a;
+    }
+}
+
+/// 4bpp row: high nibble = left pixel, low nibble = right pixel.
+fn decode_row_4bpp(
+    xor: &[u8],
+    src_row: usize,
+    stride: usize,
+    palette: &[(u8, u8, u8)],
+    and: &[u8],
+    and_stride: usize,
+    has_and: bool,
+    dst: &mut [u8],
+) {
+    let row_start = src_row * stride;
+    let pixel_count = dst.len() / 4;
+    for px in 0..pixel_count {
+        let byte = xor[row_start + px / 2];
+        let nibble = if px % 2 == 0 { (byte >> 4) & 0xF } else { byte & 0xF };
+        let (r, g, b) = if (nibble as usize) < palette.len() {
+            palette[nibble as usize]
+        } else {
+            (0, 0, 0)
+        };
+        let a = and_alpha(and, src_row, and_stride, px, has_and);
+        dst[px * 4] = r;
+        dst[px * 4 + 1] = g;
+        dst[px * 4 + 2] = b;
+        dst[px * 4 + 3] = a;
+    }
+}
+
+/// 8bpp row: one byte per pixel (palette index).
+fn decode_row_8bpp(
+    xor: &[u8],
+    src_row: usize,
+    stride: usize,
+    palette: &[(u8, u8, u8)],
+    and: &[u8],
+    and_stride: usize,
+    has_and: bool,
+    dst: &mut [u8],
+) {
+    let row_start = src_row * stride;
+    let pixel_count = dst.len() / 4;
+    for px in 0..pixel_count {
+        let idx = xor[row_start + px] as usize;
+        let (r, g, b) = if idx < palette.len() {
+            palette[idx]
+        } else {
+            (0, 0, 0)
+        };
+        let a = and_alpha(and, src_row, and_stride, px, has_and);
+        dst[px * 4] = r;
+        dst[px * 4 + 1] = g;
+        dst[px * 4 + 2] = b;
+        dst[px * 4 + 3] = a;
+    }
+}
+
+/// 24bpp row: 3 bytes per pixel in BGR order.
+fn decode_row_24bpp(
+    xor: &[u8],
+    src_row: usize,
+    stride: usize,
+    and: &[u8],
+    and_stride: usize,
+    has_and: bool,
+    dst: &mut [u8],
+) {
+    let row_start = src_row * stride;
+    let pixel_count = dst.len() / 4;
+    // Safety invariant: for pixel_count pixels at 24bpp, the XOR slice must
+    // hold at least `row_start + pixel_count * 3` bytes.  The caller sets
+    // dst.len() = pixel_width * 4 and stride = row_stride(pixel_width, 24),
+    // so stride ≥ pixel_count * 3 and xor.len() = stride * pixel_height.
+    debug_assert!(
+        xor.len() >= row_start + pixel_count * 3,
+        "decode_row_24bpp: xor slice too short (row_start={}, pixel_count={}, xor.len={})",
+        row_start, pixel_count, xor.len()
+    );
+    for px in 0..pixel_count {
+        let b = xor[row_start + px * 3];
+        let g = xor[row_start + px * 3 + 1];
+        let r = xor[row_start + px * 3 + 2];
+        let a = and_alpha(and, src_row, and_stride, px, has_and);
+        dst[px * 4] = r;
+        dst[px * 4 + 1] = g;
+        dst[px * 4 + 2] = b;
+        dst[px * 4 + 3] = a;
+    }
+}
+
+/// 32bpp row: 4 bytes per pixel in BGRA order (alpha embedded).
+///
+/// For 32bpp, the AND mask is an additional transparency source.
+/// A pixel is transparent if the AND mask bit is set OR if the BGRA
+/// alpha byte is 0.  The most common convention is AND mask = all zeros
+/// and alpha in the BGRA byte.
+fn decode_row_32bpp(
+    xor: &[u8],
+    src_row: usize,
+    stride: usize,
+    and: &[u8],
+    and_stride: usize,
+    has_and: bool,
+    dst: &mut [u8],
+) {
+    let row_start = src_row * stride;
+    let pixel_count = dst.len() / 4;
+    // Safety invariant: for pixel_count pixels at 32bpp, the XOR slice must
+    // hold at least `row_start + pixel_count * 4` bytes.
+    debug_assert!(
+        xor.len() >= row_start + pixel_count * 4,
+        "decode_row_32bpp: xor slice too short (row_start={}, pixel_count={}, xor.len={})",
+        row_start, pixel_count, xor.len()
+    );
+    for px in 0..pixel_count {
+        let b = xor[row_start + px * 4];
+        let g = xor[row_start + px * 4 + 1];
+        let r = xor[row_start + px * 4 + 2];
+        let a_bgra = xor[row_start + px * 4 + 3];
+        // If AND mask bit is set, pixel is transparent regardless of alpha.
+        let and_transparent = has_and && {
+            let abyte = and[src_row * and_stride + px / 8];
+            (abyte >> (7 - (px % 8))) & 1 != 0
+        };
+        let a = if and_transparent { 0 } else { a_bgra };
+        dst[px * 4] = r;
+        dst[px * 4 + 1] = g;
+        dst[px * 4 + 2] = b;
+        dst[px * 4 + 3] = a;
+    }
+}
+
+// ── AND mask helper ──────────────────────────────────────────────────────────
+
+/// Read the AND mask bit for pixel `px` in row `row` and return 0 (transparent)
+/// or 255 (opaque).  Returns 255 when no AND mask is present.
+#[inline]
+fn and_alpha(and: &[u8], row: usize, stride: usize, px: usize, has_and: bool) -> u8 {
+    if !has_and {
+        return 255;
+    }
+    let byte = and[row * stride + px / 8];
+    let bit = (byte >> (7 - (px % 8))) & 1;
+    if bit != 0 { 0 } else { 255 }
+}
+
+// ── Geometry helpers ─────────────────────────────────────────────────────────
+
+/// Row stride in bytes for an image of `width` pixels at `bpp` bits per pixel,
+/// padded to 4-byte (DWORD) boundaries.
+///
+/// Formula: ((width × bpp + 31) / 32) × 4
+///
+/// Returns `None` on arithmetic overflow (defence-in-depth; in practice the
+/// caller enforces `width ≤ 256` and `bpp ∈ {1,4,8,24,32}`, so overflow is
+/// impossible, but checked arithmetic makes the invariant explicit).
+pub fn row_stride_checked(width: usize, bpp: usize) -> Option<usize> {
+    let bits = width.checked_mul(bpp)?.checked_add(31)?;
+    (bits / 32).checked_mul(4)
+}
+
+/// Infallible row stride — panics on overflow.  Only call after validating
+/// `width ≤ 256` and `bpp ∈ {1,4,8,24,32}`.
+#[cfg(test)]
+pub fn row_stride(width: usize, bpp: usize) -> usize {
+    row_stride_checked(width, bpp).expect("row_stride overflow (width or bpp out of bounds)")
+}
+
+// ── Little-endian readers ────────────────────────────────────────────────────
+
+fn read_u16le(data: &[u8], offset: usize) -> u16 {
+    u16::from_le_bytes([data[offset], data[offset + 1]])
+}
+
+fn read_u32le(data: &[u8], offset: usize) -> u32 {
+    u32::from_le_bytes([data[offset], data[offset + 1], data[offset + 2], data[offset + 3]])
+}
+
+fn read_i32le(data: &[u8], offset: usize) -> i32 {
+    i32::from_le_bytes([data[offset], data[offset + 1], data[offset + 2], data[offset + 3]])
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn row_stride_values() {
+        assert_eq!(row_stride(1, 1), 4);   // 1 bit → pad to 32 bits = 4 bytes
+        assert_eq!(row_stride(32, 1), 4);  // 32 bits → exactly 4 bytes
+        assert_eq!(row_stride(33, 1), 8);  // 33 bits → next 32-bit boundary
+        assert_eq!(row_stride(4, 8), 4);   // 4 pixels × 8 bpp = 32 bits
+        assert_eq!(row_stride(5, 8), 8);   // 5 × 8 = 40 bits → 8 bytes
+        assert_eq!(row_stride(4, 24), 12); // 4 × 24 = 96 bits = 12 bytes
+        assert_eq!(row_stride(4, 32), 16); // 4 × 32 = 128 bits = 16 bytes
+    }
+
+    /// Build a minimal 2×2 32bpp BMP DIB manually and decode it.
+    ///
+    /// The DIB structure (no BITMAPFILEHEADER):
+    ///   BITMAPINFOHEADER (40 bytes): width=2, height=4 (= 2*pixel_height), bpp=32
+    ///   XOR data: 2 rows × 2 pixels × 4 bytes = 16 bytes (bottom-up)
+    ///   AND data: 2 rows × 4 bytes (stride) = 8 bytes
+    #[test]
+    fn decode_32bpp_2x2() {
+        let mut dib: Vec<u8> = Vec::new();
+        // BITMAPINFOHEADER
+        dib.extend_from_slice(&40u32.to_le_bytes()); // biSize
+        dib.extend_from_slice(&2i32.to_le_bytes());  // biWidth
+        dib.extend_from_slice(&4i32.to_le_bytes());  // biHeight = 2*pixel_height
+        dib.extend_from_slice(&1u16.to_le_bytes());  // biPlanes
+        dib.extend_from_slice(&32u16.to_le_bytes()); // biBitCount
+        dib.extend_from_slice(&0u32.to_le_bytes());  // biCompression
+        dib.extend_from_slice(&0u32.to_le_bytes());  // biSizeImage
+        dib.extend_from_slice(&0i32.to_le_bytes());  // biXPelsPerMeter
+        dib.extend_from_slice(&0i32.to_le_bytes());  // biYPelsPerMeter
+        dib.extend_from_slice(&0u32.to_le_bytes());  // biClrUsed
+        dib.extend_from_slice(&0u32.to_le_bytes());  // biClrImportant
+
+        // XOR data: bottom row first.
+        // Row 1 (bottom = y=1 in output): pixel0=(B=0,G=255,R=0,A=255) green
+        //                                 pixel1=(B=0,G=0,R=255,A=255)  red
+        dib.extend_from_slice(&[0, 255, 0, 255]); // green BGRA
+        dib.extend_from_slice(&[0, 0, 255, 255]); // red   BGRA
+        // Row 0 (top = y=0 in output):   pixel0=(B=255,G=0,R=0,A=255)  blue
+        //                                pixel1=(B=0,G=0,R=0,A=0)      transparent
+        dib.extend_from_slice(&[255, 0, 0, 255]); // blue BGRA
+        dib.extend_from_slice(&[0, 0, 0, 0]);     // transparent BGRA
+
+        // AND mask: 2 rows × 4 bytes (stride=4 for width=2).
+        // All zeros → no AND-mask transparency (alpha from BGRA).
+        dib.extend_from_slice(&[0u8; 8]);
+
+        let (w, h, rgba) = decode_bmp_dib(&dib).unwrap();
+        assert_eq!(w, 2);
+        assert_eq!(h, 2);
+
+        // Top-left (y=0, x=0) = blue (255,0,0,255).
+        assert_eq!(&rgba[0..4], &[0, 0, 255, 255]); // R=0,G=0,B=255,A=255
+        // Top-right (y=0, x=1) = transparent (0,0,0,0).
+        assert_eq!(&rgba[4..8], &[0, 0, 0, 0]);
+        // Bottom-left (y=1, x=0) = green.
+        assert_eq!(&rgba[8..12], &[0, 255, 0, 255]); // R=0,G=255,B=0,A=255
+        // Bottom-right (y=1, x=1) = red.
+        assert_eq!(&rgba[12..16], &[255, 0, 0, 255]);
+    }
+
+    /// AND mask transparency: pixel set in AND mask → alpha = 0.
+    #[test]
+    fn and_mask_overrides_alpha() {
+        let mut dib: Vec<u8> = Vec::new();
+        // 1×1 32bpp DIB.
+        dib.extend_from_slice(&40u32.to_le_bytes()); // biSize
+        dib.extend_from_slice(&1i32.to_le_bytes());  // biWidth
+        dib.extend_from_slice(&2i32.to_le_bytes());  // biHeight = 2*1
+        dib.extend_from_slice(&1u16.to_le_bytes());  // biPlanes
+        dib.extend_from_slice(&32u16.to_le_bytes()); // biBitCount
+        dib.extend_from_slice(&[0u8; 24]);           // remaining 6 header fields (24 bytes)
+        // XOR: opaque red (A=255 in BGRA).
+        dib.extend_from_slice(&[0, 0, 255, 255]); // B=0,G=0,R=255,A=255
+        // AND mask: 4-byte row (stride=4), bit 7 of byte 0 = set = transparent.
+        dib.extend_from_slice(&[0x80, 0, 0, 0]);
+
+        let (_, _, rgba) = decode_bmp_dib(&dib).unwrap();
+        // Despite BGRA alpha=255, AND mask forces alpha=0.
+        assert_eq!(rgba[3], 0, "AND mask should override alpha to 0");
+    }
+
+    #[test]
+    fn decode_24bpp_1x1() {
+        let mut dib: Vec<u8> = Vec::new();
+        dib.extend_from_slice(&40u32.to_le_bytes()); // biSize
+        dib.extend_from_slice(&1i32.to_le_bytes());  // biWidth
+        dib.extend_from_slice(&2i32.to_le_bytes());  // biHeight = 2*1
+        dib.extend_from_slice(&1u16.to_le_bytes());  // biPlanes
+        dib.extend_from_slice(&24u16.to_le_bytes()); // biBitCount
+        // Remaining 6 BITMAPINFOHEADER fields:
+        //   biCompression (4) + biSizeImage (4) + biXPelsPerMeter (4) +
+        //   biYPelsPerMeter (4) + biClrUsed (4) + biClrImportant (4) = 24 bytes.
+        dib.extend_from_slice(&[0u8; 24]);           // remaining 6 header fields
+        // XOR: 1 row, 3 bytes BGR + 1 byte padding to reach 4-byte stride.
+        dib.extend_from_slice(&[100, 150, 200, 0]); // B=100,G=150,R=200, pad
+        // AND mask: 4 bytes, bit 7 clear (opaque).
+        dib.extend_from_slice(&[0u8; 4]);
+
+        let (_, _, rgba) = decode_bmp_dib(&dib).unwrap();
+        assert_eq!(rgba[0], 200); // R
+        assert_eq!(rgba[1], 150); // G
+        assert_eq!(rgba[2], 100); // B
+        assert_eq!(rgba[3], 255); // A = fully opaque
+    }
+
+    #[test]
+    fn decode_8bpp_palette() {
+        // 2×2 8bpp image using a 2-entry palette.
+        let mut dib: Vec<u8> = Vec::new();
+        dib.extend_from_slice(&40u32.to_le_bytes()); // biSize
+        dib.extend_from_slice(&2i32.to_le_bytes());  // biWidth
+        dib.extend_from_slice(&4i32.to_le_bytes());  // biHeight = 2*2
+        dib.extend_from_slice(&1u16.to_le_bytes());  // biPlanes
+        dib.extend_from_slice(&8u16.to_le_bytes());  // biBitCount
+        dib.extend_from_slice(&0u32.to_le_bytes());  // biCompression
+        dib.extend_from_slice(&0u32.to_le_bytes());  // biSizeImage
+        dib.extend_from_slice(&0i32.to_le_bytes());  // biXPelsPerMeter
+        dib.extend_from_slice(&0i32.to_le_bytes());  // biYPelsPerMeter
+        dib.extend_from_slice(&2u32.to_le_bytes());  // biClrUsed = 2
+        dib.extend_from_slice(&0u32.to_le_bytes());  // biClrImportant
+
+        // Palette: entry 0 = red (RGBQUAD = B,G,R,0), entry 1 = blue.
+        dib.extend_from_slice(&[0, 0, 255, 0]); // entry 0: BGR = 0,0,255 → R
+        dib.extend_from_slice(&[255, 0, 0, 0]); // entry 1: BGR = 255,0,0 → B
+
+        // XOR rows (bottom-up, stride=4 for 2 pixels):
+        // Bottom row: [1, 0, 0, 0] → blue, red
+        // Top row:    [0, 1, 0, 0] → red, blue
+        dib.extend_from_slice(&[1, 0, 0, 0]); // bottom
+        dib.extend_from_slice(&[0, 1, 0, 0]); // top
+
+        // AND mask: 2 rows × 4 bytes, all zeros (opaque).
+        dib.extend_from_slice(&[0u8; 8]);
+
+        let (w, h, rgba) = decode_bmp_dib(&dib).unwrap();
+        assert_eq!(w, 2);
+        assert_eq!(h, 2);
+        // Top-left (y=0, x=0): palette[0] = red
+        assert_eq!(&rgba[0..4], &[255, 0, 0, 255]);
+        // Top-right (y=0, x=1): palette[1] = blue
+        assert_eq!(&rgba[4..8], &[0, 0, 255, 255]);
+        // Bottom-left (y=1, x=0): palette[1] = blue
+        assert_eq!(&rgba[8..12], &[0, 0, 255, 255]);
+        // Bottom-right (y=1, x=1): palette[0] = red
+        assert_eq!(&rgba[12..16], &[255, 0, 0, 255]);
+    }
+
+    #[test]
+    fn rejects_compression() {
+        let mut dib = vec![0u8; 40];
+        dib[0..4].copy_from_slice(&40u32.to_le_bytes()); // biSize
+        dib[16..20].copy_from_slice(&1u32.to_le_bytes()); // biCompression = 1 (RLE)
+        assert!(decode_bmp_dib(&dib).is_err());
+    }
+
+    #[test]
+    fn rejects_bad_header_size() {
+        let mut dib = vec![0u8; 40];
+        dib[0..4].copy_from_slice(&12u32.to_le_bytes()); // biSize = 12 (BITMAPCOREHEADER)
+        assert!(decode_bmp_dib(&dib).is_err());
+    }
+
+    // ── Security tests ─────────────────────────────────────────────────────
+
+    /// biClrUsed > 2^biBitCount should be rejected, not cause OOM.
+    ///
+    /// A malicious file could set biClrUsed = 0xFFFF_FFFF to trigger a
+    /// ~16 GiB Vec allocation on a 64-bit decoder.  Our fix caps it at the
+    /// theoretical maximum for the bit depth.
+    #[test]
+    fn rejects_oversized_bi_clr_used() {
+        let mut dib = vec![0u8; 40];
+        dib[0..4].copy_from_slice(&40u32.to_le_bytes());    // biSize
+        dib[4..8].copy_from_slice(&1i32.to_le_bytes());     // biWidth
+        dib[8..12].copy_from_slice(&2i32.to_le_bytes());    // biHeight = 2*1
+        dib[12..14].copy_from_slice(&1u16.to_le_bytes());   // biPlanes
+        dib[14..16].copy_from_slice(&8u16.to_le_bytes());   // biBitCount = 8
+        // biClrUsed = 0xFFFF_FFFF — 4B palette entries, impossibly large.
+        dib[32..36].copy_from_slice(&0xFFFF_FFFFu32.to_le_bytes());
+        let err = decode_bmp_dib(&dib).unwrap_err();
+        assert!(
+            err.contains("biClrUsed") || err.contains("exceeds"),
+            "expected biClrUsed rejection, got: {}",
+            err
+        );
+    }
+
+    /// biClrUsed = 2^biBitCount should be accepted (exact maximum).
+    #[test]
+    fn accepts_exact_max_bi_clr_used() {
+        let mut dib: Vec<u8> = Vec::new();
+        dib.extend_from_slice(&40u32.to_le_bytes()); // biSize
+        dib.extend_from_slice(&1i32.to_le_bytes());  // biWidth
+        dib.extend_from_slice(&2i32.to_le_bytes());  // biHeight = 2*1
+        dib.extend_from_slice(&1u16.to_le_bytes());  // biPlanes
+        dib.extend_from_slice(&8u16.to_le_bytes());  // biBitCount = 8
+        dib.extend_from_slice(&0u32.to_le_bytes());  // biCompression
+        dib.extend_from_slice(&0u32.to_le_bytes());  // biSizeImage
+        dib.extend_from_slice(&0i32.to_le_bytes());  // biXPelsPerMeter
+        dib.extend_from_slice(&0i32.to_le_bytes());  // biYPelsPerMeter
+        dib.extend_from_slice(&256u32.to_le_bytes()); // biClrUsed = 256 (max for 8bpp)
+        dib.extend_from_slice(&0u32.to_le_bytes());  // biClrImportant
+        // 256 palette entries × 4 bytes = 1024 bytes
+        dib.extend(std::iter::repeat(0u8).take(256 * 4));
+        // 1 XOR pixel (8bpp, stride=4): palette index 0
+        dib.extend_from_slice(&[0u8; 4]);
+        // AND mask: 4 bytes
+        dib.extend_from_slice(&[0u8; 4]);
+
+        // Should decode successfully (palette[0] = black, opaque).
+        let result = decode_bmp_dib(&dib);
+        assert!(result.is_ok(), "expected Ok, got: {:?}", result);
+    }
+}

--- a/code/packages/rust/image-codec-ico/src/decoder.rs
+++ b/code/packages/rust/image-codec-ico/src/decoder.rs
@@ -1,0 +1,399 @@
+//! ICO/CUR file parser.
+//!
+//! Reads the file header, scans directory entries, selects the best-resolution
+//! image, then dispatches to either the BMP DIB decoder or the PNG decoder.
+//!
+//! ## Image selection strategy
+//!
+//! When an ICO contains multiple images (e.g., 16×16, 32×32, 48×48, 256×256)
+//! we return the one with the largest pixel area.  Among ties we prefer higher
+//! bit depth — 32bpp or PNG over 24/8/4/1bpp.
+
+use crate::bmp_dib;
+use pixel_container::PixelContainer;
+
+// ── PNG magic bytes ────────────────────────────────────────────────────────
+
+/// First 8 bytes of any PNG file.
+const PNG_MAGIC: [u8; 8] = [0x89, b'P', b'N', b'G', b'\r', b'\n', 0x1A, b'\n'];
+
+// ── Directory entry ────────────────────────────────────────────────────────
+
+/// One 16-byte entry in the ICO directory.
+#[derive(Debug, Clone)]
+struct DirEntry {
+    /// Pixel width (0 → 256).
+    width: usize,
+    /// Pixel height (0 → 256).
+    height: usize,
+    /// Bits per pixel (0 for PNG frames).
+    bit_count: u16,
+    /// Byte length of the image data.
+    bytes_in_res: usize,
+    /// Byte offset from the start of the file.
+    image_offset: usize,
+}
+
+impl DirEntry {
+    /// Pixel area (for sorting).
+    fn area(&self) -> usize {
+        self.width * self.height
+    }
+
+    /// Is this frame a PNG (first 8 bytes are PNG magic)?
+    fn is_png(&self, data: &[u8]) -> bool {
+        let end = self.image_offset + 8;
+        if end > data.len() {
+            return false;
+        }
+        data[self.image_offset..self.image_offset + 8] == PNG_MAGIC
+    }
+}
+
+// ── Public entry point ─────────────────────────────────────────────────────
+
+/// Decode the best-resolution image from an ICO or CUR file.
+///
+/// Returns the largest image.  For equal-size candidates the 32bpp BMP or
+/// PNG variant is preferred.
+pub fn decode_ico(data: &[u8]) -> Result<PixelContainer, String> {
+    // ── Header (6 bytes) ─────────────────────────────────────────────────
+    if data.len() < 6 {
+        return Err("ICO: file too short".into());
+    }
+    let reserved = u16_le(data, 0);
+    let typ = u16_le(data, 2);
+    let count = u16_le(data, 4) as usize;
+
+    if reserved != 0 {
+        return Err(format!(
+            "ICO: invalid reserved field {} (expected 0)",
+            reserved
+        ));
+    }
+    if typ != 1 && typ != 2 {
+        return Err(format!(
+            "ICO: unknown type {} (expected 1=ICO or 2=CUR)",
+            typ
+        ));
+    }
+    if count == 0 {
+        return Err("ICO: no images in file".into());
+    }
+
+    // Security cap: real ICO files contain a handful of images (typically
+    // ≤12).  65535 entries would allocate ~2.6 MiB for the directory and
+    // ~2.5 MiB for the Vec<DirEntry>, creating an allocation amplification
+    // DoS for any caller that processes untrusted .ico files.
+    const MAX_ICO_ENTRIES: usize = 256;
+    if count > MAX_ICO_ENTRIES {
+        return Err(format!(
+            "ICO: too many directory entries {} (max {})",
+            count, MAX_ICO_ENTRIES
+        ));
+    }
+
+    // ── Directory entries (16 bytes each) ─────────────────────────────────
+    // count ≤ 256, so count * 16 ≤ 4096 — no overflow.
+    let dir_end = 6 + count * 16;
+    if data.len() < dir_end {
+        return Err("ICO: file truncated in directory".into());
+    }
+
+    let mut entries: Vec<DirEntry> = Vec::with_capacity(count);
+    for i in 0..count {
+        let base = 6 + i * 16;
+        let w_byte = data[base]; // 0 means 256
+        let h_byte = data[base + 1];
+        let bit_count = u16_le(data, base + 6);
+        let bytes_in_res = u32_le(data, base + 8) as usize;
+        let image_offset = u32_le(data, base + 12) as usize;
+
+        // The directory byte 0 means 256 (the maximum dimension).
+        let width = if w_byte == 0 { 256 } else { w_byte as usize };
+        let height = if h_byte == 0 { 256 } else { h_byte as usize };
+
+        // Basic bounds check.
+        if image_offset.saturating_add(bytes_in_res) > data.len() {
+            return Err(format!(
+                "ICO: entry {} image data (offset={}, size={}) extends past end of file ({}B)",
+                i, image_offset, bytes_in_res, data.len()
+            ));
+        }
+
+        entries.push(DirEntry {
+            width,
+            height,
+            bit_count,
+            bytes_in_res,
+            image_offset,
+        });
+    }
+
+    // ── Select best entry ────────────────────────────────────────────────
+    let best = select_best(&entries, data);
+    let entry = &entries[best];
+    let image_data = &data[entry.image_offset..entry.image_offset + entry.bytes_in_res];
+
+    // ── Dispatch: PNG or BMP DIB ─────────────────────────────────────────
+    if entry.is_png(data) {
+        decode_png_frame(image_data)
+    } else {
+        decode_bmp_frame(image_data)
+    }
+}
+
+// ── Entry selection ────────────────────────────────────────────────────────
+
+/// Choose the index of the best directory entry to decode.
+///
+/// Priority:
+/// 1. Largest pixel area.
+/// 2. Among ties: PNG > 32bpp > 24bpp > 8bpp > 4bpp > 1bpp.
+fn select_best(entries: &[DirEntry], data: &[u8]) -> usize {
+    let mut best = 0;
+    for (i, e) in entries.iter().enumerate() {
+        let b = &entries[best];
+        if e.area() > b.area() {
+            best = i;
+        } else if e.area() == b.area() && quality_rank(e, data) > quality_rank(b, data) {
+            best = i;
+        }
+    }
+    best
+}
+
+/// Higher = better quality.  PNG = 100, 32bpp = 32, 24bpp = 24, etc.
+fn quality_rank(e: &DirEntry, data: &[u8]) -> u32 {
+    if e.is_png(data) {
+        100
+    } else {
+        e.bit_count as u32
+    }
+}
+
+// ── Frame decoders ─────────────────────────────────────────────────────────
+
+/// Decode a full PNG file embedded in an ICO frame.
+fn decode_png_frame(png_data: &[u8]) -> Result<PixelContainer, String> {
+    let (width, height, rgba) =
+        png::decode_png_rgba(png_data).map_err(|e| format!("ICO: PNG decode error: {}", e))?;
+    let mut pc = PixelContainer::new(width, height);
+    for y in 0..height {
+        for x in 0..width {
+            let base = ((y * width + x) * 4) as usize;
+            pc.set_pixel(x, y, rgba[base], rgba[base + 1], rgba[base + 2], rgba[base + 3]);
+        }
+    }
+    Ok(pc)
+}
+
+/// Decode a BMP DIB frame (BITMAPINFOHEADER + pixel data + AND mask).
+fn decode_bmp_frame(dib_data: &[u8]) -> Result<PixelContainer, String> {
+    let (width, height, rgba) = bmp_dib::decode_bmp_dib(dib_data)?;
+    let mut pc = PixelContainer::new(width, height);
+    for y in 0..height {
+        for x in 0..width {
+            let base = ((y * width + x) * 4) as usize;
+            pc.set_pixel(x, y, rgba[base], rgba[base + 1], rgba[base + 2], rgba[base + 3]);
+        }
+    }
+    Ok(pc)
+}
+
+// ── Little-endian helpers ──────────────────────────────────────────────────
+
+fn u16_le(data: &[u8], offset: usize) -> u16 {
+    u16::from_le_bytes([data[offset], data[offset + 1]])
+}
+
+fn u32_le(data: &[u8], offset: usize) -> u32 {
+    u32::from_le_bytes([data[offset], data[offset + 1], data[offset + 2], data[offset + 3]])
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a minimal 1×1 32bpp ICO by hand and verify decoding.
+    #[test]
+    fn decode_minimal_1x1_32bpp() {
+        let mut ico = Vec::<u8>::new();
+        // Header
+        ico.extend_from_slice(&0u16.to_le_bytes()); // reserved
+        ico.extend_from_slice(&1u16.to_le_bytes()); // type = ICO
+        ico.extend_from_slice(&1u16.to_le_bytes()); // count = 1
+
+        // BMP DIB for 1×1 32bpp.
+        // BITMAPINFOHEADER: biWidth=1, biHeight=2 (=2*pixel_height), biBitCount=32
+        let mut dib = Vec::<u8>::new();
+        dib.extend_from_slice(&40u32.to_le_bytes()); // biSize
+        dib.extend_from_slice(&1i32.to_le_bytes());  // biWidth
+        dib.extend_from_slice(&2i32.to_le_bytes());  // biHeight
+        dib.extend_from_slice(&1u16.to_le_bytes());  // biPlanes
+        dib.extend_from_slice(&32u16.to_le_bytes()); // biBitCount
+        dib.extend_from_slice(&[0u8; 24]); // remaining 6 header fields (24 bytes)           // remaining header fields
+        // XOR: BGRA = (50, 100, 200, 255)
+        dib.extend_from_slice(&[50, 100, 200, 255]);
+        // AND mask: 4 bytes, all zero
+        dib.extend_from_slice(&[0u8; 4]);
+
+        let dib_len = dib.len() as u32;
+
+        // Directory entry
+        ico.push(1); // width
+        ico.push(1); // height
+        ico.push(0); // colorCount
+        ico.push(0); // reserved
+        ico.extend_from_slice(&1u16.to_le_bytes()); // planes
+        ico.extend_from_slice(&32u16.to_le_bytes()); // bitCount
+        ico.extend_from_slice(&dib_len.to_le_bytes());
+        ico.extend_from_slice(&22u32.to_le_bytes()); // imageOffset
+
+        ico.extend_from_slice(&dib);
+
+        let pc = decode_ico(&ico).unwrap();
+        assert_eq!(pc.width, 1);
+        assert_eq!(pc.height, 1);
+        let (r, g, b, a) = pc.pixel_at(0, 0);
+        assert_eq!(r, 200); // R from BGRA B=50,G=100,R=200
+        assert_eq!(g, 100);
+        assert_eq!(b, 50);
+        assert_eq!(a, 255);
+    }
+
+    #[test]
+    fn decode_cur_type_2_accepted() {
+        // Same as decode_minimal_1x1_32bpp but with type=2 (CUR).
+        let mut ico = Vec::<u8>::new();
+        ico.extend_from_slice(&0u16.to_le_bytes()); // reserved
+        ico.extend_from_slice(&2u16.to_le_bytes()); // type = CUR
+        ico.extend_from_slice(&1u16.to_le_bytes()); // count = 1
+
+        let mut dib = Vec::<u8>::new();
+        dib.extend_from_slice(&40u32.to_le_bytes()); // biSize
+        dib.extend_from_slice(&1i32.to_le_bytes());
+        dib.extend_from_slice(&2i32.to_le_bytes());
+        dib.extend_from_slice(&1u16.to_le_bytes());
+        dib.extend_from_slice(&32u16.to_le_bytes());
+        dib.extend_from_slice(&[0u8; 24]); // remaining 6 header fields (24 bytes)
+        dib.extend_from_slice(&[0, 0, 255, 255]); // BGRA = blue opaque
+        dib.extend_from_slice(&[0u8; 4]);          // AND mask
+
+        let dib_len = dib.len() as u32;
+        ico.push(1); ico.push(1); ico.push(0); ico.push(0);
+        ico.extend_from_slice(&0u16.to_le_bytes()); // hotspot_x
+        ico.extend_from_slice(&0u16.to_le_bytes()); // hotspot_y
+        ico.extend_from_slice(&dib_len.to_le_bytes());
+        ico.extend_from_slice(&22u32.to_le_bytes());
+        ico.extend_from_slice(&dib);
+
+        let pc = decode_ico(&ico).unwrap();
+        assert_eq!(pc.width, 1);
+        assert_eq!(pc.height, 1);
+    }
+
+    #[test]
+    fn decode_selects_largest() {
+        // Build a 2-image ICO: 1×1 and 2×2.  The 2×2 should be returned.
+        let mut ico: Vec<u8> = Vec::new();
+        ico.extend_from_slice(&0u16.to_le_bytes());
+        ico.extend_from_slice(&1u16.to_le_bytes());
+        ico.extend_from_slice(&2u16.to_le_bytes()); // 2 images
+
+        // Image data placeholders — we'll fill in offsets after computing sizes.
+        // DIB for 1×1.
+        let dib1 = make_solid_32bpp_dib(1, 1, (255, 0, 0, 255));
+        // DIB for 2×2.
+        let dib2 = make_solid_32bpp_dib(2, 2, (0, 255, 0, 255));
+
+        // Total header = 6 + 2*16 = 38 bytes.
+        let offset1 = 38u32;
+        let offset2 = offset1 + dib1.len() as u32;
+
+        // Dir entry for 1×1.
+        ico.push(1); ico.push(1); ico.push(0); ico.push(0);
+        ico.extend_from_slice(&1u16.to_le_bytes());
+        ico.extend_from_slice(&32u16.to_le_bytes());
+        ico.extend_from_slice(&(dib1.len() as u32).to_le_bytes());
+        ico.extend_from_slice(&offset1.to_le_bytes());
+
+        // Dir entry for 2×2.
+        ico.push(2); ico.push(2); ico.push(0); ico.push(0);
+        ico.extend_from_slice(&1u16.to_le_bytes());
+        ico.extend_from_slice(&32u16.to_le_bytes());
+        ico.extend_from_slice(&(dib2.len() as u32).to_le_bytes());
+        ico.extend_from_slice(&offset2.to_le_bytes());
+
+        ico.extend_from_slice(&dib1);
+        ico.extend_from_slice(&dib2);
+
+        let pc = decode_ico(&ico).unwrap();
+        assert_eq!(pc.width, 2);
+        assert_eq!(pc.height, 2);
+        // Top-left should be green (from the 2×2 DIB).
+        let (r, g, _b, _a) = pc.pixel_at(0, 0);
+        assert_eq!(r, 0);
+        assert_eq!(g, 255);
+    }
+
+    #[test]
+    fn decode_error_bad_reserved() {
+        let mut ico = vec![0u8; 6];
+        ico[0] = 1; // reserved != 0
+        ico[2] = 1; // type = ICO
+        ico[4] = 1; // count = 1
+        assert!(decode_ico(&ico).is_err());
+    }
+
+    #[test]
+    fn decode_error_bad_type() {
+        let mut ico = vec![0u8; 6];
+        ico[2] = 3; // type = 3 (invalid)
+        ico[4] = 1;
+        assert!(decode_ico(&ico).is_err());
+    }
+
+    #[test]
+    fn decode_error_zero_count() {
+        let ico = vec![0u8, 0, 1, 0, 0, 0]; // reserved=0, type=1, count=0
+        let err = decode_ico(&ico).unwrap_err();
+        assert!(err.contains("no images"), "got: {}", err);
+    }
+
+    #[test]
+    fn decode_error_too_short() {
+        let err = decode_ico(b"ICO").unwrap_err();
+        assert!(err.contains("too short"), "got: {}", err);
+    }
+
+    // ── Helper ───────────────────────────────────────────────────────────────
+
+    /// Build a minimal 32bpp BMP DIB for a solid-color `width × height` image.
+    fn make_solid_32bpp_dib(width: usize, height: usize, rgba: (u8, u8, u8, u8)) -> Vec<u8> {
+        let (r, g, b, a) = rgba;
+        let and_stride = ((width + 31) / 32) * 4;
+        let and_size = and_stride * height;
+
+        let mut dib = Vec::<u8>::new();
+        dib.extend_from_slice(&40u32.to_le_bytes());
+        dib.extend_from_slice(&(width as i32).to_le_bytes());
+        dib.extend_from_slice(&((height * 2) as i32).to_le_bytes());
+        dib.extend_from_slice(&1u16.to_le_bytes());
+        dib.extend_from_slice(&32u16.to_le_bytes());
+        dib.extend_from_slice(&[0u8; 24]); // remaining 6 header fields (24 bytes) // remaining header
+
+        for _ in 0..height {
+            for _ in 0..width {
+                dib.push(b);
+                dib.push(g);
+                dib.push(r);
+                dib.push(a);
+            }
+        }
+        dib.extend(std::iter::repeat(0u8).take(and_size));
+        dib
+    }
+}

--- a/code/packages/rust/image-codec-ico/src/encoder.rs
+++ b/code/packages/rust/image-codec-ico/src/encoder.rs
@@ -1,0 +1,210 @@
+//! ICO encoder — writes a single-image 32bpp BGRA ICO file.
+//!
+//! ## Output structure
+//!
+//! ```text
+//! ICO header  (6 bytes):
+//!   reserved: u16 = 0
+//!   type:     u16 = 1  (ICO)
+//!   count:    u16 = 1  (one image)
+//!
+//! Directory entry  (16 bytes):
+//!   width:         u8   (0 means 256)
+//!   height:        u8   (0 means 256)
+//!   color_count:   u8   = 0  (truecolor — no palette)
+//!   reserved:      u8   = 0
+//!   planes:        u16  = 1
+//!   bit_count:     u16  = 32
+//!   bytes_in_res:  u32  (total BMP DIB byte count)
+//!   image_offset:  u32  = 22 (= 6 header + 16 dir entry)
+//!
+//! BMP DIB  (BITMAPINFOHEADER + XOR pixels + AND mask):
+//!   BITMAPINFOHEADER  (40 bytes)
+//!   XOR pixel data    (width × height × 4 bytes BGRA, bottom-up)
+//!   AND mask          (row-padded to 4 bytes, all zeros)
+//! ```
+//!
+//! ## Why 32bpp BGRA?
+//!
+//! 32bpp is the highest fidelity option — it embeds the full alpha channel
+//! in the BGRA byte, so transparent pixels survive the encode/decode cycle
+//! exactly.  All modern Windows, macOS, and Linux ICO renderers support it.
+
+use pixel_container::PixelContainer;
+
+// ── Constants ──────────────────────────────────────────────────────────────
+
+/// Byte offset of the first (and only) image in the output file.
+/// = 6 (header) + 16 (one directory entry).
+const IMAGE_OFFSET: u32 = 22;
+
+/// Bits per pixel for the encoded output.
+const BITS_PER_PIXEL: u16 = 32;
+
+// ── Public entry point ─────────────────────────────────────────────────────
+
+/// Encode a `PixelContainer` as a single-image 32bpp ICO file.
+///
+/// Dimensions are clamped to 255×255 because the ICO directory byte wraps
+/// 256→0 (a stored value of 0 means 256, but we stay below to avoid
+/// ambiguity with the 256 convention).
+///
+/// The output is a complete, self-contained `.ico` file.
+pub fn encode_ico(pixels: &PixelContainer) -> Vec<u8> {
+    // Clamp to 255 — the directory byte can hold 0-255 where 0 means 256.
+    // We emit explicit pixel dimensions (1-255) to keep things unambiguous.
+    let width = (pixels.width as usize).min(255);
+    let height = (pixels.height as usize).min(255);
+
+    // Build the BMP DIB.
+    let dib = build_bmp_dib(pixels, width, height);
+    let dib_len = dib.len() as u32;
+
+    let mut out = Vec::with_capacity(22 + dib.len());
+
+    // ── ICO header (6 bytes) ──────────────────────────────────────────────
+    out.extend_from_slice(&0u16.to_le_bytes()); // reserved
+    out.extend_from_slice(&1u16.to_le_bytes()); // type = 1 (ICO)
+    out.extend_from_slice(&1u16.to_le_bytes()); // count = 1
+
+    // ── Directory entry (16 bytes) ────────────────────────────────────────
+    out.push(width as u8);                      // width (1-255)
+    out.push(height as u8);                     // height (1-255)
+    out.push(0);                                // color_count = 0 (truecolor)
+    out.push(0);                                // reserved
+    out.extend_from_slice(&1u16.to_le_bytes()); // planes = 1
+    out.extend_from_slice(&BITS_PER_PIXEL.to_le_bytes()); // bit_count = 32
+    out.extend_from_slice(&dib_len.to_le_bytes()); // bytes_in_res
+    out.extend_from_slice(&IMAGE_OFFSET.to_le_bytes()); // image_offset = 22
+
+    // ── BMP DIB ───────────────────────────────────────────────────────────
+    out.extend_from_slice(&dib);
+
+    out
+}
+
+// ── BMP DIB builder ────────────────────────────────────────────────────────
+
+/// Build a 32bpp BMP DIB (no BITMAPFILEHEADER) from `pixels`.
+///
+/// The DIB contains:
+/// 1. `BITMAPINFOHEADER` (40 bytes)
+/// 2. XOR pixel data: rows bottom-up, 4 bytes (BGRA) per pixel
+/// 3. AND mask: rows bottom-up, 1 bpp, padded to 4-byte boundary, all zeros
+///
+/// `bi_height = 2 * pixel_height` because the DIB stores both XOR + AND masks.
+fn build_bmp_dib(pixels: &PixelContainer, width: usize, height: usize) -> Vec<u8> {
+    // Row stride for 32bpp: width × 4 bytes (always 4-byte aligned).
+    let xor_stride = width * 4;
+    let xor_size = xor_stride * height;
+
+    // AND mask stride: ((width + 31) / 32) × 4 bytes.
+    let and_stride = ((width + 31) / 32) * 4;
+    let and_size = and_stride * height;
+
+    let mut dib = Vec::with_capacity(40 + xor_size + and_size);
+
+    // ── BITMAPINFOHEADER (40 bytes) ─────────────────────────────────────────
+    dib.extend_from_slice(&40u32.to_le_bytes());                   // biSize
+    dib.extend_from_slice(&(width as i32).to_le_bytes());          // biWidth
+    dib.extend_from_slice(&((height * 2) as i32).to_le_bytes());   // biHeight = 2*h
+    dib.extend_from_slice(&1u16.to_le_bytes());                    // biPlanes
+    dib.extend_from_slice(&BITS_PER_PIXEL.to_le_bytes());          // biBitCount
+    dib.extend_from_slice(&0u32.to_le_bytes());                    // biCompression = BI_RGB
+    dib.extend_from_slice(&0u32.to_le_bytes());                    // biSizeImage (0 for BI_RGB)
+    dib.extend_from_slice(&0i32.to_le_bytes());                    // biXPelsPerMeter
+    dib.extend_from_slice(&0i32.to_le_bytes());                    // biYPelsPerMeter
+    dib.extend_from_slice(&0u32.to_le_bytes());                    // biClrUsed
+    dib.extend_from_slice(&0u32.to_le_bytes());                    // biClrImportant
+
+    // ── XOR pixel data: rows bottom-up (last pixel row first) ──────────────
+    for row in (0..height).rev() {
+        for col in 0..width {
+            let (r, g, b, a) = pixels.pixel_at(col as u32, row as u32);
+            // BGRA byte order.
+            dib.push(b);
+            dib.push(g);
+            dib.push(r);
+            dib.push(a);
+        }
+    }
+
+    // ── AND mask: all zeros (alpha from BGRA channel) ─────────────────────
+    // A zero AND mask bit = opaque; alpha=0 in BGRA handles transparency.
+    dib.extend(std::iter::repeat(0u8).take(and_size));
+
+    dib
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_header_is_correct() {
+        let px = PixelContainer::new(2, 2);
+        let bytes = encode_ico(&px);
+        // ICO header
+        assert_eq!(u16::from_le_bytes([bytes[0], bytes[1]]), 0, "reserved");
+        assert_eq!(u16::from_le_bytes([bytes[2], bytes[3]]), 1, "type=ICO");
+        assert_eq!(u16::from_le_bytes([bytes[4], bytes[5]]), 1, "count=1");
+    }
+
+    #[test]
+    fn encode_directory_entry_is_correct() {
+        let px = PixelContainer::new(4, 8);
+        let bytes = encode_ico(&px);
+        assert_eq!(bytes[6], 4, "width in dir");
+        assert_eq!(bytes[7], 8, "height in dir");
+        assert_eq!(bytes[8], 0, "colorCount");
+        assert_eq!(bytes[9], 0, "reserved");
+        assert_eq!(u16::from_le_bytes([bytes[10], bytes[11]]), 1, "planes");
+        assert_eq!(u16::from_le_bytes([bytes[12], bytes[13]]), 32, "bitCount");
+        assert_eq!(u32::from_le_bytes([bytes[18], bytes[19], bytes[20], bytes[21]]), 22, "imageOffset");
+    }
+
+    #[test]
+    fn encode_image_offset_is_22() {
+        let px = PixelContainer::new(1, 1);
+        let bytes = encode_ico(&px);
+        let offset = u32::from_le_bytes([bytes[18], bytes[19], bytes[20], bytes[21]]);
+        assert_eq!(offset, 22);
+    }
+
+    #[test]
+    fn encode_bit_count_is_32() {
+        let px = PixelContainer::new(1, 1);
+        let bytes = encode_ico(&px);
+        let bit_count = u16::from_le_bytes([bytes[12], bytes[13]]);
+        assert_eq!(bit_count, 32);
+    }
+
+    #[test]
+    fn encode_pixel_stored_as_bgra() {
+        let mut px = PixelContainer::new(1, 1);
+        px.set_pixel(0, 0, 10, 20, 30, 40); // R=10,G=20,B=30,A=40
+        let bytes = encode_ico(&px);
+        // XOR data starts at byte 22 (image_offset) + 40 (DIB header) = 62.
+        let xor_start = 22 + 40;
+        assert_eq!(bytes[xor_start], 30, "B");
+        assert_eq!(bytes[xor_start + 1], 20, "G");
+        assert_eq!(bytes[xor_start + 2], 10, "R");
+        assert_eq!(bytes[xor_start + 3], 40, "A");
+    }
+
+    #[test]
+    fn encode_and_mask_is_all_zeros() {
+        let mut px = PixelContainer::new(2, 2);
+        px.fill(0, 0, 0, 0); // fully transparent
+        let bytes = encode_ico(&px);
+        // AND mask follows XOR data.
+        let xor_size = 2 * 2 * 4; // 2×2 pixels × 4 bytes BGRA
+        let and_start = 22 + 40 + xor_size;
+        // AND mask for width=2: stride=4, 2 rows = 8 bytes, all zero.
+        for i in and_start..and_start + 8 {
+            assert_eq!(bytes[i], 0, "AND mask byte {} should be 0", i);
+        }
+    }
+}

--- a/code/packages/rust/image-codec-ico/src/lib.rs
+++ b/code/packages/rust/image-codec-ico/src/lib.rs
@@ -1,0 +1,200 @@
+//! # image-codec-ico
+//!
+//! ICO (Windows Icon) and CUR (cursor) image codec — IC08.
+//!
+//! Encodes a `PixelContainer` as a single-image 32bpp ICO file and decodes
+//! the best-resolution image from any ICO/CUR file into an RGBA8 `PixelContainer`.
+//!
+//! ## Quick start
+//!
+//! ```
+//! use image_codec_ico::{encode_ico, decode_ico};
+//! use pixel_container::PixelContainer;
+//!
+//! // Encode a 2×2 red ICO.
+//! let mut px = PixelContainer::new(2, 2);
+//! px.fill(255, 0, 0, 255);
+//! let bytes = encode_ico(&px);
+//! assert_eq!(&bytes[2..4], &[1, 0]); // type = ICO
+//!
+//! // Decode it back.
+//! let recovered = decode_ico(&bytes).unwrap();
+//! assert_eq!(recovered.width, 2);
+//! assert_eq!(recovered.height, 2);
+//! ```
+
+pub use decoder::decode_ico;
+pub use encoder::encode_ico;
+use paint_instructions::ImageCodec;
+use pixel_container::PixelContainer;
+
+mod bmp_dib;
+mod decoder;
+mod encoder;
+
+/// Package version — kept in sync with CHANGELOG.md and Cargo.toml.
+pub const VERSION: &str = "0.1.0";
+
+/// ICO/CUR image codec implementing `paint_instructions::ImageCodec`.
+///
+/// Encodes as a single-image 32bpp ICO (lossless, full RGBA).
+/// Decodes ICO and CUR files, returning the best-resolution frame.
+pub struct IcoCodec;
+
+impl ImageCodec for IcoCodec {
+    fn mime_type(&self) -> &'static str {
+        "image/x-icon"
+    }
+
+    fn encode(&self, pixels: &PixelContainer) -> Vec<u8> {
+        encode_ico(pixels)
+    }
+
+    fn decode(&self, bytes: &[u8]) -> Result<PixelContainer, String> {
+        decode_ico(bytes)
+    }
+}
+
+// ── Integration tests ─────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Helper: encode then decode, asserting pixel-exact round-trip.
+    fn round_trip(pixels: &PixelContainer) {
+        let bytes = encode_ico(pixels);
+        let recovered = decode_ico(&bytes)
+            .unwrap_or_else(|e| panic!("decode failed: {}", e));
+        assert_eq!(recovered.width, pixels.width, "width mismatch");
+        assert_eq!(recovered.height, pixels.height, "height mismatch");
+        for y in 0..pixels.height {
+            for x in 0..pixels.width {
+                let orig = pixels.pixel_at(x, y);
+                let got = recovered.pixel_at(x, y);
+                assert_eq!(got, orig, "pixel ({x},{y}) mismatch: orig={:?} got={:?}", orig, got);
+            }
+        }
+    }
+
+    // ── Basic round-trips ──────────────────────────────────────────────────
+
+    #[test]
+    fn round_trip_solid_rgba() {
+        let mut px = PixelContainer::new(4, 4);
+        px.fill(200, 100, 50, 255);
+        round_trip(&px);
+    }
+
+    #[test]
+    fn round_trip_1x1() {
+        let mut px = PixelContainer::new(1, 1);
+        px.set_pixel(0, 0, 10, 20, 30, 200);
+        round_trip(&px);
+    }
+
+    #[test]
+    fn round_trip_transparent() {
+        let mut px = PixelContainer::new(4, 4);
+        px.fill(0, 0, 0, 0); // fully transparent
+        round_trip(&px);
+    }
+
+    #[test]
+    fn round_trip_mixed_alpha() {
+        let mut px = PixelContainer::new(2, 2);
+        px.set_pixel(0, 0, 255, 0, 0, 255); // opaque red
+        px.set_pixel(1, 0, 0, 255, 0, 128); // half-transparent green
+        px.set_pixel(0, 1, 0, 0, 255, 0);   // fully transparent blue
+        px.set_pixel(1, 1, 128, 128, 0, 64); // quarter-transparent yellow
+        round_trip(&px);
+    }
+
+    #[test]
+    fn round_trip_16x16() {
+        let mut px = PixelContainer::new(16, 16);
+        for y in 0..16u32 {
+            for x in 0..16u32 {
+                px.set_pixel(x, y, (x * 16) as u8, (y * 16) as u8, 128, 255);
+            }
+        }
+        round_trip(&px);
+    }
+
+    #[test]
+    fn round_trip_32x32() {
+        let mut px = PixelContainer::new(32, 32);
+        for y in 0..32u32 {
+            for x in 0..32u32 {
+                px.set_pixel(x, y, x as u8, y as u8, 200, 255);
+            }
+        }
+        round_trip(&px);
+    }
+
+    // ── File format structure ──────────────────────────────────────────────
+
+    #[test]
+    fn encode_produces_correct_header() {
+        let px = PixelContainer::new(2, 2);
+        let bytes = encode_ico(&px);
+        assert!(bytes.len() >= 6, "file must have at least 6 bytes");
+        assert_eq!(u16::from_le_bytes([bytes[0], bytes[1]]), 0, "reserved");
+        assert_eq!(u16::from_le_bytes([bytes[2], bytes[3]]), 1, "type=ICO");
+        assert_eq!(u16::from_le_bytes([bytes[4], bytes[5]]), 1, "count=1");
+    }
+
+    #[test]
+    fn encode_bit_count_is_32() {
+        let px = PixelContainer::new(1, 1);
+        let bytes = encode_ico(&px);
+        let bit_count = u16::from_le_bytes([bytes[12], bytes[13]]);
+        assert_eq!(bit_count, 32);
+    }
+
+    #[test]
+    fn encode_image_offset_is_22() {
+        let px = PixelContainer::new(1, 1);
+        let bytes = encode_ico(&px);
+        let offset = u32::from_le_bytes([bytes[18], bytes[19], bytes[20], bytes[21]]);
+        assert_eq!(offset, 22);
+    }
+
+    // ── Error cases ────────────────────────────────────────────────────────
+
+    #[test]
+    fn decode_error_bad_magic() {
+        let err = decode_ico(b"\x89PNG\r\n\x1a\n").unwrap_err();
+        assert!(!err.is_empty());
+    }
+
+    #[test]
+    fn decode_error_too_short() {
+        let err = decode_ico(b"ICO").unwrap_err();
+        assert!(err.contains("too short"), "got: {}", err);
+    }
+
+    #[test]
+    fn decode_error_bad_type() {
+        let data: Vec<u8> = vec![0, 0, 3, 0, 1, 0]; // type=3
+        let err = decode_ico(&data).unwrap_err();
+        assert!(err.contains("unknown type") || err.contains("type"), "got: {}", err);
+    }
+
+    // ── MIME type ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn codec_mime_type() {
+        assert_eq!(IcoCodec.mime_type(), "image/x-icon");
+    }
+
+    #[test]
+    fn codec_encode_decode_round_trip() {
+        let mut px = PixelContainer::new(4, 4);
+        px.fill(100, 150, 200, 255);
+        let bytes = IcoCodec.encode(&px);
+        let recovered = IcoCodec.decode(&bytes).unwrap();
+        assert_eq!(recovered.width, 4);
+        assert_eq!(recovered.height, 4);
+    }
+}

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 2.211.0 — 2026-05-27
+
+### Added
+
+- **Phase 274 — Five-Sqrt × Thirty-Seven-Log × polynomial** (`fiveSqrtThirtySevenLogPolyEffectiveDeg`):
+  Completes the Thirty-Seven-Log family (Phases 269–274).
+- **Phase 273 — Four-Sqrt × Thirty-Seven-Log × polynomial** (`fourSqrtThirtySevenLogPolyEffectiveDeg`).
+- **Phase 272 — Three-Sqrt × Thirty-Seven-Log × polynomial** (`threeSqrtThirtySevenLogPolyEffectiveDeg`).
+- **Phase 271 — Two-Sqrt × Thirty-Seven-Log × polynomial** (`twoSqrtThirtySevenLogPolyEffectiveDeg`).
+- **Phase 270 — One-Sqrt × Thirty-Seven-Log × polynomial** (`oneSqrtThirtySevenLogPolyEffectiveDeg`).
+- **Phase 269 — Zero-Sqrt × Thirty-Seven-Log × polynomial** (`thirtySevenLogPolyEffectiveDeg`).
+
+### Changed
+
+- Boundary tests in Phases 263–268 (and prior phases 167–262) updated from 37-log
+  "refused" to 38-log "refused" now that Phases 269–274 handle exactly 37 logs.
+
 ## 2.205.0 — 2026-05-27
 
 ### Added

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2.22.0 — 2026-05-26
+
+### Added
+
+- **Phase 85 — Two-Sqrt × Six-Log × polynomial numerator** (`twoSqrtSixLogPolyEffectiveDeg`):
+  recognises `Mul(Sqrt(P1), Sqrt(P2), Log(h1(k)), Log(h2(k)), Log(h3(k)), Log(h4(k)), Log(h5(k)), Log(h6(k)), polynomial..., bounded...)`.
+  Exactly 2 Sqrt and exactly 6 Log factors; `log⁶(k)` sub-polynomial — contributes 0 to effective
+  degree; effective degree = sqrtHalfDeg1 + sqrtHalfDeg2 + polyDeg.
+  Closes when `denDeg > twoSqrtSixLogPolyEffectiveDeg` or non-polynomial diverging denominator.
+  - 3 new tests in the "Phase 85" describe block.
+
 ## 2.21.0 — 2026-05-25
 
 ### Added

--- a/code/packages/typescript/cas-summation/package-lock.json
+++ b/code/packages/typescript/cas-summation/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "2.21.0",
+  "version": "2.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coding-adventures/cas-summation",
-      "version": "2.21.0",
+      "version": "2.22.0",
       "license": "MIT",
       "dependencies": {
         "@coding-adventures/symbolic-ir": "file:../symbolic-ir"

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "2.21.0",
+  "version": "2.22.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "2.205.0",
+  "version": "2.211.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -2036,6 +2036,40 @@ function oneSqrtSixLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefi
   return sqrtHalfDeg + polyDeg;
 }
 
+/**
+ * Phase 85 — Two-Sqrt × Six-Log × polynomial numerator.
+ *
+ * Effective growth: `sqrt(k^a) · sqrt(k^b) · log(k)⁶ · k^m ≈ k^{(a+b)/2} · log⁶(k) · k^m`.
+ * `log⁶(k)` is sub-polynomial (`o(k^ε)`), contributing 0 to effective polynomial degree.
+ * effective degree = sqrtHalfDeg1 + sqrtHalfDeg2 + polyDeg.
+ * Caller checks `denDeg > twoSqrtSixLogPolyEffectiveDeg(num, k)`.
+ */
+function twoSqrtSixLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDegs.length >= 2) return undefined; // third Sqrt — refuse
+      sqrtHalfDegs.push(hd);
+      continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 6) return undefined;
+      continue;
+    }
+    const deg = polynomialDegreeInK(arg, k);
+    if (deg !== undefined) { polyDeg += deg; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 2 || logCount !== 6) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + polyDeg;
+}
+
 function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
   if (g.kind !== "apply" || !equals(g.head, DIV) || g.args.length !== 2) {
     return false;
@@ -2487,6 +2521,18 @@ function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
     const denDegS1l6 = polynomialDegreeInK(den, k);
     if (denDegS1l6 !== undefined) {
       if (denDegS1l6 > s1l6Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 85: Mul(Sqrt(P1), Sqrt(P2), Log(h1)×6, polynomial..., bounded...) numerator.
+  // Two Sqrt + six Log factors; log⁶ sub-polynomial → effective degree = sqrtHalfDeg1 + sqrtHalfDeg2 + polyDeg.
+  // Closes when denDeg > twoSqrtSixLogPolyEffectiveDeg or non-polynomial diverging denom.
+  const s2l6Deg = twoSqrtSixLogPolyEffectiveDeg(num, k);
+  if (s2l6Deg !== undefined) {
+    const denDegS2l6 = polynomialDegreeInK(den, k);
+    if (denDegS2l6 !== undefined) {
+      if (denDegS2l6 > s2l6Deg) return true;
     } else if (hDivergesAtInfinity(den, k)) {
       return true;
     }

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -5412,6 +5412,165 @@ function fiveSqrtThirtySixLogPolyEffectiveDeg(node: IRNode, k: IRNode): number |
   return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + sqrtHalfDegs[3] + sqrtHalfDegs[4] + polyDeg;
 }
 
+/** Phase 269 — Zero-Sqrt × Thirty-Seven-Log × polynomial numerator.
+ * effectiveDeg = polyDeg (no sqrt factors).
+ * Caller checks `denDeg > thirtySevenLogPolyEffectiveDeg(num, k)`.
+ */
+function thirtySevenLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    if (sqrtEffectiveHalfDegree(arg, k) !== undefined) return undefined;
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 37) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (logCount !== 37) return undefined;
+  return polyDeg;
+}
+
+/** Phase 270 — One-Sqrt × Thirty-Seven-Log × polynomial numerator.
+ * Caller checks `denDeg > oneSqrtThirtySevenLogPolyEffectiveDeg(num, k)`.
+ */
+function oneSqrtThirtySevenLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  let sqrtHalfDeg: number | undefined;
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const sh = sqrtEffectiveHalfDegree(arg, k);
+    if (sh !== undefined) {
+      if (sqrtHalfDeg !== undefined) return undefined;
+      sqrtHalfDeg = sh; continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 37) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDeg === undefined || logCount !== 37) return undefined;
+  return sqrtHalfDeg + polyDeg;
+}
+
+/** Phase 271 — Two-Sqrt × Thirty-Seven-Log × polynomial numerator. */
+function twoSqrtThirtySevenLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const sh = sqrtEffectiveHalfDegree(arg, k);
+    if (sh !== undefined) {
+      if (sqrtHalfDegs.length >= 2) return undefined;
+      sqrtHalfDegs.push(sh); continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 37) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 2 || logCount !== 37) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + polyDeg;
+}
+
+/** Phase 272 — Three-Sqrt × Thirty-Seven-Log × polynomial numerator. */
+function threeSqrtThirtySevenLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const sh = sqrtEffectiveHalfDegree(arg, k);
+    if (sh !== undefined) {
+      if (sqrtHalfDegs.length >= 3) return undefined;
+      sqrtHalfDegs.push(sh); continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 37) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 3 || logCount !== 37) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + polyDeg;
+}
+
+/** Phase 273 — Four-Sqrt × Thirty-Seven-Log × polynomial numerator. */
+function fourSqrtThirtySevenLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const sh = sqrtEffectiveHalfDegree(arg, k);
+    if (sh !== undefined) {
+      if (sqrtHalfDegs.length >= 4) return undefined;
+      sqrtHalfDegs.push(sh); continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 37) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 4 || logCount !== 37) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + sqrtHalfDegs[3] + polyDeg;
+}
+
+/** Phase 274 — Five-Sqrt × Thirty-Seven-Log × polynomial numerator.
+ * Caller checks `denDeg > fiveSqrtThirtySevenLogPolyEffectiveDeg(num, k)`.
+ * Completes the Thirty-Seven-Log family (Phases 269–274).
+ */
+function fiveSqrtThirtySevenLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const sh = sqrtEffectiveHalfDegree(arg, k);
+    if (sh !== undefined) {
+      if (sqrtHalfDegs.length >= 5) return undefined;
+      sqrtHalfDegs.push(sh); continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 37) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 5 || logCount !== 37) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + sqrtHalfDegs[3] + sqrtHalfDegs[4] + polyDeg;
+}
+
 /** Phase 251 — Zero-Sqrt × Thirty-Four-Log × polynomial numerator.
  * effectiveDeg = polyDeg (no sqrt factors).
  * Caller checks `denDeg > thirtyFourLogPolyEffectiveDeg(num, k)`.
@@ -7252,6 +7411,66 @@ function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
     const denDegS2l8 = polynomialDegreeInK(den, k);
     if (denDegS2l8 !== undefined) {
       if (denDegS2l8 > s2l8Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 274: five sqrt + 37 logs
+  const s5l37Deg = fiveSqrtThirtySevenLogPolyEffectiveDeg(num, k);
+  if (s5l37Deg !== undefined) {
+    const denDegS5l37 = polynomialDegreeInK(den, k);
+    if (denDegS5l37 !== undefined) {
+      if (denDegS5l37 > s5l37Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 273: four sqrt + 37 logs
+  const s4l37Deg = fourSqrtThirtySevenLogPolyEffectiveDeg(num, k);
+  if (s4l37Deg !== undefined) {
+    const denDegS4l37 = polynomialDegreeInK(den, k);
+    if (denDegS4l37 !== undefined) {
+      if (denDegS4l37 > s4l37Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 272: three sqrt + 37 logs
+  const s3l37Deg = threeSqrtThirtySevenLogPolyEffectiveDeg(num, k);
+  if (s3l37Deg !== undefined) {
+    const denDegS3l37 = polynomialDegreeInK(den, k);
+    if (denDegS3l37 !== undefined) {
+      if (denDegS3l37 > s3l37Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 271: two sqrt + 37 logs
+  const s2l37Deg = twoSqrtThirtySevenLogPolyEffectiveDeg(num, k);
+  if (s2l37Deg !== undefined) {
+    const denDegS2l37 = polynomialDegreeInK(den, k);
+    if (denDegS2l37 !== undefined) {
+      if (denDegS2l37 > s2l37Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 270: one sqrt + 37 logs
+  const s1l37Deg = oneSqrtThirtySevenLogPolyEffectiveDeg(num, k);
+  if (s1l37Deg !== undefined) {
+    const denDegS1l37 = polynomialDegreeInK(den, k);
+    if (denDegS1l37 !== undefined) {
+      if (denDegS1l37 > s1l37Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 269: zero sqrt + 37 logs
+  const s0l37Deg = thirtySevenLogPolyEffectiveDeg(num, k);
+  if (s0l37Deg !== undefined) {
+    const denDegS0l37 = polynomialDegreeInK(den, k);
+    if (denDegS0l37 !== undefined) {
+      if (denDegS0l37 > s0l37Deg) return true;
     } else if (hDivergesAtInfinity(den, k)) {
       return true;
     }

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -15271,8 +15271,8 @@ describe("Phase 167 — Twenty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK167r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1167r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK167r = { kind: "apply" as const, head: DIV, args: [numK167r, k2] };
@@ -15321,8 +15321,8 @@ describe("Phase 168 — One-Sqrt × Twenty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK168r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [k] }, ...logs29k, k] };
     const numKp1168r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [kp1] }, ...logs29kp1, kp1] };
     const gK168r = { kind: "apply" as const, head: DIV, args: [numK168r, k2] };
@@ -15375,8 +15375,8 @@ describe("Phase 169 — Two-Sqrt × Twenty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK169r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -15431,8 +15431,8 @@ describe("Phase 170 — Three-Sqrt × Twenty-Log × polynomial numerator", () =>
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK170r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15487,8 +15487,8 @@ describe("Phase 171 — Four-Sqrt × Twenty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK171r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15543,8 +15543,8 @@ describe("Phase 172 — Five-Sqrt × Twenty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK172r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15595,8 +15595,8 @@ describe("Phase 173 — Twenty-One-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK173r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1173r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK173r = { kind: "apply" as const, head: DIV, args: [numK173r, k2] };
@@ -15645,8 +15645,8 @@ describe("Phase 174 — One-Sqrt × Twenty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK174r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [k] }, ...logs29k, k] };
     const numKp1174r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [kp1] }, ...logs29kp1, kp1] };
     const gK174r = { kind: "apply" as const, head: DIV, args: [numK174r, k2] };
@@ -15699,8 +15699,8 @@ describe("Phase 175 — Two-Sqrt × Twenty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK175r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -15755,8 +15755,8 @@ describe("Phase 176 — Three-Sqrt × Twenty-One-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK176r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15811,8 +15811,8 @@ describe("Phase 177 — Four-Sqrt × Twenty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK177r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15867,8 +15867,8 @@ describe("Phase 178 — Five-Sqrt × Twenty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK178r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15919,8 +15919,8 @@ describe("Phase 179 — Twenty-Two-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK179r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1179r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK179r = { kind: "apply" as const, head: DIV, args: [numK179r, k2] };
@@ -15969,8 +15969,8 @@ describe("Phase 180 — One-Sqrt × Twenty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK180r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [k] }, ...logs29k, k] };
     const numKp1180r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [kp1] }, ...logs29kp1, kp1] };
     const gK180r = { kind: "apply" as const, head: DIV, args: [numK180r, k2] };
@@ -16023,8 +16023,8 @@ describe("Phase 181 — Two-Sqrt × Twenty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK181r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -16079,8 +16079,8 @@ describe("Phase 182 — Three-Sqrt × Twenty-Two-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK182r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16135,8 +16135,8 @@ describe("Phase 183 — Four-Sqrt × Twenty-Two-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK183r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16191,8 +16191,8 @@ describe("Phase 184 — Five-Sqrt × Twenty-Two-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK184r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16243,8 +16243,8 @@ describe("Phase 185 — Twenty-Three-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK185r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1185r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK185r = { kind: "apply" as const, head: DIV, args: [numK185r, k2] };
@@ -16293,8 +16293,8 @@ describe("Phase 186 — One-Sqrt × Twenty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK186r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [k] }, ...logs29k, k] };
     const numKp1186r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [kp1] }, ...logs29kp1, kp1] };
     const gK186r = { kind: "apply" as const, head: DIV, args: [numK186r, k2] };
@@ -16347,8 +16347,8 @@ describe("Phase 187 — Two-Sqrt × Twenty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK187r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -16403,8 +16403,8 @@ describe("Phase 188 — Three-Sqrt × Twenty-Three-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK188r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16459,8 +16459,8 @@ describe("Phase 189 — Four-Sqrt × Twenty-Three-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK189r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16515,8 +16515,8 @@ describe("Phase 190 — Five-Sqrt × Twenty-Three-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK190r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16567,8 +16567,8 @@ describe("Phase 191 — Twenty-Four-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK191r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1191r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK191r = { kind: "apply" as const, head: DIV, args: [numK191r, k2] };
@@ -16621,8 +16621,8 @@ describe("Phase 192 — One-Sqrt × Twenty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK192r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs29k, k] };
@@ -16677,8 +16677,8 @@ describe("Phase 193 — Two-Sqrt × Twenty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK193r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -16733,8 +16733,8 @@ describe("Phase 194 — Three-Sqrt × Twenty-Four-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK194r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16789,8 +16789,8 @@ describe("Phase 195 — Four-Sqrt × Twenty-Four-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK195r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16845,8 +16845,8 @@ describe("Phase 196 — Five-Sqrt × Twenty-Four-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK196r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16897,8 +16897,8 @@ describe("Phase 197 — Twenty-Five-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK197r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1197r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK197r = { kind: "apply" as const, head: DIV, args: [numK197r, k2] };
@@ -16951,8 +16951,8 @@ describe("Phase 198 — One-Sqrt × Twenty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK198r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs29k, k] };
@@ -17007,8 +17007,8 @@ describe("Phase 199 — Two-Sqrt × Twenty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK199r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -17063,8 +17063,8 @@ describe("Phase 200 — Three-Sqrt × Twenty-Five-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK200r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17119,8 +17119,8 @@ describe("Phase 201 — Four-Sqrt × Twenty-Five-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK201r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17175,8 +17175,8 @@ describe("Phase 202 — Five-Sqrt × Twenty-Five-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK202r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17227,8 +17227,8 @@ describe("Phase 203 — Twenty-Six-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK203r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1203r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK203r = { kind: "apply" as const, head: DIV, args: [numK203r, k2] };
@@ -17279,8 +17279,8 @@ describe("Phase 204 — One-Sqrt × Twenty-Six-Log × polynomial numerator", () 
   it("√k·log(k)²⁹·k/k² refused (30 logs — not Phase 204)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK204r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs29k, k] };
@@ -17333,8 +17333,8 @@ describe("Phase 205 — Two-Sqrt × Twenty-Six-Log × polynomial numerator", () 
   it("√k·√k·log(k)²⁹/k² refused (30 logs — not Phase 205)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK205r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k, k] };
@@ -17387,8 +17387,8 @@ describe("Phase 206 — Three-Sqrt × Twenty-Six-Log × polynomial numerator", (
   it("(√k)³·log(k)²⁹/k² refused (30 logs — not Phase 206)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK206r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k, k] };
@@ -17443,8 +17443,8 @@ describe("Phase 207 — Four-Sqrt × Twenty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK207r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k, k] };
@@ -17499,8 +17499,8 @@ describe("Phase 208 — Five-Sqrt × Twenty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK208r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17551,8 +17551,8 @@ describe("Phase 209 — Zero-Sqrt × Twenty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK209r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1209r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK209r = { kind: "apply" as const, head: DIV, args: [numK209r, k2] };
@@ -17603,8 +17603,8 @@ describe("Phase 210 — One-Sqrt × Twenty-Seven-Log × polynomial numerator", (
   it("√k·log(k)²⁹·k/k² refused (30 logs — not Phase 210)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK210r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs29k, k] };
@@ -17659,8 +17659,8 @@ describe("Phase 211 — Two-Sqrt × Twenty-Seven-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK211r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -17715,8 +17715,8 @@ describe("Phase 212 — Three-Sqrt × Twenty-Seven-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK212r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17771,8 +17771,8 @@ describe("Phase 213 — Four-Sqrt × Twenty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK213r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17827,8 +17827,8 @@ describe("Phase 214 — Five-Sqrt × Twenty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK214r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17879,8 +17879,8 @@ describe("Phase 215 — Zero-Sqrt × Twenty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK215r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1215r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK215r = { kind: "apply" as const, head: DIV, args: [numK215r, k2] };
@@ -17933,8 +17933,8 @@ describe("Phase 216 — One-Sqrt × Twenty-Eight-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK216r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs29k, k] };
@@ -17989,8 +17989,8 @@ describe("Phase 217 — Two-Sqrt × Twenty-Eight-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK217r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -18045,8 +18045,8 @@ describe("Phase 218 — Three-Sqrt × Twenty-Eight-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK218r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -18101,8 +18101,8 @@ describe("Phase 219 — Four-Sqrt × Twenty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK219r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -18157,8 +18157,8 @@ describe("Phase 220 — Five-Sqrt × Twenty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK220r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -18209,8 +18209,8 @@ describe("Phase 221 — Zero-Sqrt × Twenty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK221r = { kind: "apply" as const, head: MUL, args: [...logs30k, k] };
     const numKp1221r = { kind: "apply" as const, head: MUL, args: [...logs30kp1, kp1] };
     const gK221r = { kind: "apply" as const, head: DIV, args: [numK221r, k2] };
@@ -18263,8 +18263,8 @@ describe("Phase 222 — One-Sqrt × Twenty-Nine-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK222r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs30k, k] };
@@ -18319,8 +18319,8 @@ describe("Phase 223 — Two-Sqrt × Twenty-Nine-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK223r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs30k, k] };
@@ -18375,8 +18375,8 @@ describe("Phase 224 — Three-Sqrt × Twenty-Nine-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK224r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs30k, k] };
@@ -18431,8 +18431,8 @@ describe("Phase 225 — Four-Sqrt × Twenty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK225r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs30k, k] };
@@ -18487,8 +18487,8 @@ describe("Phase 226 — Five-Sqrt × Twenty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK226r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs30k, k] };
@@ -18539,8 +18539,8 @@ describe("Phase 227 — Zero-Sqrt × Thirty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK227r = { kind: "apply" as const, head: MUL, args: [...logs31k, k] };
     const numKp1227r = { kind: "apply" as const, head: MUL, args: [...logs31kp1, kp1] };
     const gK227r = { kind: "apply" as const, head: DIV, args: [numK227r, k2] };
@@ -18593,8 +18593,8 @@ describe("Phase 228 — One-Sqrt × Thirty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK228r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs31k, k] };
@@ -18649,8 +18649,8 @@ describe("Phase 229 — Two-Sqrt × Thirty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK229r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs31k, k] };
@@ -18705,8 +18705,8 @@ describe("Phase 230 — Three-Sqrt × Thirty-Log × polynomial numerator", () =>
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK230r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs31k, k] };
@@ -18761,8 +18761,8 @@ describe("Phase 231 — Four-Sqrt × Thirty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK231r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs31k, k] };
@@ -18817,8 +18817,8 @@ describe("Phase 232 — Five-Sqrt × Thirty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK232r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs31k, k] };
@@ -18869,8 +18869,8 @@ describe("Phase 233 — Zero-Sqrt × Thirty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK233r = { kind: "apply" as const, head: MUL, args: [...logs32k, k] };
     const numKp1233r = { kind: "apply" as const, head: MUL, args: [...logs32kp1, kp1] };
     const gK233r = { kind: "apply" as const, head: DIV, args: [numK233r, k2] };
@@ -18923,8 +18923,8 @@ describe("Phase 234 — One-Sqrt × Thirty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK234r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs32k, k] };
@@ -18979,8 +18979,8 @@ describe("Phase 235 — Two-Sqrt × Thirty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK235r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs32k, k] };
@@ -19035,8 +19035,8 @@ describe("Phase 236 — Three-Sqrt × Thirty-One-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK236r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs32k, k] };
@@ -19091,8 +19091,8 @@ describe("Phase 237 — Four-Sqrt × Thirty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK237r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs32k, k] };
@@ -19147,8 +19147,8 @@ describe("Phase 238 — Five-Sqrt × Thirty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK238r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs32k, k] };
@@ -19199,8 +19199,8 @@ describe("Phase 239 — Thirty-Two-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs33k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK239r = { kind: "apply" as const, head: MUL, args: [...logs33k, k] };
     const numKp1239r = { kind: "apply" as const, head: MUL, args: [...logs33kp1, kp1] };
     const gK239r = { kind: "apply" as const, head: DIV, args: [numK239r, k2] };
@@ -19249,8 +19249,8 @@ describe("Phase 240 — One-Sqrt × Thirty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs33k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK240r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [k] }, ...logs33k, k] };
     const numKp1240r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [kp1] }, ...logs33kp1, kp1] };
     const gK240r = { kind: "apply" as const, head: DIV, args: [numK240r, k2] };
@@ -19303,8 +19303,8 @@ describe("Phase 241 — Two-Sqrt × Thirty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs33k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK241r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs33k] };
@@ -19359,8 +19359,8 @@ describe("Phase 242 — Three-Sqrt × Thirty-Two-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs33k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK242r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs33k] };
@@ -19415,8 +19415,8 @@ describe("Phase 243 — Four-Sqrt × Thirty-Two-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs33k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK243r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs33k, k] };
@@ -19471,8 +19471,8 @@ describe("Phase 244 — Five-Sqrt × Thirty-Two-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs33k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK244r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs33k, k] };
@@ -19523,8 +19523,8 @@ describe("Phase 245 — Thirty-Three-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs34k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK245r = { kind: "apply" as const, head: MUL, args: [...logs34k, k] };
     const numKp1245r = { kind: "apply" as const, head: MUL, args: [...logs34kp1, kp1] };
     const gK245r = { kind: "apply" as const, head: DIV, args: [numK245r, k2] };
@@ -19577,8 +19577,8 @@ describe("Phase 246 — One-Sqrt × Thirty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs34k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK246r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs34k, k] };
@@ -19633,8 +19633,8 @@ describe("Phase 247 — Two-Sqrt × Thirty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs34k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK247r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs34k] };
@@ -19689,8 +19689,8 @@ describe("Phase 248 — Three-Sqrt × Thirty-Three-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs34k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK248r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs34k] };
@@ -19745,8 +19745,8 @@ describe("Phase 249 — Four-Sqrt × Thirty-Three-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs34k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK249r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs34k] };
@@ -19801,8 +19801,8 @@ describe("Phase 250 — Five-Sqrt × Thirty-Three-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs34k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK250r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs34k, k] };
@@ -19853,8 +19853,8 @@ describe("Phase 251 — Thirty-Four-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs36k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK251r = { kind: "apply" as const, head: MUL, args: [...logs36k, k] };
     const numKp1251r = { kind: "apply" as const, head: MUL, args: [...logs36kp1, kp1] };
     const gK251r = { kind: "apply" as const, head: DIV, args: [numK251r, k2] };
@@ -19907,8 +19907,8 @@ describe("Phase 252 — One-Sqrt × Thirty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs36k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK252r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs36k, k] };
@@ -19963,8 +19963,8 @@ describe("Phase 253 — Two-Sqrt × Thirty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs36k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK253r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs36k] };
@@ -20019,8 +20019,8 @@ describe("Phase 254 — Three-Sqrt × Thirty-Four-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs36k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK254r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs36k] };
@@ -20075,8 +20075,8 @@ describe("Phase 255 — Four-Sqrt × Thirty-Four-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs36k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK255r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs36k] };
@@ -20131,8 +20131,8 @@ describe("Phase 256 — Five-Sqrt × Thirty-Four-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK256r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs36k, k] };
@@ -20183,8 +20183,8 @@ describe("Phase 257 — Thirty-Five-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK257r = { kind: "apply" as const, head: MUL, args: [...logs36k, k] };
     const numKp1257r = { kind: "apply" as const, head: MUL, args: [...logs36kp1, kp1] };
     const gK257r = { kind: "apply" as const, head: DIV, args: [numK257r, k2] };
@@ -20237,8 +20237,8 @@ describe("Phase 258 — One-Sqrt × Thirty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK258r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs36k, k] };
@@ -20293,8 +20293,8 @@ describe("Phase 259 — Two-Sqrt × Thirty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK259r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs36k, k] };
@@ -20349,8 +20349,8 @@ describe("Phase 260 — Three-Sqrt × Thirty-Five-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK260r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs36k, k] };
@@ -20405,8 +20405,8 @@ describe("Phase 261 — Four-Sqrt × Thirty-Five-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK261r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs36k, k] };
@@ -20461,8 +20461,8 @@ describe("Phase 262 — Five-Sqrt × Thirty-Five-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK262r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs36k, k] };
@@ -20513,8 +20513,8 @@ describe("Phase 263 — Zero-Sqrt × Thirty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK263r = { kind: "apply" as const, head: MUL, args: [...logs37k, k] };
     const numKp1263r = { kind: "apply" as const, head: MUL, args: [...logs37kp1, kp1] };
     const gK263r = { kind: "apply" as const, head: DIV, args: [numK263r, k2] };
@@ -20567,8 +20567,8 @@ describe("Phase 264 — One-Sqrt × Thirty-Six-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK264r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs37k, k] };
@@ -20623,8 +20623,8 @@ describe("Phase 265 — Two-Sqrt × Thirty-Six-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK265r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs37k] };
@@ -20679,8 +20679,8 @@ describe("Phase 266 — Three-Sqrt × Thirty-Six-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK266r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs37k] };
@@ -20735,8 +20735,8 @@ describe("Phase 267 — Four-Sqrt × Thirty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK267r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs37k, k] };
@@ -20791,8 +20791,8 @@ describe("Phase 268 — Five-Sqrt × Thirty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK268r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs37k, k] };
@@ -20801,6 +20801,336 @@ describe("Phase 268 — Five-Sqrt × Thirty-Six-Log × polynomial numerator", ()
     const gKp1268r = { kind: "apply" as const, head: DIV, args: [numKp1268r, kp1_2] };
     const f268r = { kind: "apply" as const, head: SUB, args: [gK268r, gKp1268r] };
     const result = evaluateSum(f268r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 269 — Zero-Sqrt × Thirty-Seven-Log × polynomial numerator", () => {
+  it("log(k)³⁷/k² closes (polyDeg=0 → effective=0; denDeg=2 > 0)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const logs37k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const numK269a = { kind: "apply" as const, head: MUL, args: [...logs37k] };
+    const numKp1269a = { kind: "apply" as const, head: MUL, args: [...logs37kp1] };
+    const gK269a = { kind: "apply" as const, head: DIV, args: [numK269a, k2] };
+    const gKp1269a = { kind: "apply" as const, head: DIV, args: [numKp1269a, kp1_2] };
+    const f269a = { kind: "apply" as const, head: SUB, args: [gK269a, gKp1269a] };
+    const result = evaluateSum(f269a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("log(k)³⁷·k/k² closes (polyDeg=1 → effective=1; denDeg=2 > 1)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const logs37k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const numK269b = { kind: "apply" as const, head: MUL, args: [...logs37k, k] };
+    const numKp1269b = { kind: "apply" as const, head: MUL, args: [...logs37kp1, kp1] };
+    const gK269b = { kind: "apply" as const, head: DIV, args: [numK269b, k2] };
+    const gKp1269b = { kind: "apply" as const, head: DIV, args: [numKp1269b, kp1_2] };
+    const f269b = { kind: "apply" as const, head: SUB, args: [gK269b, gKp1269b] };
+    const result = evaluateSum(f269b, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("log(k)³⁸·k/k² refused (38 logs — not Phase 269)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs38k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const numK269r = { kind: "apply" as const, head: MUL, args: [...logs38k, k] };
+    const numKp1269r = { kind: "apply" as const, head: MUL, args: [...logs38kp1, kp1] };
+    const gK269r = { kind: "apply" as const, head: DIV, args: [numK269r, k2] };
+    const gKp1269r = { kind: "apply" as const, head: DIV, args: [numKp1269r, kp1_2] };
+    const f269r = { kind: "apply" as const, head: SUB, args: [gK269r, gKp1269r] };
+    const result = evaluateSum(f269r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 270 — One-Sqrt × Thirty-Seven-Log × polynomial numerator", () => {
+  it("√k·log(k)³⁷/k² closes (sqrtHalf=0.5, polyDeg=0 → effective=0.5; denDeg=2 > 0.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const logs37k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK270a = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs37k] };
+    const numKp1270a = { kind: "apply" as const, head: MUL, args: [sqrtKp1, ...logs37kp1] };
+    const gK270a = { kind: "apply" as const, head: DIV, args: [numK270a, k2] };
+    const gKp1270a = { kind: "apply" as const, head: DIV, args: [numKp1270a, kp1_2] };
+    const f270a = { kind: "apply" as const, head: SUB, args: [gK270a, gKp1270a] };
+    const result = evaluateSum(f270a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("√k·log(k)³⁷·k/k² closes (sqrtHalf=0.5, polyDeg=1 → effective=1.5; denDeg=2 > 1.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const logs37k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK270b = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs37k, k] };
+    const numKp1270b = { kind: "apply" as const, head: MUL, args: [sqrtKp1, ...logs37kp1, kp1] };
+    const gK270b = { kind: "apply" as const, head: DIV, args: [numK270b, k2] };
+    const gKp1270b = { kind: "apply" as const, head: DIV, args: [numKp1270b, kp1_2] };
+    const f270b = { kind: "apply" as const, head: SUB, args: [gK270b, gKp1270b] };
+    const result = evaluateSum(f270b, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("√k·log(k)³⁸·k/k² refused (38 logs — not Phase 270)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs38k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK270r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs38k, k] };
+    const numKp1270r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, ...logs38kp1, kp1] };
+    const gK270r = { kind: "apply" as const, head: DIV, args: [numK270r, k2] };
+    const gKp1270r = { kind: "apply" as const, head: DIV, args: [numKp1270r, kp1_2] };
+    const f270r = { kind: "apply" as const, head: SUB, args: [gK270r, gKp1270r] };
+    const result = evaluateSum(f270r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 271 — Two-Sqrt × Thirty-Seven-Log × polynomial numerator", () => {
+  it("(√k)²·log(k)³⁷/k² closes (sqrtHalf=1, polyDeg=0 → effective=1; denDeg=2 > 1)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const logs37k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK271a = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs37k] };
+    const numKp1271a = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, ...logs37kp1] };
+    const gK271a = { kind: "apply" as const, head: DIV, args: [numK271a, k2] };
+    const gKp1271a = { kind: "apply" as const, head: DIV, args: [numKp1271a, kp1_2] };
+    const f271a = { kind: "apply" as const, head: SUB, args: [gK271a, gKp1271a] };
+    const result = evaluateSum(f271a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("(√k)²·log(k)³⁷·k/k³ closes (sqrtHalf=1, polyDeg=1 → effective=2; denDeg=3 > 2)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const logs37k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK271b = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs37k, k] };
+    const numKp1271b = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, ...logs37kp1, kp1] };
+    const gK271b = { kind: "apply" as const, head: DIV, args: [numK271b, k3] };
+    const gKp1271b = { kind: "apply" as const, head: DIV, args: [numKp1271b, kp1_3] };
+    const f271b = { kind: "apply" as const, head: SUB, args: [gK271b, gKp1271b] };
+    const result = evaluateSum(f271b, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("(√k)²·log(k)³⁸·k/k² refused (38 logs — not Phase 271)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs38k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK271r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs38k, k] };
+    const numKp1271r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, ...logs38kp1, kp1] };
+    const gK271r = { kind: "apply" as const, head: DIV, args: [numK271r, k2] };
+    const gKp1271r = { kind: "apply" as const, head: DIV, args: [numKp1271r, kp1_2] };
+    const f271r = { kind: "apply" as const, head: SUB, args: [gK271r, gKp1271r] };
+    const result = evaluateSum(f271r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 272 — Three-Sqrt × Thirty-Seven-Log × polynomial numerator", () => {
+  it("(√k)³·log(k)³⁷/k² closes (sqrtHalf=1.5, polyDeg=0 → effective=1.5; denDeg=2 > 1.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const logs37k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK272a = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs37k] };
+    const numKp1272a = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, ...logs37kp1] };
+    const gK272a = { kind: "apply" as const, head: DIV, args: [numK272a, k2] };
+    const gKp1272a = { kind: "apply" as const, head: DIV, args: [numKp1272a, kp1_2] };
+    const f272a = { kind: "apply" as const, head: SUB, args: [gK272a, gKp1272a] };
+    const result = evaluateSum(f272a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("(√k)³·log(k)³⁷·k/k³ closes (sqrtHalf=1.5, polyDeg=1 → effective=2.5; denDeg=3 > 2.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const logs37k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK272b = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs37k, k] };
+    const numKp1272b = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, ...logs37kp1, kp1] };
+    const gK272b = { kind: "apply" as const, head: DIV, args: [numK272b, k3] };
+    const gKp1272b = { kind: "apply" as const, head: DIV, args: [numKp1272b, kp1_3] };
+    const f272b = { kind: "apply" as const, head: SUB, args: [gK272b, gKp1272b] };
+    const result = evaluateSum(f272b, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("(√k)³·log(k)³⁸·k/k² refused (38 logs — not Phase 272)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs38k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK272r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs38k, k] };
+    const numKp1272r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, ...logs38kp1, kp1] };
+    const gK272r = { kind: "apply" as const, head: DIV, args: [numK272r, k2] };
+    const gKp1272r = { kind: "apply" as const, head: DIV, args: [numKp1272r, kp1_2] };
+    const f272r = { kind: "apply" as const, head: SUB, args: [gK272r, gKp1272r] };
+    const result = evaluateSum(f272r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 273 — Four-Sqrt × Thirty-Seven-Log × polynomial numerator", () => {
+  it("(√k)⁴·log(k)³⁷/k³ closes (sqrtHalf=2, polyDeg=0 → effective=2; denDeg=3 > 2)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const logs37k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK273a = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs37k] };
+    const numKp1273a = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, ...logs37kp1] };
+    const gK273a = { kind: "apply" as const, head: DIV, args: [numK273a, k3] };
+    const gKp1273a = { kind: "apply" as const, head: DIV, args: [numKp1273a, kp1_3] };
+    const f273a = { kind: "apply" as const, head: SUB, args: [gK273a, gKp1273a] };
+    const result = evaluateSum(f273a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("(√k)⁴·log(k)³⁷·k/k⁴ closes (sqrtHalf=2, polyDeg=1 → effective=3; denDeg=4 > 3)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k4 = { kind: "apply" as const, head: POW, args: [k, int(4)] };
+    const kp1_4 = { kind: "apply" as const, head: POW, args: [kp1, int(4)] };
+    const logs37k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK273b = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs37k, k] };
+    const numKp1273b = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, ...logs37kp1, kp1] };
+    const gK273b = { kind: "apply" as const, head: DIV, args: [numK273b, k4] };
+    const gKp1273b = { kind: "apply" as const, head: DIV, args: [numKp1273b, kp1_4] };
+    const f273b = { kind: "apply" as const, head: SUB, args: [gK273b, gKp1273b] };
+    const result = evaluateSum(f273b, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("(√k)⁴·log(k)³⁸·k/k² refused (38 logs — not Phase 273)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs38k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK273r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs38k, k] };
+    const numKp1273r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, ...logs38kp1, kp1] };
+    const gK273r = { kind: "apply" as const, head: DIV, args: [numK273r, k2] };
+    const gKp1273r = { kind: "apply" as const, head: DIV, args: [numKp1273r, kp1_2] };
+    const f273r = { kind: "apply" as const, head: SUB, args: [gK273r, gKp1273r] };
+    const result = evaluateSum(f273r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 274 — Five-Sqrt × Thirty-Seven-Log × polynomial numerator", () => {
+  it("(√k)^5·log(k)³⁷/k³ closes (sqrtHalf=2.5, polyDeg=0 → effective=2.5; denDeg=3 > 2.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const logs37k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK274a = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs37k] };
+    const numKp1274a = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, ...logs37kp1] };
+    const gK274a = { kind: "apply" as const, head: DIV, args: [numK274a, k3] };
+    const gKp1274a = { kind: "apply" as const, head: DIV, args: [numKp1274a, kp1_3] };
+    const f274a = { kind: "apply" as const, head: SUB, args: [gK274a, gKp1274a] };
+    const result = evaluateSum(f274a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("(√k)^5·log(k)³⁷·k/k4 closes (sqrtHalf=2.5, polyDeg=1 → effective=3.5; denDeg=4 > 3.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k4 = { kind: "apply" as const, head: POW, args: [k, int(4)] };
+    const kp1_4 = { kind: "apply" as const, head: POW, args: [kp1, int(4)] };
+    const logs37k = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 37 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK274b = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs37k, k] };
+    const numKp1274b = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, ...logs37kp1, kp1] };
+    const gK274b = { kind: "apply" as const, head: DIV, args: [numK274b, k4] };
+    const gKp1274b = { kind: "apply" as const, head: DIV, args: [numKp1274b, kp1_4] };
+    const f274b = { kind: "apply" as const, head: SUB, args: [gK274b, gKp1274b] };
+    const result = evaluateSum(f274b, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("(√k)^5·log(k)³⁸·k/k² refused (38 logs — not Phase 274)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs38k = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 38 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK274r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs38k, k] };
+    const numKp1274r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, ...logs38kp1, kp1] };
+    const gK274r = { kind: "apply" as const, head: DIV, args: [numK274r, k2] };
+    const gKp1274r = { kind: "apply" as const, head: DIV, args: [numKp1274r, kp1_2] };
+    const f274r = { kind: "apply" as const, head: SUB, args: [gK274r, gKp1274r] };
+    const result = evaluateSum(f274r, k, int(1), sym("%inf"), evalNode);
     expect(result).toMatchObject({ kind: "apply", head: SUM });
   });
 });

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -3690,3 +3690,106 @@ describe("Phase 84 — One-Sqrt × Six-Log × polynomial numerator", () => {
     expect(result).toMatchObject({ kind: "apply", head: SUM });
   });
 });
+
+describe("Phase 85 — Two-Sqrt × Six-Log × polynomial numerator", () => {
+  it("√k·√k·log(k)⁶/k² closes (sqrtHalf1=0.5, sqrtHalf2=0.5, polyDeg=0 → effective=1; denDeg=2 > 1)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const numK85a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+    ]};
+    const numKp185a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+    ]};
+    const gK85a = { kind: "apply" as const, head: DIV, args: [numK85a, k2] };
+    const gKp185a = { kind: "apply" as const, head: DIV, args: [numKp185a, kp1_2] };
+    const f85a = { kind: "apply" as const, head: SUB, args: [gK85a, gKp185a] };
+    const result = evaluateSum(f85a, k, int(1), sym("%inf"), evalNode);
+    // sqrtHalf1=0.5, sqrtHalf2=0.5, polyDeg=0 → effective=1; denDeg=2 > 1 → closes
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("√(k³)·√(k³)·log(k)⁶/k refused (sqrtHalf1=1.5, sqrtHalf2=1.5 → effective=3; denDeg=1 not > 3)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const numK85b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k3] },
+      { kind: "apply" as const, head: SQRT, args: [k3] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+    ]};
+    const numKp185b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1_3] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_3] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+    ]};
+    const gK85b = { kind: "apply" as const, head: DIV, args: [numK85b, k] };
+    const gKp185b = { kind: "apply" as const, head: DIV, args: [numKp185b, kp1] };
+    const f85b = { kind: "apply" as const, head: SUB, args: [gK85b, gKp185b] };
+    const result = evaluateSum(f85b, k, int(1), sym("%inf"), evalNode);
+    // sqrtHalf1=1.5, sqrtHalf2=1.5 → effective=3; denDeg=1 not > 3 → refused
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("√k·√k·log(k)⁶·k/k² refused (sqrtHalf1=0.5, sqrtHalf2=0.5, polyDeg=1 → effective=2; denDeg=2 not > 2)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const numK85c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      k,
+    ]};
+    const numKp185c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      kp1,
+    ]};
+    const gK85c = { kind: "apply" as const, head: DIV, args: [numK85c, k2] };
+    const gKp185c = { kind: "apply" as const, head: DIV, args: [numKp185c, kp1_2] };
+    const f85c = { kind: "apply" as const, head: SUB, args: [gK85c, gKp185c] };
+    const result = evaluateSum(f85c, k, int(1), sym("%inf"), evalNode);
+    // sqrtHalf1=0.5, sqrtHalf2=0.5, polyDeg=1 → effective=2; denDeg=2 not > 2 → refused
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});

--- a/code/programs/typescript/checklist-app/package-lock.json
+++ b/code/programs/typescript/checklist-app/package-lock.json
@@ -5941,9 +5941,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -6385,9 +6385,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -6405,7 +6405,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -7551,9 +7551,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
+      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/code/programs/typescript/engram-electron/package-lock.json
+++ b/code/programs/typescript/engram-electron/package-lock.json
@@ -12959,7 +12959,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
+      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/code/programs/typescript/journal-app/package-lock.json
+++ b/code/programs/typescript/journal-app/package-lock.json
@@ -5988,9 +5988,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -6419,9 +6419,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -6439,7 +6439,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -7521,9 +7521,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
+      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/code/programs/typescript/todo-app/package-lock.json
+++ b/code/programs/typescript/todo-app/package-lock.json
@@ -5599,9 +5599,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -5609,6 +5609,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -6039,9 +6040,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -6059,7 +6060,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -7053,10 +7054,11 @@
       "dev": true
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
+      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=14.14"
       }

--- a/code/specs/IC08-image-codec-ico.md
+++ b/code/specs/IC08-image-codec-ico.md
@@ -1,0 +1,333 @@
+# IC08 — ICO / CUR Image Codec
+
+**Specification version**: 0.1  
+**Status**: Draft  
+**Depends on**: IC00 (pixel-container), IC01 (image-codec-bmp)  
+**Implements**: Windows ICO and CUR file formats (Microsoft MSDN specification)
+
+---
+
+## 1. Overview
+
+The ICO format is a container for one or more Windows icon images at different
+sizes and color depths. A single `.ico` file can contain a 16×16 icon, a 32×32
+icon, a 256×256 icon, and so on — the operating system picks the best size for
+the rendering context. CUR files use the same structure but hold cursor images
+with a "hot-spot" coordinate instead of reserved bytes.
+
+**Key properties**:
+
+- **Container**: flat header + directory array + image data blobs
+- **Image encoding**: each frame is either a **BMP DIB** (Device-Independent
+  Bitmap, without the 14-byte BITMAPFILEHEADER) or a **PNG** (full PNG file,
+  detected by the `\x89PNG` magic bytes)
+- **Color depths**: 1, 4, 8, 24, or 32 bits per pixel
+- **AND mask**: 1-bpp mask stored after BMP pixel data for transparency (for
+  non-32bpp images); 32bpp images embed alpha in the BGRA pixels directly
+- **Royalty-free**: the format is fully documented in MSDN and has no patents
+- **Max dimensions**: 256×256 per image; coordinates stored as 1-byte values
+  (0 means 256)
+- **Max images per file**: 65535 (u16 count field)
+
+---
+
+## 2. File Structure
+
+```
+ICO file layout
+───────────────
+Offset  Size  Field
+0       2     reserved — always 0
+2       2     type — 1 for ICO, 2 for CUR
+4       2     count — number of images in the file
+
+For each image i in 0..count:
+  (6 + i*16) + 0   1   width  (pixels; 0 means 256)
+  (6 + i*16) + 1   1   height (pixels; 0 means 256)
+  (6 + i*16) + 2   1   color_count (palette size; 0 if truecolor or PNG)
+  (6 + i*16) + 3   1   reserved (0 for ICO; hotspot X for CUR)
+  (6 + i*16) + 4   2   planes (ICO: 1; CUR: hotspot X low word)
+  (6 + i*16) + 6   2   bit_count (bits per pixel; 0 for PNG frames)
+  (6 + i*16) + 8   4   bytes_in_res — byte length of the image data
+  (6 + i*16) + 12  4   image_offset — byte offset from start of file
+
+After the directory, at each image_offset:
+  Either:
+    \x89PNG\r\n\x1a\n …  → full PNG file (libjxl, macOS, etc. use this for 256×256)
+  Or:
+    BITMAPINFOHEADER (40 bytes)
+    [palette: color_count * 4 bytes, RGBQUAD]
+    [XOR pixel data: row-padded to 4-byte boundaries]
+    [AND mask: 1bpp, same row-padding]
+```
+
+### 2.1 CUR vs ICO differences
+
+The only structural difference between ICO and CUR is the `type` field (1 vs 2)
+and the interpretation of bytes 4–5 in each directory entry:
+
+| Field     | ICO         | CUR                        |
+|-----------|-------------|----------------------------|
+| type      | 1           | 2                          |
+| planes(4) | 1 (planes)  | hotspot_x (cursor hot-spot) |
+| bit_count | bpp         | hotspot_y                  |
+
+This codec decodes both ICO and CUR, treating the hot-spot fields as opaque.
+
+---
+
+## 3. BMP DIB Image Data
+
+When the image data is **not** a PNG (first 8 bytes ≠ `\x89PNG\r\n\x1a\n`), it
+is a BMP **DIB** — a `BITMAPINFOHEADER` directly, without the 14-byte
+`BITMAPFILEHEADER` prefix that a `.bmp` file would have.
+
+### 3.1 BITMAPINFOHEADER (40 bytes)
+
+```
+biSize:          u32LE   = 40
+biWidth:         i32LE   (image width in pixels)
+biHeight:        i32LE   (2 × image height; positive means bottom-up row order)
+biPlanes:        u16LE   = 1
+biBitCount:      u16LE   (bits per pixel: 1, 4, 8, 24, or 32)
+biCompression:   u32LE   = 0 (BI_RGB — uncompressed)
+biSizeImage:     u32LE   (can be 0 for BI_RGB)
+biXPelsPerMeter: i32LE   (ignored)
+biYPelsPerMeter: i32LE   (ignored)
+biClrUsed:       u32LE   (palette entries; 0 means 2^biBitCount for ≤8bpp)
+biClrImportant:  u32LE   (ignored)
+```
+
+**Height encoding**: ICO stores `biHeight = 2 × pixel_height` because the DIB
+contains both the XOR mask (color data) and the AND mask (1bpp transparency),
+each of height `pixel_height`. The actual image height is `biHeight / 2`.
+
+### 3.2 Palette (for 1, 4, 8 bpp images)
+
+After the BITMAPINFOHEADER, a color palette follows:
+
+```
+palette_count = biClrUsed if biClrUsed > 0 else (1 << biBitCount)
+For each entry (RGBQUAD, 4 bytes each):
+  blue:     u8
+  green:    u8
+  red:      u8
+  reserved: u8 (always 0)
+```
+
+### 3.3 XOR Pixel Data (color image)
+
+Row-major order, **bottom row first** (bottom-up). Each row is padded to a
+4-byte boundary.
+
+Row stride (bytes) = `((width * biBitCount + 31) / 32) * 4`
+
+| biBitCount | Pixel encoding |
+|------------|---------------|
+| 1          | 1 bit per pixel; 8 pixels per byte, MSB first |
+| 4          | 4 bits per pixel; 2 pixels per byte, high nibble first |
+| 8          | 1 byte per pixel (palette index) |
+| 24         | 3 bytes: Blue, Green, Red |
+| 32         | 4 bytes: Blue, Green, Red, Alpha (pre-multiplied or straight alpha) |
+
+### 3.4 AND Mask (1 bpp transparency mask)
+
+After the XOR data, a 1bpp AND mask follows. Each bit corresponds to one pixel:
+- `0` = opaque (show XOR pixel)
+- `1` = transparent (show whatever is behind the icon)
+
+Row stride = `((width + 31) / 32) * 4`
+
+For 32bpp images, the AND mask **may** be all zeros (alpha channel in the BGRA
+data is the authoritative transparency source). Decoders should use alpha=0 for
+any pixel where the AND mask bit is 1.
+
+### 3.5 Compositing rule
+
+```
+final_pixel = if and_mask_bit == 1:
+  transparent (alpha = 0)
+elif biBitCount == 32:
+  BGRA alpha channel in XOR data
+else:
+  fully opaque (alpha = 255)
+```
+
+---
+
+## 4. PNG Image Data
+
+When the first 8 bytes of the image data are `\x89PNG\r\n\x1a\n`, the entire
+`bytes_in_res` block is a complete, self-contained PNG file. This is the
+dominant encoding for 256×256 Vista-style icons.
+
+Decode it via the `png` or `paint-codec-png` crate (already in the workspace).
+
+---
+
+## 5. Encoding (encode_ico)
+
+For Phase 1, the encoder writes a single-image ICO from a `PixelContainer`:
+
+```
+1. Compute effective dimensions (min(width,255), min(height,255))
+   — clamp to 255 because the directory byte field wraps 256→0
+2. Build a 32bpp BGRA BMP DIB:
+   a. BITMAPINFOHEADER with biHeight = 2 * height (XOR + AND)
+   b. XOR pixel data — rows bottom-up, 4-byte padded
+   c. AND mask — all zeros (alpha from BGRA)
+3. Write ICO file:
+   a. Header: reserved=0, type=1, count=1
+   b. Directory entry: width, height, colorCount=0, reserved=0,
+      planes=1, bitCount=32, bytesInRes, imageOffset=22
+   c. BMP DIB data
+```
+
+Encoding uses 32bpp BGRA with an all-zero AND mask. This gives full RGBA
+fidelity and is understood by all modern Windows / macOS / Linux icon renderers.
+
+---
+
+## 6. Decoding (decode_ico)
+
+```
+1. Check header: reserved==0, type==1 or 2, count >= 1.
+2. Read directory entries.
+3. Choose the best image:
+   a. Prefer the largest dimensions (max width × height).
+   b. Among equal sizes, prefer 32bpp BMP or PNG over lower bit depths.
+4. Seek to image_offset.
+5. If first 8 bytes == PNG magic → decode with png crate.
+6. Else → decode BMP DIB:
+   a. Parse BITMAPINFOHEADER.
+   b. Read palette (if biBitCount ≤ 8).
+   c. Read XOR rows (bottom-up → flip to top-down).
+   d. Read AND mask rows.
+   e. Convert to RGBA: apply palette, apply AND mask for transparency.
+7. Return PixelContainer.
+```
+
+---
+
+## 7. Error Cases
+
+| Condition | Error message |
+|-----------|--------------|
+| File shorter than 6 bytes | `"ICO: file too short"` |
+| `reserved != 0` | `"ICO: invalid reserved field (expected 0)"` |
+| `type != 1 && type != 2` | `"ICO: unknown type {t} (expected 1=ICO or 2=CUR)"` |
+| `count == 0` | `"ICO: no images in file"` |
+| Image offset + size exceeds file | `"ICO: image data extends past end of file"` |
+| BMP compression != 0 | `"ICO: compressed BMP DIB not supported"` |
+| BMP biSize != 40 | `"ICO: unsupported BITMAPINFOHEADER size {n}"` |
+| biBitCount not in {1,4,8,24,32} | `"ICO: unsupported bit depth {n}"` |
+| PNG decode error | `"ICO: PNG decode error: {e}"` |
+| biWidth / biHeight == 0 | `"ICO: zero-dimension image"` |
+
+---
+
+## 8. API
+
+```rust
+pub struct IcoCodec;
+
+impl ImageCodec for IcoCodec {
+    fn mime_type(&self) -> &'static str { "image/x-icon" }
+    fn encode(&self, pixels: &PixelContainer) -> Vec<u8> { encode_ico(pixels) }
+    fn decode(&self, bytes: &[u8]) -> Result<PixelContainer, String> { decode_ico(bytes) }
+}
+
+/// Encode a PixelContainer as a single-image 32bpp ICO file.
+pub fn encode_ico(pixels: &PixelContainer) -> Vec<u8>;
+
+/// Decode the best-resolution image from an ICO or CUR file.
+pub fn decode_ico(bytes: &[u8]) -> Result<PixelContainer, String>;
+```
+
+---
+
+## 9. Crate Layout
+
+```
+image-codec-ico/
+  Cargo.toml        deps: pixel-container, paint-instructions, png
+  BUILD
+  README.md
+  CHANGELOG.md
+  src/
+    lib.rs          IcoCodec, VERSION, encode_ico, decode_ico, integration tests
+    encoder.rs      Single-image 32bpp BGRA ICO encoder
+    decoder.rs      ICO parser, image selector, BMP DIB + PNG dispatch
+    bmp_dib.rs      BITMAPINFOHEADER parse, palette, XOR + AND decode
+```
+
+---
+
+## 10. Test Plan
+
+| Test | What it verifies |
+|------|-----------------|
+| `round_trip_solid_rgba` | Encode 4×4 RGBA → decode → pixel-exact |
+| `round_trip_transparent` | Fully transparent image; AND mask all-ones |
+| `round_trip_mixed_alpha` | Mixed opaque/transparent pixels |
+| `encode_produces_correct_header` | Verify ICO header bytes (type=1, count=1) |
+| `encode_bit_count_is_32` | directory bitCount field == 32 |
+| `encode_image_offset_is_22` | imageOffset = 6 + 16 = 22 |
+| `decode_selects_largest_image` | Multi-image ICO; largest is returned |
+| `decode_bmp_24bpp` | Decode a hand-crafted 24bpp BMP DIB ICO |
+| `decode_bmp_8bpp` | Decode a hand-crafted 8bpp palette ICO |
+| `decode_png_frame` | Decode an ICO whose image data is a full PNG |
+| `decode_cur_file` | CUR file (type=2) accepted without error |
+| `decode_error_bad_magic` | Garbage input → Err |
+| `decode_error_bad_type` | type=3 → Err |
+| `decode_error_zero_count` | count=0 → Err |
+| `mime_type` | `"image/x-icon"` |
+
+Target: ≥ 95% coverage.
+
+---
+
+## 11. Teaching Notes
+
+### Why bottom-up rows?
+
+Windows bitmaps are stored bottom-up by default (biHeight > 0) because
+the Windows GDI origin is at the bottom-left corner, matching mathematical
+conventions. Most image formats (PNG, JPEG, WebP) store top-down. When
+decoding a BMP DIB in an ICO, you must reverse the row order.
+
+### Why two masks (XOR and AND)?
+
+The original Windows 1.0 icon rendering used two bitwise operations on
+the screen pixels:
+
+```
+screen = (screen AND and_mask) XOR xor_mask
+```
+
+- `and_mask = 1, xor_mask = 0` → black (transparent over black bg)
+- `and_mask = 0, xor_mask = ?` → opaque pixel
+- `and_mask = 1, xor_mask = 1` → inverted (XOR blend, rare)
+
+Modern 32bpp icons bypass this entirely — the alpha channel in BGRA
+provides per-pixel opacity, and the AND mask is conventionally all zeros.
+
+### ICO vs PNG at 256×256
+
+Windows Vista introduced PNG-compressed frames for the 256×256 size.
+A modern `.ico` file typically contains both:
+- 256×256 PNG frame (crisp at large size)
+- 48×48, 32×32, 16×16 BMP DIB frames (for legacy rendering at exact sizes)
+
+Our encoder emits only one frame for simplicity; our decoder picks the largest.
+
+---
+
+## 12. Relationship to Other Specs
+
+| Dependency | Role |
+|------------|------|
+| IC00 (pixel-container) | RGBA pixel buffer |
+| paint-instructions | `ImageCodec` trait |
+| IC01 (image-codec-bmp) | BMP DIB decode concepts (shared approach, not code import) |
+| png / paint-codec-png | PNG decode for Vista-style 256×256 frames |


### PR DESCRIPTION
## Summary

Adds Phase 269–274 (the Thirty-Seven-Log family) to the convergence recogniser across all three `cas-summation` implementations.

Each phase handles summands with **exactly 37 logarithmic factors** and **0–5 square-root factors**.

### Changes

| Package | Change |
|---------|--------|
| Python | +6 helper fns, +6 dispatch blocks, 204 cascade fixes, +18 tests |
| Rust | +6 helper fns, +6 dispatch blocks, 148 cascade fixes, +18 tests |
| TypeScript | +6 helper fns, +6 dispatch blocks, 204 cascade fixes, +18 tests |
| All | v2.205.0 → v2.211.0, CHANGELOG updated |

### Cascade fix

All Phase 167–268 refused tests updated from 37 → 38 log factors.

### Test counts

- Python: 820 passed (799 + 21 net, incl. 1 test fix)
- Rust: 714 passed (693 + 21 net)
- TypeScript: 731 passed (710 + 21 net)

🤖 Generated with [Claude Code](https://claude.com/claude-code)