### PR TITLE
feat(cas-summation): Phase 287-292 — Forty-Log family (v2.223.0→v2.229.0)

### DIFF
--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 2.229.0 — 2026-05-27
+
+### Added
+
+- **Phase 292 — Five-Sqrt × Forty-Log × polynomial** (`_five_sqrt_forty_log_poly_effective_x2`):
+  Completes the Forty-Log family (Phases 287–292).
+- **Phase 291 — Four-Sqrt × Forty-Log × polynomial** (`_four_sqrt_forty_log_poly_effective_x2`).
+- **Phase 290 — Three-Sqrt × Forty-Log × polynomial** (`_three_sqrt_forty_log_poly_effective_x2`).
+- **Phase 289 — Two-Sqrt × Forty-Log × polynomial** (`_two_sqrt_forty_log_poly_effective_x2`).
+- **Phase 288 — One-Sqrt × Forty-Log × polynomial** (`_one_sqrt_forty_log_poly_effective_x2`).
+- **Phase 287 — Zero-Sqrt × Forty-Log × polynomial** (`_forty_log_poly_effective_x2`).
+
+### Changed
+
+- Boundary tests in Phases 281–286 (and prior phases 167–280) updated from 40-log
+  "refused" to 41-log "refused" now that Phases 287–292 handle exactly 40 logs.
+
 ## 2.223.0 — 2026-05-27
 
 ### Added

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "2.223.0"
+version = "2.229.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -1477,6 +1477,60 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
                 return True
         elif _h_diverges_at_infinity(den, k):
             return True
+    # Phase 292: ``Mul(Sqrt(P1)×5, Log(h1)×40, polynomial..., bounded...)`` numerator.
+    s5l40p_x2 = _five_sqrt_forty_log_poly_effective_x2(num, k)
+    if s5l40p_x2 is not None:
+        den_deg_s5l40 = _polynomial_degree_in_k(den, k)
+        if den_deg_s5l40 is not None:
+            if 2 * den_deg_s5l40 > s5l40p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 291: ``Mul(Sqrt(P1)×4, Log(h1)×40, polynomial..., bounded...)`` numerator.
+    s4l40p_x2 = _four_sqrt_forty_log_poly_effective_x2(num, k)
+    if s4l40p_x2 is not None:
+        den_deg_s4l40 = _polynomial_degree_in_k(den, k)
+        if den_deg_s4l40 is not None:
+            if 2 * den_deg_s4l40 > s4l40p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 290: ``Mul(Sqrt(P1)×3, Log(h1)×40, polynomial..., bounded...)`` numerator.
+    s3l40p_x2 = _three_sqrt_forty_log_poly_effective_x2(num, k)
+    if s3l40p_x2 is not None:
+        den_deg_s3l40 = _polynomial_degree_in_k(den, k)
+        if den_deg_s3l40 is not None:
+            if 2 * den_deg_s3l40 > s3l40p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 289: ``Mul(Sqrt(P1), Sqrt(P2), Log(h1)×40, polynomial..., bounded...)`` numerator.
+    s2l40p_x2 = _two_sqrt_forty_log_poly_effective_x2(num, k)
+    if s2l40p_x2 is not None:
+        den_deg_s2l40 = _polynomial_degree_in_k(den, k)
+        if den_deg_s2l40 is not None:
+            if 2 * den_deg_s2l40 > s2l40p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 288: ``Mul(Sqrt(P), Log(h1)×40, polynomial..., bounded...)`` numerator.
+    s1l40p_x2 = _one_sqrt_forty_log_poly_effective_x2(num, k)
+    if s1l40p_x2 is not None:
+        den_deg_s1l40 = _polynomial_degree_in_k(den, k)
+        if den_deg_s1l40 is not None:
+            if 2 * den_deg_s1l40 > s1l40p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 287: ``Mul(Log(h1)×40, polynomial..., bounded...)`` numerator.
+    sl40p_x2 = _forty_log_poly_effective_x2(num, k)
+    if sl40p_x2 is not None:
+        den_deg_sl40 = _polynomial_degree_in_k(den, k)
+        if den_deg_sl40 is not None:
+            if 2 * den_deg_sl40 > sl40p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
     # Phase 286: ``Mul(Sqrt(P1)×5, Log(h1)×39, polynomial..., bounded...)`` numerator.
     s5l39p_x2 = _five_sqrt_thirty_nine_log_poly_effective_x2(num, k)
     if s5l39p_x2 is not None:
@@ -11296,6 +11350,207 @@ def _five_sqrt_thirty_nine_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> i
             continue
         return None
     if len(sqrt_degs_x2) != 5 or log_count != 39:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _forty_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 287 — Zero-Sqrt × Forty-Log × polynomial numerator.
+
+    The Forty-Log family (Phases 287–292) extends the recogniser to
+    summands whose numerator contains exactly forty logarithmic factors
+    and zero to five square-root factors.  This is Phase 287: zero sqrts.
+
+    Parameters
+    ----------
+    node : IRNode
+        The numerator node.
+    k : IRSymbol
+        The summation variable.
+
+    Returns
+    -------
+    int | None
+        ``2 * poly_deg_sum`` when the shape matches (always even); ``None``
+        when the pattern is not recognised.
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        if _sqrt_effective_half_degree_x2(arg, k) is not None:
+            return None
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 40:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if log_count != 40:
+        return None
+    return 2 * poly_deg_sum
+
+
+def _one_sqrt_forty_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 288 — One-Sqrt × Forty-Log × polynomial numerator."""
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_deg_x2: int | None = None
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if sqrt_deg_x2 is not None:
+                return None
+            sqrt_deg_x2 = deg_x2
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 40:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if sqrt_deg_x2 is None or log_count != 40:
+        return None
+    return sqrt_deg_x2 + 2 * poly_deg_sum
+
+
+def _two_sqrt_forty_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 289 — Two-Sqrt × Forty-Log × polynomial numerator."""
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 2:
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 40:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 2 or log_count != 40:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _three_sqrt_forty_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 290 — Three-Sqrt × Forty-Log × polynomial numerator."""
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 3:
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 40:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 3 or log_count != 40:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _four_sqrt_forty_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 291 — Four-Sqrt × Forty-Log × polynomial numerator."""
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 4:
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 40:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 4 or log_count != 40:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _five_sqrt_forty_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 292 — Five-Sqrt × Forty-Log × polynomial numerator.
+    Completes the Forty-Log family (Phases 287-292).
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 5:
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 40:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 5 or log_count != 40:
         return None
     return sum(sqrt_degs_x2) + 2 * poly_deg_sum
 

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -12014,6 +12014,7 @@ class TestPhase167TwentyLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,
@@ -12030,6 +12031,7 @@ class TestPhase167TwentyLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         )), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -12164,6 +12166,7 @@ class TestPhase168OneSqrtTwentyLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -12180,6 +12183,7 @@ class TestPhase168OneSqrtTwentyLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         )),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -12314,6 +12318,7 @@ class TestPhase169TwoSqrtTwentyLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -12330,6 +12335,7 @@ class TestPhase169TwoSqrtTwentyLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         )), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -12464,6 +12470,7 @@ class TestPhase170ThreeSqrtTwentyLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -12480,6 +12487,7 @@ class TestPhase170ThreeSqrtTwentyLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         )), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -12619,6 +12627,7 @@ class TestPhase171FourSqrtTwentyLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -12635,6 +12644,7 @@ class TestPhase171FourSqrtTwentyLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         )), IRApply(SQRT, (kp1,)),
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -12774,6 +12784,7 @@ class TestPhase172FiveSqrtTwentyLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -12790,6 +12801,7 @@ class TestPhase172FiveSqrtTwentyLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         )), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -12924,6 +12936,7 @@ class TestPhase173TwentyOneLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,
@@ -12940,6 +12953,7 @@ class TestPhase173TwentyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         )), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -13068,6 +13082,7 @@ class TestPhase174OneSqrtTwentyOneLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -13084,6 +13099,7 @@ class TestPhase174OneSqrtTwentyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         )),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -13213,6 +13229,7 @@ class TestPhase175TwoSqrtTwentyOneLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -13229,6 +13246,7 @@ class TestPhase175TwoSqrtTwentyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         )), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -13358,6 +13376,7 @@ class TestPhase176ThreeSqrtTwentyOneLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -13374,6 +13393,7 @@ class TestPhase176ThreeSqrtTwentyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         )), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -13508,6 +13528,7 @@ class TestPhase177FourSqrtTwentyOneLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -13524,6 +13545,7 @@ class TestPhase177FourSqrtTwentyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         )), IRApply(SQRT, (kp1,)),
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -13659,6 +13681,7 @@ class TestPhase178FiveSqrtTwentyOneLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -13675,6 +13698,7 @@ class TestPhase178FiveSqrtTwentyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         )), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -13804,6 +13828,7 @@ class TestPhase179TwentyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,
@@ -13820,6 +13845,7 @@ class TestPhase179TwentyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         )), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -13952,6 +13978,7 @@ class TestPhase180OneSqrtTwentyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -13968,6 +13995,7 @@ class TestPhase180OneSqrtTwentyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         )),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -14101,6 +14129,7 @@ class TestPhase181TwoSqrtTwentyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -14117,6 +14146,7 @@ class TestPhase181TwoSqrtTwentyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         )), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -14250,6 +14280,7 @@ class TestPhase182ThreeSqrtTwentyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -14266,6 +14297,7 @@ class TestPhase182ThreeSqrtTwentyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         )), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -14404,6 +14436,7 @@ class TestPhase183FourSqrtTwentyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -14420,6 +14453,7 @@ class TestPhase183FourSqrtTwentyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         )), IRApply(SQRT, (kp1,)),
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -14559,6 +14593,7 @@ class TestPhase184FiveSqrtTwentyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -14575,6 +14610,7 @@ class TestPhase184FiveSqrtTwentyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         )), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -14704,6 +14740,7 @@ class TestPhase185TwentyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,
@@ -14720,6 +14757,7 @@ class TestPhase185TwentyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         )), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -14852,6 +14890,7 @@ class TestPhase186OneSqrtTwentyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -14868,6 +14907,7 @@ class TestPhase186OneSqrtTwentyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         )),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -15001,6 +15041,7 @@ class TestPhase187TwoSqrtTwentyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -15017,6 +15058,7 @@ class TestPhase187TwoSqrtTwentyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         )), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -15150,6 +15192,7 @@ class TestPhase188ThreeSqrtTwentyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -15166,6 +15209,7 @@ class TestPhase188ThreeSqrtTwentyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         )), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -15304,6 +15348,7 @@ class TestPhase189FourSqrtTwentyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -15320,6 +15365,7 @@ class TestPhase189FourSqrtTwentyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         )), IRApply(SQRT, (kp1,)),
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -15459,6 +15505,7 @@ class TestPhase190FiveSqrtTwentyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -15475,6 +15522,7 @@ class TestPhase190FiveSqrtTwentyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         )), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -15603,6 +15651,7 @@ class TestPhase191TwentyFourLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,
@@ -15619,6 +15668,7 @@ class TestPhase191TwentyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         )), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -15749,6 +15799,7 @@ class TestPhase192OneSqrtTwentyFourLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -15765,6 +15816,7 @@ class TestPhase192OneSqrtTwentyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         )),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -15895,6 +15947,7 @@ class TestPhase193TwoSqrtTwentyFourLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -15911,6 +15964,7 @@ class TestPhase193TwoSqrtTwentyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         )), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -16040,6 +16094,7 @@ class TestPhase194ThreeSqrtTwentyFourLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -16056,6 +16111,7 @@ class TestPhase194ThreeSqrtTwentyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         )), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -16190,6 +16246,7 @@ class TestPhase195FourSqrtTwentyFourLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -16206,6 +16263,7 @@ class TestPhase195FourSqrtTwentyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         )), IRApply(SQRT, (kp1,)),
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -16341,6 +16399,7 @@ class TestPhase196FiveSqrtTwentyFourLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -16357,6 +16416,7 @@ class TestPhase196FiveSqrtTwentyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         )), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -16487,6 +16547,7 @@ class TestPhase197TwentyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,
@@ -16503,6 +16564,7 @@ class TestPhase197TwentyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         )), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -16637,6 +16699,7 @@ class TestPhase198OneSqrtTwentyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -16653,6 +16716,7 @@ class TestPhase198OneSqrtTwentyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         )),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -16787,6 +16851,7 @@ class TestPhase199TwoSqrtTwentyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -16803,6 +16868,7 @@ class TestPhase199TwoSqrtTwentyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         )), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -16936,6 +17002,7 @@ class TestPhase200ThreeSqrtTwentyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -16952,6 +17019,7 @@ class TestPhase200ThreeSqrtTwentyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         )), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -17090,6 +17158,7 @@ class TestPhase201FourSqrtTwentyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -17106,6 +17175,7 @@ class TestPhase201FourSqrtTwentyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         )), IRApply(SQRT, (kp1,)),
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -17245,6 +17315,7 @@ class TestPhase202FiveSqrtTwentyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,
@@ -17261,6 +17332,7 @@ class TestPhase202FiveSqrtTwentyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         )), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -17393,6 +17465,7 @@ class TestPhase203TwentySixLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -17420,6 +17493,7 @@ class TestPhase203TwentySixLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -17545,6 +17619,7 @@ class TestPhase204OneSqrtTwentySixLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -17573,6 +17648,7 @@ class TestPhase204OneSqrtTwentySixLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -17698,6 +17774,7 @@ class TestPhase205TwoSqrtTwentySixLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -17725,6 +17802,7 @@ class TestPhase205TwoSqrtTwentySixLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -17849,6 +17927,7 @@ class TestPhase206ThreeSqrtTwentySixLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -17876,6 +17955,7 @@ class TestPhase206ThreeSqrtTwentySixLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -18005,6 +18085,7 @@ class TestPhase207FourSqrtTwentySixLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -18033,6 +18114,7 @@ class TestPhase207FourSqrtTwentySixLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -18162,6 +18244,7 @@ class TestPhase208FiveSqrtTwentySixLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -18190,6 +18273,7 @@ class TestPhase208FiveSqrtTwentySixLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -18313,6 +18397,7 @@ class TestPhase209TwentySevenLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -18340,6 +18425,7 @@ class TestPhase209TwentySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -18469,6 +18555,7 @@ class TestPhase210OneSqrtTwentySevenLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -18497,6 +18584,7 @@ class TestPhase210OneSqrtTwentySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -18626,6 +18714,7 @@ class TestPhase211TwoSqrtTwentySevenLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -18653,6 +18742,7 @@ class TestPhase211TwoSqrtTwentySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -18781,6 +18871,7 @@ class TestPhase212ThreeSqrtTwentySevenLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -18808,6 +18899,7 @@ class TestPhase212ThreeSqrtTwentySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -18941,6 +19033,7 @@ class TestPhase213FourSqrtTwentySevenLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -18969,6 +19062,7 @@ class TestPhase213FourSqrtTwentySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -19102,6 +19196,7 @@ class TestPhase214FiveSqrtTwentySevenLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -19130,6 +19225,7 @@ class TestPhase214FiveSqrtTwentySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -19257,6 +19353,7 @@ class TestPhase215TwentyEightLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -19284,6 +19381,7 @@ class TestPhase215TwentyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -19417,6 +19515,7 @@ class TestPhase216OneSqrtTwentyEightLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -19445,6 +19544,7 @@ class TestPhase216OneSqrtTwentyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -19578,6 +19678,7 @@ class TestPhase217TwoSqrtTwentyEightLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -19605,6 +19706,7 @@ class TestPhase217TwoSqrtTwentyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -19737,6 +19839,7 @@ class TestPhase218ThreeSqrtTwentyEightLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -19764,6 +19867,7 @@ class TestPhase218ThreeSqrtTwentyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -19901,6 +20005,7 @@ class TestPhase219FourSqrtTwentyEightLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -19929,6 +20034,7 @@ class TestPhase219FourSqrtTwentyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -20066,6 +20172,7 @@ class TestPhase220FiveSqrtTwentyEightLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -20094,6 +20201,7 @@ class TestPhase220FiveSqrtTwentyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -20226,6 +20334,7 @@ class TestPhase221TwentyNineLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -20253,6 +20362,7 @@ class TestPhase221TwentyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -20390,6 +20500,7 @@ class TestPhase222OneSqrtTwentyNineLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -20418,6 +20529,7 @@ class TestPhase222OneSqrtTwentyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -20555,6 +20667,7 @@ class TestPhase223TwoSqrtTwentyNineLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -20582,6 +20695,7 @@ class TestPhase223TwoSqrtTwentyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -20718,6 +20832,7 @@ class TestPhase224ThreeSqrtTwentyNineLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -20745,6 +20860,7 @@ class TestPhase224ThreeSqrtTwentyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -20886,6 +21002,7 @@ class TestPhase225FourSqrtTwentyNineLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -20914,6 +21031,7 @@ class TestPhase225FourSqrtTwentyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -21055,6 +21173,7 @@ class TestPhase226FiveSqrtTwentyNineLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -21083,6 +21202,7 @@ class TestPhase226FiveSqrtTwentyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -21218,6 +21338,7 @@ class TestPhase227ThirtyLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -21245,6 +21366,7 @@ class TestPhase227ThirtyLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -21386,6 +21508,7 @@ class TestPhase228OneSqrtThirtyLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -21414,6 +21537,7 @@ class TestPhase228OneSqrtThirtyLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -21555,6 +21679,7 @@ class TestPhase229TwoSqrtThirtyLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -21582,6 +21707,7 @@ class TestPhase229TwoSqrtThirtyLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -21722,6 +21848,7 @@ class TestPhase230ThreeSqrtThirtyLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -21749,6 +21876,7 @@ class TestPhase230ThreeSqrtThirtyLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -21889,6 +22017,7 @@ class TestPhase231FourSqrtThirtyLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -21916,6 +22045,7 @@ class TestPhase231FourSqrtThirtyLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -22061,6 +22191,7 @@ class TestPhase232FiveSqrtThirtyLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -22089,6 +22220,7 @@ class TestPhase232FiveSqrtThirtyLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -22228,6 +22360,7 @@ class TestPhase233ThirtyOneLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -22255,6 +22388,7 @@ class TestPhase233ThirtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -22400,6 +22534,7 @@ class TestPhase234OneSqrtThirtyOneLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -22428,6 +22563,7 @@ class TestPhase234OneSqrtThirtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -22573,6 +22709,7 @@ class TestPhase235TwoSqrtThirtyOneLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -22600,6 +22737,7 @@ class TestPhase235TwoSqrtThirtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -22744,6 +22882,7 @@ class TestPhase236ThreeSqrtThirtyOneLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -22771,6 +22910,7 @@ class TestPhase236ThreeSqrtThirtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -22920,6 +23060,7 @@ class TestPhase237FourSqrtThirtyOneLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -22948,6 +23089,7 @@ class TestPhase237FourSqrtThirtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -23097,6 +23239,7 @@ class TestPhase238FiveSqrtThirtyOneLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -23125,6 +23268,7 @@ class TestPhase238FiveSqrtThirtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -23268,6 +23412,7 @@ class TestPhase239ThirtyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -23295,6 +23440,7 @@ class TestPhase239ThirtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -23444,6 +23590,7 @@ class TestPhase240OneSqrtThirtyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -23472,6 +23619,7 @@ class TestPhase240OneSqrtThirtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -23621,6 +23769,7 @@ class TestPhase241TwoSqrtThirtyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -23648,6 +23797,7 @@ class TestPhase241TwoSqrtThirtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -23796,6 +23946,7 @@ class TestPhase242ThreeSqrtThirtyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -23823,6 +23974,7 @@ class TestPhase242ThreeSqrtThirtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -23976,6 +24128,7 @@ class TestPhase243FourSqrtThirtyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -24004,6 +24157,7 @@ class TestPhase243FourSqrtThirtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -24157,6 +24311,7 @@ class TestPhase244FiveSqrtThirtyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -24185,6 +24340,7 @@ class TestPhase244FiveSqrtThirtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -24332,6 +24488,7 @@ class TestPhase245ThirtyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -24359,6 +24516,7 @@ class TestPhase245ThirtyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -24512,6 +24670,7 @@ class TestPhase246OneSqrtThirtyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -24540,6 +24699,7 @@ class TestPhase246OneSqrtThirtyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -24693,6 +24853,7 @@ class TestPhase247TwoSqrtThirtyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -24720,6 +24881,7 @@ class TestPhase247TwoSqrtThirtyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -24872,6 +25034,7 @@ class TestPhase248ThreeSqrtThirtyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -24899,6 +25062,7 @@ class TestPhase248ThreeSqrtThirtyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -25056,6 +25220,7 @@ class TestPhase249FourSqrtThirtyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -25084,6 +25249,7 @@ class TestPhase249FourSqrtThirtyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -25241,6 +25407,7 @@ class TestPhase250FiveSqrtThirtyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -25269,6 +25436,7 @@ class TestPhase250FiveSqrtThirtyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -25420,6 +25588,7 @@ class TestPhase251ThirtyFourLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -25447,6 +25616,7 @@ class TestPhase251ThirtyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -25604,6 +25774,7 @@ class TestPhase252OneSqrtThirtyFourLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -25632,6 +25803,7 @@ class TestPhase252OneSqrtThirtyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -25789,6 +25961,7 @@ class TestPhase253TwoSqrtThirtyFourLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -25816,6 +25989,7 @@ class TestPhase253TwoSqrtThirtyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -25972,6 +26146,7 @@ class TestPhase254ThreeSqrtThirtyFourLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -25999,6 +26174,7 @@ class TestPhase254ThreeSqrtThirtyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -26160,6 +26336,7 @@ class TestPhase255FourSqrtThirtyFourLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -26188,6 +26365,7 @@ class TestPhase255FourSqrtThirtyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -26349,6 +26527,7 @@ class TestPhase256FiveSqrtThirtyFourLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -26377,6 +26556,7 @@ class TestPhase256FiveSqrtThirtyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -26532,6 +26712,7 @@ class TestPhase257ThirtyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -26559,6 +26740,7 @@ class TestPhase257ThirtyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -26720,6 +26902,7 @@ class TestPhase258OneSqrtThirtyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -26748,6 +26931,7 @@ class TestPhase258OneSqrtThirtyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -26909,6 +27093,7 @@ class TestPhase259TwoSqrtThirtyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -26936,6 +27121,7 @@ class TestPhase259TwoSqrtThirtyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -27096,6 +27282,7 @@ class TestPhase260ThreeSqrtThirtyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -27123,6 +27310,7 @@ class TestPhase260ThreeSqrtThirtyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -27288,6 +27476,7 @@ class TestPhase261FourSqrtThirtyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -27316,6 +27505,7 @@ class TestPhase261FourSqrtThirtyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -27481,6 +27671,7 @@ class TestPhase262FiveSqrtThirtyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -27509,6 +27700,7 @@ class TestPhase262FiveSqrtThirtyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -27668,6 +27860,7 @@ class TestPhase263ThirtySixLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -27695,6 +27888,7 @@ class TestPhase263ThirtySixLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -27860,6 +28054,7 @@ class TestPhase264OneSqrtThirtySixLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -27888,6 +28083,7 @@ class TestPhase264OneSqrtThirtySixLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -28053,6 +28249,7 @@ class TestPhase265TwoSqrtThirtySixLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -28080,6 +28277,7 @@ class TestPhase265TwoSqrtThirtySixLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -28244,6 +28442,7 @@ class TestPhase266ThreeSqrtThirtySixLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -28271,6 +28470,7 @@ class TestPhase266ThreeSqrtThirtySixLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -28440,6 +28640,7 @@ class TestPhase267FourSqrtThirtySixLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -28468,6 +28669,7 @@ class TestPhase267FourSqrtThirtySixLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -28637,6 +28839,7 @@ class TestPhase268FiveSqrtThirtySixLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -28665,6 +28868,7 @@ class TestPhase268FiveSqrtThirtySixLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -28830,6 +29034,7 @@ class TestPhase269ThirtySevenLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -28856,6 +29061,7 @@ class TestPhase269ThirtySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -29023,6 +29229,7 @@ class TestPhase270OneSqrtThirtySevenLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -29050,6 +29257,7 @@ class TestPhase270OneSqrtThirtySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -29217,6 +29425,7 @@ class TestPhase271TwoSqrtThirtySevenLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -29244,6 +29453,7 @@ class TestPhase271TwoSqrtThirtySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -29411,6 +29621,7 @@ class TestPhase272ThreeSqrtThirtySevenLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -29438,6 +29649,7 @@ class TestPhase272ThreeSqrtThirtySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -29605,6 +29817,7 @@ class TestPhase273FourSqrtThirtySevenLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -29632,6 +29845,7 @@ class TestPhase273FourSqrtThirtySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -29804,6 +30018,7 @@ class TestPhase274FiveSqrtThirtySevenLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -29832,6 +30047,7 @@ class TestPhase274FiveSqrtThirtySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -30000,6 +30216,7 @@ class TestPhase275ThirtyEightLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -30026,6 +30243,7 @@ class TestPhase275ThirtyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -30197,6 +30415,7 @@ class TestPhase276OneSqrtThirtyEightLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -30224,6 +30443,7 @@ class TestPhase276OneSqrtThirtyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -30395,6 +30615,7 @@ class TestPhase277TwoSqrtThirtyEightLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -30422,6 +30643,7 @@ class TestPhase277TwoSqrtThirtyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -30593,6 +30815,7 @@ class TestPhase278ThreeSqrtThirtyEightLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -30620,6 +30843,7 @@ class TestPhase278ThreeSqrtThirtyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -30796,6 +31020,7 @@ class TestPhase279FourSqrtThirtyEightLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -30824,6 +31049,7 @@ class TestPhase279FourSqrtThirtyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -31000,6 +31226,7 @@ class TestPhase280FiveSqrtThirtyEightLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -31028,6 +31255,7 @@ class TestPhase280FiveSqrtThirtyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -31201,6 +31429,7 @@ class TestPhase281ThirtyNineLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -31227,6 +31456,7 @@ class TestPhase281ThirtyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -31402,6 +31632,7 @@ class TestPhase282OneSqrtThirtyNineLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -31429,6 +31660,7 @@ class TestPhase282OneSqrtThirtyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -31606,6 +31838,7 @@ class TestPhase283TwoSqrtThirtyNineLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -31633,6 +31866,7 @@ class TestPhase283TwoSqrtThirtyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -31810,6 +32044,7 @@ class TestPhase284ThreeSqrtThirtyNineLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -31837,6 +32072,7 @@ class TestPhase284ThreeSqrtThirtyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -32014,6 +32250,7 @@ class TestPhase285FourSqrtThirtyNineLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -32041,6 +32278,7 @@ class TestPhase285FourSqrtThirtyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -32218,6 +32456,7 @@ class TestPhase286FiveSqrtThirtyNineLogPoly:
             IRApply(LOG, (_k,)),  # 38th log
             IRApply(LOG, (_k,)),  # 39th log
             IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -32245,6 +32484,1260 @@ class TestPhase286FiveSqrtThirtyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 38th log
             IRApply(LOG, (kp1,)),  # 39th log
             IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase287FortyLogPoly:
+    """Phase 287 -- Forty-Log x polynomial numerator."""
+
+    def test_log40_k_over_k2_closes(self):
+        """test log40 k over k2 closes: eff_x2=0; 2*2=4 > 0 -> closes"""
+        from symbolic_ir import SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_log40_k_times_k2_over_k3_closes(self):
+        """test log40 k times k2 over k3 closes: eff_x2=4; 2*3=6 > 4 -> closes"""
+        from symbolic_ir import SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_k = IRApply(MUL, (
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            k2,
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            kp1_2,
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_log41_k_over_k2_refused(self):
+        """log(k)^41/k^2: 41 logs -> not Phase 287 -> refused."""
+        from symbolic_ir import SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+class TestPhase288OneSqrtFortyLogPoly:
+    """Phase 288 -- One-Sqrt x Forty-Log x polynomial numerator."""
+
+    def test_sqrt_k_log40_k_over_k2_closes(self):
+        """test sqrt k log40 k over k2 closes: eff_x2=1; 2*2=4 > 1 -> closes"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_log40_k_times_k_over_k2_closes(self):
+        """test sqrt k log40 k times k over k2 closes: eff_x2=3; 2*2=4 > 3 -> closes"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            _k,
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            kp1,
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_log41_k_over_k2_refused(self):
+        """sqrt(k)*log(k)^41/k^2: 41 logs -> not Phase 288 -> refused."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+class TestPhase289TwoSqrtFortyLogPoly:
+    """Phase 289 -- Two-Sqrt x Forty-Log x polynomial numerator."""
+
+    def test_two_sqrt_k_log40_k_over_k2_closes(self):
+        """test two sqrt k log40 k over k2 closes: eff_x2=2; 2*2=4 > 2 -> closes"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_two_sqrt_k_log40_k_times_k_over_k3_closes(self):
+        """test two sqrt k log40 k times k over k3 closes: eff_x2=4; 2*3=6 > 4 -> closes"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            _k,
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            kp1,
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_two_sqrt_k_log41_k_over_k2_refused(self):
+        """(sqrt(k))^2*log(k)^41/k^2: 41 logs -> not Phase 289 -> refused."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+class TestPhase290ThreeSqrtFortyLogPoly:
+    """Phase 290 -- Three-Sqrt x Forty-Log x polynomial numerator."""
+
+    def test_three_sqrt_k_log40_k_over_k2_closes(self):
+        """test three sqrt k log40 k over k2 closes: eff_x2=3; 2*2=4 > 3 -> closes"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_three_sqrt_k_log40_k_times_k_over_k3_closes(self):
+        """test three sqrt k log40 k times k over k3 closes: eff_x2=5; 2*3=6 > 5 -> closes"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            _k,
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            kp1,
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_three_sqrt_k_log41_k_over_k2_refused(self):
+        """(sqrt(k))^3*log(k)^41/k^2: 41 logs -> not Phase 290 -> refused."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+class TestPhase291FourSqrtFortyLogPoly:
+    """Phase 291 -- Four-Sqrt x Forty-Log x polynomial numerator."""
+
+    def test_4_sqrt_k_log40_k_over_k3_closes(self):
+        """test 4 sqrt k log40 k over k3 closes: eff_x2=4; 2*3=6 > 4 -> closes"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_4_sqrt_k_log40_k_times_k_over_k4_closes(self):
+        """test 4 sqrt k log40 k times k over k4 closes: eff_x2=6; 2*4=8 > 6 -> closes"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        k4 = IRApply(POW, (_k, IRInteger(4)))
+        kp1_4 = IRApply(POW, (kp1, IRInteger(4)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            _k,
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            kp1,
+        ))
+        g_k = IRApply(DIV, (num_k, k4))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_4))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_4_sqrt_k_log41_k_over_k3_refused(self):
+        """(sqrt(k))^4*log(k)^41/k^3: 41 logs -> not Phase 291 -> refused."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+class TestPhase292FiveSqrtFortyLogPoly:
+    """Phase 292 -- Five-Sqrt x Forty-Log x polynomial numerator."""
+
+    def test_5_sqrt_k_log40_k_over_k3_closes(self):
+        """test 5 sqrt k log40 k over k3 closes: eff_x2=5; 2*3=6 > 5 -> closes"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_5_sqrt_k_log40_k_times_k_over_k4_closes(self):
+        """test 5 sqrt k log40 k times k over k4 closes: eff_x2=7; 2*4=8 > 7 -> closes"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        k4 = IRApply(POW, (_k, IRInteger(4)))
+        kp1_4 = IRApply(POW, (kp1, IRInteger(4)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            _k,
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            kp1,
+        ))
+        g_k = IRApply(DIV, (num_k, k4))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_4))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_5_sqrt_k_log41_k_over_k3_refused(self):
+        """(sqrt(k))^5*log(k)^41/k^3: 41 logs -> not Phase 292 -> refused."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))

--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 2.229.0 — 2026-05-27
+
+### Added
+
+- **Phase 292 — Five-Sqrt × Forty-Log × polynomial** (`five_sqrt_forty_log_poly_effective_x2`):
+  Completes the Forty-Log family (Phases 287–292).
+- **Phase 291 — Four-Sqrt × Forty-Log × polynomial** (`four_sqrt_forty_log_poly_effective_x2`).
+- **Phase 290 — Three-Sqrt × Forty-Log × polynomial** (`three_sqrt_forty_log_poly_effective_x2`).
+- **Phase 289 — Two-Sqrt × Forty-Log × polynomial** (`two_sqrt_forty_log_poly_effective_x2`).
+- **Phase 288 — One-Sqrt × Forty-Log × polynomial** (`one_sqrt_forty_log_poly_effective_x2`).
+- **Phase 287 — Zero-Sqrt × Forty-Log × polynomial** (`forty_log_poly_effective_x2`).
+
+### Changed
+
+- Boundary tests in Phases 281–286 (and prior phases 167–280) updated from 40-log
+  "refused" to 41-log "refused" now that Phases 287–292 handle exactly 40 logs.
+
 ## 2.223.0 — 2026-05-27
 
 ### Added

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "2.223.0"
+version = "2.229.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -6728,6 +6728,169 @@ fn five_sqrt_thirty_nine_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Opt
     Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg_sum)
 }
 
+/// Phase 287 — Zero-Sqrt × Forty-Log × polynomial numerator.
+///
+/// The Forty-Log family (Phases 287–292) extends the recogniser to
+/// summands whose numerator contains exactly forty logarithmic factors
+/// and zero to five square-root factors.  This is Phase 287: zero sqrts.
+fn forty_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if sqrt_effective_half_degree_x2(arg, k).is_some() { return None; }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 40 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg; continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if log_count != 40 { return None; }
+    Some(2 * poly_deg_sum)
+}
+
+/// Phase 288 — One-Sqrt × Forty-Log × polynomial numerator.
+fn one_sqrt_forty_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut sqrt_deg_x2: Option<i64> = None;
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_deg_x2.is_some() { return None; }
+            sqrt_deg_x2 = Some(d); continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 40 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg; continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_deg_x2.is_none() || log_count != 40 { return None; }
+    Some(sqrt_deg_x2.unwrap() + 2 * poly_deg_sum)
+}
+
+/// Phase 289 — Two-Sqrt × Forty-Log × polynomial numerator.
+fn two_sqrt_forty_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut sqrt_degs: Vec<i64> = Vec::new();
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs.len() >= 2 { return None; }
+            sqrt_degs.push(d); continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 40 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg; continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs.len() != 2 || log_count != 40 { return None; }
+    Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg_sum)
+}
+
+/// Phase 290 — Three-Sqrt × Forty-Log × polynomial numerator.
+fn three_sqrt_forty_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut sqrt_degs: Vec<i64> = Vec::new();
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs.len() >= 3 { return None; }
+            sqrt_degs.push(d); continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 40 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg; continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs.len() != 3 || log_count != 40 { return None; }
+    Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg_sum)
+}
+
+/// Phase 291 — Four-Sqrt × Forty-Log × polynomial numerator.
+fn four_sqrt_forty_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut sqrt_degs: Vec<i64> = Vec::new();
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs.len() >= 4 { return None; }
+            sqrt_degs.push(d); continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 40 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg; continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs.len() != 4 || log_count != 40 { return None; }
+    Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg_sum)
+}
+
+/// Phase 292 — Five-Sqrt × Forty-Log × polynomial numerator.
+/// Completes the Forty-Log family (Phases 287–292).
+fn five_sqrt_forty_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut sqrt_degs: Vec<i64> = Vec::new();
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs.len() >= 5 { return None; }
+            sqrt_degs.push(d); continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 40 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg; continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs.len() != 5 || log_count != 40 { return None; }
+    Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg_sum)
+}
+
 /// Phase 251 — Zero-Sqrt × Thirty-Four-Log × polynomial numerator.
 ///
 /// The Thirty-Four-Log family (Phases 251–256) extends the recogniser to
@@ -8406,6 +8569,42 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
         } else if h_diverges_at_infinity(den, k) {
             return true;
         }
+    }
+    // Phase 292: Mul(Sqrt(P1)×5, Log(h1)×40, ...) numerator.
+    if let Some(s5l40_x2) = five_sqrt_forty_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s5l40) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s5l40 > s5l40_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 291: Mul(Sqrt(P1)×4, Log(h1)×40, ...) numerator.
+    if let Some(s4l40_x2) = four_sqrt_forty_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s4l40) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s4l40 > s4l40_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 290: Mul(Sqrt(P1)×3, Log(h1)×40, ...) numerator.
+    if let Some(s3l40_x2) = three_sqrt_forty_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s3l40) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s3l40 > s3l40_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 289: Mul(Sqrt(P), Sqrt(P2), Log(h1)×40, ...) numerator.
+    if let Some(s2l40_x2) = two_sqrt_forty_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s2l40) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s2l40 > s2l40_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 288: Mul(Sqrt(P), Log(h1)×40, ...) numerator.
+    if let Some(s1l40_x2) = one_sqrt_forty_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s1l40) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s1l40 > s1l40_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 287: Mul(Log(h1)×40, ...) numerator.
+    if let Some(sl40_x2) = forty_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_sl40) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_sl40 > sl40_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
     }
     // Phase 286: Mul(Sqrt(P1)×5, Log(h1)×39, ...) numerator.
     if let Some(s5l39_x2) = five_sqrt_thirty_nine_log_poly_effective_x2(num, k) {

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -13259,7 +13259,8 @@ fn phase191_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 37th log
         log_k.clone(), // 38th log
         log_k.clone(), // 39th log
-        log_k, // 40th log
+        log_k.clone(), // 40th log
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -13276,7 +13277,8 @@ fn phase191_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 37th log
         log_kp1.clone(), // 38th log
         log_kp1.clone(), // 39th log
-        log_kp1, // 40th log
+        log_kp1.clone(), // 40th log
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -13384,7 +13386,8 @@ fn phase192_sqrt_k_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 37th log
         log_k.clone(), // 38th log
         log_k.clone(), // 39th log
-        log_k, // 40th log
+        log_k.clone(), // 40th log
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -13402,7 +13405,8 @@ fn phase192_sqrt_k_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 37th log
         log_kp1.clone(), // 38th log
         log_kp1.clone(), // 39th log
-        log_kp1, // 40th log
+        log_kp1.clone(), // 40th log
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -13923,7 +13927,8 @@ fn phase197_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 37th log
         log_k.clone(), // 38th log
         log_k.clone(), // 39th log
-        log_k, // 40th log
+        log_k.clone(), // 40th log
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -13940,7 +13945,8 @@ fn phase197_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 37th log
         log_kp1.clone(), // 38th log
         log_kp1.clone(), // 39th log
-        log_kp1, // 40th log
+        log_kp1.clone(), // 40th log
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -14048,7 +14054,8 @@ fn phase198_sqrt_k_log29_k_over_k_refused() {
         log_k.clone(), // 37th log
         log_k.clone(), // 38th log
         log_k.clone(), // 39th log
-        log_k, // 40th log
+        log_k.clone(), // 40th log
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -14066,7 +14073,8 @@ fn phase198_sqrt_k_log29_k_over_k_refused() {
         log_kp1.clone(), // 37th log
         log_kp1.clone(), // 38th log
         log_kp1.clone(), // 39th log
-        log_kp1, // 40th log
+        log_kp1.clone(), // 40th log
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let g_k198c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -14172,7 +14180,8 @@ fn phase199_sqrt2_k_log29_k_over_k_refused() {
         log_k.clone(), // 37th log
         log_k.clone(), // 38th log
         log_k.clone(), // 39th log
-        log_k, // 40th log
+        log_k.clone(), // 40th log
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -14190,7 +14199,8 @@ fn phase199_sqrt2_k_log29_k_over_k_refused() {
         log_kp1.clone(), // 37th log
         log_kp1.clone(), // 38th log
         log_kp1.clone(), // 39th log
-        log_kp1, // 40th log
+        log_kp1.clone(), // 40th log
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let g_k199c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -14296,7 +14306,8 @@ fn phase200_sqrt3_k_log29_k_over_k_refused() {
         log_k.clone(), // 37th log
         log_k.clone(), // 38th log
         log_k.clone(), // 39th log
-        log_k, // 40th log
+        log_k.clone(), // 40th log
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -14314,7 +14325,8 @@ fn phase200_sqrt3_k_log29_k_over_k_refused() {
         log_kp1.clone(), // 37th log
         log_kp1.clone(), // 38th log
         log_kp1.clone(), // 39th log
-        log_kp1, // 40th log
+        log_kp1.clone(), // 40th log
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let g_k200c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -14420,7 +14432,8 @@ fn phase201_sqrt4_k_log29_k_over_k_refused() {
         log_k.clone(), // 37th log
         log_k.clone(), // 38th log
         log_k.clone(), // 39th log
-        log_k, // 40th log
+        log_k.clone(), // 40th log
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -14438,7 +14451,8 @@ fn phase201_sqrt4_k_log29_k_over_k_refused() {
         log_kp1.clone(), // 37th log
         log_kp1.clone(), // 38th log
         log_kp1.clone(), // 39th log
-        log_kp1, // 40th log
+        log_kp1.clone(), // 40th log
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let g_k201c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -14544,7 +14558,8 @@ fn phase202_sqrt5_k_log29_k_over_k_refused() {
         log_k.clone(), // 37th log
         log_k.clone(), // 38th log
         log_k.clone(), // 39th log
-        log_k, // 40th log
+        log_k.clone(), // 40th log
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -14562,7 +14577,8 @@ fn phase202_sqrt5_k_log29_k_over_k_refused() {
         log_kp1.clone(), // 37th log
         log_kp1.clone(), // 38th log
         log_kp1.clone(), // 39th log
-        log_kp1, // 40th log
+        log_kp1.clone(), // 40th log
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let g_k202c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -14657,7 +14673,8 @@ fn phase203_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 37th log
         log_k.clone(), // 38th log
         log_k.clone(), // 39th log
-        log_k, // 40th log
+        log_k.clone(), // 40th log
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -14674,7 +14691,8 @@ fn phase203_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 37th log
         log_kp1.clone(), // 38th log
         log_kp1.clone(), // 39th log
-        log_kp1, // 40th log
+        log_kp1.clone(), // 40th log
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -14782,7 +14800,8 @@ fn phase204_sqrt_k_log29_k_over_k_refused() {
         log_k.clone(), // 37th log
         log_k.clone(), // 38th log
         log_k.clone(), // 39th log
-        log_k, // 40th log
+        log_k.clone(), // 40th log
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -14800,7 +14819,8 @@ fn phase204_sqrt_k_log29_k_over_k_refused() {
         log_kp1.clone(), // 37th log
         log_kp1.clone(), // 38th log
         log_kp1.clone(), // 39th log
-        log_kp1, // 40th log
+        log_kp1.clone(), // 40th log
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let g_k204c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -14906,7 +14926,8 @@ fn phase205_sqrt2_k_log29_k_over_k_refused() {
         log_k.clone(), // 37th log
         log_k.clone(), // 38th log
         log_k.clone(), // 39th log
-        log_k, // 40th log
+        log_k.clone(), // 40th log
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -14924,7 +14945,8 @@ fn phase205_sqrt2_k_log29_k_over_k_refused() {
         log_kp1.clone(), // 37th log
         log_kp1.clone(), // 38th log
         log_kp1.clone(), // 39th log
-        log_kp1, // 40th log
+        log_kp1.clone(), // 40th log
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let g_k205c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -15030,7 +15052,8 @@ fn phase206_sqrt3_k_log29_k_over_k_refused() {
         log_k.clone(), // 37th log
         log_k.clone(), // 38th log
         log_k.clone(), // 39th log
-        log_k, // 40th log
+        log_k.clone(), // 40th log
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -15048,7 +15071,8 @@ fn phase206_sqrt3_k_log29_k_over_k_refused() {
         log_kp1.clone(), // 37th log
         log_kp1.clone(), // 38th log
         log_kp1.clone(), // 39th log
-        log_kp1, // 40th log
+        log_kp1.clone(), // 40th log
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let g_k206c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -15154,7 +15178,8 @@ fn phase207_sqrt4_k_log29_k_over_k_refused() {
         log_k.clone(), // 37th log
         log_k.clone(), // 38th log
         log_k.clone(), // 39th log
-        log_k, // 40th log
+        log_k.clone(), // 40th log
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -15172,7 +15197,8 @@ fn phase207_sqrt4_k_log29_k_over_k_refused() {
         log_kp1.clone(), // 37th log
         log_kp1.clone(), // 38th log
         log_kp1.clone(), // 39th log
-        log_kp1, // 40th log
+        log_kp1.clone(), // 40th log
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let g_k207c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -15278,7 +15304,8 @@ fn phase208_sqrt5_k_log29_k_over_k_refused() {
         log_k.clone(), // 37th log
         log_k.clone(), // 38th log
         log_k.clone(), // 39th log
-        log_k, // 40th log
+        log_k.clone(), // 40th log
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -15296,7 +15323,8 @@ fn phase208_sqrt5_k_log29_k_over_k_refused() {
         log_kp1.clone(), // 37th log
         log_kp1.clone(), // 38th log
         log_kp1.clone(), // 39th log
-        log_kp1, // 40th log
+        log_kp1.clone(), // 40th log
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let g_k208c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -15396,7 +15424,8 @@ fn phase209_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 37th log
         log_k.clone(), // 38th log
         log_k.clone(), // 39th log
-        log_k, // 40th log
+        log_k.clone(), // 40th log
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -15414,7 +15443,8 @@ fn phase209_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 37th log
         log_kp1.clone(), // 38th log
         log_kp1.clone(), // 39th log
-        log_kp1, // 40th log
+        log_kp1.clone(), // 40th log
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -15527,7 +15557,8 @@ fn phase210_sqrt_k_log29_k_over_k_refused() {
         log_k.clone(), // 37th log
         log_k.clone(), // 38th log
         log_k.clone(), // 39th log
-        log_k, // 40th log
+        log_k.clone(), // 40th log
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -15546,7 +15577,8 @@ fn phase210_sqrt_k_log29_k_over_k_refused() {
         log_kp1.clone(), // 37th log
         log_kp1.clone(), // 38th log
         log_kp1.clone(), // 39th log
-        log_kp1, // 40th log
+        log_kp1.clone(), // 40th log
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let g_k210c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -15657,7 +15689,8 @@ fn phase211_sqrt2_k_log29_k_over_k_refused() {
         log_k.clone(), // 37th log
         log_k.clone(), // 38th log
         log_k.clone(), // 39th log
-        log_k, // 40th log
+        log_k.clone(), // 40th log
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -15676,7 +15709,8 @@ fn phase211_sqrt2_k_log29_k_over_k_refused() {
         log_kp1.clone(), // 37th log
         log_kp1.clone(), // 38th log
         log_kp1.clone(), // 39th log
-        log_kp1, // 40th log
+        log_kp1.clone(), // 40th log
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let g_k211c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -15787,7 +15821,8 @@ fn phase212_sqrt3_k_log29_k_over_k_refused() {
         log_k.clone(), // 37th log
         log_k.clone(), // 38th log
         log_k.clone(), // 39th log
-        log_k, // 40th log
+        log_k.clone(), // 40th log
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -15806,7 +15841,8 @@ fn phase212_sqrt3_k_log29_k_over_k_refused() {
         log_kp1.clone(), // 37th log
         log_kp1.clone(), // 38th log
         log_kp1.clone(), // 39th log
-        log_kp1, // 40th log
+        log_kp1.clone(), // 40th log
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let g_k212c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -15917,7 +15953,8 @@ fn phase213_sqrt4_k_log29_k_over_k_refused() {
         log_k.clone(), // 37th log
         log_k.clone(), // 38th log
         log_k.clone(), // 39th log
-        log_k, // 40th log
+        log_k.clone(), // 40th log
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -15936,7 +15973,8 @@ fn phase213_sqrt4_k_log29_k_over_k_refused() {
         log_kp1.clone(), // 37th log
         log_kp1.clone(), // 38th log
         log_kp1.clone(), // 39th log
-        log_kp1, // 40th log
+        log_kp1.clone(), // 40th log
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let g_k213c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -16047,7 +16085,8 @@ fn phase214_sqrt5_k_log29_k_over_k_refused() {
         log_k.clone(), // 37th log
         log_k.clone(), // 38th log
         log_k.clone(), // 39th log
-        log_k, // 40th log
+        log_k.clone(), // 40th log
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -16066,7 +16105,8 @@ fn phase214_sqrt5_k_log29_k_over_k_refused() {
         log_kp1.clone(), // 37th log
         log_kp1.clone(), // 38th log
         log_kp1.clone(), // 39th log
-        log_kp1, // 40th log
+        log_kp1.clone(), // 40th log
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let g_k214c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -16166,7 +16206,8 @@ fn phase215_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 37th log
         log_k.clone(), // 38th log
         log_k.clone(), // 39th log
-        log_k, // 40th log
+        log_k.clone(), // 40th log
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -16184,7 +16225,8 @@ fn phase215_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 37th log
         log_kp1.clone(), // 38th log
         log_kp1.clone(), // 39th log
-        log_kp1, // 40th log
+        log_kp1.clone(), // 40th log
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -16297,7 +16339,8 @@ fn phase216_sqrt_k_log29_k_over_k_refused() {
         log_k.clone(), // 37th log
         log_k.clone(), // 38th log
         log_k.clone(), // 39th log
-        log_k, // 40th log
+        log_k.clone(), // 40th log
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -16316,7 +16359,8 @@ fn phase216_sqrt_k_log29_k_over_k_refused() {
         log_kp1.clone(), // 37th log
         log_kp1.clone(), // 38th log
         log_kp1.clone(), // 39th log
-        log_kp1, // 40th log
+        log_kp1.clone(), // 40th log
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let g_k216c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -16427,7 +16471,8 @@ fn phase217_sqrt2_k_log29_k_over_k_refused() {
         log_k.clone(), // 37th log
         log_k.clone(), // 38th log
         log_k.clone(), // 39th log
-        log_k, // 40th log
+        log_k.clone(), // 40th log
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -16446,7 +16491,8 @@ fn phase217_sqrt2_k_log29_k_over_k_refused() {
         log_kp1.clone(), // 37th log
         log_kp1.clone(), // 38th log
         log_kp1.clone(), // 39th log
-        log_kp1, // 40th log
+        log_kp1.clone(), // 40th log
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let g_k217c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -16557,7 +16603,8 @@ fn phase218_sqrt3_k_log29_k_over_k_refused() {
         log_k.clone(), // 37th log
         log_k.clone(), // 38th log
         log_k.clone(), // 39th log
-        log_k, // 40th log
+        log_k.clone(), // 40th log
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -16576,7 +16623,8 @@ fn phase218_sqrt3_k_log29_k_over_k_refused() {
         log_kp1.clone(), // 37th log
         log_kp1.clone(), // 38th log
         log_kp1.clone(), // 39th log
-        log_kp1, // 40th log
+        log_kp1.clone(), // 40th log
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let g_k218c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -16687,7 +16735,8 @@ fn phase219_sqrt4_k_log29_k_over_k_refused() {
         log_k.clone(), // 37th log
         log_k.clone(), // 38th log
         log_k.clone(), // 39th log
-        log_k, // 40th log
+        log_k.clone(), // 40th log
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -16706,7 +16755,8 @@ fn phase219_sqrt4_k_log29_k_over_k_refused() {
         log_kp1.clone(), // 37th log
         log_kp1.clone(), // 38th log
         log_kp1.clone(), // 39th log
-        log_kp1, // 40th log
+        log_kp1.clone(), // 40th log
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let g_k219c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -16817,7 +16867,8 @@ fn phase220_sqrt5_k_log29_k_over_k_refused() {
         log_k.clone(), // 37th log
         log_k.clone(), // 38th log
         log_k.clone(), // 39th log
-        log_k, // 40th log
+        log_k.clone(), // 40th log
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -16836,7 +16887,8 @@ fn phase220_sqrt5_k_log29_k_over_k_refused() {
         log_kp1.clone(), // 37th log
         log_kp1.clone(), // 38th log
         log_kp1.clone(), // 39th log
-        log_kp1, // 40th log
+        log_kp1.clone(), // 40th log
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let g_k220c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -16936,7 +16988,8 @@ fn phase221_log30_k_times_k_over_k2_refused() {
         log_k.clone(), // 37th log
         log_k.clone(), // 38th log
         log_k.clone(), // 39th log
-        log_k, // 40th log
+        log_k.clone(), // 40th log
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -16954,7 +17007,8 @@ fn phase221_log30_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 37th log
         log_kp1.clone(), // 38th log
         log_kp1.clone(), // 39th log
-        log_kp1, // 40th log
+        log_kp1.clone(), // 40th log
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -17067,7 +17121,8 @@ fn phase222_sqrt1_k_log30_k_over_k_refused() {
         log_k.clone(), // 37th log
         log_k.clone(), // 38th log
         log_k.clone(), // 39th log
-        log_k, // 40th log
+        log_k.clone(), // 40th log
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -17086,7 +17141,8 @@ fn phase222_sqrt1_k_log30_k_over_k_refused() {
         log_kp1.clone(), // 37th log
         log_kp1.clone(), // 38th log
         log_kp1.clone(), // 39th log
-        log_kp1, // 40th log
+        log_kp1.clone(), // 40th log
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let g_k222c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -17197,7 +17253,8 @@ fn phase223_sqrt2_k_log30_k_over_k_refused() {
         log_k.clone(), // 37th log
         log_k.clone(), // 38th log
         log_k.clone(), // 39th log
-        log_k, // 40th log
+        log_k.clone(), // 40th log
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -17216,7 +17273,8 @@ fn phase223_sqrt2_k_log30_k_over_k_refused() {
         log_kp1.clone(), // 37th log
         log_kp1.clone(), // 38th log
         log_kp1.clone(), // 39th log
-        log_kp1, // 40th log
+        log_kp1.clone(), // 40th log
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let g_k223c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -17327,7 +17385,8 @@ fn phase224_sqrt3_k_log30_k_over_k_refused() {
         log_k.clone(), // 37th log
         log_k.clone(), // 38th log
         log_k.clone(), // 39th log
-        log_k, // 40th log
+        log_k.clone(), // 40th log
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -17346,7 +17405,8 @@ fn phase224_sqrt3_k_log30_k_over_k_refused() {
         log_kp1.clone(), // 37th log
         log_kp1.clone(), // 38th log
         log_kp1.clone(), // 39th log
-        log_kp1, // 40th log
+        log_kp1.clone(), // 40th log
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let g_k224c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -17457,7 +17517,8 @@ fn phase225_sqrt4_k_log30_k_over_k_refused() {
         log_k.clone(), // 37th log
         log_k.clone(), // 38th log
         log_k.clone(), // 39th log
-        log_k, // 40th log
+        log_k.clone(), // 40th log
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -17476,7 +17537,8 @@ fn phase225_sqrt4_k_log30_k_over_k_refused() {
         log_kp1.clone(), // 37th log
         log_kp1.clone(), // 38th log
         log_kp1.clone(), // 39th log
-        log_kp1, // 40th log
+        log_kp1.clone(), // 40th log
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let g_k225c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -17587,7 +17649,8 @@ fn phase226_sqrt5_k_log30_k_over_k_refused() {
         log_k.clone(), // 37th log
         log_k.clone(), // 38th log
         log_k.clone(), // 39th log
-        log_k, // 40th log
+        log_k.clone(), // 40th log
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -17606,7 +17669,8 @@ fn phase226_sqrt5_k_log30_k_over_k_refused() {
         log_kp1.clone(), // 37th log
         log_kp1.clone(), // 38th log
         log_kp1.clone(), // 39th log
-        log_kp1, // 40th log
+        log_kp1.clone(), // 40th log
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let g_k226c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -17706,7 +17770,8 @@ fn phase227_log31_k_times_k_over_k2_refused() {
         log_k.clone(), // 37th log
         log_k.clone(), // 38th log
         log_k.clone(), // 39th log
-        log_k, // 40th log
+        log_k.clone(), // 40th log
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -17724,7 +17789,8 @@ fn phase227_log31_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 37th log
         log_kp1.clone(), // 38th log
         log_kp1.clone(), // 39th log
-        log_kp1, // 40th log
+        log_kp1.clone(), // 40th log
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -17837,7 +17903,8 @@ fn phase228_sqrt1_k_log31_k_times_k_over_k_refused() {
         log_k.clone(), // 37th log
         log_k.clone(), // 38th log
         log_k.clone(), // 39th log
-        log_k, // 40th log
+        log_k.clone(), // 40th log
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -17856,7 +17923,8 @@ fn phase228_sqrt1_k_log31_k_times_k_over_k_refused() {
         log_kp1.clone(), // 37th log
         log_kp1.clone(), // 38th log
         log_kp1.clone(), // 39th log
-        log_kp1, // 40th log
+        log_kp1.clone(), // 40th log
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let g_k228c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -17967,7 +18035,8 @@ fn phase229_sqrt2_k_log31_k_times_k_over_k_refused() {
         log_k.clone(), // 37th log
         log_k.clone(), // 38th log
         log_k.clone(), // 39th log
-        log_k, // 40th log
+        log_k.clone(), // 40th log
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -17986,7 +18055,8 @@ fn phase229_sqrt2_k_log31_k_times_k_over_k_refused() {
         log_kp1.clone(), // 37th log
         log_kp1.clone(), // 38th log
         log_kp1.clone(), // 39th log
-        log_kp1, // 40th log
+        log_kp1.clone(), // 40th log
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let g_k229c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -18097,7 +18167,8 @@ fn phase230_sqrt3_k_log31_k_over_k_refused() {
         log_k.clone(), // 37th log
         log_k.clone(), // 38th log
         log_k.clone(), // 39th log
-        log_k, // 40th log
+        log_k.clone(), // 40th log
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -18116,7 +18187,8 @@ fn phase230_sqrt3_k_log31_k_over_k_refused() {
         log_kp1.clone(), // 37th log
         log_kp1.clone(), // 38th log
         log_kp1.clone(), // 39th log
-        log_kp1, // 40th log
+        log_kp1.clone(), // 40th log
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let g_k230c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -18227,7 +18299,8 @@ fn phase231_sqrt4_k_log31_k_over_k_refused() {
         log_k.clone(), // 37th log
         log_k.clone(), // 38th log
         log_k.clone(), // 39th log
-        log_k, // 40th log
+        log_k.clone(), // 40th log
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -18246,7 +18319,8 @@ fn phase231_sqrt4_k_log31_k_over_k_refused() {
         log_kp1.clone(), // 37th log
         log_kp1.clone(), // 38th log
         log_kp1.clone(), // 39th log
-        log_kp1, // 40th log
+        log_kp1.clone(), // 40th log
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let g_k231c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -18357,7 +18431,8 @@ fn phase232_sqrt5_k_log31_k_over_k_refused() {
         log_k.clone(), // 37th log
         log_k.clone(), // 38th log
         log_k.clone(), // 39th log
-        log_k, // 40th log
+        log_k.clone(), // 40th log
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -18376,7 +18451,8 @@ fn phase232_sqrt5_k_log31_k_over_k_refused() {
         log_kp1.clone(), // 37th log
         log_kp1.clone(), // 38th log
         log_kp1.clone(), // 39th log
-        log_kp1, // 40th log
+        log_kp1.clone(), // 40th log
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let g_k232c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -18476,7 +18552,8 @@ fn phase233_log32_k_times_k_over_k2_refused() {
         log_k.clone(), // 37th log
         log_k.clone(), // 38th log
         log_k.clone(), // 39th log
-        log_k, // 40th log
+        log_k.clone(), // 40th log
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -18494,7 +18571,8 @@ fn phase233_log32_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 37th log
         log_kp1.clone(), // 38th log
         log_kp1.clone(), // 39th log
-        log_kp1, // 40th log
+        log_kp1.clone(), // 40th log
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -18607,7 +18685,8 @@ fn phase234_sqrt1_k_log32_k_times_k_over_k_refused() {
         log_k.clone(), // 37th log
         log_k.clone(), // 38th log
         log_k.clone(), // 39th log
-        log_k, // 40th log
+        log_k.clone(), // 40th log
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -18626,7 +18705,8 @@ fn phase234_sqrt1_k_log32_k_times_k_over_k_refused() {
         log_kp1.clone(), // 37th log
         log_kp1.clone(), // 38th log
         log_kp1.clone(), // 39th log
-        log_kp1, // 40th log
+        log_kp1.clone(), // 40th log
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let g_k234c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -18737,7 +18817,8 @@ fn phase235_sqrt2_k_log32_k_over_k_refused() {
         log_k.clone(), // 37th log
         log_k.clone(), // 38th log
         log_k.clone(), // 39th log
-        log_k, // 40th log
+        log_k.clone(), // 40th log
+        log_k, // 41st log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -18755,7 +18836,8 @@ fn phase235_sqrt2_k_log32_k_over_k_refused() {
         log_kp1.clone(), // 37th log
         log_kp1.clone(), // 38th log
         log_kp1.clone(), // 39th log
-        log_kp1, // 40th log
+        log_kp1.clone(), // 40th log
+        log_kp1, // 41st log
     ]);
     let g_k235c = apply(sym(DIV), vec![num_k, k.clone()]);
     let g_kp1_235c = apply(sym(DIV), vec![num_kp1, kp1.clone()]);
@@ -18865,7 +18947,8 @@ fn phase236_sqrt3_k_log32_k_over_k_refused() {
         log_k.clone(), // 37th log
         log_k.clone(), // 38th log
         log_k.clone(), // 39th log
-        log_k, // 40th log
+        log_k.clone(), // 40th log
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -18884,7 +18967,8 @@ fn phase236_sqrt3_k_log32_k_over_k_refused() {
         log_kp1.clone(), // 37th log
         log_kp1.clone(), // 38th log
         log_kp1.clone(), // 39th log
-        log_kp1, // 40th log
+        log_kp1.clone(), // 40th log
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let g_k236c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -18995,7 +19079,8 @@ fn phase237_sqrt4_k_log32_k_over_k_refused() {
         log_k.clone(), // 37th log
         log_k.clone(), // 38th log
         log_k.clone(), // 39th log
-        log_k, // 40th log
+        log_k.clone(), // 40th log
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -19014,7 +19099,8 @@ fn phase237_sqrt4_k_log32_k_over_k_refused() {
         log_kp1.clone(), // 37th log
         log_kp1.clone(), // 38th log
         log_kp1.clone(), // 39th log
-        log_kp1, // 40th log
+        log_kp1.clone(), // 40th log
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let g_k237c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -19125,7 +19211,8 @@ fn phase238_sqrt5_k_log32_k_over_k_refused() {
         log_k.clone(), // 37th log
         log_k.clone(), // 38th log
         log_k.clone(), // 39th log
-        log_k, // 40th log
+        log_k.clone(), // 40th log
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -19144,7 +19231,8 @@ fn phase238_sqrt5_k_log32_k_over_k_refused() {
         log_kp1.clone(), // 37th log
         log_kp1.clone(), // 38th log
         log_kp1.clone(), // 39th log
-        log_kp1, // 40th log
+        log_kp1.clone(), // 40th log
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let g_k238c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -19247,7 +19335,8 @@ fn phase239_log33_k_times_k_over_k2_refused() {
         log_k.clone(), // 37 logs
         log_k.clone(), // 38 logs
         log_k.clone(), // 39 logs
-        log_k, // 40 logs
+        log_k.clone(), // 40 logs
+        log_k, // 41 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -19264,7 +19353,8 @@ fn phase239_log33_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 37 logs
         log_kp1.clone(), // 38 logs
         log_kp1.clone(), // 39 logs
-        log_kp1, // 40 logs
+        log_kp1.clone(), // 40 logs
+        log_kp1, // 41 logs
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -19380,7 +19470,8 @@ fn phase240_sqrt1_k_log33_k_times_k_over_k_refused() {
         log_k.clone(), // 37 logs
         log_k.clone(), // 38 logs
         log_k.clone(), // 39 logs
-        log_k, // 40 logs
+        log_k.clone(), // 40 logs
+        log_k, // 41 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -19398,7 +19489,8 @@ fn phase240_sqrt1_k_log33_k_times_k_over_k_refused() {
         log_kp1.clone(), // 37 logs
         log_kp1.clone(), // 38 logs
         log_kp1.clone(), // 39 logs
-        log_kp1, // 40 logs
+        log_kp1.clone(), // 40 logs
+        log_kp1, // 41 logs
         kp1.clone(),
     ]);
     let g_k240c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -19512,7 +19604,8 @@ fn phase241_sqrt2_k_log33_k_over_k_refused() {
         log_k.clone(), // 37 logs
         log_k.clone(), // 38 logs
         log_k.clone(), // 39 logs
-        log_k, // 40 logs
+        log_k.clone(), // 40 logs
+        log_k, // 41 logs
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -19529,7 +19622,8 @@ fn phase241_sqrt2_k_log33_k_over_k_refused() {
         log_kp1.clone(), // 37 logs
         log_kp1.clone(), // 38 logs
         log_kp1.clone(), // 39 logs
-        log_kp1, // 40 logs
+        log_kp1.clone(), // 40 logs
+        log_kp1, // 41 logs
     ]);
     let g_k241c = apply(sym(DIV), vec![num_k, k.clone()]);
     let g_kp1_241c = apply(sym(DIV), vec![num_kp1, kp1.clone()]);
@@ -19642,7 +19736,8 @@ fn phase242_sqrt3_k_log33_k_over_k_refused() {
         log_k.clone(), // 37 logs
         log_k.clone(), // 38 logs
         log_k.clone(), // 39 logs
-        log_k, // 40 logs
+        log_k.clone(), // 40 logs
+        log_k, // 41 logs
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -19659,7 +19754,8 @@ fn phase242_sqrt3_k_log33_k_over_k_refused() {
         log_kp1.clone(), // 37 logs
         log_kp1.clone(), // 38 logs
         log_kp1.clone(), // 39 logs
-        log_kp1, // 40 logs
+        log_kp1.clone(), // 40 logs
+        log_kp1, // 41 logs
     ]);
     let g_k242c = apply(sym(DIV), vec![num_k, k.clone()]);
     let g_kp1_242c = apply(sym(DIV), vec![num_kp1, kp1.clone()]);
@@ -19772,7 +19868,8 @@ fn phase243_sqrt4_k_log33_k_over_k_refused() {
         log_k.clone(), // 37 logs
         log_k.clone(), // 38 logs
         log_k.clone(), // 39 logs
-        log_k, // 40 logs
+        log_k.clone(), // 40 logs
+        log_k, // 41 logs
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -19789,7 +19886,8 @@ fn phase243_sqrt4_k_log33_k_over_k_refused() {
         log_kp1.clone(), // 37 logs
         log_kp1.clone(), // 38 logs
         log_kp1.clone(), // 39 logs
-        log_kp1, // 40 logs
+        log_kp1.clone(), // 40 logs
+        log_kp1, // 41 logs
     ]);
     let g_k243c = apply(sym(DIV), vec![num_k, k.clone()]);
     let g_kp1_243c = apply(sym(DIV), vec![num_kp1, kp1.clone()]);
@@ -19898,7 +19996,8 @@ fn phase244_sqrt5_k_log33_k_over_k_refused() {
         log_k.clone(), // 37 logs
         log_k.clone(), // 38 logs
         log_k.clone(), // 39 logs
-        log_k, // 40 logs
+        log_k.clone(), // 40 logs
+        log_k, // 41 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -19916,7 +20015,8 @@ fn phase244_sqrt5_k_log33_k_over_k_refused() {
         log_kp1.clone(), // 37 logs
         log_kp1.clone(), // 38 logs
         log_kp1.clone(), // 39 logs
-        log_kp1, // 40 logs
+        log_kp1.clone(), // 40 logs
+        log_kp1, // 41 logs
         kp1.clone(),
     ]);
     let g_k244c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -20018,7 +20118,8 @@ fn phase245_log34_k_times_k_over_k2_refused() {
         log_k.clone(), // 37 logs
         log_k.clone(), // 38 logs
         log_k.clone(), // 39 logs
-        log_k, // 40 logs
+        log_k.clone(), // 40 logs
+        log_k, // 41 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -20034,7 +20135,8 @@ fn phase245_log34_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 37 logs
         log_kp1.clone(), // 38 logs
         log_kp1.clone(), // 39 logs
-        log_kp1, // 40 logs
+        log_kp1.clone(), // 40 logs
+        log_kp1, // 41 logs
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -20149,7 +20251,8 @@ fn phase246_sqrt1_k_log34_k_over_k_refused() {
         log_k.clone(), // 37 logs
         log_k.clone(), // 38 logs
         log_k.clone(), // 39 logs
-        log_k, // 40 logs
+        log_k.clone(), // 40 logs
+        log_k, // 41 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -20166,7 +20269,8 @@ fn phase246_sqrt1_k_log34_k_over_k_refused() {
         log_kp1.clone(), // 37 logs
         log_kp1.clone(), // 38 logs
         log_kp1.clone(), // 39 logs
-        log_kp1, // 40 logs
+        log_kp1.clone(), // 40 logs
+        log_kp1, // 41 logs
         kp1.clone(),
     ]);
     let g_k246c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -20279,7 +20383,8 @@ fn phase247_sqrt2_k_log34_k_over_k_refused() {
         log_k.clone(), // 37 logs
         log_k.clone(), // 38 logs
         log_k.clone(), // 39 logs
-        log_k, // 40 logs
+        log_k.clone(), // 40 logs
+        log_k, // 41 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -20296,7 +20401,8 @@ fn phase247_sqrt2_k_log34_k_over_k_refused() {
         log_kp1.clone(), // 37 logs
         log_kp1.clone(), // 38 logs
         log_kp1.clone(), // 39 logs
-        log_kp1, // 40 logs
+        log_kp1.clone(), // 40 logs
+        log_kp1, // 41 logs
         kp1.clone(),
     ]);
     let g_k247c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -20409,7 +20515,8 @@ fn phase248_sqrt3_k_log34_k_over_k_refused() {
         log_k.clone(), // 37 logs
         log_k.clone(), // 38 logs
         log_k.clone(), // 39 logs
-        log_k, // 40 logs
+        log_k.clone(), // 40 logs
+        log_k, // 41 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -20426,7 +20533,8 @@ fn phase248_sqrt3_k_log34_k_over_k_refused() {
         log_kp1.clone(), // 37 logs
         log_kp1.clone(), // 38 logs
         log_kp1.clone(), // 39 logs
-        log_kp1, // 40 logs
+        log_kp1.clone(), // 40 logs
+        log_kp1, // 41 logs
         kp1.clone(),
     ]);
     let g_k248c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -20539,7 +20647,8 @@ fn phase249_sqrt4_k_log34_k_over_k_refused() {
         log_k.clone(), // 37 logs
         log_k.clone(), // 38 logs
         log_k.clone(), // 39 logs
-        log_k, // 40 logs
+        log_k.clone(), // 40 logs
+        log_k, // 41 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -20556,7 +20665,8 @@ fn phase249_sqrt4_k_log34_k_over_k_refused() {
         log_kp1.clone(), // 37 logs
         log_kp1.clone(), // 38 logs
         log_kp1.clone(), // 39 logs
-        log_kp1, // 40 logs
+        log_kp1.clone(), // 40 logs
+        log_kp1, // 41 logs
         kp1.clone(),
     ]);
     let g_k249c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -20669,7 +20779,8 @@ fn phase250_sqrt5_k_log34_k_over_k_refused() {
         log_k.clone(), // 37 logs
         log_k.clone(), // 38 logs
         log_k.clone(), // 39 logs
-        log_k, // 40 logs
+        log_k.clone(), // 40 logs
+        log_k, // 41 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -20686,7 +20797,8 @@ fn phase250_sqrt5_k_log34_k_over_k_refused() {
         log_kp1.clone(), // 37 logs
         log_kp1.clone(), // 38 logs
         log_kp1.clone(), // 39 logs
-        log_kp1, // 40 logs
+        log_kp1.clone(), // 40 logs
+        log_kp1, // 41 logs
         kp1.clone(),
     ]);
     let g_k250c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -20787,7 +20899,8 @@ fn phase251_log36_k_times_k_over_k2_refused() {
         log_k.clone(), // 37 logs
         log_k.clone(), // 38 logs
         log_k.clone(), // 39 logs
-        log_k, // 40 logs
+        log_k.clone(), // 40 logs
+        log_k, // 41 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -20802,7 +20915,8 @@ fn phase251_log36_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 37 logs
         log_kp1.clone(), // 38 logs
         log_kp1.clone(), // 39 logs
-        log_kp1, // 40 logs
+        log_kp1.clone(), // 40 logs
+        log_kp1, // 41 logs
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -20916,7 +21030,8 @@ fn phase252_sqrt1_k_log36_k_over_k_refused() {
         log_k.clone(), // 37 logs
         log_k.clone(), // 38 logs
         log_k.clone(), // 39 logs
-        log_k, // 40 logs
+        log_k.clone(), // 40 logs
+        log_k, // 41 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -20932,7 +21047,8 @@ fn phase252_sqrt1_k_log36_k_over_k_refused() {
         log_kp1.clone(), // 37 logs
         log_kp1.clone(), // 38 logs
         log_kp1.clone(), // 39 logs
-        log_kp1, // 40 logs
+        log_kp1.clone(), // 40 logs
+        log_kp1, // 41 logs
         kp1.clone(),
     ]);
     let g_k252c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -21044,7 +21160,8 @@ fn phase253_sqrt2_k_log36_k_over_k_refused() {
         log_k.clone(), // 37 logs
         log_k.clone(), // 38 logs
         log_k.clone(), // 39 logs
-        log_k, // 40 logs
+        log_k.clone(), // 40 logs
+        log_k, // 41 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -21060,7 +21177,8 @@ fn phase253_sqrt2_k_log36_k_over_k_refused() {
         log_kp1.clone(), // 37 logs
         log_kp1.clone(), // 38 logs
         log_kp1.clone(), // 39 logs
-        log_kp1, // 40 logs
+        log_kp1.clone(), // 40 logs
+        log_kp1, // 41 logs
         kp1.clone(),
     ]);
     let g_k253c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -21172,7 +21290,8 @@ fn phase254_sqrt3_k_log36_k_over_k_refused() {
         log_k.clone(), // 37 logs
         log_k.clone(), // 38 logs
         log_k.clone(), // 39 logs
-        log_k, // 40 logs
+        log_k.clone(), // 40 logs
+        log_k, // 41 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -21188,7 +21307,8 @@ fn phase254_sqrt3_k_log36_k_over_k_refused() {
         log_kp1.clone(), // 37 logs
         log_kp1.clone(), // 38 logs
         log_kp1.clone(), // 39 logs
-        log_kp1, // 40 logs
+        log_kp1.clone(), // 40 logs
+        log_kp1, // 41 logs
         kp1.clone(),
     ]);
     let g_k254c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -21300,7 +21420,8 @@ fn phase255_sqrt4_k_log36_k_over_k_refused() {
         log_k.clone(), // 37 logs
         log_k.clone(), // 38 logs
         log_k.clone(), // 39 logs
-        log_k, // 40 logs
+        log_k.clone(), // 40 logs
+        log_k, // 41 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -21316,7 +21437,8 @@ fn phase255_sqrt4_k_log36_k_over_k_refused() {
         log_kp1.clone(), // 37 logs
         log_kp1.clone(), // 38 logs
         log_kp1.clone(), // 39 logs
-        log_kp1, // 40 logs
+        log_kp1.clone(), // 40 logs
+        log_kp1, // 41 logs
         kp1.clone(),
     ]);
     let g_k255c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -21428,7 +21550,8 @@ fn phase256_sqrt5_k_log36_k_over_k_refused() {
         log_k.clone(), // 37 logs
         log_k.clone(), // 38 logs
         log_k.clone(), // 39 logs
-        log_k, // 40 logs
+        log_k.clone(), // 40 logs
+        log_k, // 41 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -21444,7 +21567,8 @@ fn phase256_sqrt5_k_log36_k_over_k_refused() {
         log_kp1.clone(), // 37 logs
         log_kp1.clone(), // 38 logs
         log_kp1.clone(), // 39 logs
-        log_kp1, // 40 logs
+        log_kp1.clone(), // 40 logs
+        log_kp1, // 41 logs
         kp1.clone(),
     ]);
     let g_k256c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -21545,7 +21669,8 @@ fn phase257_log36_k_times_k_over_k2_refused() {
         log_k.clone(), // 37 logs
         log_k.clone(), // 38 logs
         log_k.clone(), // 39 logs
-        log_k, // 40 logs
+        log_k.clone(), // 40 logs
+        log_k, // 41 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -21560,7 +21685,8 @@ fn phase257_log36_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 37 logs
         log_kp1.clone(), // 38 logs
         log_kp1.clone(), // 39 logs
-        log_kp1, // 40 logs
+        log_kp1.clone(), // 40 logs
+        log_kp1, // 41 logs
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -21674,7 +21800,8 @@ fn phase258_sqrt1_k_log36_k_over_k_refused() {
         log_k.clone(), // 37 logs
         log_k.clone(), // 38 logs
         log_k.clone(), // 39 logs
-        log_k, // 40 logs
+        log_k.clone(), // 40 logs
+        log_k, // 41 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -21690,7 +21817,8 @@ fn phase258_sqrt1_k_log36_k_over_k_refused() {
         log_kp1.clone(), // 37 logs
         log_kp1.clone(), // 38 logs
         log_kp1.clone(), // 39 logs
-        log_kp1, // 40 logs
+        log_kp1.clone(), // 40 logs
+        log_kp1, // 41 logs
         kp1.clone(),
     ]);
     let g_k258c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -21802,7 +21930,8 @@ fn phase259_sqrt2_k_log36_k_over_k_refused() {
         log_k.clone(), // 37 logs
         log_k.clone(), // 38 logs
         log_k.clone(), // 39 logs
-        log_k, // 40 logs
+        log_k.clone(), // 40 logs
+        log_k, // 41 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -21818,7 +21947,8 @@ fn phase259_sqrt2_k_log36_k_over_k_refused() {
         log_kp1.clone(), // 37 logs
         log_kp1.clone(), // 38 logs
         log_kp1.clone(), // 39 logs
-        log_kp1, // 40 logs
+        log_kp1.clone(), // 40 logs
+        log_kp1, // 41 logs
         kp1.clone(),
     ]);
     let g_k259c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -21930,7 +22060,8 @@ fn phase260_sqrt3_k_log36_k_over_k_refused() {
         log_k.clone(), // 37 logs
         log_k.clone(), // 38 logs
         log_k.clone(), // 39 logs
-        log_k, // 40 logs
+        log_k.clone(), // 40 logs
+        log_k, // 41 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -21946,7 +22077,8 @@ fn phase260_sqrt3_k_log36_k_over_k_refused() {
         log_kp1.clone(), // 37 logs
         log_kp1.clone(), // 38 logs
         log_kp1.clone(), // 39 logs
-        log_kp1, // 40 logs
+        log_kp1.clone(), // 40 logs
+        log_kp1, // 41 logs
         kp1.clone(),
     ]);
     let g_k260c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -22058,7 +22190,8 @@ fn phase261_sqrt4_k_log36_k_over_k_refused() {
         log_k.clone(), // 37 logs
         log_k.clone(), // 38 logs
         log_k.clone(), // 39 logs
-        log_k, // 40 logs
+        log_k.clone(), // 40 logs
+        log_k, // 41 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -22074,7 +22207,8 @@ fn phase261_sqrt4_k_log36_k_over_k_refused() {
         log_kp1.clone(), // 37 logs
         log_kp1.clone(), // 38 logs
         log_kp1.clone(), // 39 logs
-        log_kp1, // 40 logs
+        log_kp1.clone(), // 40 logs
+        log_kp1, // 41 logs
         kp1.clone(),
     ]);
     let g_k261c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -22186,7 +22320,8 @@ fn phase262_sqrt5_k_log36_k_over_k_refused() {
         log_k.clone(), // 37 logs
         log_k.clone(), // 38 logs
         log_k.clone(), // 39 logs
-        log_k, // 40 logs
+        log_k.clone(), // 40 logs
+        log_k, // 41 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -22202,7 +22337,8 @@ fn phase262_sqrt5_k_log36_k_over_k_refused() {
         log_kp1.clone(), // 37 logs
         log_kp1.clone(), // 38 logs
         log_kp1.clone(), // 39 logs
-        log_kp1, // 40 logs
+        log_kp1.clone(), // 40 logs
+        log_kp1, // 41 logs
         kp1.clone(),
     ]);
     let g_k262c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -22306,7 +22442,8 @@ fn phase263_log37_k_over_k_refused() {
         log_k.clone(), // 37 logs
         log_k.clone(), // 38 logs
         log_k.clone(), // 39 logs
-        log_k, // 40 logs
+        log_k.clone(), // 40 logs
+        log_k, // 41 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -22321,7 +22458,8 @@ fn phase263_log37_k_over_k_refused() {
         log_kp1.clone(), // 37 logs
         log_kp1.clone(), // 38 logs
         log_kp1.clone(), // 39 logs
-        log_kp1, // 40 logs
+        log_kp1.clone(), // 40 logs
+        log_kp1, // 41 logs
         kp1.clone(),
     ]);
     let g_k263c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -22435,7 +22573,8 @@ fn phase264_sqrt1_k_log37_k_over_k_refused() {
         log_k.clone(), // 37 logs
         log_k.clone(), // 38 logs
         log_k.clone(), // 39 logs
-        log_k, // 40 logs
+        log_k.clone(), // 40 logs
+        log_k, // 41 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -22451,7 +22590,8 @@ fn phase264_sqrt1_k_log37_k_over_k_refused() {
         log_kp1.clone(), // 37 logs
         log_kp1.clone(), // 38 logs
         log_kp1.clone(), // 39 logs
-        log_kp1, // 40 logs
+        log_kp1.clone(), // 40 logs
+        log_kp1, // 41 logs
         kp1.clone(),
     ]);
     let g_k264c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -22565,7 +22705,8 @@ fn phase265_sqrt2_k_log37_k_over_k_refused() {
         log_k.clone(), // 37 logs
         log_k.clone(), // 38 logs
         log_k.clone(), // 39 logs
-        log_k, // 40 logs
+        log_k.clone(), // 40 logs
+        log_k, // 41 logs
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -22580,7 +22721,8 @@ fn phase265_sqrt2_k_log37_k_over_k_refused() {
         log_kp1.clone(), // 37 logs
         log_kp1.clone(), // 38 logs
         log_kp1.clone(), // 39 logs
-        log_kp1, // 40 logs
+        log_kp1.clone(), // 40 logs
+        log_kp1, // 41 logs
     ]);
     let g_k265c = apply(sym(DIV), vec![num_k, k.clone()]);
     let g_kp1_265c = apply(sym(DIV), vec![num_kp1, kp1.clone()]);
@@ -22693,7 +22835,8 @@ fn phase266_sqrt3_k_log37_k_over_k_refused() {
         log_k.clone(), // 37 logs
         log_k.clone(), // 38 logs
         log_k.clone(), // 39 logs
-        log_k, // 40 logs
+        log_k.clone(), // 40 logs
+        log_k, // 41 logs
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -22708,7 +22851,8 @@ fn phase266_sqrt3_k_log37_k_over_k_refused() {
         log_kp1.clone(), // 37 logs
         log_kp1.clone(), // 38 logs
         log_kp1.clone(), // 39 logs
-        log_kp1, // 40 logs
+        log_kp1.clone(), // 40 logs
+        log_kp1, // 41 logs
     ]);
     let g_k266c = apply(sym(DIV), vec![num_k, k.clone()]);
     let g_kp1_266c = apply(sym(DIV), vec![num_kp1, kp1.clone()]);
@@ -22821,7 +22965,8 @@ fn phase267_sqrt4_k_log37_k_over_k_refused() {
         log_k.clone(), // 37 logs
         log_k.clone(), // 38 logs
         log_k.clone(), // 39 logs
-        log_k, // 40 logs
+        log_k.clone(), // 40 logs
+        log_k, // 41 logs
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -22836,7 +22981,8 @@ fn phase267_sqrt4_k_log37_k_over_k_refused() {
         log_kp1.clone(), // 37 logs
         log_kp1.clone(), // 38 logs
         log_kp1.clone(), // 39 logs
-        log_kp1, // 40 logs
+        log_kp1.clone(), // 40 logs
+        log_kp1, // 41 logs
     ]);
     let g_k267c = apply(sym(DIV), vec![num_k, k.clone()]);
     let g_kp1_267c = apply(sym(DIV), vec![num_kp1, kp1.clone()]);
@@ -22949,7 +23095,8 @@ fn phase268_sqrt5_k_log37_k_over_k_refused() {
         log_k.clone(), // 37 logs
         log_k.clone(), // 38 logs
         log_k.clone(), // 39 logs
-        log_k, // 40 logs
+        log_k.clone(), // 40 logs
+        log_k, // 41 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -22965,7 +23112,8 @@ fn phase268_sqrt5_k_log37_k_over_k_refused() {
         log_kp1.clone(), // 37 logs
         log_kp1.clone(), // 38 logs
         log_kp1.clone(), // 39 logs
-        log_kp1, // 40 logs
+        log_kp1.clone(), // 40 logs
+        log_kp1, // 41 logs
         kp1.clone(),
     ]);
     let g_k268c = apply(sym(DIV), vec![num_k, k.clone()]);
@@ -23076,7 +23224,8 @@ fn phase269_log38_k_over_k2_refused() {
         log_k.clone(), // 37 logs
         log_k.clone(), // 38 logs
         log_k.clone(), // 39 logs
-        log_k, // 40 logs
+        log_k.clone(), // 40 logs
+        log_k, // 41 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -23091,7 +23240,8 @@ fn phase269_log38_k_over_k2_refused() {
         log_kp1.clone(), // 37 logs
         log_kp1.clone(), // 38 logs
         log_kp1.clone(), // 39 logs
-        log_kp1, // 40 logs
+        log_kp1.clone(), // 40 logs
+        log_kp1, // 41 logs
         kp1.clone(),
     ]);
     let g_k269c = apply(sym(DIV), vec![num_k, k2]);
@@ -23213,7 +23363,8 @@ fn phase270_sqrt_k_log38_k_over_k2_refused() {
         log_k.clone(), // 37 logs
         log_k.clone(), // 38 logs
         log_k.clone(), // 39 logs
-        log_k, // 40 logs
+        log_k.clone(), // 40 logs
+        log_k, // 41 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -23229,7 +23380,8 @@ fn phase270_sqrt_k_log38_k_over_k2_refused() {
         log_kp1.clone(), // 37 logs
         log_kp1.clone(), // 38 logs
         log_kp1.clone(), // 39 logs
-        log_kp1, // 40 logs
+        log_kp1.clone(), // 40 logs
+        log_kp1, // 41 logs
         kp1.clone(),
     ]);
     let g_k270c = apply(sym(DIV), vec![num_k, k2]);
@@ -23351,7 +23503,8 @@ fn phase271_sqrt2_k_log38_k_over_k2_refused() {
         log_k.clone(), // 37 logs
         log_k.clone(), // 38 logs
         log_k.clone(), // 39 logs
-        log_k, // 40 logs
+        log_k.clone(), // 40 logs
+        log_k, // 41 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -23367,7 +23520,8 @@ fn phase271_sqrt2_k_log38_k_over_k2_refused() {
         log_kp1.clone(), // 37 logs
         log_kp1.clone(), // 38 logs
         log_kp1.clone(), // 39 logs
-        log_kp1, // 40 logs
+        log_kp1.clone(), // 40 logs
+        log_kp1, // 41 logs
         kp1.clone(),
     ]);
     let g_k271c = apply(sym(DIV), vec![num_k, k2]);
@@ -23489,7 +23643,8 @@ fn phase272_sqrt3_k_log38_k_over_k2_refused() {
         log_k.clone(), // 37 logs
         log_k.clone(), // 38 logs
         log_k.clone(), // 39 logs
-        log_k, // 40 logs
+        log_k.clone(), // 40 logs
+        log_k, // 41 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -23505,7 +23660,8 @@ fn phase272_sqrt3_k_log38_k_over_k2_refused() {
         log_kp1.clone(), // 37 logs
         log_kp1.clone(), // 38 logs
         log_kp1.clone(), // 39 logs
-        log_kp1, // 40 logs
+        log_kp1.clone(), // 40 logs
+        log_kp1, // 41 logs
         kp1.clone(),
     ]);
     let g_k272c = apply(sym(DIV), vec![num_k, k2]);
@@ -23627,7 +23783,8 @@ fn phase273_sqrt4_k_log38_k_over_k3_refused() {
         log_k.clone(), // 37 logs
         log_k.clone(), // 38 logs
         log_k.clone(), // 39 logs
-        log_k, // 40 logs
+        log_k.clone(), // 40 logs
+        log_k, // 41 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -23643,7 +23800,8 @@ fn phase273_sqrt4_k_log38_k_over_k3_refused() {
         log_kp1.clone(), // 37 logs
         log_kp1.clone(), // 38 logs
         log_kp1.clone(), // 39 logs
-        log_kp1, // 40 logs
+        log_kp1.clone(), // 40 logs
+        log_kp1, // 41 logs
         kp1.clone(),
     ]);
     let g_k273c = apply(sym(DIV), vec![num_k, k3]);
@@ -23765,7 +23923,8 @@ fn phase274_sqrt5_k_log38_k_over_k3_refused() {
         log_k.clone(), // 37 logs
         log_k.clone(), // 38 logs
         log_k.clone(), // 39 logs
-        log_k, // 40 logs
+        log_k.clone(), // 40 logs
+        log_k, // 41 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -23781,7 +23940,8 @@ fn phase274_sqrt5_k_log38_k_over_k3_refused() {
         log_kp1.clone(), // 37 logs
         log_kp1.clone(), // 38 logs
         log_kp1.clone(), // 39 logs
-        log_kp1, // 40 logs
+        log_kp1.clone(), // 40 logs
+        log_kp1, // 41 logs
         kp1.clone(),
     ]);
     let g_k274c = apply(sym(DIV), vec![num_k, k3]);
@@ -23896,7 +24056,8 @@ fn phase275_log39_k_over_k2_refused() {
         log_k.clone(), // 37 logs
         log_k.clone(), // 38 logs
         log_k.clone(), // 39 logs
-        log_k, // 40 logs
+        log_k.clone(), // 40 logs
+        log_k, // 41 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -23911,7 +24072,8 @@ fn phase275_log39_k_over_k2_refused() {
         log_kp1.clone(), // 37 logs
         log_kp1.clone(), // 38 logs
         log_kp1.clone(), // 39 logs
-        log_kp1, // 40 logs
+        log_kp1.clone(), // 40 logs
+        log_kp1, // 41 logs
         kp1.clone(),
     ]);
     let g_k275c = apply(sym(DIV), vec![num_k, k2]);
@@ -24037,7 +24199,8 @@ fn phase276_sqrt_k_log39_k_over_k2_refused() {
         log_k.clone(), // 37 logs
         log_k.clone(), // 38 logs
         log_k.clone(), // 39 logs
-        log_k, // 40 logs
+        log_k.clone(), // 40 logs
+        log_k, // 41 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -24053,7 +24216,8 @@ fn phase276_sqrt_k_log39_k_over_k2_refused() {
         log_kp1.clone(), // 37 logs
         log_kp1.clone(), // 38 logs
         log_kp1.clone(), // 39 logs
-        log_kp1, // 40 logs
+        log_kp1.clone(), // 40 logs
+        log_kp1, // 41 logs
         kp1.clone(),
     ]);
     let g_k276c = apply(sym(DIV), vec![num_k, k2]);
@@ -24179,7 +24343,8 @@ fn phase277_sqrt2_k_log39_k_over_k2_refused() {
         log_k.clone(), // 37 logs
         log_k.clone(), // 38 logs
         log_k.clone(), // 39 logs
-        log_k, // 40 logs
+        log_k.clone(), // 40 logs
+        log_k, // 41 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -24195,7 +24360,8 @@ fn phase277_sqrt2_k_log39_k_over_k2_refused() {
         log_kp1.clone(), // 37 logs
         log_kp1.clone(), // 38 logs
         log_kp1.clone(), // 39 logs
-        log_kp1, // 40 logs
+        log_kp1.clone(), // 40 logs
+        log_kp1, // 41 logs
         kp1.clone(),
     ]);
     let g_k277c = apply(sym(DIV), vec![num_k, k2]);
@@ -24321,7 +24487,8 @@ fn phase278_sqrt3_k_log39_k_over_k2_refused() {
         log_k.clone(), // 37 logs
         log_k.clone(), // 38 logs
         log_k.clone(), // 39 logs
-        log_k, // 40 logs
+        log_k.clone(), // 40 logs
+        log_k, // 41 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -24337,7 +24504,8 @@ fn phase278_sqrt3_k_log39_k_over_k2_refused() {
         log_kp1.clone(), // 37 logs
         log_kp1.clone(), // 38 logs
         log_kp1.clone(), // 39 logs
-        log_kp1, // 40 logs
+        log_kp1.clone(), // 40 logs
+        log_kp1, // 41 logs
         kp1.clone(),
     ]);
     let g_k278c = apply(sym(DIV), vec![num_k, k2]);
@@ -24463,7 +24631,8 @@ fn phase279_sqrt4_k_log39_k_over_k3_refused() {
         log_k.clone(), // 37 logs
         log_k.clone(), // 38 logs
         log_k.clone(), // 39 logs
-        log_k, // 40 logs
+        log_k.clone(), // 40 logs
+        log_k, // 41 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -24479,7 +24648,8 @@ fn phase279_sqrt4_k_log39_k_over_k3_refused() {
         log_kp1.clone(), // 37 logs
         log_kp1.clone(), // 38 logs
         log_kp1.clone(), // 39 logs
-        log_kp1, // 40 logs
+        log_kp1.clone(), // 40 logs
+        log_kp1, // 41 logs
         kp1.clone(),
     ]);
     let g_k279c = apply(sym(DIV), vec![num_k, k3]);
@@ -24605,7 +24775,8 @@ fn phase280_sqrt5_k_log39_k_over_k3_refused() {
         log_k.clone(), // 37 logs
         log_k.clone(), // 38 logs
         log_k.clone(), // 39 logs
-        log_k, // 40 logs
+        log_k.clone(), // 40 logs
+        log_k, // 41 logs
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -24621,7 +24792,8 @@ fn phase280_sqrt5_k_log39_k_over_k3_refused() {
         log_kp1.clone(), // 37 logs
         log_kp1.clone(), // 38 logs
         log_kp1.clone(), // 39 logs
-        log_kp1, // 40 logs
+        log_kp1.clone(), // 40 logs
+        log_kp1, // 41 logs
         kp1.clone(),
     ]);
     let g_k280c = apply(sym(DIV), vec![num_k, k3]);
@@ -24727,7 +24899,8 @@ fn phase281_log40_k_over_k2_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
-        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k, // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -24738,7 +24911,8 @@ fn phase281_log40_k_over_k2_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
-        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1, // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let g_kphase281r = apply(sym(DIV), vec![num_k, k2]);
@@ -24852,7 +25026,8 @@ fn phase282_sqrt1_k_log40_k_over_k2_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
-        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k, // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -24864,7 +25039,8 @@ fn phase282_sqrt1_k_log40_k_over_k2_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
-        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1, // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let g_kphase282r = apply(sym(DIV), vec![num_k, k2]);
@@ -24978,7 +25154,8 @@ fn phase283_sqrt2_k_log40_k_over_k2_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
-        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k, // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -24990,7 +25167,8 @@ fn phase283_sqrt2_k_log40_k_over_k2_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
-        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1, // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let g_kphase283r = apply(sym(DIV), vec![num_k, k2]);
@@ -25104,7 +25282,8 @@ fn phase284_sqrt3_k_log40_k_over_k2_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
-        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k, // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -25116,7 +25295,8 @@ fn phase284_sqrt3_k_log40_k_over_k2_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
-        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1, // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let g_kphase284r = apply(sym(DIV), vec![num_k, k2]);
@@ -25230,7 +25410,8 @@ fn phase285_sqrt4_k_log40_k_over_k3_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
-        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k, // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -25242,7 +25423,8 @@ fn phase285_sqrt4_k_log40_k_over_k3_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
-        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1, // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let g_kphase285r = apply(sym(DIV), vec![num_k, k3]);
@@ -25356,7 +25538,8 @@ fn phase286_sqrt5_k_log40_k_over_k3_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
-        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k, // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k, // 41st log
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -25368,12 +25551,759 @@ fn phase286_sqrt5_k_log40_k_over_k3_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
-        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1, // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1, // 41st log
         kp1.clone(),
     ]);
     let g_kphase286r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase286r = apply(sym(DIV), vec![num_kp1, kp1_3]);
     let fphase286r = apply(sym(SUB), vec![g_kphase286r, g_kp1_phase286r]);
     let out = evaluate_sum(fphase286r, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+// ── Phase 287: Zero-Sqrt × Forty-Log × polynomial ──────────────────────────
+
+#[test]
+fn phase287_log40_k_over_k2_converges() {
+    // log(k)^40 / k2: eff_x2=0; 2·2=4 > 0 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k, // 40 logs
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1, // 40 logs
+    ]);
+    let g_kphase287a = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_phase287a = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let fphase287a = apply(sym(SUB), vec![g_kphase287a, g_kp1_phase287a]);
+    let out = evaluate_sum(fphase287a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase287_log40_k_times_k2_over_k3_converges() {
+    // log(k)^40·k² / k3: eff_x2=4; 2·3=6 > 4 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        k2.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        kp1_2.clone(),
+    ]);
+    let g_kphase287b = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_phase287b = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let fphase287b = apply(sym(SUB), vec![g_kphase287b, g_kp1_phase287b]);
+    let out = evaluate_sum(fphase287b, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase287_log41_k_over_k2_refused() {
+    // phase287 log41 k over k2 refused: 41 logs → refused (Phase 287 handles exactly 40).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k, // 41st log
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1, // 41st log
+    ]);
+    let g_kphase287r = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_phase287r = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let fphase287r = apply(sym(SUB), vec![g_kphase287r, g_kp1_phase287r]);
+    let out = evaluate_sum(fphase287r, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+// ── Phase 288: One-Sqrt × Forty-Log × polynomial ──────────────────────────
+
+#[test]
+fn phase288_sqrt1_k_log40_k_over_k2_converges() {
+    // sqrt_k·log(k)^40 / k2: eff_x2=1; 2·2=4 > 1 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k, // 40 logs
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1, // 40 logs
+    ]);
+    let g_kphase288a = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_phase288a = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let fphase288a = apply(sym(SUB), vec![g_kphase288a, g_kp1_phase288a]);
+    let out = evaluate_sum(fphase288a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase288_sqrt1_k_log40_k_times_k_over_k3_converges() {
+    // sqrt_k·log(k)^40·k / k3: eff_x2=3; 2·3=6 > 3 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        kp1.clone(),
+    ]);
+    let g_kphase288b = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_phase288b = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let fphase288b = apply(sym(SUB), vec![g_kphase288b, g_kp1_phase288b]);
+    let out = evaluate_sum(fphase288b, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase288_sqrt1_k_log41_k_over_k2_refused() {
+    // phase288 sqrt1 k log41 k over k2 refused: 41 logs → refused (Phase 288 handles exactly 40).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k, // 41st log
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1, // 41st log
+    ]);
+    let g_kphase288r = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_phase288r = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let fphase288r = apply(sym(SUB), vec![g_kphase288r, g_kp1_phase288r]);
+    let out = evaluate_sum(fphase288r, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+// ── Phase 289: Two-Sqrt × Forty-Log × polynomial ──────────────────────────
+
+#[test]
+fn phase289_sqrt2_k_log40_k_over_k2_converges() {
+    // sqrt_k^2·log(k)^40 / k2: eff_x2=2; 2·2=4 > 2 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k, // 40 logs
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1, // 40 logs
+    ]);
+    let g_kphase289a = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_phase289a = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let fphase289a = apply(sym(SUB), vec![g_kphase289a, g_kp1_phase289a]);
+    let out = evaluate_sum(fphase289a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase289_sqrt2_k_log40_k_times_k_over_k3_converges() {
+    // sqrt_k^2·log(k)^40·k / k3: eff_x2=4; 2·3=6 > 4 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        kp1.clone(),
+    ]);
+    let g_kphase289b = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_phase289b = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let fphase289b = apply(sym(SUB), vec![g_kphase289b, g_kp1_phase289b]);
+    let out = evaluate_sum(fphase289b, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase289_sqrt2_k_log41_k_over_k2_refused() {
+    // phase289 sqrt2 k log41 k over k2 refused: 41 logs → refused (Phase 289 handles exactly 40).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k, // 41st log
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1, // 41st log
+    ]);
+    let g_kphase289r = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_phase289r = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let fphase289r = apply(sym(SUB), vec![g_kphase289r, g_kp1_phase289r]);
+    let out = evaluate_sum(fphase289r, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+// ── Phase 290: Three-Sqrt × Forty-Log × polynomial ──────────────────────────
+
+#[test]
+fn phase290_sqrt3_k_log40_k_over_k3_converges() {
+    // sqrt_k^3·log(k)^40 / k3: eff_x2=3; 2·3=6 > 3 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k, // 40 logs
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1, // 40 logs
+    ]);
+    let g_kphase290a = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_phase290a = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let fphase290a = apply(sym(SUB), vec![g_kphase290a, g_kp1_phase290a]);
+    let out = evaluate_sum(fphase290a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase290_sqrt3_k_log40_k_times_k_over_k4_converges() {
+    // sqrt_k^3·log(k)^40·k / k4: eff_x2=5; 2·4=8 > 5 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k4 = apply(sym(POW), vec![k.clone(), int(4)]);
+    let kp1_4 = apply(sym(POW), vec![kp1.clone(), int(4)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        kp1.clone(),
+    ]);
+    let g_kphase290b = apply(sym(DIV), vec![num_k, k4]);
+    let g_kp1_phase290b = apply(sym(DIV), vec![num_kp1, kp1_4]);
+    let fphase290b = apply(sym(SUB), vec![g_kphase290b, g_kp1_phase290b]);
+    let out = evaluate_sum(fphase290b, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase290_sqrt3_k_log41_k_over_k3_refused() {
+    // phase290 sqrt3 k log41 k over k3 refused: 41 logs → refused (Phase 290 handles exactly 40).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k, // 41st log
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1, // 41st log
+    ]);
+    let g_kphase290r = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_phase290r = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let fphase290r = apply(sym(SUB), vec![g_kphase290r, g_kp1_phase290r]);
+    let out = evaluate_sum(fphase290r, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+// ── Phase 291: Four-Sqrt × Forty-Log × polynomial ──────────────────────────
+
+#[test]
+fn phase291_sqrt4_k_log40_k_over_k3_converges() {
+    // sqrt_k^4·log(k)^40 / k3: eff_x2=4; 2·3=6 > 4 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k, // 40 logs
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1, // 40 logs
+    ]);
+    let g_kphase291a = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_phase291a = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let fphase291a = apply(sym(SUB), vec![g_kphase291a, g_kp1_phase291a]);
+    let out = evaluate_sum(fphase291a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase291_sqrt4_k_log40_k_times_k_over_k4_converges() {
+    // sqrt_k^4·log(k)^40·k / k4: eff_x2=6; 2·4=8 > 6 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k4 = apply(sym(POW), vec![k.clone(), int(4)]);
+    let kp1_4 = apply(sym(POW), vec![kp1.clone(), int(4)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        kp1.clone(),
+    ]);
+    let g_kphase291b = apply(sym(DIV), vec![num_k, k4]);
+    let g_kp1_phase291b = apply(sym(DIV), vec![num_kp1, kp1_4]);
+    let fphase291b = apply(sym(SUB), vec![g_kphase291b, g_kp1_phase291b]);
+    let out = evaluate_sum(fphase291b, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase291_sqrt4_k_log41_k_over_k3_refused() {
+    // phase291 sqrt4 k log41 k over k3 refused: 41 logs → refused (Phase 291 handles exactly 40).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k, // 41st log
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1, // 41st log
+    ]);
+    let g_kphase291r = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_phase291r = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let fphase291r = apply(sym(SUB), vec![g_kphase291r, g_kp1_phase291r]);
+    let out = evaluate_sum(fphase291r, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+// ── Phase 292: Five-Sqrt × Forty-Log × polynomial ──────────────────────────
+
+#[test]
+fn phase292_sqrt5_k_log40_k_over_k3_converges() {
+    // sqrt_k^5·log(k)^40 / k3: eff_x2=5; 2·3=6 > 5 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k, // 40 logs
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1, // 40 logs
+    ]);
+    let g_kphase292a = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_phase292a = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let fphase292a = apply(sym(SUB), vec![g_kphase292a, g_kp1_phase292a]);
+    let out = evaluate_sum(fphase292a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase292_sqrt5_k_log40_k_times_k_over_k4_converges() {
+    // sqrt_k^5·log(k)^40·k / k4: eff_x2=7; 2·4=8 > 7 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k4 = apply(sym(POW), vec![k.clone(), int(4)]);
+    let kp1_4 = apply(sym(POW), vec![kp1.clone(), int(4)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        kp1.clone(),
+    ]);
+    let g_kphase292b = apply(sym(DIV), vec![num_k, k4]);
+    let g_kp1_phase292b = apply(sym(DIV), vec![num_kp1, kp1_4]);
+    let fphase292b = apply(sym(SUB), vec![g_kphase292b, g_kp1_phase292b]);
+    let out = evaluate_sum(fphase292b, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase292_sqrt5_k_log41_k_over_k3_refused() {
+    // phase292 sqrt5 k log41 k over k3 refused: 41 logs → refused (Phase 292 handles exactly 40).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k, // 41st log
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1, // 41st log
+    ]);
+    let g_kphase292r = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_phase292r = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let fphase292r = apply(sym(SUB), vec![g_kphase292r, g_kp1_phase292r]);
+    let out = evaluate_sum(fphase292r, k, int(1), sym("%inf"), eval);
     assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 2.229.0 — 2026-05-27
+
+### Added
+
+- **Phase 292 — Five-Sqrt × Forty-Log × polynomial** (`fiveSqrtFortyLogPolyEffectiveDeg`):
+  Completes the Forty-Log family (Phases 287–292).
+- **Phase 291 — Four-Sqrt × Forty-Log × polynomial** (`fourSqrtFortyLogPolyEffectiveDeg`).
+- **Phase 290 — Three-Sqrt × Forty-Log × polynomial** (`threeSqrtFortyLogPolyEffectiveDeg`).
+- **Phase 289 — Two-Sqrt × Forty-Log × polynomial** (`twoSqrtFortyLogPolyEffectiveDeg`).
+- **Phase 288 — One-Sqrt × Forty-Log × polynomial** (`oneSqrtFortyLogPolyEffectiveDeg`).
+- **Phase 287 — Zero-Sqrt × Forty-Log × polynomial** (`fortyLogPolyEffectiveDeg`).
+
+### Changed
+
+- Boundary tests in Phases 281–286 (and prior phases 167–280) updated from 40-log
+  "refused" to 41-log "refused" now that Phases 287–292 handle exactly 40 logs.
+
 ## 2.223.0 — 2026-05-27
 
 ### Added

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "2.223.0",
+  "version": "2.229.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -5889,6 +5889,165 @@ function fiveSqrtThirtyNineLogPolyEffectiveDeg(node: IRNode, k: IRNode): number 
   return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + sqrtHalfDegs[3] + sqrtHalfDegs[4] + polyDeg;
 }
 
+/** Phase 287 — Zero-Sqrt × Forty-Log × polynomial numerator.
+ * effectiveDeg = polyDeg (no sqrt factors).
+ * Caller checks `denDeg > fortyLogPolyEffectiveDeg(num, k)`.
+ */
+function fortyLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    if (sqrtEffectiveHalfDegree(arg, k) !== undefined) return undefined;
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 40) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (logCount !== 40) return undefined;
+  return polyDeg;
+}
+
+/** Phase 288 — One-Sqrt × Forty-Log × polynomial numerator.
+ * Caller checks `denDeg > oneSqrtFortyLogPolyEffectiveDeg(num, k)`.
+ */
+function oneSqrtFortyLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  let sqrtHalfDeg: number | undefined;
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const sh = sqrtEffectiveHalfDegree(arg, k);
+    if (sh !== undefined) {
+      if (sqrtHalfDeg !== undefined) return undefined;
+      sqrtHalfDeg = sh; continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 40) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDeg === undefined || logCount !== 40) return undefined;
+  return sqrtHalfDeg + polyDeg;
+}
+
+/** Phase 289 — Two-Sqrt × Forty-Log × polynomial numerator. */
+function twoSqrtFortyLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const sh = sqrtEffectiveHalfDegree(arg, k);
+    if (sh !== undefined) {
+      if (sqrtHalfDegs.length >= 2) return undefined;
+      sqrtHalfDegs.push(sh); continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 40) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 2 || logCount !== 40) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + polyDeg;
+}
+
+/** Phase 290 — Three-Sqrt × Forty-Log × polynomial numerator. */
+function threeSqrtFortyLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const sh = sqrtEffectiveHalfDegree(arg, k);
+    if (sh !== undefined) {
+      if (sqrtHalfDegs.length >= 3) return undefined;
+      sqrtHalfDegs.push(sh); continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 40) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 3 || logCount !== 40) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + polyDeg;
+}
+
+/** Phase 291 — Four-Sqrt × Forty-Log × polynomial numerator. */
+function fourSqrtFortyLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const sh = sqrtEffectiveHalfDegree(arg, k);
+    if (sh !== undefined) {
+      if (sqrtHalfDegs.length >= 4) return undefined;
+      sqrtHalfDegs.push(sh); continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 40) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 4 || logCount !== 40) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + sqrtHalfDegs[3] + polyDeg;
+}
+
+/** Phase 292 — Five-Sqrt × Forty-Log × polynomial numerator.
+ * Caller checks `denDeg > fiveSqrtFortyLogPolyEffectiveDeg(num, k)`.
+ * Completes the Forty-Log family (Phases 287–292).
+ */
+function fiveSqrtFortyLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const sh = sqrtEffectiveHalfDegree(arg, k);
+    if (sh !== undefined) {
+      if (sqrtHalfDegs.length >= 5) return undefined;
+      sqrtHalfDegs.push(sh); continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 40) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 5 || logCount !== 40) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + sqrtHalfDegs[3] + sqrtHalfDegs[4] + polyDeg;
+}
+
 /** Phase 251 — Zero-Sqrt × Thirty-Four-Log × polynomial numerator.
  * effectiveDeg = polyDeg (no sqrt factors).
  * Caller checks `denDeg > thirtyFourLogPolyEffectiveDeg(num, k)`.
@@ -7729,6 +7888,66 @@ function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
     const denDegS2l8 = polynomialDegreeInK(den, k);
     if (denDegS2l8 !== undefined) {
       if (denDegS2l8 > s2l8Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 292: five sqrt + 40 logs
+  const s5l40Deg = fiveSqrtFortyLogPolyEffectiveDeg(num, k);
+  if (s5l40Deg !== undefined) {
+    const denDegS5l40 = polynomialDegreeInK(den, k);
+    if (denDegS5l40 !== undefined) {
+      if (denDegS5l40 > s5l40Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 291: four sqrt + 40 logs
+  const s4l40Deg = fourSqrtFortyLogPolyEffectiveDeg(num, k);
+  if (s4l40Deg !== undefined) {
+    const denDegS4l40 = polynomialDegreeInK(den, k);
+    if (denDegS4l40 !== undefined) {
+      if (denDegS4l40 > s4l40Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 290: three sqrt + 40 logs
+  const s3l40Deg = threeSqrtFortyLogPolyEffectiveDeg(num, k);
+  if (s3l40Deg !== undefined) {
+    const denDegS3l40 = polynomialDegreeInK(den, k);
+    if (denDegS3l40 !== undefined) {
+      if (denDegS3l40 > s3l40Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 289: two sqrt + 40 logs
+  const s2l40Deg = twoSqrtFortyLogPolyEffectiveDeg(num, k);
+  if (s2l40Deg !== undefined) {
+    const denDegS2l40 = polynomialDegreeInK(den, k);
+    if (denDegS2l40 !== undefined) {
+      if (denDegS2l40 > s2l40Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 288: one sqrt + 40 logs
+  const s1l40Deg = oneSqrtFortyLogPolyEffectiveDeg(num, k);
+  if (s1l40Deg !== undefined) {
+    const denDegS1l40 = polynomialDegreeInK(den, k);
+    if (denDegS1l40 !== undefined) {
+      if (denDegS1l40 > s1l40Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 287: zero sqrt + 40 logs
+  const s0l40Deg = fortyLogPolyEffectiveDeg(num, k);
+  if (s0l40Deg !== undefined) {
+    const denDegS0l40 = polynomialDegreeInK(den, k);
+    if (denDegS0l40 !== undefined) {
+      if (denDegS0l40 > s0l40Deg) return true;
     } else if (hDivergesAtInfinity(den, k)) {
       return true;
     }

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -15271,8 +15271,8 @@ describe("Phase 167 — Twenty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK167r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1167r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK167r = { kind: "apply" as const, head: DIV, args: [numK167r, k2] };
@@ -15321,8 +15321,8 @@ describe("Phase 168 — One-Sqrt × Twenty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK168r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [k] }, ...logs29k, k] };
     const numKp1168r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [kp1] }, ...logs29kp1, kp1] };
     const gK168r = { kind: "apply" as const, head: DIV, args: [numK168r, k2] };
@@ -15375,8 +15375,8 @@ describe("Phase 169 — Two-Sqrt × Twenty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK169r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -15431,8 +15431,8 @@ describe("Phase 170 — Three-Sqrt × Twenty-Log × polynomial numerator", () =>
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK170r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15487,8 +15487,8 @@ describe("Phase 171 — Four-Sqrt × Twenty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK171r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15543,8 +15543,8 @@ describe("Phase 172 — Five-Sqrt × Twenty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK172r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15595,8 +15595,8 @@ describe("Phase 173 — Twenty-One-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK173r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1173r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK173r = { kind: "apply" as const, head: DIV, args: [numK173r, k2] };
@@ -15645,8 +15645,8 @@ describe("Phase 174 — One-Sqrt × Twenty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK174r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [k] }, ...logs29k, k] };
     const numKp1174r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [kp1] }, ...logs29kp1, kp1] };
     const gK174r = { kind: "apply" as const, head: DIV, args: [numK174r, k2] };
@@ -15699,8 +15699,8 @@ describe("Phase 175 — Two-Sqrt × Twenty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK175r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -15755,8 +15755,8 @@ describe("Phase 176 — Three-Sqrt × Twenty-One-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK176r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15811,8 +15811,8 @@ describe("Phase 177 — Four-Sqrt × Twenty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK177r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15867,8 +15867,8 @@ describe("Phase 178 — Five-Sqrt × Twenty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK178r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15919,8 +15919,8 @@ describe("Phase 179 — Twenty-Two-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK179r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1179r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK179r = { kind: "apply" as const, head: DIV, args: [numK179r, k2] };
@@ -15969,8 +15969,8 @@ describe("Phase 180 — One-Sqrt × Twenty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK180r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [k] }, ...logs29k, k] };
     const numKp1180r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [kp1] }, ...logs29kp1, kp1] };
     const gK180r = { kind: "apply" as const, head: DIV, args: [numK180r, k2] };
@@ -16023,8 +16023,8 @@ describe("Phase 181 — Two-Sqrt × Twenty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK181r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -16079,8 +16079,8 @@ describe("Phase 182 — Three-Sqrt × Twenty-Two-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK182r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16135,8 +16135,8 @@ describe("Phase 183 — Four-Sqrt × Twenty-Two-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK183r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16191,8 +16191,8 @@ describe("Phase 184 — Five-Sqrt × Twenty-Two-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK184r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16243,8 +16243,8 @@ describe("Phase 185 — Twenty-Three-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK185r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1185r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK185r = { kind: "apply" as const, head: DIV, args: [numK185r, k2] };
@@ -16293,8 +16293,8 @@ describe("Phase 186 — One-Sqrt × Twenty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK186r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [k] }, ...logs29k, k] };
     const numKp1186r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [kp1] }, ...logs29kp1, kp1] };
     const gK186r = { kind: "apply" as const, head: DIV, args: [numK186r, k2] };
@@ -16347,8 +16347,8 @@ describe("Phase 187 — Two-Sqrt × Twenty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK187r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -16403,8 +16403,8 @@ describe("Phase 188 — Three-Sqrt × Twenty-Three-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK188r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16459,8 +16459,8 @@ describe("Phase 189 — Four-Sqrt × Twenty-Three-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK189r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16515,8 +16515,8 @@ describe("Phase 190 — Five-Sqrt × Twenty-Three-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK190r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16567,8 +16567,8 @@ describe("Phase 191 — Twenty-Four-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK191r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1191r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK191r = { kind: "apply" as const, head: DIV, args: [numK191r, k2] };
@@ -16621,8 +16621,8 @@ describe("Phase 192 — One-Sqrt × Twenty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK192r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs29k, k] };
@@ -16677,8 +16677,8 @@ describe("Phase 193 — Two-Sqrt × Twenty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK193r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -16733,8 +16733,8 @@ describe("Phase 194 — Three-Sqrt × Twenty-Four-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK194r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16789,8 +16789,8 @@ describe("Phase 195 — Four-Sqrt × Twenty-Four-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK195r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16845,8 +16845,8 @@ describe("Phase 196 — Five-Sqrt × Twenty-Four-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK196r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16897,8 +16897,8 @@ describe("Phase 197 — Twenty-Five-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK197r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1197r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK197r = { kind: "apply" as const, head: DIV, args: [numK197r, k2] };
@@ -16951,8 +16951,8 @@ describe("Phase 198 — One-Sqrt × Twenty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK198r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs29k, k] };
@@ -17007,8 +17007,8 @@ describe("Phase 199 — Two-Sqrt × Twenty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK199r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -17063,8 +17063,8 @@ describe("Phase 200 — Three-Sqrt × Twenty-Five-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK200r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17119,8 +17119,8 @@ describe("Phase 201 — Four-Sqrt × Twenty-Five-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK201r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17175,8 +17175,8 @@ describe("Phase 202 — Five-Sqrt × Twenty-Five-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK202r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17227,8 +17227,8 @@ describe("Phase 203 — Twenty-Six-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK203r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1203r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK203r = { kind: "apply" as const, head: DIV, args: [numK203r, k2] };
@@ -17279,8 +17279,8 @@ describe("Phase 204 — One-Sqrt × Twenty-Six-Log × polynomial numerator", () 
   it("√k·log(k)²⁹·k/k² refused (30 logs — not Phase 204)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK204r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs29k, k] };
@@ -17333,8 +17333,8 @@ describe("Phase 205 — Two-Sqrt × Twenty-Six-Log × polynomial numerator", () 
   it("√k·√k·log(k)²⁹/k² refused (30 logs — not Phase 205)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK205r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k, k] };
@@ -17387,8 +17387,8 @@ describe("Phase 206 — Three-Sqrt × Twenty-Six-Log × polynomial numerator", (
   it("(√k)³·log(k)²⁹/k² refused (30 logs — not Phase 206)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK206r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k, k] };
@@ -17443,8 +17443,8 @@ describe("Phase 207 — Four-Sqrt × Twenty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK207r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k, k] };
@@ -17499,8 +17499,8 @@ describe("Phase 208 — Five-Sqrt × Twenty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK208r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17551,8 +17551,8 @@ describe("Phase 209 — Zero-Sqrt × Twenty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK209r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1209r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK209r = { kind: "apply" as const, head: DIV, args: [numK209r, k2] };
@@ -17603,8 +17603,8 @@ describe("Phase 210 — One-Sqrt × Twenty-Seven-Log × polynomial numerator", (
   it("√k·log(k)²⁹·k/k² refused (30 logs — not Phase 210)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK210r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs29k, k] };
@@ -17659,8 +17659,8 @@ describe("Phase 211 — Two-Sqrt × Twenty-Seven-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK211r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -17715,8 +17715,8 @@ describe("Phase 212 — Three-Sqrt × Twenty-Seven-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK212r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17771,8 +17771,8 @@ describe("Phase 213 — Four-Sqrt × Twenty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK213r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17827,8 +17827,8 @@ describe("Phase 214 — Five-Sqrt × Twenty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK214r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17879,8 +17879,8 @@ describe("Phase 215 — Zero-Sqrt × Twenty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK215r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1215r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK215r = { kind: "apply" as const, head: DIV, args: [numK215r, k2] };
@@ -17933,8 +17933,8 @@ describe("Phase 216 — One-Sqrt × Twenty-Eight-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK216r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs29k, k] };
@@ -17989,8 +17989,8 @@ describe("Phase 217 — Two-Sqrt × Twenty-Eight-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK217r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -18045,8 +18045,8 @@ describe("Phase 218 — Three-Sqrt × Twenty-Eight-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK218r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -18101,8 +18101,8 @@ describe("Phase 219 — Four-Sqrt × Twenty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK219r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -18157,8 +18157,8 @@ describe("Phase 220 — Five-Sqrt × Twenty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK220r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -18209,8 +18209,8 @@ describe("Phase 221 — Zero-Sqrt × Twenty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK221r = { kind: "apply" as const, head: MUL, args: [...logs30k, k] };
     const numKp1221r = { kind: "apply" as const, head: MUL, args: [...logs30kp1, kp1] };
     const gK221r = { kind: "apply" as const, head: DIV, args: [numK221r, k2] };
@@ -18263,8 +18263,8 @@ describe("Phase 222 — One-Sqrt × Twenty-Nine-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK222r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs30k, k] };
@@ -18319,8 +18319,8 @@ describe("Phase 223 — Two-Sqrt × Twenty-Nine-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK223r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs30k, k] };
@@ -18375,8 +18375,8 @@ describe("Phase 224 — Three-Sqrt × Twenty-Nine-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK224r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs30k, k] };
@@ -18431,8 +18431,8 @@ describe("Phase 225 — Four-Sqrt × Twenty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK225r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs30k, k] };
@@ -18487,8 +18487,8 @@ describe("Phase 226 — Five-Sqrt × Twenty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK226r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs30k, k] };
@@ -18539,8 +18539,8 @@ describe("Phase 227 — Zero-Sqrt × Thirty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK227r = { kind: "apply" as const, head: MUL, args: [...logs31k, k] };
     const numKp1227r = { kind: "apply" as const, head: MUL, args: [...logs31kp1, kp1] };
     const gK227r = { kind: "apply" as const, head: DIV, args: [numK227r, k2] };
@@ -18593,8 +18593,8 @@ describe("Phase 228 — One-Sqrt × Thirty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK228r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs31k, k] };
@@ -18649,8 +18649,8 @@ describe("Phase 229 — Two-Sqrt × Thirty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK229r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs31k, k] };
@@ -18705,8 +18705,8 @@ describe("Phase 230 — Three-Sqrt × Thirty-Log × polynomial numerator", () =>
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK230r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs31k, k] };
@@ -18761,8 +18761,8 @@ describe("Phase 231 — Four-Sqrt × Thirty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK231r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs31k, k] };
@@ -18817,8 +18817,8 @@ describe("Phase 232 — Five-Sqrt × Thirty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK232r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs31k, k] };
@@ -18869,8 +18869,8 @@ describe("Phase 233 — Zero-Sqrt × Thirty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK233r = { kind: "apply" as const, head: MUL, args: [...logs32k, k] };
     const numKp1233r = { kind: "apply" as const, head: MUL, args: [...logs32kp1, kp1] };
     const gK233r = { kind: "apply" as const, head: DIV, args: [numK233r, k2] };
@@ -18923,8 +18923,8 @@ describe("Phase 234 — One-Sqrt × Thirty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK234r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs32k, k] };
@@ -18979,8 +18979,8 @@ describe("Phase 235 — Two-Sqrt × Thirty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK235r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs32k, k] };
@@ -19035,8 +19035,8 @@ describe("Phase 236 — Three-Sqrt × Thirty-One-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK236r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs32k, k] };
@@ -19091,8 +19091,8 @@ describe("Phase 237 — Four-Sqrt × Thirty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK237r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs32k, k] };
@@ -19147,8 +19147,8 @@ describe("Phase 238 — Five-Sqrt × Thirty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK238r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs32k, k] };
@@ -19199,8 +19199,8 @@ describe("Phase 239 — Thirty-Two-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs33k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK239r = { kind: "apply" as const, head: MUL, args: [...logs33k, k] };
     const numKp1239r = { kind: "apply" as const, head: MUL, args: [...logs33kp1, kp1] };
     const gK239r = { kind: "apply" as const, head: DIV, args: [numK239r, k2] };
@@ -19249,8 +19249,8 @@ describe("Phase 240 — One-Sqrt × Thirty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs33k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK240r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [k] }, ...logs33k, k] };
     const numKp1240r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [kp1] }, ...logs33kp1, kp1] };
     const gK240r = { kind: "apply" as const, head: DIV, args: [numK240r, k2] };
@@ -19303,8 +19303,8 @@ describe("Phase 241 — Two-Sqrt × Thirty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs33k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK241r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs33k] };
@@ -19359,8 +19359,8 @@ describe("Phase 242 — Three-Sqrt × Thirty-Two-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs33k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK242r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs33k] };
@@ -19415,8 +19415,8 @@ describe("Phase 243 — Four-Sqrt × Thirty-Two-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs33k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK243r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs33k, k] };
@@ -19471,8 +19471,8 @@ describe("Phase 244 — Five-Sqrt × Thirty-Two-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs33k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK244r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs33k, k] };
@@ -19523,8 +19523,8 @@ describe("Phase 245 — Thirty-Three-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs34k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK245r = { kind: "apply" as const, head: MUL, args: [...logs34k, k] };
     const numKp1245r = { kind: "apply" as const, head: MUL, args: [...logs34kp1, kp1] };
     const gK245r = { kind: "apply" as const, head: DIV, args: [numK245r, k2] };
@@ -19577,8 +19577,8 @@ describe("Phase 246 — One-Sqrt × Thirty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs34k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK246r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs34k, k] };
@@ -19633,8 +19633,8 @@ describe("Phase 247 — Two-Sqrt × Thirty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs34k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK247r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs34k] };
@@ -19689,8 +19689,8 @@ describe("Phase 248 — Three-Sqrt × Thirty-Three-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs34k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK248r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs34k] };
@@ -19745,8 +19745,8 @@ describe("Phase 249 — Four-Sqrt × Thirty-Three-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs34k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK249r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs34k] };
@@ -19801,8 +19801,8 @@ describe("Phase 250 — Five-Sqrt × Thirty-Three-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs34k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK250r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs34k, k] };
@@ -19853,8 +19853,8 @@ describe("Phase 251 — Thirty-Four-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs36k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK251r = { kind: "apply" as const, head: MUL, args: [...logs36k, k] };
     const numKp1251r = { kind: "apply" as const, head: MUL, args: [...logs36kp1, kp1] };
     const gK251r = { kind: "apply" as const, head: DIV, args: [numK251r, k2] };
@@ -19907,8 +19907,8 @@ describe("Phase 252 — One-Sqrt × Thirty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs36k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK252r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs36k, k] };
@@ -19963,8 +19963,8 @@ describe("Phase 253 — Two-Sqrt × Thirty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs36k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK253r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs36k] };
@@ -20019,8 +20019,8 @@ describe("Phase 254 — Three-Sqrt × Thirty-Four-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs36k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK254r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs36k] };
@@ -20075,8 +20075,8 @@ describe("Phase 255 — Four-Sqrt × Thirty-Four-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs36k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK255r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs36k] };
@@ -20131,8 +20131,8 @@ describe("Phase 256 — Five-Sqrt × Thirty-Four-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK256r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs36k, k] };
@@ -20183,8 +20183,8 @@ describe("Phase 257 — Thirty-Five-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK257r = { kind: "apply" as const, head: MUL, args: [...logs36k, k] };
     const numKp1257r = { kind: "apply" as const, head: MUL, args: [...logs36kp1, kp1] };
     const gK257r = { kind: "apply" as const, head: DIV, args: [numK257r, k2] };
@@ -20237,8 +20237,8 @@ describe("Phase 258 — One-Sqrt × Thirty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK258r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs36k, k] };
@@ -20293,8 +20293,8 @@ describe("Phase 259 — Two-Sqrt × Thirty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK259r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs36k, k] };
@@ -20349,8 +20349,8 @@ describe("Phase 260 — Three-Sqrt × Thirty-Five-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK260r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs36k, k] };
@@ -20405,8 +20405,8 @@ describe("Phase 261 — Four-Sqrt × Thirty-Five-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK261r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs36k, k] };
@@ -20461,8 +20461,8 @@ describe("Phase 262 — Five-Sqrt × Thirty-Five-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK262r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs36k, k] };
@@ -20513,8 +20513,8 @@ describe("Phase 263 — Zero-Sqrt × Thirty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK263r = { kind: "apply" as const, head: MUL, args: [...logs37k, k] };
     const numKp1263r = { kind: "apply" as const, head: MUL, args: [...logs37kp1, kp1] };
     const gK263r = { kind: "apply" as const, head: DIV, args: [numK263r, k2] };
@@ -20567,8 +20567,8 @@ describe("Phase 264 — One-Sqrt × Thirty-Six-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK264r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs37k, k] };
@@ -20623,8 +20623,8 @@ describe("Phase 265 — Two-Sqrt × Thirty-Six-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK265r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs37k] };
@@ -20679,8 +20679,8 @@ describe("Phase 266 — Three-Sqrt × Thirty-Six-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK266r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs37k] };
@@ -20735,8 +20735,8 @@ describe("Phase 267 — Four-Sqrt × Thirty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK267r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs37k, k] };
@@ -20791,8 +20791,8 @@ describe("Phase 268 — Five-Sqrt × Thirty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK268r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs37k, k] };
@@ -20843,8 +20843,8 @@ describe("Phase 269 — Zero-Sqrt × Thirty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs38k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs38kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs38k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK269r = { kind: "apply" as const, head: MUL, args: [...logs38k, k] };
     const numKp1269r = { kind: "apply" as const, head: MUL, args: [...logs38kp1, kp1] };
     const gK269r = { kind: "apply" as const, head: DIV, args: [numK269r, k2] };
@@ -20897,8 +20897,8 @@ describe("Phase 270 — One-Sqrt × Thirty-Seven-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs38k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs38kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs38k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK270r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs38k, k] };
@@ -20953,8 +20953,8 @@ describe("Phase 271 — Two-Sqrt × Thirty-Seven-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs38k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs38kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs38k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK271r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs38k, k] };
@@ -21009,8 +21009,8 @@ describe("Phase 272 — Three-Sqrt × Thirty-Seven-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs38k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs38kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs38k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK272r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs38k, k] };
@@ -21065,8 +21065,8 @@ describe("Phase 273 — Four-Sqrt × Thirty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs38k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs38kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs38k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK273r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs38k, k] };
@@ -21121,8 +21121,8 @@ describe("Phase 274 — Five-Sqrt × Thirty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs38k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs38kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs38k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK274r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs38k, k] };
@@ -21173,8 +21173,8 @@ describe("Phase 275 — Zero-Sqrt × Thirty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs39k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs39kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs39k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs39kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK275r = { kind: "apply" as const, head: MUL, args: [...logs39k, k] };
     const numKp1275r = { kind: "apply" as const, head: MUL, args: [...logs39kp1, kp1] };
     const gK275r = { kind: "apply" as const, head: DIV, args: [numK275r, k2] };
@@ -21227,8 +21227,8 @@ describe("Phase 276 — One-Sqrt × Thirty-Eight-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs39k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs39kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs39k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs39kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK276r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs39k, k] };
@@ -21283,8 +21283,8 @@ describe("Phase 277 — Two-Sqrt × Thirty-Eight-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs39k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs39kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs39k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs39kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK277r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs39k, k] };
@@ -21339,8 +21339,8 @@ describe("Phase 278 — Three-Sqrt × Thirty-Eight-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs39k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs39kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs39k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs39kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK278r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs39k, k] };
@@ -21395,8 +21395,8 @@ describe("Phase 279 — Four-Sqrt × Thirty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs39k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs39kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs39k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs39kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK279r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs39k, k] };
@@ -21451,8 +21451,8 @@ describe("Phase 280 — Five-Sqrt × Thirty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs39k = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs39kp1 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs39k = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs39kp1 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK280r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs39k, k] };
@@ -21504,8 +21504,8 @@ describe("Phase 281 — Zero-Sqrt × Thirty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs40k281 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs40kp1281 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs40k281 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1281 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK281r = { kind: "apply" as const, head: MUL, args: [...logs40k281, k] };
     const numKp1281r = { kind: "apply" as const, head: MUL, args: [...logs40kp1281, kp1] };
     const gK281r = { kind: "apply" as const, head: DIV, args: [numK281r, k2r] };
@@ -21558,8 +21558,8 @@ describe("Phase 282 — One-Sqrt × Thirty-Nine-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs40k282 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs40kp1282 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs40k282 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1282 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK282r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs40k282, k] };
@@ -21614,8 +21614,8 @@ describe("Phase 283 — Two-Sqrt × Thirty-Nine-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs40k283 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs40kp1283 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs40k283 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1283 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK283r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs40k283, k] };
@@ -21670,8 +21670,8 @@ describe("Phase 284 — Three-Sqrt × Thirty-Nine-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs40k284 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs40kp1284 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs40k284 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1284 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK284r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs40k284, k] };
@@ -21726,8 +21726,8 @@ describe("Phase 285 — Four-Sqrt × Thirty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs40k285 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs40kp1285 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs40k285 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1285 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK285r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs40k285, k] };
@@ -21782,8 +21782,8 @@ describe("Phase 286 — Five-Sqrt × Thirty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs40k286 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs40kp1286 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs40k286 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1286 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK286r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs40k286, k] };
@@ -21792,6 +21792,336 @@ describe("Phase 286 — Five-Sqrt × Thirty-Nine-Log × polynomial numerator", (
     const gKp1286r = { kind: "apply" as const, head: DIV, args: [numKp1286r, kp1_3r] };
     const f286r = { kind: "apply" as const, head: SUB, args: [gK286r, gKp1286r] };
     const result = evaluateSum(f286r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 287 — Zero-Sqrt × Forty-Log × polynomial numerator", () => {
+  it("log(k)⁴⁰/k² closes (0 → effective=0; denDeg=2 > 0)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const logs40k287 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1287 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const numK287a = { kind: "apply" as const, head: MUL, args: [...logs40k287] };
+    const numKp1287a = { kind: "apply" as const, head: MUL, args: [...logs40kp1287] };
+    const gK287a = { kind: "apply" as const, head: DIV, args: [numK287a, k2] };
+    const gKp1287a = { kind: "apply" as const, head: DIV, args: [numKp1287a, kp1_2] };
+    const f287a = { kind: "apply" as const, head: SUB, args: [gK287a, gKp1287a] };
+    const result = evaluateSum(f287a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("log(k)⁴⁰·k/k² closes (polyDeg=1 → effective=1; denDeg=2 > 1)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const logs40k287 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1287 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const numK287b = { kind: "apply" as const, head: MUL, args: [...logs40k287, k] };
+    const numKp1287b = { kind: "apply" as const, head: MUL, args: [...logs40kp1287, kp1] };
+    const gK287b = { kind: "apply" as const, head: DIV, args: [numK287b, k2] };
+    const gKp1287b = { kind: "apply" as const, head: DIV, args: [numKp1287b, kp1_2] };
+    const f287b = { kind: "apply" as const, head: SUB, args: [gK287b, gKp1287b] };
+    const result = evaluateSum(f287b, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("log(k)⁴¹·k/k² refused (41 logs — not Phase 287)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs41k287 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs41kp1287 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const numK287r = { kind: "apply" as const, head: MUL, args: [...logs41k287, k] };
+    const numKp1287r = { kind: "apply" as const, head: MUL, args: [...logs41kp1287, kp1] };
+    const gK287r = { kind: "apply" as const, head: DIV, args: [numK287r, k2r] };
+    const gKp1287r = { kind: "apply" as const, head: DIV, args: [numKp1287r, kp1_2r] };
+    const f287r = { kind: "apply" as const, head: SUB, args: [gK287r, gKp1287r] };
+    const result = evaluateSum(f287r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 288 — One-Sqrt × Forty-Log × polynomial numerator", () => {
+  it("√k·log(k)⁴⁰/k² closes (sqrtHalf=0.5, polyDeg=0 → effective=0.5; denDeg=2 > 0.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const logs40k288 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1288 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK288a = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs40k288] };
+    const numKp1288a = { kind: "apply" as const, head: MUL, args: [sqrtKp1, ...logs40kp1288] };
+    const gK288a = { kind: "apply" as const, head: DIV, args: [numK288a, k2] };
+    const gKp1288a = { kind: "apply" as const, head: DIV, args: [numKp1288a, kp1_2] };
+    const f288a = { kind: "apply" as const, head: SUB, args: [gK288a, gKp1288a] };
+    const result = evaluateSum(f288a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("√k·log(k)⁴⁰·k/k² closes (sqrtHalf=0.5, polyDeg=1 → effective=1.5; denDeg=2 > 1.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const logs40k288 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1288 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK288b = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs40k288, k] };
+    const numKp1288b = { kind: "apply" as const, head: MUL, args: [sqrtKp1, ...logs40kp1288, kp1] };
+    const gK288b = { kind: "apply" as const, head: DIV, args: [numK288b, k2] };
+    const gKp1288b = { kind: "apply" as const, head: DIV, args: [numKp1288b, kp1_2] };
+    const f288b = { kind: "apply" as const, head: SUB, args: [gK288b, gKp1288b] };
+    const result = evaluateSum(f288b, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("√k·log(k)⁴¹·k/k² refused (41 logs — not Phase 288)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs41k288 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs41kp1288 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK288r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs41k288, k] };
+    const numKp1288r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, ...logs41kp1288, kp1] };
+    const gK288r = { kind: "apply" as const, head: DIV, args: [numK288r, k2r] };
+    const gKp1288r = { kind: "apply" as const, head: DIV, args: [numKp1288r, kp1_2r] };
+    const f288r = { kind: "apply" as const, head: SUB, args: [gK288r, gKp1288r] };
+    const result = evaluateSum(f288r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 289 — Two-Sqrt × Forty-Log × polynomial numerator", () => {
+  it("(√k)²·log(k)⁴⁰/k² closes (sqrtHalf=1, polyDeg=0 → effective=1; denDeg=2 > 1)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const logs40k289 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1289 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK289a = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs40k289] };
+    const numKp1289a = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, ...logs40kp1289] };
+    const gK289a = { kind: "apply" as const, head: DIV, args: [numK289a, k2] };
+    const gKp1289a = { kind: "apply" as const, head: DIV, args: [numKp1289a, kp1_2] };
+    const f289a = { kind: "apply" as const, head: SUB, args: [gK289a, gKp1289a] };
+    const result = evaluateSum(f289a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("(√k)²·log(k)⁴⁰·k/k³ closes (sqrtHalf=1, polyDeg=1 → effective=2; denDeg=3 > 2)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const logs40k289 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1289 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK289b = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs40k289, k] };
+    const numKp1289b = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, ...logs40kp1289, kp1] };
+    const gK289b = { kind: "apply" as const, head: DIV, args: [numK289b, k3] };
+    const gKp1289b = { kind: "apply" as const, head: DIV, args: [numKp1289b, kp1_3] };
+    const f289b = { kind: "apply" as const, head: SUB, args: [gK289b, gKp1289b] };
+    const result = evaluateSum(f289b, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("(√k)²·log(k)⁴¹·k/k² refused (41 logs — not Phase 289)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs41k289 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs41kp1289 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK289r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs41k289, k] };
+    const numKp1289r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, ...logs41kp1289, kp1] };
+    const gK289r = { kind: "apply" as const, head: DIV, args: [numK289r, k2r] };
+    const gKp1289r = { kind: "apply" as const, head: DIV, args: [numKp1289r, kp1_2r] };
+    const f289r = { kind: "apply" as const, head: SUB, args: [gK289r, gKp1289r] };
+    const result = evaluateSum(f289r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 290 — Three-Sqrt × Forty-Log × polynomial numerator", () => {
+  it("(√k)³·log(k)⁴⁰/k³ closes (sqrtHalf=1.5, polyDeg=0 → effective=1.5; denDeg=3 > 1.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const logs40k290 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1290 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK290a = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs40k290] };
+    const numKp1290a = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, ...logs40kp1290] };
+    const gK290a = { kind: "apply" as const, head: DIV, args: [numK290a, k3] };
+    const gKp1290a = { kind: "apply" as const, head: DIV, args: [numKp1290a, kp1_3] };
+    const f290a = { kind: "apply" as const, head: SUB, args: [gK290a, gKp1290a] };
+    const result = evaluateSum(f290a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("(√k)³·log(k)⁴⁰·k/k⁴ closes (sqrtHalf=1.5, polyDeg=1 → effective=2.5; denDeg=4 > 2.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k4 = { kind: "apply" as const, head: POW, args: [k, int(4)] };
+    const kp1_4 = { kind: "apply" as const, head: POW, args: [kp1, int(4)] };
+    const logs40k290 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1290 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK290b = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs40k290, k] };
+    const numKp1290b = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, ...logs40kp1290, kp1] };
+    const gK290b = { kind: "apply" as const, head: DIV, args: [numK290b, k4] };
+    const gKp1290b = { kind: "apply" as const, head: DIV, args: [numKp1290b, kp1_4] };
+    const f290b = { kind: "apply" as const, head: SUB, args: [gK290b, gKp1290b] };
+    const result = evaluateSum(f290b, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("(√k)³·log(k)⁴¹·k/k³ refused (41 logs — not Phase 290)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs41k290 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs41kp1290 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK290r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs41k290, k] };
+    const numKp1290r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, ...logs41kp1290, kp1] };
+    const gK290r = { kind: "apply" as const, head: DIV, args: [numK290r, k3r] };
+    const gKp1290r = { kind: "apply" as const, head: DIV, args: [numKp1290r, kp1_3r] };
+    const f290r = { kind: "apply" as const, head: SUB, args: [gK290r, gKp1290r] };
+    const result = evaluateSum(f290r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 291 — Four-Sqrt × Forty-Log × polynomial numerator", () => {
+  it("(√k)⁴·log(k)⁴⁰/k³ closes (sqrtHalf=2, polyDeg=0 → effective=2; denDeg=3 > 2)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const logs40k291 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1291 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK291a = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs40k291] };
+    const numKp1291a = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, ...logs40kp1291] };
+    const gK291a = { kind: "apply" as const, head: DIV, args: [numK291a, k3] };
+    const gKp1291a = { kind: "apply" as const, head: DIV, args: [numKp1291a, kp1_3] };
+    const f291a = { kind: "apply" as const, head: SUB, args: [gK291a, gKp1291a] };
+    const result = evaluateSum(f291a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("(√k)⁴·log(k)⁴⁰·k/k⁴ closes (sqrtHalf=2, polyDeg=1 → effective=3; denDeg=4 > 3)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k4 = { kind: "apply" as const, head: POW, args: [k, int(4)] };
+    const kp1_4 = { kind: "apply" as const, head: POW, args: [kp1, int(4)] };
+    const logs40k291 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1291 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK291b = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs40k291, k] };
+    const numKp1291b = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, ...logs40kp1291, kp1] };
+    const gK291b = { kind: "apply" as const, head: DIV, args: [numK291b, k4] };
+    const gKp1291b = { kind: "apply" as const, head: DIV, args: [numKp1291b, kp1_4] };
+    const f291b = { kind: "apply" as const, head: SUB, args: [gK291b, gKp1291b] };
+    const result = evaluateSum(f291b, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("(√k)⁴·log(k)⁴¹·k/k³ refused (41 logs — not Phase 291)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs41k291 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs41kp1291 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK291r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs41k291, k] };
+    const numKp1291r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, ...logs41kp1291, kp1] };
+    const gK291r = { kind: "apply" as const, head: DIV, args: [numK291r, k3r] };
+    const gKp1291r = { kind: "apply" as const, head: DIV, args: [numKp1291r, kp1_3r] };
+    const f291r = { kind: "apply" as const, head: SUB, args: [gK291r, gKp1291r] };
+    const result = evaluateSum(f291r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 292 — Five-Sqrt × Forty-Log × polynomial numerator", () => {
+  it("(√k)^5·log(k)⁴⁰/k³ closes (sqrtHalf=2.5, polyDeg=0 → effective=2.5; denDeg=3 > 2.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const logs40k292 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1292 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK292a = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs40k292] };
+    const numKp1292a = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, ...logs40kp1292] };
+    const gK292a = { kind: "apply" as const, head: DIV, args: [numK292a, k3] };
+    const gKp1292a = { kind: "apply" as const, head: DIV, args: [numKp1292a, kp1_3] };
+    const f292a = { kind: "apply" as const, head: SUB, args: [gK292a, gKp1292a] };
+    const result = evaluateSum(f292a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("(√k)^5·log(k)⁴⁰·k/k⁴ closes (sqrtHalf=2.5, polyDeg=1 → effective=3.5; denDeg=4 > 3.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k4 = { kind: "apply" as const, head: POW, args: [k, int(4)] };
+    const kp1_4 = { kind: "apply" as const, head: POW, args: [kp1, int(4)] };
+    const logs40k292 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1292 = Array.from({ length: 40 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK292b = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs40k292, k] };
+    const numKp1292b = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, ...logs40kp1292, kp1] };
+    const gK292b = { kind: "apply" as const, head: DIV, args: [numK292b, k4] };
+    const gKp1292b = { kind: "apply" as const, head: DIV, args: [numKp1292b, kp1_4] };
+    const f292b = { kind: "apply" as const, head: SUB, args: [gK292b, gKp1292b] };
+    const result = evaluateSum(f292b, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("(√k)^5·log(k)⁴¹·k/k³ refused (41 logs — not Phase 292)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs41k292 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs41kp1292 = Array.from({ length: 41 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK292r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs41k292, k] };
+    const numKp1292r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, ...logs41kp1292, kp1] };
+    const gK292r = { kind: "apply" as const, head: DIV, args: [numK292r, k3r] };
+    const gKp1292r = { kind: "apply" as const, head: DIV, args: [numKp1292r, kp1_3r] };
+    const f292r = { kind: "apply" as const, head: SUB, args: [gK292r, gKp1292r] };
+    const result = evaluateSum(f292r, k, int(1), sym("%inf"), evalNode);
     expect(result).toMatchObject({ kind: "apply", head: SUM });
   });
 });


### PR DESCRIPTION
## Summary

Adds Phase 287–292 (the Forty-Log family) to the convergence recogniser across all three `cas-summation` implementations.

Each phase handles summands with **exactly 40 logarithmic factors** and **0–5 square-root factors**.

### Changes

| Package | Change |
|---------|--------|
| Python | +6 helper fns, +6 dispatch blocks, 240 cascade fixes, +18 tests |
| Rust | +6 helper fns, +6 dispatch blocks, 184 cascade fixes (100 ordinal + 84 cardinal), +18 tests |
| TypeScript | +6 helper fns, +6 dispatch blocks, 240 cascade fixes, +18 tests |
| All | v2.223.0 → v2.229.0, CHANGELOG updated |

### Cascade fix

All Phase 167–286 refused tests updated from 40 → 41 log factors.

### Test counts

- Python: 874 passed (856 + 18 new)
- Rust: 768 passed (750 + 18 new)
- TypeScript: 785 passed (767 + 18 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)