### PR TITLE
feat(cas-summation): add Phase 353-358 (Fifty-One-Log family, v2.289.0→v2.295.0)

### DIFF
--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 2.295.0 — 2026-05-28
+
+### Added
+
+- **Phase 358 — Five-Sqrt × Fifty-One-Log × polynomial** (`_five_sqrt_fifty_one_log_poly_effective_x2`):
+  Completes the Fifty-One-Log family (Phases 353–358).
+- **Phase 357 — Four-Sqrt × Fifty-One-Log × polynomial** (`_four_sqrt_fifty_one_log_poly_effective_x2`).
+- **Phase 356 — Three-Sqrt × Fifty-One-Log × polynomial** (`_three_sqrt_fifty_one_log_poly_effective_x2`).
+- **Phase 355 — Two-Sqrt × Fifty-One-Log × polynomial** (`_two_sqrt_fifty_one_log_poly_effective_x2`).
+- **Phase 354 — One-Sqrt × Fifty-One-Log × polynomial** (`_one_sqrt_fifty_one_log_poly_effective_x2`).
+- **Phase 353 — Zero-Sqrt × Fifty-One-Log × polynomial** (`_fifty_one_log_poly_effective_x2`).
+
+### Changed
+
+- Boundary tests in Phases 347–352 updated from 51-log "refused" to 52-log "refused"
+  now that Phases 353–358 handle exactly 51 logs.
+
 ## 2.289.0 — 2026-05-28
 
 ### Added

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "2.289.0"
+version = "2.295.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -1477,6 +1477,60 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
                 return True
         elif _h_diverges_at_infinity(den, k):
             return True
+    # Phase 358: ``Mul(Sqrt(P1)×5, Log(h1)×51, polynomial..., bounded...)`` numerator.
+    s5l51p_x2 = _five_sqrt_fifty_one_log_poly_effective_x2(num, k)
+    if s5l51p_x2 is not None:
+        den_deg_s5l51 = _polynomial_degree_in_k(den, k)
+        if den_deg_s5l51 is not None:
+            if 2 * den_deg_s5l51 > s5l51p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 357: ``Mul(Sqrt(P1)×4, Log(h1)×51, polynomial..., bounded...)`` numerator.
+    s4l51p_x2 = _four_sqrt_fifty_one_log_poly_effective_x2(num, k)
+    if s4l51p_x2 is not None:
+        den_deg_s4l51 = _polynomial_degree_in_k(den, k)
+        if den_deg_s4l51 is not None:
+            if 2 * den_deg_s4l51 > s4l51p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 356: ``Mul(Sqrt(P1)×3, Log(h1)×51, polynomial..., bounded...)`` numerator.
+    s3l51p_x2 = _three_sqrt_fifty_one_log_poly_effective_x2(num, k)
+    if s3l51p_x2 is not None:
+        den_deg_s3l51 = _polynomial_degree_in_k(den, k)
+        if den_deg_s3l51 is not None:
+            if 2 * den_deg_s3l51 > s3l51p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 355: ``Mul(Sqrt(P), Sqrt(P2), Log(h1)×51, polynomial..., bounded...)`` numerator.
+    s2l51p_x2 = _two_sqrt_fifty_one_log_poly_effective_x2(num, k)
+    if s2l51p_x2 is not None:
+        den_deg_s2l51 = _polynomial_degree_in_k(den, k)
+        if den_deg_s2l51 is not None:
+            if 2 * den_deg_s2l51 > s2l51p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 354: ``Mul(Sqrt(P), Log(h1)×51, polynomial..., bounded...)`` numerator.
+    s1l51p_x2 = _one_sqrt_fifty_one_log_poly_effective_x2(num, k)
+    if s1l51p_x2 is not None:
+        den_deg_s1l51 = _polynomial_degree_in_k(den, k)
+        if den_deg_s1l51 is not None:
+            if 2 * den_deg_s1l51 > s1l51p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 353: ``Mul(Log(h1)×51, polynomial..., bounded...)`` numerator.
+    sl51p_x2 = _fifty_one_log_poly_effective_x2(num, k)
+    if sl51p_x2 is not None:
+        den_deg_sl51 = _polynomial_degree_in_k(den, k)
+        if den_deg_sl51 is not None:
+            if 2 * den_deg_sl51 > sl51p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
     # Phase 352: ``Mul(Sqrt(P1)×5, Log(h1)×50, polynomial..., bounded...)`` numerator.
     s5l50p_x2 = _five_sqrt_fifty_log_poly_effective_x2(num, k)
     if s5l50p_x2 is not None:
@@ -12493,6 +12547,207 @@ def _five_sqrt_forty_three_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> i
             continue
         return None
     if len(sqrt_degs_x2) != 5 or log_count != 43:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _fifty_one_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 353 — Zero-Sqrt × Fifty-One-Log × polynomial numerator.
+
+    The Fifty-One-Log family (Phases 353–358) extends the recogniser to
+    summands whose numerator contains exactly fifty-one logarithmic factors
+    and zero to five square-root factors.  This is Phase 353: zero sqrts.
+
+    Parameters
+    ----------
+    node : IRNode
+        The numerator node.
+    k : IRSymbol
+        The summation variable.
+
+    Returns
+    -------
+    int | None
+        ``2 * poly_deg_sum`` when the shape matches (always even); ``None``
+        when the pattern is not recognised.
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        if _sqrt_effective_half_degree_x2(arg, k) is not None:
+            return None
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 51:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if log_count != 51:
+        return None
+    return 2 * poly_deg_sum
+
+
+def _one_sqrt_fifty_one_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 354 — One-Sqrt × Fifty-One-Log × polynomial numerator."""
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_deg_x2: int | None = None
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if sqrt_deg_x2 is not None:
+                return None
+            sqrt_deg_x2 = deg_x2
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 51:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if sqrt_deg_x2 is None or log_count != 51:
+        return None
+    return sqrt_deg_x2 + 2 * poly_deg_sum
+
+
+def _two_sqrt_fifty_one_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 355 — Two-Sqrt × Fifty-One-Log × polynomial numerator."""
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 2:
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 51:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 2 or log_count != 51:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _three_sqrt_fifty_one_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 356 — Three-Sqrt × Fifty-One-Log × polynomial numerator."""
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 3:
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 51:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 3 or log_count != 51:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _four_sqrt_fifty_one_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 357 — Four-Sqrt × Fifty-One-Log × polynomial numerator."""
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 4:
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 51:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 4 or log_count != 51:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _five_sqrt_fifty_one_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 358 — Five-Sqrt × Fifty-One-Log × polynomial numerator.
+    Completes the Fifty-One-Log family (Phases 353-358).
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 5:
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 51:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 5 or log_count != 51:
         return None
     return sum(sqrt_degs_x2) + 2 * poly_deg_sum
 

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -17474,8 +17474,10 @@ class TestPhase203TwentySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -17512,8 +17514,10 @@ class TestPhase203TwentySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -17648,8 +17652,10 @@ class TestPhase204OneSqrtTwentySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -17687,8 +17693,10 @@ class TestPhase204OneSqrtTwentySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -17823,8 +17831,10 @@ class TestPhase205TwoSqrtTwentySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -17861,8 +17871,10 @@ class TestPhase205TwoSqrtTwentySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -17996,8 +18008,10 @@ class TestPhase206ThreeSqrtTwentySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -18034,8 +18048,10 @@ class TestPhase206ThreeSqrtTwentySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -18174,8 +18190,10 @@ class TestPhase207FourSqrtTwentySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -18213,8 +18231,10 @@ class TestPhase207FourSqrtTwentySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -18353,8 +18373,10 @@ class TestPhase208FiveSqrtTwentySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -18392,8 +18414,10 @@ class TestPhase208FiveSqrtTwentySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -18526,8 +18550,10 @@ class TestPhase209TwentySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -18564,8 +18590,10 @@ class TestPhase209TwentySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -18704,8 +18732,10 @@ class TestPhase210OneSqrtTwentySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -18743,8 +18773,10 @@ class TestPhase210OneSqrtTwentySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -18883,8 +18915,10 @@ class TestPhase211TwoSqrtTwentySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -18921,8 +18955,10 @@ class TestPhase211TwoSqrtTwentySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -19060,8 +19096,10 @@ class TestPhase212ThreeSqrtTwentySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -19098,8 +19136,10 @@ class TestPhase212ThreeSqrtTwentySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -19242,8 +19282,10 @@ class TestPhase213FourSqrtTwentySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -19281,8 +19323,10 @@ class TestPhase213FourSqrtTwentySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -19425,8 +19469,10 @@ class TestPhase214FiveSqrtTwentySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -19464,8 +19510,10 @@ class TestPhase214FiveSqrtTwentySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -19602,8 +19650,10 @@ class TestPhase215TwentyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -19640,8 +19690,10 @@ class TestPhase215TwentyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -19784,8 +19836,10 @@ class TestPhase216OneSqrtTwentyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -19823,8 +19877,10 @@ class TestPhase216OneSqrtTwentyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -19967,8 +20023,10 @@ class TestPhase217TwoSqrtTwentyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -20005,8 +20063,10 @@ class TestPhase217TwoSqrtTwentyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -20148,8 +20208,10 @@ class TestPhase218ThreeSqrtTwentyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -20186,8 +20248,10 @@ class TestPhase218ThreeSqrtTwentyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -20334,8 +20398,10 @@ class TestPhase219FourSqrtTwentyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -20373,8 +20439,10 @@ class TestPhase219FourSqrtTwentyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -20521,8 +20589,10 @@ class TestPhase220FiveSqrtTwentyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -20560,8 +20630,10 @@ class TestPhase220FiveSqrtTwentyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -20703,8 +20775,10 @@ class TestPhase221TwentyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -20741,8 +20815,10 @@ class TestPhase221TwentyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -20889,8 +20965,10 @@ class TestPhase222OneSqrtTwentyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -20928,8 +21006,10 @@ class TestPhase222OneSqrtTwentyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -21076,8 +21156,10 @@ class TestPhase223TwoSqrtTwentyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -21114,8 +21196,10 @@ class TestPhase223TwoSqrtTwentyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -21261,8 +21345,10 @@ class TestPhase224ThreeSqrtTwentyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -21299,8 +21385,10 @@ class TestPhase224ThreeSqrtTwentyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -21451,8 +21539,10 @@ class TestPhase225FourSqrtTwentyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -21490,8 +21580,10 @@ class TestPhase225FourSqrtTwentyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -21642,8 +21734,10 @@ class TestPhase226FiveSqrtTwentyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -21681,8 +21775,10 @@ class TestPhase226FiveSqrtTwentyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -21827,8 +21923,10 @@ class TestPhase227ThirtyLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -21865,8 +21963,10 @@ class TestPhase227ThirtyLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -22017,8 +22117,10 @@ class TestPhase228OneSqrtThirtyLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -22056,8 +22158,10 @@ class TestPhase228OneSqrtThirtyLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -22208,8 +22312,10 @@ class TestPhase229TwoSqrtThirtyLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -22246,8 +22352,10 @@ class TestPhase229TwoSqrtThirtyLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -22397,8 +22505,10 @@ class TestPhase230ThreeSqrtThirtyLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -22435,8 +22545,10 @@ class TestPhase230ThreeSqrtThirtyLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -22586,8 +22698,10 @@ class TestPhase231FourSqrtThirtyLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -22624,8 +22738,10 @@ class TestPhase231FourSqrtThirtyLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -22780,8 +22896,10 @@ class TestPhase232FiveSqrtThirtyLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -22819,8 +22937,10 @@ class TestPhase232FiveSqrtThirtyLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -22969,8 +23089,10 @@ class TestPhase233ThirtyOneLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -23007,8 +23129,10 @@ class TestPhase233ThirtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -23163,8 +23287,10 @@ class TestPhase234OneSqrtThirtyOneLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -23202,8 +23328,10 @@ class TestPhase234OneSqrtThirtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -23358,8 +23486,10 @@ class TestPhase235TwoSqrtThirtyOneLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -23396,8 +23526,10 @@ class TestPhase235TwoSqrtThirtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -23551,8 +23683,10 @@ class TestPhase236ThreeSqrtThirtyOneLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -23589,8 +23723,10 @@ class TestPhase236ThreeSqrtThirtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -23749,8 +23885,10 @@ class TestPhase237FourSqrtThirtyOneLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -23788,8 +23926,10 @@ class TestPhase237FourSqrtThirtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -23948,8 +24088,10 @@ class TestPhase238FiveSqrtThirtyOneLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -23987,8 +24129,10 @@ class TestPhase238FiveSqrtThirtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -24141,8 +24285,10 @@ class TestPhase239ThirtyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -24179,8 +24325,10 @@ class TestPhase239ThirtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -24339,8 +24487,10 @@ class TestPhase240OneSqrtThirtyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -24378,8 +24528,10 @@ class TestPhase240OneSqrtThirtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -24538,8 +24690,10 @@ class TestPhase241TwoSqrtThirtyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -24576,8 +24730,10 @@ class TestPhase241TwoSqrtThirtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -24735,8 +24891,10 @@ class TestPhase242ThreeSqrtThirtyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -24773,8 +24931,10 @@ class TestPhase242ThreeSqrtThirtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -24937,8 +25097,10 @@ class TestPhase243FourSqrtThirtyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -24976,8 +25138,10 @@ class TestPhase243FourSqrtThirtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -25140,8 +25304,10 @@ class TestPhase244FiveSqrtThirtyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -25179,8 +25345,10 @@ class TestPhase244FiveSqrtThirtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -25337,8 +25505,10 @@ class TestPhase245ThirtyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -25375,8 +25545,10 @@ class TestPhase245ThirtyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -25539,8 +25711,10 @@ class TestPhase246OneSqrtThirtyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -25578,8 +25752,10 @@ class TestPhase246OneSqrtThirtyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -25742,8 +25918,10 @@ class TestPhase247TwoSqrtThirtyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -25780,8 +25958,10 @@ class TestPhase247TwoSqrtThirtyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -25943,8 +26123,10 @@ class TestPhase248ThreeSqrtThirtyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -25981,8 +26163,10 @@ class TestPhase248ThreeSqrtThirtyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -26149,8 +26333,10 @@ class TestPhase249FourSqrtThirtyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -26188,8 +26374,10 @@ class TestPhase249FourSqrtThirtyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -26356,8 +26544,10 @@ class TestPhase250FiveSqrtThirtyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -26395,8 +26585,10 @@ class TestPhase250FiveSqrtThirtyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -26557,8 +26749,10 @@ class TestPhase251ThirtyFourLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -26595,8 +26789,10 @@ class TestPhase251ThirtyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -26763,8 +26959,10 @@ class TestPhase252OneSqrtThirtyFourLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -26802,8 +27000,10 @@ class TestPhase252OneSqrtThirtyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -26970,8 +27170,10 @@ class TestPhase253TwoSqrtThirtyFourLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -27008,8 +27210,10 @@ class TestPhase253TwoSqrtThirtyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -27175,8 +27379,10 @@ class TestPhase254ThreeSqrtThirtyFourLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -27213,8 +27419,10 @@ class TestPhase254ThreeSqrtThirtyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -27385,8 +27593,10 @@ class TestPhase255FourSqrtThirtyFourLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -27424,8 +27634,10 @@ class TestPhase255FourSqrtThirtyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -27596,8 +27808,10 @@ class TestPhase256FiveSqrtThirtyFourLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -27635,8 +27849,10 @@ class TestPhase256FiveSqrtThirtyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -27801,8 +28017,10 @@ class TestPhase257ThirtyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -27839,8 +28057,10 @@ class TestPhase257ThirtyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -28011,8 +28231,10 @@ class TestPhase258OneSqrtThirtyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -28050,8 +28272,10 @@ class TestPhase258OneSqrtThirtyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -28222,8 +28446,10 @@ class TestPhase259TwoSqrtThirtyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -28260,8 +28486,10 @@ class TestPhase259TwoSqrtThirtyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -28431,8 +28659,10 @@ class TestPhase260ThreeSqrtThirtyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -28469,8 +28699,10 @@ class TestPhase260ThreeSqrtThirtyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -28645,8 +28877,10 @@ class TestPhase261FourSqrtThirtyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -28684,8 +28918,10 @@ class TestPhase261FourSqrtThirtyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -28860,8 +29096,10 @@ class TestPhase262FiveSqrtThirtyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -28899,8 +29137,10 @@ class TestPhase262FiveSqrtThirtyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -29069,8 +29309,10 @@ class TestPhase263ThirtySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -29107,8 +29349,10 @@ class TestPhase263ThirtySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -29283,8 +29527,10 @@ class TestPhase264OneSqrtThirtySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -29322,8 +29568,10 @@ class TestPhase264OneSqrtThirtySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -29498,8 +29746,10 @@ class TestPhase265TwoSqrtThirtySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -29536,8 +29786,10 @@ class TestPhase265TwoSqrtThirtySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -29711,8 +29963,10 @@ class TestPhase266ThreeSqrtThirtySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -29749,8 +30003,10 @@ class TestPhase266ThreeSqrtThirtySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -29929,8 +30185,10 @@ class TestPhase267FourSqrtThirtySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -29968,8 +30226,10 @@ class TestPhase267FourSqrtThirtySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -30148,8 +30408,10 @@ class TestPhase268FiveSqrtThirtySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -30187,8 +30449,10 @@ class TestPhase268FiveSqrtThirtySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -30363,8 +30627,10 @@ class TestPhase269ThirtySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -30400,8 +30666,10 @@ class TestPhase269ThirtySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -30578,8 +30846,10 @@ class TestPhase270OneSqrtThirtySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -30616,8 +30886,10 @@ class TestPhase270OneSqrtThirtySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -30794,8 +31066,10 @@ class TestPhase271TwoSqrtThirtySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -30832,8 +31106,10 @@ class TestPhase271TwoSqrtThirtySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -31010,8 +31286,10 @@ class TestPhase272ThreeSqrtThirtySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -31048,8 +31326,10 @@ class TestPhase272ThreeSqrtThirtySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -31226,8 +31506,10 @@ class TestPhase273FourSqrtThirtySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -31264,8 +31546,10 @@ class TestPhase273FourSqrtThirtySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -31447,8 +31731,10 @@ class TestPhase274FiveSqrtThirtySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -31486,8 +31772,10 @@ class TestPhase274FiveSqrtThirtySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -31665,8 +31953,10 @@ class TestPhase275ThirtyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -31702,8 +31992,10 @@ class TestPhase275ThirtyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -31884,8 +32176,10 @@ class TestPhase276OneSqrtThirtyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -31922,8 +32216,10 @@ class TestPhase276OneSqrtThirtyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -32104,8 +32400,10 @@ class TestPhase277TwoSqrtThirtyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -32142,8 +32440,10 @@ class TestPhase277TwoSqrtThirtyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -32324,8 +32624,10 @@ class TestPhase278ThreeSqrtThirtyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -32362,8 +32664,10 @@ class TestPhase278ThreeSqrtThirtyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -32549,8 +32853,10 @@ class TestPhase279FourSqrtThirtyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -32588,8 +32894,10 @@ class TestPhase279FourSqrtThirtyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -32775,8 +33083,10 @@ class TestPhase280FiveSqrtThirtyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -32814,8 +33124,10 @@ class TestPhase280FiveSqrtThirtyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -32998,8 +33310,10 @@ class TestPhase281ThirtyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -33035,8 +33349,10 @@ class TestPhase281ThirtyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -33221,8 +33537,10 @@ class TestPhase282OneSqrtThirtyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -33259,8 +33577,10 @@ class TestPhase282OneSqrtThirtyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -33447,8 +33767,10 @@ class TestPhase283TwoSqrtThirtyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -33485,8 +33807,10 @@ class TestPhase283TwoSqrtThirtyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -33673,8 +33997,10 @@ class TestPhase284ThreeSqrtThirtyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -33711,8 +34037,10 @@ class TestPhase284ThreeSqrtThirtyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -33899,8 +34227,10 @@ class TestPhase285FourSqrtThirtyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -33937,8 +34267,10 @@ class TestPhase285FourSqrtThirtyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -34125,8 +34457,10 @@ class TestPhase286FiveSqrtThirtyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -34163,8 +34497,10 @@ class TestPhase286FiveSqrtThirtyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -34351,8 +34687,10 @@ class TestPhase287FortyLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -34388,8 +34726,10 @@ class TestPhase287FortyLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -34578,8 +34918,10 @@ class TestPhase288OneSqrtFortyLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -34616,8 +34958,10 @@ class TestPhase288OneSqrtFortyLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -34808,8 +35152,10 @@ class TestPhase289TwoSqrtFortyLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -34846,8 +35192,10 @@ class TestPhase289TwoSqrtFortyLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -35038,8 +35386,10 @@ class TestPhase290ThreeSqrtFortyLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -35076,8 +35426,10 @@ class TestPhase290ThreeSqrtFortyLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -35268,8 +35620,10 @@ class TestPhase291FourSqrtFortyLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -35306,8 +35660,10 @@ class TestPhase291FourSqrtFortyLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -35498,8 +35854,10 @@ class TestPhase292FiveSqrtFortyLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -35536,8 +35894,10 @@ class TestPhase292FiveSqrtFortyLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -35728,8 +36088,10 @@ class TestPhase293FortyOneLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -35765,8 +36127,10 @@ class TestPhase293FortyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -35888,8 +36252,10 @@ class TestPhase294OneSqrtFortyOneLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -35926,8 +36292,10 @@ class TestPhase294OneSqrtFortyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -36049,8 +36417,10 @@ class TestPhase295TwoSqrtFortyOneLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -36087,8 +36457,10 @@ class TestPhase295TwoSqrtFortyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -36210,8 +36582,10 @@ class TestPhase296ThreeSqrtFortyOneLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -36248,8 +36622,10 @@ class TestPhase296ThreeSqrtFortyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -36371,8 +36747,10 @@ class TestPhase297FourSqrtFortyOneLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -36409,8 +36787,10 @@ class TestPhase297FourSqrtFortyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -36532,8 +36912,10 @@ class TestPhase298FiveSqrtFortyOneLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -36570,8 +36952,10 @@ class TestPhase298FiveSqrtFortyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -36693,8 +37077,10 @@ class TestPhase299FortyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -36730,8 +37116,10 @@ class TestPhase299FortyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -36855,8 +37243,10 @@ class TestPhase300OneSqrtFortyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -36893,8 +37283,10 @@ class TestPhase300OneSqrtFortyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -37018,8 +37410,10 @@ class TestPhase301TwoSqrtFortyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -37056,8 +37450,10 @@ class TestPhase301TwoSqrtFortyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -37181,8 +37577,10 @@ class TestPhase302ThreeSqrtFortyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -37219,8 +37617,10 @@ class TestPhase302ThreeSqrtFortyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -37344,8 +37744,10 @@ class TestPhase303FourSqrtFortyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -37382,8 +37784,10 @@ class TestPhase303FourSqrtFortyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -37507,8 +37911,10 @@ class TestPhase304FiveSqrtFortyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -37545,8 +37951,10 @@ class TestPhase304FiveSqrtFortyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -37670,8 +38078,10 @@ class TestPhase305FortyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -37707,8 +38117,10 @@ class TestPhase305FortyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -37835,8 +38247,10 @@ class TestPhase306OneSqrtFortyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -37873,8 +38287,10 @@ class TestPhase306OneSqrtFortyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -38001,8 +38417,10 @@ class TestPhase307TwoSqrtFortyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -38039,8 +38457,10 @@ class TestPhase307TwoSqrtFortyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -38167,8 +38587,10 @@ class TestPhase308ThreeSqrtFortyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -38205,8 +38627,10 @@ class TestPhase308ThreeSqrtFortyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -38333,8 +38757,10 @@ class TestPhase309FourSqrtFortyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -38371,8 +38797,10 @@ class TestPhase309FourSqrtFortyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -38499,8 +38927,10 @@ class TestPhase310FiveSqrtFortyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -38537,8 +38967,10 @@ class TestPhase310FiveSqrtFortyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -38664,8 +39096,10 @@ class TestPhase311FortyFourLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -38701,8 +39135,10 @@ class TestPhase311FortyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -38831,8 +39267,10 @@ class TestPhase312OneSqrtFortyFourLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -38869,8 +39307,10 @@ class TestPhase312OneSqrtFortyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -38999,8 +39439,10 @@ class TestPhase313TwoSqrtFortyFourLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -39037,8 +39479,10 @@ class TestPhase313TwoSqrtFortyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -39167,8 +39611,10 @@ class TestPhase314ThreeSqrtFortyFourLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -39205,8 +39651,10 @@ class TestPhase314ThreeSqrtFortyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -39335,8 +39783,10 @@ class TestPhase315FourSqrtFortyFourLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -39373,8 +39823,10 @@ class TestPhase315FourSqrtFortyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -39503,8 +39955,10 @@ class TestPhase316FiveSqrtFortyFourLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -39541,8 +39995,10 @@ class TestPhase316FiveSqrtFortyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -39670,8 +40126,10 @@ class TestPhase317FortyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -39707,8 +40165,10 @@ class TestPhase317FortyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -39838,8 +40298,10 @@ class TestPhase318OneSqrtFortyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -39876,8 +40338,10 @@ class TestPhase318OneSqrtFortyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -40007,8 +40471,10 @@ class TestPhase319TwoSqrtFortyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -40045,8 +40511,10 @@ class TestPhase319TwoSqrtFortyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -40176,8 +40644,10 @@ class TestPhase320ThreeSqrtFortyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -40214,8 +40684,10 @@ class TestPhase320ThreeSqrtFortyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -40345,8 +40817,10 @@ class TestPhase321FourSqrtFortyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -40383,8 +40857,10 @@ class TestPhase321FourSqrtFortyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -40514,8 +40990,10 @@ class TestPhase322FiveSqrtFortyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -40552,8 +41030,10 @@ class TestPhase322FiveSqrtFortyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -40683,8 +41163,10 @@ class TestPhase323FortysSixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -40720,8 +41202,10 @@ class TestPhase323FortysSixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -40853,8 +41337,10 @@ class TestPhase324OneSqrtFortySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -40891,8 +41377,10 @@ class TestPhase324OneSqrtFortySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -41024,8 +41512,10 @@ class TestPhase325TwoSqrtFortySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -41062,8 +41552,10 @@ class TestPhase325TwoSqrtFortySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -41195,8 +41687,10 @@ class TestPhase326ThreeSqrtFortySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -41233,8 +41727,10 @@ class TestPhase326ThreeSqrtFortySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -41366,8 +41862,10 @@ class TestPhase327FourSqrtFortySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -41404,8 +41902,10 @@ class TestPhase327FourSqrtFortySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -41537,8 +42037,10 @@ class TestPhase328FiveSqrtFortySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -41575,8 +42077,10 @@ class TestPhase328FiveSqrtFortySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -41708,8 +42212,10 @@ class TestPhase329FortySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -41745,8 +42251,10 @@ class TestPhase329FortySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -41880,8 +42388,10 @@ class TestPhase330OneSqrtFortySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -41918,8 +42428,10 @@ class TestPhase330OneSqrtFortySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -42053,8 +42565,10 @@ class TestPhase331TwoSqrtFortySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -42091,8 +42605,10 @@ class TestPhase331TwoSqrtFortySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -42226,8 +42742,10 @@ class TestPhase332ThreeSqrtFortySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -42264,8 +42782,10 @@ class TestPhase332ThreeSqrtFortySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -42399,8 +42919,10 @@ class TestPhase333FourSqrtFortySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -42437,8 +42959,10 @@ class TestPhase333FourSqrtFortySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -42572,8 +43096,10 @@ class TestPhase334FiveSqrtFortySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -42610,8 +43136,10 @@ class TestPhase334FiveSqrtFortySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -42745,8 +43273,10 @@ class TestPhase335FortyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -42782,8 +43312,10 @@ class TestPhase335FortyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -42920,8 +43452,10 @@ class TestPhase336OneSqrtFortyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -42958,8 +43492,10 @@ class TestPhase336OneSqrtFortyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -43096,8 +43632,10 @@ class TestPhase337TwoSqrtFortyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -43134,8 +43672,10 @@ class TestPhase337TwoSqrtFortyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -43272,8 +43812,10 @@ class TestPhase338ThreeSqrtFortyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -43310,8 +43852,10 @@ class TestPhase338ThreeSqrtFortyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -43448,8 +43992,10 @@ class TestPhase339FourSqrtFortyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -43486,8 +44032,10 @@ class TestPhase339FourSqrtFortyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -43624,8 +44172,10 @@ class TestPhase340FiveSqrtFortyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -43662,8 +44212,10 @@ class TestPhase340FiveSqrtFortyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -43799,8 +44351,10 @@ class TestPhase341FortyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -43836,8 +44390,10 @@ class TestPhase341FortyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -43976,8 +44532,10 @@ class TestPhase342OneSqrtFortyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -44014,8 +44572,10 @@ class TestPhase342OneSqrtFortyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -44154,8 +44714,10 @@ class TestPhase343TwoSqrtFortyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -44192,8 +44754,10 @@ class TestPhase343TwoSqrtFortyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -44332,8 +44896,10 @@ class TestPhase344ThreeSqrtFortyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -44370,8 +44936,10 @@ class TestPhase344ThreeSqrtFortyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -44510,8 +45078,10 @@ class TestPhase345FourSqrtFortyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -44548,8 +45118,10 @@ class TestPhase345FourSqrtFortyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -44688,8 +45260,10 @@ class TestPhase346FiveSqrtFortyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -44726,8 +45300,10 @@ class TestPhase346FiveSqrtFortyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -44825,7 +45401,7 @@ class TestPhase347FiftyLogPoly:
         assert not (isinstance(result, IRApply) and result.head == SUM)
 
     def test_log51_k_over_k2_refused(self):
-        """log(k)^51/k^2: 51 logs -> not Phase 347 -> refused."""
+        """log(k)^51/k^2: 52 logs -> not Phase 353 -> refused."""
         from symbolic_ir import SUB
 
         kp1 = IRApply(ADD, (_k, IRInteger(1)))
@@ -44866,7 +45442,8 @@ class TestPhase347FiftyLogPoly:
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
             IRApply(LOG, (_k,)),  # 50th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -44903,7 +45480,8 @@ class TestPhase347FiftyLogPoly:
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
             IRApply(LOG, (kp1,)),  # 50th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -45003,7 +45581,7 @@ class TestPhase348OneSqrtFiftyLogPoly:
         assert not (isinstance(result, IRApply) and result.head == SUM)
 
     def test_sqrt_k_log51_k_over_k2_refused(self):
-        """(sqrt(k))*log(k)^51/k^2: 51 logs -> not Phase 348 -> refused."""
+        """(sqrt(k))*log(k)^51/k^2: 52 logs -> not Phase 354 -> refused."""
         from symbolic_ir import SQRT, SUB
 
         kp1 = IRApply(ADD, (_k, IRInteger(1)))
@@ -45045,7 +45623,8 @@ class TestPhase348OneSqrtFiftyLogPoly:
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
             IRApply(LOG, (_k,)),  # 50th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -45083,7 +45662,8 @@ class TestPhase348OneSqrtFiftyLogPoly:
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
             IRApply(LOG, (kp1,)),  # 50th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -45183,7 +45763,7 @@ class TestPhase349TwoSqrtFiftyLogPoly:
         assert not (isinstance(result, IRApply) and result.head == SUM)
 
     def test_2_sqrt_k_log51_k_over_k2_refused(self):
-        """(sqrt(k))^2*log(k)^51/k^2: 51 logs -> not Phase 349 -> refused."""
+        """(sqrt(k))^2*log(k)^51/k^2: 52 logs -> not Phase 355 -> refused."""
         from symbolic_ir import SQRT, SUB
 
         kp1 = IRApply(ADD, (_k, IRInteger(1)))
@@ -45225,7 +45805,8 @@ class TestPhase349TwoSqrtFiftyLogPoly:
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
             IRApply(LOG, (_k,)),  # 50th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -45263,7 +45844,8 @@ class TestPhase349TwoSqrtFiftyLogPoly:
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
             IRApply(LOG, (kp1,)),  # 50th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -45363,7 +45945,7 @@ class TestPhase350ThreeSqrtFiftyLogPoly:
         assert not (isinstance(result, IRApply) and result.head == SUM)
 
     def test_3_sqrt_k_log51_k_over_k3_refused(self):
-        """(sqrt(k))^3*log(k)^51/k^3: 51 logs -> not Phase 350 -> refused."""
+        """(sqrt(k))^3*log(k)^51/k^3: 52 logs -> not Phase 356 -> refused."""
         from symbolic_ir import SQRT, SUB
 
         kp1 = IRApply(ADD, (_k, IRInteger(1)))
@@ -45405,7 +45987,8 @@ class TestPhase350ThreeSqrtFiftyLogPoly:
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
             IRApply(LOG, (_k,)),  # 50th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -45443,7 +46026,8 @@ class TestPhase350ThreeSqrtFiftyLogPoly:
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
             IRApply(LOG, (kp1,)),  # 50th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -45543,7 +46127,7 @@ class TestPhase351FourSqrtFiftyLogPoly:
         assert not (isinstance(result, IRApply) and result.head == SUM)
 
     def test_4_sqrt_k_log51_k_over_k3_refused(self):
-        """(sqrt(k))^4*log(k)^51/k^3: 51 logs -> not Phase 351 -> refused."""
+        """(sqrt(k))^4*log(k)^51/k^3: 52 logs -> not Phase 357 -> refused."""
         from symbolic_ir import SQRT, SUB
 
         kp1 = IRApply(ADD, (_k, IRInteger(1)))
@@ -45585,7 +46169,8 @@ class TestPhase351FourSqrtFiftyLogPoly:
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
             IRApply(LOG, (_k,)),  # 50th log
-            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -45623,7 +46208,8 @@ class TestPhase351FourSqrtFiftyLogPoly:
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
             IRApply(LOG, (kp1,)),  # 50th log
-            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -45723,7 +46309,1028 @@ class TestPhase352FiveSqrtFiftyLogPoly:
         assert not (isinstance(result, IRApply) and result.head == SUM)
 
     def test_5_sqrt_k_log51_k_over_k3_refused(self):
-        """(sqrt(k))^5*log(k)^51/k^3: 51 logs -> not Phase 352 -> refused."""
+        """(sqrt(k))^5*log(k)^51/k^3: 52 logs -> not Phase 358 -> refused."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase353FiftyOneLogPoly:
+    """Phase 353 -- Fifty-One-Log x polynomial numerator."""
+
+    def test_log51_k_over_k2_closes(self):
+        """log(k)^51/k^2: eff_x2=0; 2*2=4 > 0 -> closes"""
+        from symbolic_ir import SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_log52_k_over_k2_refused(self):
+        """log(k)^52/k^2: 52 logs -> not Phase 353 -> refused."""
+        from symbolic_ir import SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase354OneSqrtFiftyOneLogPoly:
+    """Phase 354 -- One-Sqrt x Fifty-One-Log x polynomial numerator."""
+
+    def test_sqrt_k_log51_k_over_k2_closes(self):
+        """test sqrt k log51 k over k2 closes: eff_x2=1; 2*2=4 > 1 -> closes"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_log52_k_over_k2_refused(self):
+        """(sqrt(k))*log(k)^52/k^2: 52 logs -> not Phase 354 -> refused."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase355TwoSqrtFiftyOneLogPoly:
+    """Phase 355 -- Two-Sqrt x Fifty-One-Log x polynomial numerator."""
+
+    def test_2_sqrt_k_log51_k_over_k3_closes(self):
+        """test 2 sqrt k log51 k over k3 closes: eff_x2=2; 2*3=6 > 2 -> closes"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_2_sqrt_k_log52_k_over_k3_refused(self):
+        """(sqrt(k))^2*log(k)^52/k^3: 52 logs -> not Phase 355 -> refused."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase356ThreeSqrtFiftyOneLogPoly:
+    """Phase 356 -- Three-Sqrt x Fifty-One-Log x polynomial numerator."""
+
+    def test_3_sqrt_k_log51_k_over_k3_closes(self):
+        """test 3 sqrt k log51 k over k3 closes: eff_x2=3; 2*3=6 > 3 -> closes"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_3_sqrt_k_log52_k_over_k3_refused(self):
+        """(sqrt(k))^3*log(k)^52/k^3: 52 logs -> not Phase 356 -> refused."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase357FourSqrtFiftyOneLogPoly:
+    """Phase 357 -- Four-Sqrt x Fifty-One-Log x polynomial numerator."""
+
+    def test_4_sqrt_k_log51_k_over_k3_closes(self):
+        """test 4 sqrt k log51 k over k3 closes: eff_x2=4; 2*3=6 > 4 -> closes"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_4_sqrt_k_log52_k_over_k3_refused(self):
+        """(sqrt(k))^4*log(k)^52/k^3: 52 logs -> not Phase 357 -> refused."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase358FiveSqrtFiftyOneLogPoly:
+    """Phase 358 -- Five-Sqrt x Fifty-One-Log x polynomial numerator."""
+
+    def test_5_sqrt_k_log51_k_over_k3_closes(self):
+        """test 5 sqrt k log51 k over k3 closes: eff_x2=5; 2*3=6 > 5 -> closes"""
         from symbolic_ir import SQRT, SUB
 
         kp1 = IRApply(ADD, (_k, IRInteger(1)))
@@ -45804,6 +47411,99 @@ class TestPhase352FiveSqrtFiftyLogPoly:
             IRApply(LOG, (kp1,)),  # 49th log
             IRApply(LOG, (kp1,)),  # 50th log
             IRApply(LOG, (kp1,)),  # 51st log
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_5_sqrt_k_log52_k_over_k3_refused(self):
+        """(sqrt(k))^5*log(k)^52/k^3: 52 logs -> not Phase 358 -> refused."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))

--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 2.295.0 — 2026-05-28
+
+### Added
+
+- **Phase 358 — Five-Sqrt × Fifty-One-Log × polynomial** (`five_sqrt_fifty_one_log_poly_effective_x2`):
+  Completes the Fifty-One-Log family (Phases 353–358).
+- **Phase 357 — Four-Sqrt × Fifty-One-Log × polynomial** (`four_sqrt_fifty_one_log_poly_effective_x2`).
+- **Phase 356 — Three-Sqrt × Fifty-One-Log × polynomial** (`three_sqrt_fifty_one_log_poly_effective_x2`).
+- **Phase 355 — Two-Sqrt × Fifty-One-Log × polynomial** (`two_sqrt_fifty_one_log_poly_effective_x2`).
+- **Phase 354 — One-Sqrt × Fifty-One-Log × polynomial** (`one_sqrt_fifty_one_log_poly_effective_x2`).
+- **Phase 353 — Zero-Sqrt × Fifty-One-Log × polynomial** (`fifty_one_log_poly_effective_x2`).
+
+### Changed
+
+- Boundary tests in Phases 347–352 updated from 51-log "refused" to 52-log "refused"
+  now that Phases 353–358 handle exactly 51 logs.
+
 ## 2.289.0 — 2026-05-28
 
 ### Added

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "2.289.0"
+version = "2.295.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -7329,6 +7329,170 @@ fn one_sqrt_forty_seven_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Opti
     Some(sd + 2 * poly_deg_sum)
 }
 
+/// Phase 353 — Zero-Sqrt × Fifty-One-Log × polynomial numerator.
+///
+/// The Fifty-One-Log family (Phases 353–358) extends the recogniser to
+/// summands whose numerator contains exactly fifty-one logarithmic factors
+/// and zero to five square-root factors.  This is Phase 353: zero sqrts.
+fn fifty_one_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if sqrt_effective_half_degree_x2(arg, k).is_some() { return None; }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 51 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg; continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if log_count != 51 { return None; }
+    Some(2 * poly_deg_sum)
+}
+
+/// Phase 354 — One-Sqrt × Fifty-One-Log × polynomial numerator.
+fn one_sqrt_fifty_one_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut sqrt_deg: Option<i64> = None;
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_deg.is_some() { return None; }
+            sqrt_deg = Some(d); continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 51 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg; continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    let sd = sqrt_deg?;
+    if log_count != 51 { return None; }
+    Some(sd + 2 * poly_deg_sum)
+}
+
+/// Phase 355 — Two-Sqrt × Fifty-One-Log × polynomial numerator.
+fn two_sqrt_fifty_one_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut sqrt_degs: Vec<i64> = Vec::new();
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs.len() >= 2 { return None; }
+            sqrt_degs.push(d); continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 51 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg; continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs.len() != 2 || log_count != 51 { return None; }
+    Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg_sum)
+}
+
+/// Phase 356 — Three-Sqrt × Fifty-One-Log × polynomial numerator.
+fn three_sqrt_fifty_one_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut sqrt_degs: Vec<i64> = Vec::new();
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs.len() >= 3 { return None; }
+            sqrt_degs.push(d); continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 51 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg; continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs.len() != 3 || log_count != 51 { return None; }
+    Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg_sum)
+}
+
+/// Phase 357 — Four-Sqrt × Fifty-One-Log × polynomial numerator.
+fn four_sqrt_fifty_one_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut sqrt_degs: Vec<i64> = Vec::new();
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs.len() >= 4 { return None; }
+            sqrt_degs.push(d); continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 51 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg; continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs.len() != 4 || log_count != 51 { return None; }
+    Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg_sum)
+}
+
+/// Phase 358 — Five-Sqrt × Fifty-One-Log × polynomial numerator.
+/// Completes the Fifty-One-Log family (Phases 353–358).
+fn five_sqrt_fifty_one_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut sqrt_degs: Vec<i64> = Vec::new();
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs.len() >= 5 { return None; }
+            sqrt_degs.push(d); continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 51 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg; continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs.len() != 5 || log_count != 51 { return None; }
+    Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg_sum)
+}
+
 /// Phase 347 — Zero-Sqrt × Fifty-Log × polynomial numerator.
 ///
 /// The Fifty-Log family (Phases 347–352) extends the recogniser to
@@ -10205,6 +10369,42 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
         } else if h_diverges_at_infinity(den, k) {
             return true;
         }
+    }
+    // Phase 358: Mul(Sqrt(P1)×5, Log(h1)×51, ...) numerator.
+    if let Some(s5l51_x2) = five_sqrt_fifty_one_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s5l51) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s5l51 > s5l51_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 357: Mul(Sqrt(P1)×4, Log(h1)×51, ...) numerator.
+    if let Some(s4l51_x2) = four_sqrt_fifty_one_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s4l51) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s4l51 > s4l51_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 356: Mul(Sqrt(P1)×3, Log(h1)×51, ...) numerator.
+    if let Some(s3l51_x2) = three_sqrt_fifty_one_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s3l51) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s3l51 > s3l51_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 355: Mul(Sqrt(P), Sqrt(P2), Log(h1)×51, ...) numerator.
+    if let Some(s2l51_x2) = two_sqrt_fifty_one_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s2l51) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s2l51 > s2l51_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 354: Mul(Sqrt(P), Log(h1)×51, ...) numerator.
+    if let Some(s1l51_x2) = one_sqrt_fifty_one_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s1l51) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s1l51 > s1l51_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 353: Mul(Log(h1)×51, ...) numerator.
+    if let Some(sl51_x2) = fifty_one_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_sl51) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_sl51 > sl51_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
     }
     // Phase 352: Mul(Sqrt(P1)×5, Log(h1)×50, ...) numerator.
     if let Some(s5l50_x2) = five_sqrt_fifty_log_poly_effective_x2(num, k) {

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -13269,8 +13269,9 @@ fn phase191_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -13297,8 +13298,9 @@ fn phase191_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -13416,8 +13418,9 @@ fn phase192_sqrt_k_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -13445,8 +13448,9 @@ fn phase192_sqrt_k_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -13977,8 +13981,9 @@ fn phase197_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -14005,8 +14010,9 @@ fn phase197_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -14743,8 +14749,9 @@ fn phase203_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -14771,8 +14778,9 @@ fn phase203_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -15514,8 +15522,9 @@ fn phase209_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -15543,8 +15552,9 @@ fn phase209_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -16316,8 +16326,9 @@ fn phase215_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -16345,8 +16356,9 @@ fn phase215_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -17118,8 +17130,9 @@ fn phase221_log30_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -17147,8 +17160,9 @@ fn phase221_log30_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -17920,8 +17934,9 @@ fn phase227_log31_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -17949,8 +17964,9 @@ fn phase227_log31_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -18722,8 +18738,9 @@ fn phase233_log32_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -18751,8 +18768,9 @@ fn phase233_log32_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -19525,8 +19543,9 @@ fn phase239_log33_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -19553,8 +19572,9 @@ fn phase239_log33_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -20328,8 +20348,9 @@ fn phase245_log34_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -20355,8 +20376,9 @@ fn phase245_log34_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -21129,8 +21151,9 @@ fn phase251_log36_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -21155,8 +21178,9 @@ fn phase251_log36_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -21919,8 +21943,9 @@ fn phase257_log36_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -21945,8 +21970,9 @@ fn phase257_log36_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -23494,8 +23520,9 @@ fn phase269_log38_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -23520,8 +23547,9 @@ fn phase269_log38_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
         kp1.clone(),
     ]);
     let g_k269c = apply(sym(DIV), vec![num_k, k2]);
@@ -23653,8 +23681,9 @@ fn phase270_sqrt_k_log38_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -23680,8 +23709,9 @@ fn phase270_sqrt_k_log38_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
         kp1.clone(),
     ]);
     let g_k270c = apply(sym(DIV), vec![num_k, k2]);
@@ -24366,8 +24396,9 @@ fn phase275_log39_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -24392,8 +24423,9 @@ fn phase275_log39_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
         kp1.clone(),
     ]);
     let g_k275c = apply(sym(DIV), vec![num_k, k2]);
@@ -24529,8 +24561,9 @@ fn phase276_sqrt_k_log39_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -24556,8 +24589,9 @@ fn phase276_sqrt_k_log39_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
         kp1.clone(),
     ]);
     let g_k276c = apply(sym(DIV), vec![num_k, k2]);
@@ -25249,8 +25283,9 @@ fn phase281_log40_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -25271,8 +25306,9 @@ fn phase281_log40_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
         kp1.clone(),
     ]);
     let g_kphase281r = apply(sym(DIV), vec![num_k, k2]);
@@ -25396,8 +25432,9 @@ fn phase282_sqrt1_k_log40_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -25419,8 +25456,9 @@ fn phase282_sqrt1_k_log40_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
         kp1.clone(),
     ]);
     let g_kphase282r = apply(sym(DIV), vec![num_k, k2]);
@@ -26046,8 +26084,9 @@ fn phase287_log42_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -26066,8 +26105,9 @@ fn phase287_log42_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase287r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase287r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -26189,8 +26229,9 @@ fn phase288_sqrt1_k_log42_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -26210,8 +26251,9 @@ fn phase288_sqrt1_k_log42_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase288r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase288r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -26333,8 +26375,9 @@ fn phase289_sqrt2_k_log42_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -26354,8 +26397,9 @@ fn phase289_sqrt2_k_log42_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase289r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase289r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -26477,8 +26521,9 @@ fn phase290_sqrt3_k_log42_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -26498,8 +26543,9 @@ fn phase290_sqrt3_k_log42_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase290r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase290r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -26621,8 +26667,9 @@ fn phase291_sqrt4_k_log42_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -26642,8 +26689,9 @@ fn phase291_sqrt4_k_log42_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase291r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase291r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -26765,8 +26813,9 @@ fn phase292_sqrt5_k_log42_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -26786,8 +26835,9 @@ fn phase292_sqrt5_k_log42_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase292r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase292r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -26862,8 +26912,9 @@ fn phase293_log42_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -26882,8 +26933,9 @@ fn phase293_log42_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase293r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase293r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -26965,8 +27017,9 @@ fn phase294_sqrt1_k_log42_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -26986,8 +27039,9 @@ fn phase294_sqrt1_k_log42_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase294r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase294r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -27069,8 +27123,9 @@ fn phase295_sqrt2_k_log42_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -27090,8 +27145,9 @@ fn phase295_sqrt2_k_log42_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase295r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase295r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -27173,8 +27229,9 @@ fn phase296_sqrt3_k_log42_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -27194,8 +27251,9 @@ fn phase296_sqrt3_k_log42_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase296r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase296r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -27277,8 +27335,9 @@ fn phase297_sqrt4_k_log42_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -27298,8 +27357,9 @@ fn phase297_sqrt4_k_log42_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase297r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase297r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -27381,8 +27441,9 @@ fn phase298_sqrt5_k_log42_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -27402,8 +27463,9 @@ fn phase298_sqrt5_k_log42_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase298r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase298r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -27478,8 +27540,9 @@ fn phase299_log45_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -27498,8 +27561,9 @@ fn phase299_log45_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase299r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase299r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -27581,8 +27645,9 @@ fn phase300_sqrt1_k_log45_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -27602,8 +27667,9 @@ fn phase300_sqrt1_k_log45_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase300r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase300r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -27685,8 +27751,9 @@ fn phase301_sqrt2_k_log45_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -27706,8 +27773,9 @@ fn phase301_sqrt2_k_log45_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase301r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase301r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -27789,8 +27857,9 @@ fn phase302_sqrt3_k_log45_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -27810,8 +27879,9 @@ fn phase302_sqrt3_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase302r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase302r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -27893,8 +27963,9 @@ fn phase303_sqrt4_k_log45_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -27914,8 +27985,9 @@ fn phase303_sqrt4_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase303r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase303r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -27997,8 +28069,9 @@ fn phase304_sqrt5_k_log45_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -28018,8 +28091,9 @@ fn phase304_sqrt5_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase304r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase304r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -28094,8 +28168,9 @@ fn phase305_log45_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -28113,8 +28188,9 @@ fn phase305_log45_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase305r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase305r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -28195,8 +28271,9 @@ fn phase306_sqrt1_k_log45_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -28215,8 +28292,9 @@ fn phase306_sqrt1_k_log45_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase306r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase306r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -28297,8 +28375,9 @@ fn phase307_sqrt2_k_log45_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -28317,8 +28396,9 @@ fn phase307_sqrt2_k_log45_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase307r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase307r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -28399,8 +28479,9 @@ fn phase308_sqrt3_k_log45_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -28419,8 +28500,9 @@ fn phase308_sqrt3_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase308r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase308r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -28501,8 +28583,9 @@ fn phase309_sqrt4_k_log45_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -28521,8 +28604,9 @@ fn phase309_sqrt4_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase309r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase309r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -28603,8 +28687,9 @@ fn phase310_sqrt5_k_log45_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -28623,8 +28708,9 @@ fn phase310_sqrt5_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase310r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase310r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -28697,8 +28783,9 @@ fn phase311_log45_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -28715,8 +28802,9 @@ fn phase311_log45_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase311r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase311r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -28796,8 +28884,9 @@ fn phase312_sqrt1_k_log45_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -28815,8 +28904,9 @@ fn phase312_sqrt1_k_log45_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase312r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase312r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -28896,8 +28986,9 @@ fn phase313_sqrt2_k_log45_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -28915,8 +29006,9 @@ fn phase313_sqrt2_k_log45_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase313r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase313r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -28996,8 +29088,9 @@ fn phase314_sqrt3_k_log45_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -29015,8 +29108,9 @@ fn phase314_sqrt3_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase314r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase314r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -29096,8 +29190,9 @@ fn phase315_sqrt4_k_log45_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -29115,8 +29210,9 @@ fn phase315_sqrt4_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase315r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase315r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -29196,8 +29292,9 @@ fn phase316_sqrt5_k_log45_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -29215,8 +29312,9 @@ fn phase316_sqrt5_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase316r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase316r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -29288,8 +29386,9 @@ fn phase317_log46_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -29305,8 +29404,9 @@ fn phase317_log46_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase317r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase317r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -29385,8 +29485,9 @@ fn phase318_sqrt1_k_log46_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -29403,8 +29504,9 @@ fn phase318_sqrt1_k_log46_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase318r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase318r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -29483,8 +29585,9 @@ fn phase319_sqrt2_k_log46_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -29501,8 +29604,9 @@ fn phase319_sqrt2_k_log46_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase319r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase319r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -29581,8 +29685,9 @@ fn phase320_sqrt3_k_log46_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -29599,8 +29704,9 @@ fn phase320_sqrt3_k_log46_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase320r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase320r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -29679,8 +29785,9 @@ fn phase321_sqrt4_k_log46_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -29697,8 +29804,9 @@ fn phase321_sqrt4_k_log46_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase321r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase321r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -29777,8 +29885,9 @@ fn phase322_sqrt5_k_log46_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -29795,8 +29904,9 @@ fn phase322_sqrt5_k_log46_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase322r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase322r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -29870,8 +29980,9 @@ fn phase323_log47_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -29887,8 +29998,9 @@ fn phase323_log47_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase323r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase323r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -29969,8 +30081,9 @@ fn phase324_sqrt1_k_log47_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -29987,8 +30100,9 @@ fn phase324_sqrt1_k_log47_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase324r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase324r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -30069,8 +30183,9 @@ fn phase325_sqrt2_k_log47_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -30087,8 +30202,9 @@ fn phase325_sqrt2_k_log47_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase325r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase325r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -30169,8 +30285,9 @@ fn phase326_sqrt3_k_log47_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -30187,8 +30304,9 @@ fn phase326_sqrt3_k_log47_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase326r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase326r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -30269,8 +30387,9 @@ fn phase327_sqrt4_k_log47_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -30287,8 +30406,9 @@ fn phase327_sqrt4_k_log47_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase327r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase327r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -30369,8 +30489,9 @@ fn phase328_sqrt5_k_log47_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -30387,8 +30508,9 @@ fn phase328_sqrt5_k_log47_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase328r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase328r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -30443,7 +30565,7 @@ fn phase329_log47_k_over_k2_converges() {
 
 #[test]
 fn phase329_log48_k_over_k2_refused() {
-    // phase329 log48 k over k2 refused: 51 logs → refused (Phase 347 handles exactly 50).
+    // phase329 log48 k over k2 refused: 52 logs → refused (Phase 353 handles exactly 51).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -30464,8 +30586,9 @@ fn phase329_log48_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -30481,8 +30604,9 @@ fn phase329_log48_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase329r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase329r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -30541,7 +30665,7 @@ fn phase330_sqrt1_k_log47_k_over_k2_converges() {
 
 #[test]
 fn phase330_sqrt1_k_log48_k_over_k2_refused() {
-    // phase330 sqrt1 k log48 k over k2 refused: 51 logs → refused (Phase 348 handles exactly 50).
+    // phase330 sqrt1 k log48 k over k2 refused: 52 logs → refused (Phase 354 handles exactly 51).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -30565,8 +30689,9 @@ fn phase330_sqrt1_k_log48_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -30583,8 +30708,9 @@ fn phase330_sqrt1_k_log48_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase330r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase330r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -30643,7 +30769,7 @@ fn phase331_sqrt2_k_log47_k_over_k2_converges() {
 
 #[test]
 fn phase331_sqrt2_k_log48_k_over_k2_refused() {
-    // phase331 sqrt2 k log48 k over k2 refused: 51 logs → refused (Phase 349 handles exactly 50).
+    // phase331 sqrt2 k log48 k over k2 refused: 52 logs → refused (Phase 355 handles exactly 51).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -30667,8 +30793,9 @@ fn phase331_sqrt2_k_log48_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -30685,8 +30812,9 @@ fn phase331_sqrt2_k_log48_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase331r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase331r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -30745,7 +30873,7 @@ fn phase332_sqrt3_k_log47_k_over_k3_converges() {
 
 #[test]
 fn phase332_sqrt3_k_log48_k_over_k3_refused() {
-    // phase332 sqrt3 k log48 k over k3 refused: 51 logs → refused (Phase 350 handles exactly 50).
+    // phase332 sqrt3 k log48 k over k3 refused: 52 logs → refused (Phase 356 handles exactly 51).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -30769,8 +30897,9 @@ fn phase332_sqrt3_k_log48_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -30787,8 +30916,9 @@ fn phase332_sqrt3_k_log48_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase332r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase332r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -30847,7 +30977,7 @@ fn phase333_sqrt4_k_log47_k_over_k3_converges() {
 
 #[test]
 fn phase333_sqrt4_k_log48_k_over_k3_refused() {
-    // phase333 sqrt4 k log48 k over k3 refused: 51 logs → refused (Phase 351 handles exactly 50).
+    // phase333 sqrt4 k log48 k over k3 refused: 52 logs → refused (Phase 357 handles exactly 51).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -30871,8 +31001,9 @@ fn phase333_sqrt4_k_log48_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -30889,8 +31020,9 @@ fn phase333_sqrt4_k_log48_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase333r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase333r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -30949,7 +31081,7 @@ fn phase334_sqrt5_k_log47_k_over_k3_converges() {
 
 #[test]
 fn phase334_sqrt5_k_log48_k_over_k3_refused() {
-    // phase334 sqrt5 k log48 k over k3 refused: 51 logs → refused (Phase 352 handles exactly 50).
+    // phase334 sqrt5 k log48 k over k3 refused: 52 logs → refused (Phase 358 handles exactly 51).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -30973,8 +31105,9 @@ fn phase334_sqrt5_k_log48_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -30991,8 +31124,9 @@ fn phase334_sqrt5_k_log48_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase334r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase334r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -31047,7 +31181,7 @@ fn phase335_log48_k_over_k2_converges() {
 
 #[test]
 fn phase335_log50_k_over_k2_refused() {
-    // log(k)^50 / k2: 51 logs → refused (Phase 347 handles exactly 50).
+    // log(k)^50 / k2: 52 logs → refused (Phase 353 handles exactly 51).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -31068,8 +31202,9 @@ fn phase335_log50_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -31085,8 +31220,9 @@ fn phase335_log50_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase335r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase335r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -31145,7 +31281,7 @@ fn phase336_sqrt1_k_log48_k_over_k2_converges() {
 
 #[test]
 fn phase336_sqrt1_k_log50_k_over_k2_refused() {
-    // sqrt(k)*log(k)^50 / k2: 51 logs → refused (Phase 348 handles exactly 50).
+    // sqrt(k)*log(k)^50 / k2: 52 logs → refused (Phase 354 handles exactly 51).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -31169,8 +31305,9 @@ fn phase336_sqrt1_k_log50_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -31187,8 +31324,9 @@ fn phase336_sqrt1_k_log50_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase336r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase336r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -31247,7 +31385,7 @@ fn phase337_sqrt2_k_log48_k_over_k2_converges() {
 
 #[test]
 fn phase337_sqrt2_k_log50_k_over_k2_refused() {
-    // sqrt(k)^2*log(k)^50 / k2: 51 logs → refused (Phase 349 handles exactly 50).
+    // sqrt(k)^2*log(k)^50 / k2: 52 logs → refused (Phase 355 handles exactly 51).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -31271,8 +31409,9 @@ fn phase337_sqrt2_k_log50_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -31289,8 +31428,9 @@ fn phase337_sqrt2_k_log50_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase337r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase337r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -31349,7 +31489,7 @@ fn phase338_sqrt3_k_log48_k_over_k3_converges() {
 
 #[test]
 fn phase338_sqrt3_k_log50_k_over_k3_refused() {
-    // sqrt(k)^3*log(k)^50 / k3: 51 logs → refused (Phase 350 handles exactly 50).
+    // sqrt(k)^3*log(k)^50 / k3: 52 logs → refused (Phase 356 handles exactly 51).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -31373,8 +31513,9 @@ fn phase338_sqrt3_k_log50_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -31391,8 +31532,9 @@ fn phase338_sqrt3_k_log50_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase338r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase338r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -31451,7 +31593,7 @@ fn phase339_sqrt4_k_log48_k_over_k3_converges() {
 
 #[test]
 fn phase339_sqrt4_k_log50_k_over_k3_refused() {
-    // sqrt(k)^4*log(k)^50 / k3: 51 logs → refused (Phase 351 handles exactly 50).
+    // sqrt(k)^4*log(k)^50 / k3: 52 logs → refused (Phase 357 handles exactly 51).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -31475,8 +31617,9 @@ fn phase339_sqrt4_k_log50_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -31493,8 +31636,9 @@ fn phase339_sqrt4_k_log50_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase339r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase339r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -31553,7 +31697,7 @@ fn phase340_sqrt5_k_log48_k_over_k3_converges() {
 
 #[test]
 fn phase340_sqrt5_k_log50_k_over_k3_refused() {
-    // sqrt(k)^5*log(k)^50 / k3: 51 logs → refused (Phase 352 handles exactly 50).
+    // sqrt(k)^5*log(k)^50 / k3: 52 logs → refused (Phase 358 handles exactly 51).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -31577,8 +31721,9 @@ fn phase340_sqrt5_k_log50_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -31595,8 +31740,9 @@ fn phase340_sqrt5_k_log50_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase340r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase340r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -31653,7 +31799,7 @@ fn phase341_log49_k_over_k2_converges() {
 
 #[test]
 fn phase341_log50_k_over_k2_refused() {
-    // log(k)^50 / k2: 51 logs → refused (Phase 347 handles exactly 50).
+    // log(k)^50 / k2: 52 logs → refused (Phase 353 handles exactly 51).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -31674,8 +31820,9 @@ fn phase341_log50_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -31691,8 +31838,9 @@ fn phase341_log50_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase341r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase341r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -31753,7 +31901,7 @@ fn phase342_sqrt1_k_log49_k_over_k2_converges() {
 
 #[test]
 fn phase342_sqrt1_k_log50_k_over_k2_refused() {
-    // sqrt(k)*log(k)^50 / k2: 51 logs → refused (Phase 348 handles exactly 50).
+    // sqrt(k)*log(k)^50 / k2: 52 logs → refused (Phase 354 handles exactly 51).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -31777,8 +31925,9 @@ fn phase342_sqrt1_k_log50_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -31795,8 +31944,9 @@ fn phase342_sqrt1_k_log50_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase342r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase342r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -31857,7 +32007,7 @@ fn phase343_sqrt2_k_log49_k_over_k3_converges() {
 
 #[test]
 fn phase343_sqrt2_k_log50_k_over_k2_refused() {
-    // sqrt(k)^2*log(k)^50 / k2: 51 logs → refused (Phase 349 handles exactly 50).
+    // sqrt(k)^2*log(k)^50 / k2: 52 logs → refused (Phase 355 handles exactly 51).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -31881,8 +32031,9 @@ fn phase343_sqrt2_k_log50_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -31899,8 +32050,9 @@ fn phase343_sqrt2_k_log50_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase343r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase343r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -31961,7 +32113,7 @@ fn phase344_sqrt3_k_log49_k_over_k3_converges() {
 
 #[test]
 fn phase344_sqrt3_k_log50_k_over_k3_refused() {
-    // sqrt(k)^3*log(k)^50 / k3: 51 logs → refused (Phase 350 handles exactly 50).
+    // sqrt(k)^3*log(k)^50 / k3: 52 logs → refused (Phase 356 handles exactly 51).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -31985,8 +32137,9 @@ fn phase344_sqrt3_k_log50_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -32003,8 +32156,9 @@ fn phase344_sqrt3_k_log50_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase344r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase344r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -32065,7 +32219,7 @@ fn phase345_sqrt4_k_log49_k_over_k3_converges() {
 
 #[test]
 fn phase345_sqrt4_k_log50_k_over_k3_refused() {
-    // sqrt(k)^4*log(k)^50 / k3: 51 logs → refused (Phase 351 handles exactly 50).
+    // sqrt(k)^4*log(k)^50 / k3: 52 logs → refused (Phase 357 handles exactly 51).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -32089,8 +32243,9 @@ fn phase345_sqrt4_k_log50_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -32107,8 +32262,9 @@ fn phase345_sqrt4_k_log50_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase345r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase345r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -32169,7 +32325,7 @@ fn phase346_sqrt5_k_log49_k_over_k3_converges() {
 
 #[test]
 fn phase346_sqrt5_k_log50_k_over_k3_refused() {
-    // sqrt(k)^5*log(k)^50 / k3: 51 logs → refused (Phase 352 handles exactly 50).
+    // sqrt(k)^5*log(k)^50 / k3: 52 logs → refused (Phase 358 handles exactly 51).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -32193,8 +32349,9 @@ fn phase346_sqrt5_k_log50_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 51st log
-        log_k, // 52nd log (over 50; refused)
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 52nd log (over 50; refused)
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -32211,8 +32368,9 @@ fn phase346_sqrt5_k_log50_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 51st log
-        log_kp1, // 52nd log (over 50; refused)
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 52nd log (over 50; refused)
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase346r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase346r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -32271,7 +32429,7 @@ fn phase347_log50_k_over_k2_converges() {
 
 #[test]
 fn phase347_log51_k_over_k2_refused() {
-    // log(k)^51 / k2: 51 logs → refused (Phase 347 handles exactly 50).
+    // log(k)^51 / k2: 52 logs → refused (Phase 353 handles exactly 51).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -32293,7 +32451,8 @@ fn phase347_log51_k_over_k2_refused() {
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
         log_k.clone(), // 50th log
-        log_k, // 51st log
+        log_k.clone(), // 52nd log
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -32310,7 +32469,8 @@ fn phase347_log51_k_over_k2_refused() {
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
         log_kp1.clone(), // 50th log
-        log_kp1, // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase347r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase347r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -32373,7 +32533,7 @@ fn phase348_sqrt1_k_log50_k_over_k2_converges() {
 
 #[test]
 fn phase348_sqrt1_k_log51_k_over_k2_refused() {
-    // sqrt(k)*log(k)^51 / k2: 51 logs → refused (Phase 348 handles exactly 50).
+    // sqrt(k)*log(k)^51 / k2: 52 logs → refused (Phase 354 handles exactly 51).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -32398,7 +32558,8 @@ fn phase348_sqrt1_k_log51_k_over_k2_refused() {
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
         log_k.clone(), // 50th log
-        log_k, // 51st log
+        log_k.clone(), // 52nd log
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -32416,7 +32577,8 @@ fn phase348_sqrt1_k_log51_k_over_k2_refused() {
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
         log_kp1.clone(), // 50th log
-        log_kp1, // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase348r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase348r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -32479,7 +32641,7 @@ fn phase349_sqrt2_k_log50_k_over_k3_converges() {
 
 #[test]
 fn phase349_sqrt2_k_log51_k_over_k2_refused() {
-    // sqrt(k)^2*log(k)^51 / k2: 51 logs → refused (Phase 349 handles exactly 50).
+    // sqrt(k)^2*log(k)^51 / k2: 52 logs → refused (Phase 355 handles exactly 51).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -32504,7 +32666,8 @@ fn phase349_sqrt2_k_log51_k_over_k2_refused() {
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
         log_k.clone(), // 50th log
-        log_k, // 51st log
+        log_k.clone(), // 52nd log
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -32522,7 +32685,8 @@ fn phase349_sqrt2_k_log51_k_over_k2_refused() {
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
         log_kp1.clone(), // 50th log
-        log_kp1, // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase349r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase349r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -32585,7 +32749,7 @@ fn phase350_sqrt3_k_log50_k_over_k3_converges() {
 
 #[test]
 fn phase350_sqrt3_k_log51_k_over_k3_refused() {
-    // sqrt(k)^3*log(k)^51 / k3: 51 logs → refused (Phase 350 handles exactly 50).
+    // sqrt(k)^3*log(k)^51 / k3: 52 logs → refused (Phase 356 handles exactly 51).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -32610,7 +32774,8 @@ fn phase350_sqrt3_k_log51_k_over_k3_refused() {
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
         log_k.clone(), // 50th log
-        log_k, // 51st log
+        log_k.clone(), // 52nd log
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -32628,7 +32793,8 @@ fn phase350_sqrt3_k_log51_k_over_k3_refused() {
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
         log_kp1.clone(), // 50th log
-        log_kp1, // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase350r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase350r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -32691,7 +32857,7 @@ fn phase351_sqrt4_k_log50_k_over_k3_converges() {
 
 #[test]
 fn phase351_sqrt4_k_log51_k_over_k3_refused() {
-    // sqrt(k)^4*log(k)^51 / k3: 51 logs → refused (Phase 351 handles exactly 50).
+    // sqrt(k)^4*log(k)^51 / k3: 52 logs → refused (Phase 357 handles exactly 51).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -32716,7 +32882,8 @@ fn phase351_sqrt4_k_log51_k_over_k3_refused() {
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
         log_k.clone(), // 50th log
-        log_k, // 51st log
+        log_k.clone(), // 52nd log
+        log_k, // 53rd log (over 51; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -32734,7 +32901,8 @@ fn phase351_sqrt4_k_log51_k_over_k3_refused() {
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
         log_kp1.clone(), // 50th log
-        log_kp1, // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1, // 53rd log (over 51; refused)
     ]);
     let g_kphase351r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase351r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -32797,7 +32965,615 @@ fn phase352_sqrt5_k_log50_k_over_k3_converges() {
 
 #[test]
 fn phase352_sqrt5_k_log51_k_over_k3_refused() {
-    // sqrt(k)^5*log(k)^51 / k3: 51 logs → refused (Phase 352 handles exactly 50).
+    // sqrt(k)^5*log(k)^51 / k3: 52 logs → refused (Phase 358 handles exactly 51).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k.clone(), // 52nd log
+        log_k, // 53rd log (over 51; refused)
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 52nd log
+        log_kp1, // 53rd log (over 51; refused)
+    ]);
+    let g_kphase352r = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_phase352r = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let fphase352r = apply(sym(SUB), vec![g_kphase352r, g_kp1_phase352r]);
+    let out = evaluate_sum(fphase352r, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase353_log51_k_over_k2_converges() {
+    // log(k)^51 / k2: eff_x2=0; 2·2=4 > 0 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k, // 51st log
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1, // 51st log
+    ]);
+    let g_kphase353a = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_phase353a = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let fphase353a = apply(sym(SUB), vec![g_kphase353a, g_kp1_phase353a]);
+    let out = evaluate_sum(fphase353a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase353_log52_k_over_k2_refused() {
+    // log(k)^52 / k2: 52 logs → refused (Phase 353 handles exactly 51).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k.clone(), // 51st log
+        log_k.clone(), // 52nd log
+        log_k, // 53rd log (over 51; refused)
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1, // 53rd log (over 51; refused)
+    ]);
+    let g_kphase353r = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_phase353r = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let fphase353r = apply(sym(SUB), vec![g_kphase353r, g_kp1_phase353r]);
+    let out = evaluate_sum(fphase353r, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase354_sqrt1_k_log51_k_over_k2_converges() {
+    // sqrt(k)^1*log(k)^51 / k2: eff_x2=1; 2·2=4 > 1 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k, // 51st log
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1, // 51st log
+    ]);
+    let g_kphase354a = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_phase354a = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let fphase354a = apply(sym(SUB), vec![g_kphase354a, g_kp1_phase354a]);
+    let out = evaluate_sum(fphase354a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase354_sqrt1_k_log52_k_over_k2_refused() {
+    // sqrt(k)^1*log(k)^52 / k2: 52 logs → refused (Phase 354 handles exactly 51).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k.clone(), // 51st log
+        log_k.clone(), // 52nd log
+        log_k, // 53rd log (over 51; refused)
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1, // 53rd log (over 51; refused)
+    ]);
+    let g_kphase354r = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_phase354r = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let fphase354r = apply(sym(SUB), vec![g_kphase354r, g_kp1_phase354r]);
+    let out = evaluate_sum(fphase354r, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase355_sqrt2_k_log51_k_over_k3_converges() {
+    // sqrt(k)^2*log(k)^51 / k3: eff_x2=2; 2·3=6 > 2 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k, // 51st log
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1, // 51st log
+    ]);
+    let g_kphase355a = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_phase355a = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let fphase355a = apply(sym(SUB), vec![g_kphase355a, g_kp1_phase355a]);
+    let out = evaluate_sum(fphase355a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase355_sqrt2_k_log52_k_over_k3_refused() {
+    // sqrt(k)^2*log(k)^52 / k3: 52 logs → refused (Phase 355 handles exactly 51).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k.clone(), // 51st log
+        log_k.clone(), // 52nd log
+        log_k, // 53rd log (over 51; refused)
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1, // 53rd log (over 51; refused)
+    ]);
+    let g_kphase355r = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_phase355r = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let fphase355r = apply(sym(SUB), vec![g_kphase355r, g_kp1_phase355r]);
+    let out = evaluate_sum(fphase355r, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase356_sqrt3_k_log51_k_over_k3_converges() {
+    // sqrt(k)^3*log(k)^51 / k3: eff_x2=3; 2·3=6 > 3 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k, // 51st log
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1, // 51st log
+    ]);
+    let g_kphase356a = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_phase356a = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let fphase356a = apply(sym(SUB), vec![g_kphase356a, g_kp1_phase356a]);
+    let out = evaluate_sum(fphase356a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase356_sqrt3_k_log52_k_over_k3_refused() {
+    // sqrt(k)^3*log(k)^52 / k3: 52 logs → refused (Phase 356 handles exactly 51).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k.clone(), // 51st log
+        log_k.clone(), // 52nd log
+        log_k, // 53rd log (over 51; refused)
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1, // 53rd log (over 51; refused)
+    ]);
+    let g_kphase356r = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_phase356r = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let fphase356r = apply(sym(SUB), vec![g_kphase356r, g_kp1_phase356r]);
+    let out = evaluate_sum(fphase356r, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase357_sqrt4_k_log51_k_over_k3_converges() {
+    // sqrt(k)^4*log(k)^51 / k3: eff_x2=4; 2·3=6 > 4 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k, // 51st log
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1, // 51st log
+    ]);
+    let g_kphase357a = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_phase357a = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let fphase357a = apply(sym(SUB), vec![g_kphase357a, g_kp1_phase357a]);
+    let out = evaluate_sum(fphase357a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase357_sqrt4_k_log52_k_over_k3_refused() {
+    // sqrt(k)^4*log(k)^52 / k3: 52 logs → refused (Phase 357 handles exactly 51).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k.clone(), // 51st log
+        log_k.clone(), // 52nd log
+        log_k, // 53rd log (over 51; refused)
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1, // 53rd log (over 51; refused)
+    ]);
+    let g_kphase357r = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_phase357r = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let fphase357r = apply(sym(SUB), vec![g_kphase357r, g_kp1_phase357r]);
+    let out = evaluate_sum(fphase357r, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase358_sqrt5_k_log51_k_over_k3_converges() {
+    // sqrt(k)^5*log(k)^51 / k3: eff_x2=5; 2·3=6 > 5 → converges.
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -32842,9 +33618,67 @@ fn phase352_sqrt5_k_log51_k_over_k3_refused() {
         log_kp1.clone(), // 50th log
         log_kp1, // 51st log
     ]);
-    let g_kphase352r = apply(sym(DIV), vec![num_k, k3]);
-    let g_kp1_phase352r = apply(sym(DIV), vec![num_kp1, kp1_3]);
-    let fphase352r = apply(sym(SUB), vec![g_kphase352r, g_kp1_phase352r]);
-    let out = evaluate_sum(fphase352r, k, int(1), sym("%inf"), eval);
+    let g_kphase358a = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_phase358a = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let fphase358a = apply(sym(SUB), vec![g_kphase358a, g_kp1_phase358a]);
+    let out = evaluate_sum(fphase358a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase358_sqrt5_k_log52_k_over_k3_refused() {
+    // sqrt(k)^5*log(k)^52 / k3: 52 logs → refused (Phase 358 handles exactly 51).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k.clone(), // 51st log
+        log_k.clone(), // 52nd log
+        log_k, // 53rd log (over 51; refused)
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1, // 53rd log (over 51; refused)
+    ]);
+    let g_kphase358r = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_phase358r = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let fphase358r = apply(sym(SUB), vec![g_kphase358r, g_kp1_phase358r]);
+    let out = evaluate_sum(fphase358r, k, int(1), sym("%inf"), eval);
     assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 2.295.0 — 2026-05-28
+
+### Added
+
+- **Phase 358 — Five-Sqrt × Fifty-One-Log × polynomial** (`fiveSqrtFiftyOneLogPolyEffectiveDeg`):
+  Completes the Fifty-One-Log family (Phases 353–358).
+- **Phase 357 — Four-Sqrt × Fifty-One-Log × polynomial** (`fourSqrtFiftyOneLogPolyEffectiveDeg`).
+- **Phase 356 — Three-Sqrt × Fifty-One-Log × polynomial** (`threeSqrtFiftyOneLogPolyEffectiveDeg`).
+- **Phase 355 — Two-Sqrt × Fifty-One-Log × polynomial** (`twoSqrtFiftyOneLogPolyEffectiveDeg`).
+- **Phase 354 — One-Sqrt × Fifty-One-Log × polynomial** (`oneSqrtFiftyOneLogPolyEffectiveDeg`).
+- **Phase 353 — Zero-Sqrt × Fifty-One-Log × polynomial** (`fiftyOneLogPolyEffectiveDeg`).
+
+### Changed
+
+- Boundary tests in Phases 347–352 updated from 51-log "refused" to 52-log "refused"
+  now that Phases 353–358 handle exactly 51 logs.
+
 ## 2.289.0 — 2026-05-28
 
 ### Added

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "2.289.0",
+  "version": "2.295.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -6339,6 +6339,165 @@ function fourSqrtFortyThreeLogPolyEffectiveDeg(node: IRNode, k: IRNode): number 
   return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + sqrtHalfDegs[3] + polyDeg;
 }
 
+/** Phase 358 — Five-Sqrt × Fifty-One-Log × polynomial numerator.
+ * Caller checks `denDeg > fiveSqrtFiftyOneLogPolyEffectiveDeg(num, k)`.
+ * Completes the Fifty-One-Log family (Phases 353–358).
+ */
+function fiveSqrtFiftyOneLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDegs.length >= 5) return undefined;
+      sqrtHalfDegs.push(hd); continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 51) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 5 || logCount !== 51) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + sqrtHalfDegs[3] + sqrtHalfDegs[4] + polyDeg;
+}
+
+/** Phase 357 — Four-Sqrt × Fifty-One-Log × polynomial numerator. */
+function fourSqrtFiftyOneLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDegs.length >= 4) return undefined;
+      sqrtHalfDegs.push(hd); continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 51) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 4 || logCount !== 51) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + sqrtHalfDegs[3] + polyDeg;
+}
+
+/** Phase 356 — Three-Sqrt × Fifty-One-Log × polynomial numerator. */
+function threeSqrtFiftyOneLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDegs.length >= 3) return undefined;
+      sqrtHalfDegs.push(hd); continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 51) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 3 || logCount !== 51) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + polyDeg;
+}
+
+/** Phase 355 — Two-Sqrt × Fifty-One-Log × polynomial numerator. */
+function twoSqrtFiftyOneLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDegs.length >= 2) return undefined;
+      sqrtHalfDegs.push(hd); continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 51) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 2 || logCount !== 51) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + polyDeg;
+}
+
+/** Phase 354 — One-Sqrt × Fifty-One-Log × polynomial numerator.
+ * Caller checks `denDeg > oneSqrtFiftyOneLogPolyEffectiveDeg(num, k)`.
+ */
+function oneSqrtFiftyOneLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  let sqrtHalfDeg: number | undefined;
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDeg !== undefined) return undefined;
+      sqrtHalfDeg = hd; continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 51) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDeg === undefined || logCount !== 51) return undefined;
+  return sqrtHalfDeg + polyDeg;
+}
+
+/** Phase 353 — Zero-Sqrt × Fifty-One-Log × polynomial numerator.
+ * effectiveDeg = polyDeg (no sqrt factors).
+ * Caller checks `denDeg > fiftyOneLogPolyEffectiveDeg(num, k)`.
+ */
+function fiftyOneLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    if (sqrtEffectiveHalfDegree(arg, k) !== undefined) return undefined; // Sqrt present — refuse
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 51) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (logCount !== 51) return undefined;
+  return polyDeg;
+}
+
 /** Phase 352 — Five-Sqrt × Fifty-Log × polynomial numerator.
  * Caller checks `denDeg > fiveSqrtFiftyLogPolyEffectiveDeg(num, k)`.
  * Completes the Fifty-Log family (Phases 347–352).
@@ -9480,6 +9639,66 @@ function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
     const denDegS2l8 = polynomialDegreeInK(den, k);
     if (denDegS2l8 !== undefined) {
       if (denDegS2l8 > s2l8Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 358: five sqrt + 51 logs
+  const s5l51Deg = fiveSqrtFiftyOneLogPolyEffectiveDeg(num, k);
+  if (s5l51Deg !== undefined) {
+    const denDegS5l51 = polynomialDegreeInK(den, k);
+    if (denDegS5l51 !== undefined) {
+      if (denDegS5l51 > s5l51Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 357: four sqrt + 51 logs
+  const s4l51Deg = fourSqrtFiftyOneLogPolyEffectiveDeg(num, k);
+  if (s4l51Deg !== undefined) {
+    const denDegS4l51 = polynomialDegreeInK(den, k);
+    if (denDegS4l51 !== undefined) {
+      if (denDegS4l51 > s4l51Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 356: three sqrt + 51 logs
+  const s3l51Deg = threeSqrtFiftyOneLogPolyEffectiveDeg(num, k);
+  if (s3l51Deg !== undefined) {
+    const denDegS3l51 = polynomialDegreeInK(den, k);
+    if (denDegS3l51 !== undefined) {
+      if (denDegS3l51 > s3l51Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 355: two sqrt + 51 logs
+  const s2l51Deg = twoSqrtFiftyOneLogPolyEffectiveDeg(num, k);
+  if (s2l51Deg !== undefined) {
+    const denDegS2l51 = polynomialDegreeInK(den, k);
+    if (denDegS2l51 !== undefined) {
+      if (denDegS2l51 > s2l51Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 354: one sqrt + 51 logs
+  const s1l51Deg = oneSqrtFiftyOneLogPolyEffectiveDeg(num, k);
+  if (s1l51Deg !== undefined) {
+    const denDegS1l51 = polynomialDegreeInK(den, k);
+    if (denDegS1l51 !== undefined) {
+      if (denDegS1l51 > s1l51Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 353: zero sqrt + 51 logs
+  const s0l51Deg = fiftyOneLogPolyEffectiveDeg(num, k);
+  if (s0l51Deg !== undefined) {
+    const denDegS0l51 = polynomialDegreeInK(den, k);
+    if (denDegS0l51 !== undefined) {
+      if (denDegS0l51 > s0l51Deg) return true;
     } else if (hDivergesAtInfinity(den, k)) {
       return true;
     }

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -15271,8 +15271,8 @@ describe("Phase 167 — Twenty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK167r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1167r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK167r = { kind: "apply" as const, head: DIV, args: [numK167r, k2] };
@@ -15321,8 +15321,8 @@ describe("Phase 168 — One-Sqrt × Twenty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK168r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [k] }, ...logs29k, k] };
     const numKp1168r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [kp1] }, ...logs29kp1, kp1] };
     const gK168r = { kind: "apply" as const, head: DIV, args: [numK168r, k2] };
@@ -15375,8 +15375,8 @@ describe("Phase 169 — Two-Sqrt × Twenty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK169r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -15431,8 +15431,8 @@ describe("Phase 170 — Three-Sqrt × Twenty-Log × polynomial numerator", () =>
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK170r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15487,8 +15487,8 @@ describe("Phase 171 — Four-Sqrt × Twenty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK171r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15543,8 +15543,8 @@ describe("Phase 172 — Five-Sqrt × Twenty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK172r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15595,8 +15595,8 @@ describe("Phase 173 — Twenty-One-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK173r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1173r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK173r = { kind: "apply" as const, head: DIV, args: [numK173r, k2] };
@@ -15645,8 +15645,8 @@ describe("Phase 174 — One-Sqrt × Twenty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK174r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [k] }, ...logs29k, k] };
     const numKp1174r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [kp1] }, ...logs29kp1, kp1] };
     const gK174r = { kind: "apply" as const, head: DIV, args: [numK174r, k2] };
@@ -15699,8 +15699,8 @@ describe("Phase 175 — Two-Sqrt × Twenty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK175r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -15755,8 +15755,8 @@ describe("Phase 176 — Three-Sqrt × Twenty-One-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK176r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15811,8 +15811,8 @@ describe("Phase 177 — Four-Sqrt × Twenty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK177r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15867,8 +15867,8 @@ describe("Phase 178 — Five-Sqrt × Twenty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK178r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15919,8 +15919,8 @@ describe("Phase 179 — Twenty-Two-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK179r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1179r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK179r = { kind: "apply" as const, head: DIV, args: [numK179r, k2] };
@@ -15969,8 +15969,8 @@ describe("Phase 180 — One-Sqrt × Twenty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK180r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [k] }, ...logs29k, k] };
     const numKp1180r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [kp1] }, ...logs29kp1, kp1] };
     const gK180r = { kind: "apply" as const, head: DIV, args: [numK180r, k2] };
@@ -16023,8 +16023,8 @@ describe("Phase 181 — Two-Sqrt × Twenty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK181r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -16079,8 +16079,8 @@ describe("Phase 182 — Three-Sqrt × Twenty-Two-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK182r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16135,8 +16135,8 @@ describe("Phase 183 — Four-Sqrt × Twenty-Two-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK183r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16191,8 +16191,8 @@ describe("Phase 184 — Five-Sqrt × Twenty-Two-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK184r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16243,8 +16243,8 @@ describe("Phase 185 — Twenty-Three-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK185r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1185r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK185r = { kind: "apply" as const, head: DIV, args: [numK185r, k2] };
@@ -16293,8 +16293,8 @@ describe("Phase 186 — One-Sqrt × Twenty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK186r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [k] }, ...logs29k, k] };
     const numKp1186r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [kp1] }, ...logs29kp1, kp1] };
     const gK186r = { kind: "apply" as const, head: DIV, args: [numK186r, k2] };
@@ -16347,8 +16347,8 @@ describe("Phase 187 — Two-Sqrt × Twenty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK187r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -16403,8 +16403,8 @@ describe("Phase 188 — Three-Sqrt × Twenty-Three-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK188r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16459,8 +16459,8 @@ describe("Phase 189 — Four-Sqrt × Twenty-Three-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK189r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16515,8 +16515,8 @@ describe("Phase 190 — Five-Sqrt × Twenty-Three-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK190r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16567,8 +16567,8 @@ describe("Phase 191 — Twenty-Four-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK191r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1191r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK191r = { kind: "apply" as const, head: DIV, args: [numK191r, k2] };
@@ -16621,8 +16621,8 @@ describe("Phase 192 — One-Sqrt × Twenty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK192r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs29k, k] };
@@ -16677,8 +16677,8 @@ describe("Phase 193 — Two-Sqrt × Twenty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK193r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -16733,8 +16733,8 @@ describe("Phase 194 — Three-Sqrt × Twenty-Four-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK194r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16789,8 +16789,8 @@ describe("Phase 195 — Four-Sqrt × Twenty-Four-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK195r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16845,8 +16845,8 @@ describe("Phase 196 — Five-Sqrt × Twenty-Four-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK196r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16897,8 +16897,8 @@ describe("Phase 197 — Twenty-Five-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK197r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1197r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK197r = { kind: "apply" as const, head: DIV, args: [numK197r, k2] };
@@ -16951,8 +16951,8 @@ describe("Phase 198 — One-Sqrt × Twenty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK198r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs29k, k] };
@@ -17007,8 +17007,8 @@ describe("Phase 199 — Two-Sqrt × Twenty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK199r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -17063,8 +17063,8 @@ describe("Phase 200 — Three-Sqrt × Twenty-Five-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK200r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17119,8 +17119,8 @@ describe("Phase 201 — Four-Sqrt × Twenty-Five-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK201r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17175,8 +17175,8 @@ describe("Phase 202 — Five-Sqrt × Twenty-Five-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK202r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17227,8 +17227,8 @@ describe("Phase 203 — Twenty-Six-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK203r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1203r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK203r = { kind: "apply" as const, head: DIV, args: [numK203r, k2] };
@@ -17279,8 +17279,8 @@ describe("Phase 204 — One-Sqrt × Twenty-Six-Log × polynomial numerator", () 
   it("√k·log(k)²⁹·k/k² refused (30 logs — not Phase 204)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK204r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs29k, k] };
@@ -17333,8 +17333,8 @@ describe("Phase 205 — Two-Sqrt × Twenty-Six-Log × polynomial numerator", () 
   it("√k·√k·log(k)²⁹/k² refused (30 logs — not Phase 205)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK205r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k, k] };
@@ -17387,8 +17387,8 @@ describe("Phase 206 — Three-Sqrt × Twenty-Six-Log × polynomial numerator", (
   it("(√k)³·log(k)²⁹/k² refused (30 logs — not Phase 206)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK206r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k, k] };
@@ -17443,8 +17443,8 @@ describe("Phase 207 — Four-Sqrt × Twenty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK207r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k, k] };
@@ -17499,8 +17499,8 @@ describe("Phase 208 — Five-Sqrt × Twenty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK208r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17551,8 +17551,8 @@ describe("Phase 209 — Zero-Sqrt × Twenty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK209r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1209r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK209r = { kind: "apply" as const, head: DIV, args: [numK209r, k2] };
@@ -17603,8 +17603,8 @@ describe("Phase 210 — One-Sqrt × Twenty-Seven-Log × polynomial numerator", (
   it("√k·log(k)²⁹·k/k² refused (30 logs — not Phase 210)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK210r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs29k, k] };
@@ -17659,8 +17659,8 @@ describe("Phase 211 — Two-Sqrt × Twenty-Seven-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK211r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -17715,8 +17715,8 @@ describe("Phase 212 — Three-Sqrt × Twenty-Seven-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK212r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17771,8 +17771,8 @@ describe("Phase 213 — Four-Sqrt × Twenty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK213r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17827,8 +17827,8 @@ describe("Phase 214 — Five-Sqrt × Twenty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK214r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17879,8 +17879,8 @@ describe("Phase 215 — Zero-Sqrt × Twenty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK215r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1215r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK215r = { kind: "apply" as const, head: DIV, args: [numK215r, k2] };
@@ -17933,8 +17933,8 @@ describe("Phase 216 — One-Sqrt × Twenty-Eight-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK216r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs29k, k] };
@@ -17989,8 +17989,8 @@ describe("Phase 217 — Two-Sqrt × Twenty-Eight-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK217r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -18045,8 +18045,8 @@ describe("Phase 218 — Three-Sqrt × Twenty-Eight-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK218r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -18101,8 +18101,8 @@ describe("Phase 219 — Four-Sqrt × Twenty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK219r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -18157,8 +18157,8 @@ describe("Phase 220 — Five-Sqrt × Twenty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK220r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -18209,8 +18209,8 @@ describe("Phase 221 — Zero-Sqrt × Twenty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK221r = { kind: "apply" as const, head: MUL, args: [...logs30k, k] };
     const numKp1221r = { kind: "apply" as const, head: MUL, args: [...logs30kp1, kp1] };
     const gK221r = { kind: "apply" as const, head: DIV, args: [numK221r, k2] };
@@ -18263,8 +18263,8 @@ describe("Phase 222 — One-Sqrt × Twenty-Nine-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK222r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs30k, k] };
@@ -18319,8 +18319,8 @@ describe("Phase 223 — Two-Sqrt × Twenty-Nine-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK223r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs30k, k] };
@@ -18375,8 +18375,8 @@ describe("Phase 224 — Three-Sqrt × Twenty-Nine-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK224r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs30k, k] };
@@ -18431,8 +18431,8 @@ describe("Phase 225 — Four-Sqrt × Twenty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK225r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs30k, k] };
@@ -18487,8 +18487,8 @@ describe("Phase 226 — Five-Sqrt × Twenty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK226r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs30k, k] };
@@ -18539,8 +18539,8 @@ describe("Phase 227 — Zero-Sqrt × Thirty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK227r = { kind: "apply" as const, head: MUL, args: [...logs31k, k] };
     const numKp1227r = { kind: "apply" as const, head: MUL, args: [...logs31kp1, kp1] };
     const gK227r = { kind: "apply" as const, head: DIV, args: [numK227r, k2] };
@@ -18593,8 +18593,8 @@ describe("Phase 228 — One-Sqrt × Thirty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK228r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs31k, k] };
@@ -18649,8 +18649,8 @@ describe("Phase 229 — Two-Sqrt × Thirty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK229r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs31k, k] };
@@ -18705,8 +18705,8 @@ describe("Phase 230 — Three-Sqrt × Thirty-Log × polynomial numerator", () =>
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK230r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs31k, k] };
@@ -18761,8 +18761,8 @@ describe("Phase 231 — Four-Sqrt × Thirty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK231r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs31k, k] };
@@ -18817,8 +18817,8 @@ describe("Phase 232 — Five-Sqrt × Thirty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK232r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs31k, k] };
@@ -18869,8 +18869,8 @@ describe("Phase 233 — Zero-Sqrt × Thirty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK233r = { kind: "apply" as const, head: MUL, args: [...logs32k, k] };
     const numKp1233r = { kind: "apply" as const, head: MUL, args: [...logs32kp1, kp1] };
     const gK233r = { kind: "apply" as const, head: DIV, args: [numK233r, k2] };
@@ -18923,8 +18923,8 @@ describe("Phase 234 — One-Sqrt × Thirty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK234r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs32k, k] };
@@ -18979,8 +18979,8 @@ describe("Phase 235 — Two-Sqrt × Thirty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK235r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs32k, k] };
@@ -19035,8 +19035,8 @@ describe("Phase 236 — Three-Sqrt × Thirty-One-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK236r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs32k, k] };
@@ -19091,8 +19091,8 @@ describe("Phase 237 — Four-Sqrt × Thirty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK237r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs32k, k] };
@@ -19147,8 +19147,8 @@ describe("Phase 238 — Five-Sqrt × Thirty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK238r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs32k, k] };
@@ -19199,8 +19199,8 @@ describe("Phase 239 — Thirty-Two-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs33k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK239r = { kind: "apply" as const, head: MUL, args: [...logs33k, k] };
     const numKp1239r = { kind: "apply" as const, head: MUL, args: [...logs33kp1, kp1] };
     const gK239r = { kind: "apply" as const, head: DIV, args: [numK239r, k2] };
@@ -19249,8 +19249,8 @@ describe("Phase 240 — One-Sqrt × Thirty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs33k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK240r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [k] }, ...logs33k, k] };
     const numKp1240r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [kp1] }, ...logs33kp1, kp1] };
     const gK240r = { kind: "apply" as const, head: DIV, args: [numK240r, k2] };
@@ -19303,8 +19303,8 @@ describe("Phase 241 — Two-Sqrt × Thirty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs33k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK241r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs33k] };
@@ -19359,8 +19359,8 @@ describe("Phase 242 — Three-Sqrt × Thirty-Two-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs33k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK242r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs33k] };
@@ -19415,8 +19415,8 @@ describe("Phase 243 — Four-Sqrt × Thirty-Two-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs33k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK243r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs33k, k] };
@@ -19471,8 +19471,8 @@ describe("Phase 244 — Five-Sqrt × Thirty-Two-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs33k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK244r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs33k, k] };
@@ -19523,8 +19523,8 @@ describe("Phase 245 — Thirty-Three-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs34k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK245r = { kind: "apply" as const, head: MUL, args: [...logs34k, k] };
     const numKp1245r = { kind: "apply" as const, head: MUL, args: [...logs34kp1, kp1] };
     const gK245r = { kind: "apply" as const, head: DIV, args: [numK245r, k2] };
@@ -19577,8 +19577,8 @@ describe("Phase 246 — One-Sqrt × Thirty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs34k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK246r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs34k, k] };
@@ -19633,8 +19633,8 @@ describe("Phase 247 — Two-Sqrt × Thirty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs34k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK247r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs34k] };
@@ -19689,8 +19689,8 @@ describe("Phase 248 — Three-Sqrt × Thirty-Three-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs34k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK248r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs34k] };
@@ -19745,8 +19745,8 @@ describe("Phase 249 — Four-Sqrt × Thirty-Three-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs34k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK249r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs34k] };
@@ -19801,8 +19801,8 @@ describe("Phase 250 — Five-Sqrt × Thirty-Three-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs34k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK250r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs34k, k] };
@@ -19853,8 +19853,8 @@ describe("Phase 251 — Thirty-Four-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs36k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK251r = { kind: "apply" as const, head: MUL, args: [...logs36k, k] };
     const numKp1251r = { kind: "apply" as const, head: MUL, args: [...logs36kp1, kp1] };
     const gK251r = { kind: "apply" as const, head: DIV, args: [numK251r, k2] };
@@ -19907,8 +19907,8 @@ describe("Phase 252 — One-Sqrt × Thirty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs36k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK252r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs36k, k] };
@@ -19963,8 +19963,8 @@ describe("Phase 253 — Two-Sqrt × Thirty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs36k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK253r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs36k] };
@@ -20019,8 +20019,8 @@ describe("Phase 254 — Three-Sqrt × Thirty-Four-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs36k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK254r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs36k] };
@@ -20075,8 +20075,8 @@ describe("Phase 255 — Four-Sqrt × Thirty-Four-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs36k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK255r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs36k] };
@@ -20131,8 +20131,8 @@ describe("Phase 256 — Five-Sqrt × Thirty-Four-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK256r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs36k, k] };
@@ -20183,8 +20183,8 @@ describe("Phase 257 — Thirty-Five-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK257r = { kind: "apply" as const, head: MUL, args: [...logs36k, k] };
     const numKp1257r = { kind: "apply" as const, head: MUL, args: [...logs36kp1, kp1] };
     const gK257r = { kind: "apply" as const, head: DIV, args: [numK257r, k2] };
@@ -20237,8 +20237,8 @@ describe("Phase 258 — One-Sqrt × Thirty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK258r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs36k, k] };
@@ -20293,8 +20293,8 @@ describe("Phase 259 — Two-Sqrt × Thirty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK259r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs36k, k] };
@@ -20349,8 +20349,8 @@ describe("Phase 260 — Three-Sqrt × Thirty-Five-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK260r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs36k, k] };
@@ -20405,8 +20405,8 @@ describe("Phase 261 — Four-Sqrt × Thirty-Five-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK261r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs36k, k] };
@@ -20461,8 +20461,8 @@ describe("Phase 262 — Five-Sqrt × Thirty-Five-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK262r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs36k, k] };
@@ -20513,8 +20513,8 @@ describe("Phase 263 — Zero-Sqrt × Thirty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK263r = { kind: "apply" as const, head: MUL, args: [...logs37k, k] };
     const numKp1263r = { kind: "apply" as const, head: MUL, args: [...logs37kp1, kp1] };
     const gK263r = { kind: "apply" as const, head: DIV, args: [numK263r, k2] };
@@ -20567,8 +20567,8 @@ describe("Phase 264 — One-Sqrt × Thirty-Six-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK264r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs37k, k] };
@@ -20623,8 +20623,8 @@ describe("Phase 265 — Two-Sqrt × Thirty-Six-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK265r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs37k] };
@@ -20679,8 +20679,8 @@ describe("Phase 266 — Three-Sqrt × Thirty-Six-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK266r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs37k] };
@@ -20735,8 +20735,8 @@ describe("Phase 267 — Four-Sqrt × Thirty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK267r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs37k, k] };
@@ -20791,8 +20791,8 @@ describe("Phase 268 — Five-Sqrt × Thirty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK268r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs37k, k] };
@@ -20843,8 +20843,8 @@ describe("Phase 269 — Zero-Sqrt × Thirty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs38k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs38kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs38k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK269r = { kind: "apply" as const, head: MUL, args: [...logs38k, k] };
     const numKp1269r = { kind: "apply" as const, head: MUL, args: [...logs38kp1, kp1] };
     const gK269r = { kind: "apply" as const, head: DIV, args: [numK269r, k2] };
@@ -20897,8 +20897,8 @@ describe("Phase 270 — One-Sqrt × Thirty-Seven-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs38k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs38kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs38k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK270r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs38k, k] };
@@ -20953,8 +20953,8 @@ describe("Phase 271 — Two-Sqrt × Thirty-Seven-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs38k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs38kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs38k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK271r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs38k, k] };
@@ -21009,8 +21009,8 @@ describe("Phase 272 — Three-Sqrt × Thirty-Seven-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs38k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs38kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs38k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK272r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs38k, k] };
@@ -21065,8 +21065,8 @@ describe("Phase 273 — Four-Sqrt × Thirty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs38k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs38kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs38k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK273r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs38k, k] };
@@ -21121,8 +21121,8 @@ describe("Phase 274 — Five-Sqrt × Thirty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs38k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs38kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs38k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK274r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs38k, k] };
@@ -21173,8 +21173,8 @@ describe("Phase 275 — Zero-Sqrt × Thirty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs39k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs39kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs39k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs39kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK275r = { kind: "apply" as const, head: MUL, args: [...logs39k, k] };
     const numKp1275r = { kind: "apply" as const, head: MUL, args: [...logs39kp1, kp1] };
     const gK275r = { kind: "apply" as const, head: DIV, args: [numK275r, k2] };
@@ -21227,8 +21227,8 @@ describe("Phase 276 — One-Sqrt × Thirty-Eight-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs39k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs39kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs39k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs39kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK276r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs39k, k] };
@@ -21283,8 +21283,8 @@ describe("Phase 277 — Two-Sqrt × Thirty-Eight-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs39k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs39kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs39k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs39kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK277r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs39k, k] };
@@ -21339,8 +21339,8 @@ describe("Phase 278 — Three-Sqrt × Thirty-Eight-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs39k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs39kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs39k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs39kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK278r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs39k, k] };
@@ -21395,8 +21395,8 @@ describe("Phase 279 — Four-Sqrt × Thirty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs39k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs39kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs39k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs39kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK279r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs39k, k] };
@@ -21451,8 +21451,8 @@ describe("Phase 280 — Five-Sqrt × Thirty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs39k = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs39kp1 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs39k = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs39kp1 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK280r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs39k, k] };
@@ -21504,8 +21504,8 @@ describe("Phase 281 — Zero-Sqrt × Thirty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs40k281 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs40kp1281 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs40k281 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1281 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK281r = { kind: "apply" as const, head: MUL, args: [...logs40k281, k] };
     const numKp1281r = { kind: "apply" as const, head: MUL, args: [...logs40kp1281, kp1] };
     const gK281r = { kind: "apply" as const, head: DIV, args: [numK281r, k2r] };
@@ -21558,8 +21558,8 @@ describe("Phase 282 — One-Sqrt × Thirty-Nine-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs40k282 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs40kp1282 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs40k282 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1282 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK282r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs40k282, k] };
@@ -21614,8 +21614,8 @@ describe("Phase 283 — Two-Sqrt × Thirty-Nine-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs40k283 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs40kp1283 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs40k283 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1283 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK283r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs40k283, k] };
@@ -21670,8 +21670,8 @@ describe("Phase 284 — Three-Sqrt × Thirty-Nine-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs40k284 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs40kp1284 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs40k284 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1284 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK284r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs40k284, k] };
@@ -21726,8 +21726,8 @@ describe("Phase 285 — Four-Sqrt × Thirty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs40k285 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs40kp1285 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs40k285 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1285 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK285r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs40k285, k] };
@@ -21782,8 +21782,8 @@ describe("Phase 286 — Five-Sqrt × Thirty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs40k286 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs40kp1286 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs40k286 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1286 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK286r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs40k286, k] };
@@ -21834,8 +21834,8 @@ describe("Phase 287 — Zero-Sqrt × Forty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k287 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1287 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k287 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1287 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK287r = { kind: "apply" as const, head: MUL, args: [...logs42k287, k] };
     const numKp1287r = { kind: "apply" as const, head: MUL, args: [...logs42kp1287, kp1] };
     const gK287r = { kind: "apply" as const, head: DIV, args: [numK287r, k2r] };
@@ -21888,8 +21888,8 @@ describe("Phase 288 — One-Sqrt × Forty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k288 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1288 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k288 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1288 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK288r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs42k288, k] };
@@ -21944,8 +21944,8 @@ describe("Phase 289 — Two-Sqrt × Forty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k289 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1289 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k289 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1289 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK289r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs42k289, k] };
@@ -22000,8 +22000,8 @@ describe("Phase 290 — Three-Sqrt × Forty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k290 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1290 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k290 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1290 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK290r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs42k290, k] };
@@ -22056,8 +22056,8 @@ describe("Phase 291 — Four-Sqrt × Forty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k291 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1291 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k291 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1291 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK291r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs42k291, k] };
@@ -22112,8 +22112,8 @@ describe("Phase 292 — Five-Sqrt × Forty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k292 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1292 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k292 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1292 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK292r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs42k292, k] };
@@ -22164,8 +22164,8 @@ describe("Phase 293 — Zero-Sqrt × Forty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k293 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1293 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k293 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1293 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK293r = { kind: "apply" as const, head: MUL, args: [...logs42k293, k] };
     const numKp1293r = { kind: "apply" as const, head: MUL, args: [...logs42kp1293, kp1] };
     const gK293r = { kind: "apply" as const, head: DIV, args: [numK293r, k2r] };
@@ -22200,8 +22200,8 @@ describe("Phase 294 — One-Sqrt × Forty-One-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k294 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1294 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k294 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1294 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK294r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs42k294, k] };
@@ -22238,8 +22238,8 @@ describe("Phase 295 — Two-Sqrt × Forty-One-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k295 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1295 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k295 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1295 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK295r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs42k295, k] };
@@ -22276,8 +22276,8 @@ describe("Phase 296 — Three-Sqrt × Forty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k296 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1296 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k296 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1296 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK296r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs42k296, k] };
@@ -22314,8 +22314,8 @@ describe("Phase 297 — Four-Sqrt × Forty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k297 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1297 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k297 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1297 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK297r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs42k297, k] };
@@ -22352,8 +22352,8 @@ describe("Phase 298 — Five-Sqrt × Forty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k298 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1298 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k298 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1298 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK298r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs42k298, k] };
@@ -22388,8 +22388,8 @@ describe("Phase 299 — Zero-Sqrt × Forty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k299 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1299 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k299 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1299 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK299r = { kind: "apply" as const, head: MUL, args: [...logs44k299, k] };
     const numKp1299r = { kind: "apply" as const, head: MUL, args: [...logs44kp1299, kp1] };
     const gK299r = { kind: "apply" as const, head: DIV, args: [numK299r, k2r] };
@@ -22424,8 +22424,8 @@ describe("Phase 300 — One-Sqrt × Forty-Two-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k300 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1300 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k300 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1300 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK300r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs44k300, k] };
@@ -22462,8 +22462,8 @@ describe("Phase 301 — Two-Sqrt × Forty-Two-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k301 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1301 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k301 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1301 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK301r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs44k301, k] };
@@ -22500,8 +22500,8 @@ describe("Phase 302 — Three-Sqrt × Forty-Two-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k302 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1302 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k302 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1302 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK302r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs44k302, k] };
@@ -22538,8 +22538,8 @@ describe("Phase 303 — Four-Sqrt × Forty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k303 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1303 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k303 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1303 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK303r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs44k303, k] };
@@ -22576,8 +22576,8 @@ describe("Phase 304 — Five-Sqrt × Forty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k304 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1304 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k304 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1304 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK304r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs44k304, k] };
@@ -22612,8 +22612,8 @@ describe("Phase 305 — Zero-Sqrt × Forty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k305 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1305 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k305 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1305 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK305r = { kind: "apply" as const, head: MUL, args: [...logs44k305, k] };
     const numKp1305r = { kind: "apply" as const, head: MUL, args: [...logs44kp1305, kp1] };
     const gK305r = { kind: "apply" as const, head: DIV, args: [numK305r, k2r] };
@@ -22648,8 +22648,8 @@ describe("Phase 306 — One-Sqrt × Forty-Three-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k306 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1306 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k306 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1306 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK306r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs44k306, k] };
@@ -22686,8 +22686,8 @@ describe("Phase 307 — Two-Sqrt × Forty-Three-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k307 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1307 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k307 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1307 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK307r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs44k307, k] };
@@ -22724,8 +22724,8 @@ describe("Phase 308 — Three-Sqrt × Forty-Three-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1, kp1] };
-    const logs44k308 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1308 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k308 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1308 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK308r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs44k308, k] };
@@ -22762,8 +22762,8 @@ describe("Phase 309 — Four-Sqrt × Forty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1, kp1] };
-    const logs44k309 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1309 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k309 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1309 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK309r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs44k309, k] };
@@ -22800,8 +22800,8 @@ describe("Phase 310 — Five-Sqrt × Forty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k310 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1310 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k310 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1310 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK310r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs44k310, k] };
@@ -22836,8 +22836,8 @@ describe("Phase 311 — Forty-Four-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs45k311 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs45kp1311 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs45k311 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs45kp1311 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK311r = { kind: "apply" as const, head: MUL, args: [...logs45k311, k] };
     const numKp1311r = { kind: "apply" as const, head: MUL, args: [...logs45kp1311, kp1] };
     const gK311r = { kind: "apply" as const, head: DIV, args: [numK311r, k2r] };
@@ -22872,8 +22872,8 @@ describe("Phase 312 — One-Sqrt × Forty-Four-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs45k312 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs45kp1312 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs45k312 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs45kp1312 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK312r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs45k312, k] };
@@ -22910,8 +22910,8 @@ describe("Phase 313 — Two-Sqrt × Forty-Four-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs45k313 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs45kp1313 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs45k313 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs45kp1313 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK313r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs45k313, k] };
@@ -22948,8 +22948,8 @@ describe("Phase 314 — Three-Sqrt × Forty-Four-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs45k314 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs45kp1314 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs45k314 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs45kp1314 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK314r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs45k314, k] };
@@ -22986,8 +22986,8 @@ describe("Phase 315 — Four-Sqrt × Forty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs45k315 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs45kp1315 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs45k315 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs45kp1315 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK315r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs45k315, k] };
@@ -23024,8 +23024,8 @@ describe("Phase 316 — Five-Sqrt × Forty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs45k316 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs45kp1316 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs45k316 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs45kp1316 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK316r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs45k316, k] };
@@ -23060,8 +23060,8 @@ describe("Phase 317 — Forty-Five-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs46k317 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs46kp1317 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs46k317 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs46kp1317 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK317r = { kind: "apply" as const, head: MUL, args: [...logs46k317, k] };
     const numKp1317r = { kind: "apply" as const, head: MUL, args: [...logs46kp1317, kp1] };
     const gK317r = { kind: "apply" as const, head: DIV, args: [numK317r, k2r] };
@@ -23096,8 +23096,8 @@ describe("Phase 318 — One-Sqrt × Forty-Five-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs46k318 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs46kp1318 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs46k318 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs46kp1318 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK318r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs46k318, k] };
@@ -23134,8 +23134,8 @@ describe("Phase 319 — Two-Sqrt × Forty-Five-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs46k319 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs46kp1319 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs46k319 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs46kp1319 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK319r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs46k319, k] };
@@ -23172,8 +23172,8 @@ describe("Phase 320 — Three-Sqrt × Forty-Five-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs46k320 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs46kp1320 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs46k320 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs46kp1320 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK320r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs46k320, k] };
@@ -23210,8 +23210,8 @@ describe("Phase 321 — Four-Sqrt × Forty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs46k321 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs46kp1321 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs46k321 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs46kp1321 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK321r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs46k321, k] };
@@ -23248,8 +23248,8 @@ describe("Phase 322 — Five-Sqrt × Forty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs46k322 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs46kp1322 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs46k322 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs46kp1322 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK322r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs46k322, k] };
@@ -23284,8 +23284,8 @@ describe("Phase 323 — Forty-Six-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs47k323 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs47kp1323 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs47k323 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs47kp1323 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK323r = { kind: "apply" as const, head: MUL, args: [...logs47k323, k] };
     const numKp1323r = { kind: "apply" as const, head: MUL, args: [...logs47kp1323, kp1] };
     const gK323r = { kind: "apply" as const, head: DIV, args: [numK323r, k2r] };
@@ -23320,8 +23320,8 @@ describe("Phase 324 — One-Sqrt × Forty-Six-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs47k324 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs47kp1324 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs47k324 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs47kp1324 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK324r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs47k324, k] };
@@ -23358,8 +23358,8 @@ describe("Phase 325 — Two-Sqrt × Forty-Six-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs47k325 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs47kp1325 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs47k325 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs47kp1325 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK325r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs47k325, k] };
@@ -23396,8 +23396,8 @@ describe("Phase 326 — Three-Sqrt × Forty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs47k326 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs47kp1326 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs47k326 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs47kp1326 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK326r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs47k326, k] };
@@ -23434,8 +23434,8 @@ describe("Phase 327 — Four-Sqrt × Forty-Six-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs47k327 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs47kp1327 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs47k327 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs47kp1327 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK327r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs47k327, k] };
@@ -23472,8 +23472,8 @@ describe("Phase 328 — Five-Sqrt × Forty-Six-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs47k328 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs47kp1328 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs47k328 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs47kp1328 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK328r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs47k328, k] };
@@ -23508,8 +23508,8 @@ describe("Phase 329 — Forty-Seven-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k329 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1329 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k329 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1329 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK329r = { kind: "apply" as const, head: MUL, args: [...logs49k329, k] };
     const numKp1329r = { kind: "apply" as const, head: MUL, args: [...logs49kp1329, kp1] };
     const gK329r = { kind: "apply" as const, head: DIV, args: [numK329r, k2r] };
@@ -23544,8 +23544,8 @@ describe("Phase 330 — One-Sqrt × Forty-Seven-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k330 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1330 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k330 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1330 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK330r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs49k330, k] };
@@ -23582,8 +23582,8 @@ describe("Phase 331 — Two-Sqrt × Forty-Seven-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k331 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1331 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k331 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1331 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK331r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs49k331, k] };
@@ -23620,8 +23620,8 @@ describe("Phase 332 — Three-Sqrt × Forty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k332 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1332 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k332 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1332 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK332r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs49k332, k] };
@@ -23658,8 +23658,8 @@ describe("Phase 333 — Four-Sqrt × Forty-Seven-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k333 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1333 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k333 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1333 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK333r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs49k333, k] };
@@ -23696,8 +23696,8 @@ describe("Phase 334 — Five-Sqrt × Forty-Seven-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k334 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1334 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k334 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1334 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK334r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs49k334, k] };
@@ -23727,13 +23727,13 @@ describe("Phase 335 — Zero-Sqrt × Forty-Eight-Log × polynomial numerator", (
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("log(k)⁵¹·k/k² refused (51 logs — not Phase 347)", () => {
+  it("log(k)⁵¹·k/k² refused (52 logs — not Phase 353)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k335 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1335 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k335 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1335 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK335r = { kind: "apply" as const, head: MUL, args: [...logs49k335, k] };
     const numKp1335r = { kind: "apply" as const, head: MUL, args: [...logs49kp1335, kp1] };
     const gK335r = { kind: "apply" as const, head: DIV, args: [numK335r, k2r] };
@@ -23763,13 +23763,13 @@ describe("Phase 336 — One-Sqrt × Forty-Eight-Log × polynomial numerator", ()
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("√k·log(k)⁵¹·k/k² refused (51 logs — not Phase 348)", () => {
+  it("√k·log(k)⁵¹·k/k² refused (52 logs — not Phase 354)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k336 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1336 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k336 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1336 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK336r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs49k336, k] };
@@ -23801,13 +23801,13 @@ describe("Phase 337 — Two-Sqrt × Forty-Eight-Log × polynomial numerator", ()
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)²·log(k)⁵¹·k/k² refused (51 logs — not Phase 349)", () => {
+  it("(√k)²·log(k)⁵¹·k/k² refused (52 logs — not Phase 355)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k337 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1337 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k337 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1337 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK337r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs49k337, k] };
@@ -23839,13 +23839,13 @@ describe("Phase 338 — Three-Sqrt × Forty-Eight-Log × polynomial numerator", 
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)³·log(k)⁵¹·k/k³ refused (51 logs — not Phase 350)", () => {
+  it("(√k)³·log(k)⁵¹·k/k³ refused (52 logs — not Phase 356)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k338 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1338 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k338 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1338 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK338r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs49k338, k] };
@@ -23877,13 +23877,13 @@ describe("Phase 339 — Four-Sqrt × Forty-Eight-Log × polynomial numerator", (
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)⁴·log(k)⁵¹·k/k³ refused (51 logs — not Phase 351)", () => {
+  it("(√k)⁴·log(k)⁵¹·k/k³ refused (52 logs — not Phase 357)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k339 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1339 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k339 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1339 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK339r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs49k339, k] };
@@ -23915,13 +23915,13 @@ describe("Phase 340 — Five-Sqrt × Forty-Eight-Log × polynomial numerator", (
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)^5·log(k)⁵¹·k/k³ refused (51 logs — not Phase 352)", () => {
+  it("(√k)^5·log(k)⁵¹·k/k³ refused (52 logs — not Phase 358)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k340 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1340 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k340 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1340 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK340r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs49k340, k] };
@@ -23951,13 +23951,13 @@ describe("Phase 341 — Zero-Sqrt × Forty-Nine-Log × polynomial numerator", ()
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("log(k)⁵¹·k/k² refused (51 logs — not Phase 347)", () => {
+  it("log(k)⁵¹·k/k² refused (52 logs — not Phase 353)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k341 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1341 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k341 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1341 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK341r = { kind: "apply" as const, head: MUL, args: [...logs51k341, k] };
     const numKp1341r = { kind: "apply" as const, head: MUL, args: [...logs51kp1341, kp1] };
     const gK341r = { kind: "apply" as const, head: DIV, args: [numK341r, k2r] };
@@ -23987,13 +23987,13 @@ describe("Phase 342 — One-Sqrt × Forty-Nine-Log × polynomial numerator", () 
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("√k·log(k)⁵¹·k/k² refused (51 logs — not Phase 348)", () => {
+  it("√k·log(k)⁵¹·k/k² refused (52 logs — not Phase 354)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k342 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1342 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k342 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1342 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK342r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs51k342, k] };
@@ -24025,13 +24025,13 @@ describe("Phase 343 — Two-Sqrt × Forty-Nine-Log × polynomial numerator", () 
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)²·log(k)⁵¹·k/k² refused (51 logs — not Phase 349)", () => {
+  it("(√k)²·log(k)⁵¹·k/k² refused (52 logs — not Phase 355)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k343 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1343 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k343 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1343 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK343r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs51k343, k] };
@@ -24063,13 +24063,13 @@ describe("Phase 344 — Three-Sqrt × Forty-Nine-Log × polynomial numerator", (
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)³·log(k)⁵¹·k/k³ refused (51 logs — not Phase 350)", () => {
+  it("(√k)³·log(k)⁵¹·k/k³ refused (52 logs — not Phase 356)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k344 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1344 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k344 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1344 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK344r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs51k344, k] };
@@ -24101,13 +24101,13 @@ describe("Phase 345 — Four-Sqrt × Forty-Nine-Log × polynomial numerator", ()
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)⁴·log(k)⁵¹·k/k³ refused (51 logs — not Phase 351)", () => {
+  it("(√k)⁴·log(k)⁵¹·k/k³ refused (52 logs — not Phase 357)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k345 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1345 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k345 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1345 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK345r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs51k345, k] };
@@ -24139,13 +24139,13 @@ describe("Phase 346 — Five-Sqrt × Forty-Nine-Log × polynomial numerator", ()
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)^5·log(k)⁵¹·k/k³ refused (51 logs — not Phase 352)", () => {
+  it("(√k)^5·log(k)⁵¹·k/k³ refused (52 logs — not Phase 358)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k346 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1346 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k346 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1346 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK346r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs51k346, k] };
@@ -24175,13 +24175,13 @@ describe("Phase 347 — Zero-Sqrt × Fifty-Log × polynomial numerator", () => {
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("log(k)⁵¹·k/k² refused (51 logs — not Phase 347)", () => {
+  it("log(k)⁵¹·k/k² refused (52 logs — not Phase 353)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k347 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1347 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k347 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1347 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK347r = { kind: "apply" as const, head: MUL, args: [...logs51k347, k] };
     const numKp1347r = { kind: "apply" as const, head: MUL, args: [...logs51kp1347, kp1] };
     const gK347r = { kind: "apply" as const, head: DIV, args: [numK347r, k2r] };
@@ -24211,13 +24211,13 @@ describe("Phase 348 — One-Sqrt × Fifty-Log × polynomial numerator", () => {
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("√k·log(k)⁵¹·k/k² refused (51 logs — not Phase 348)", () => {
+  it("√k·log(k)⁵¹·k/k² refused (52 logs — not Phase 354)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k348 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1348 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k348 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1348 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK348r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs51k348, k] };
@@ -24249,13 +24249,13 @@ describe("Phase 349 — Two-Sqrt × Fifty-Log × polynomial numerator", () => {
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)²·log(k)⁵¹·k/k² refused (51 logs — not Phase 349)", () => {
+  it("(√k)²·log(k)⁵¹·k/k² refused (52 logs — not Phase 355)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k349 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1349 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k349 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1349 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK349r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs51k349, k] };
@@ -24287,13 +24287,13 @@ describe("Phase 350 — Three-Sqrt × Fifty-Log × polynomial numerator", () => 
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)³·log(k)⁵¹·k/k³ refused (51 logs — not Phase 350)", () => {
+  it("(√k)³·log(k)⁵¹·k/k³ refused (52 logs — not Phase 356)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k350 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1350 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k350 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1350 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK350r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs51k350, k] };
@@ -24325,13 +24325,13 @@ describe("Phase 351 — Four-Sqrt × Fifty-Log × polynomial numerator", () => {
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)⁴·log(k)⁵¹·k/k³ refused (51 logs — not Phase 351)", () => {
+  it("(√k)⁴·log(k)⁵¹·k/k³ refused (52 logs — not Phase 357)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k351 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1351 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k351 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1351 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK351r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs51k351, k] };
@@ -24363,13 +24363,13 @@ describe("Phase 352 — Five-Sqrt × Fifty-Log × polynomial numerator", () => {
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)^5·log(k)⁵¹·k/k³ refused (51 logs — not Phase 352)", () => {
+  it("(√k)^5·log(k)⁵¹·k/k³ refused (52 logs — not Phase 358)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k352 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1352 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k352 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1352 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK352r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs51k352, k] };
@@ -24378,6 +24378,231 @@ describe("Phase 352 — Five-Sqrt × Fifty-Log × polynomial numerator", () => {
     const gKp1352r = { kind: "apply" as const, head: DIV, args: [numKp1352r, kp1_3r] };
     const f352r = { kind: "apply" as const, head: SUB, args: [gK352r, gKp1352r] };
     const result = evaluateSum(f352r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+
+describe("Phase 353 — Zero-Sqrt × Fifty-One-Log × polynomial numerator", () => {
+  it("log(k)⁵¹·k/k² closes (polyDeg=1 → effective=1; denDeg=2 > 1)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const logs51k353 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1353 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const numK353a = { kind: "apply" as const, head: MUL, args: [...logs51k353, k] };
+    const numKp1353a = { kind: "apply" as const, head: MUL, args: [...logs51kp1353, kp1] };
+    const gK353a = { kind: "apply" as const, head: DIV, args: [numK353a, k2] };
+    const gKp1353a = { kind: "apply" as const, head: DIV, args: [numKp1353a, kp1_2] };
+    const f353a = { kind: "apply" as const, head: SUB, args: [gK353a, gKp1353a] };
+    const result = evaluateSum(f353a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("log(k)⁵²·k/k² refused (52 logs — not Phase 353)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs52k353 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs52kp1353 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const numK353r = { kind: "apply" as const, head: MUL, args: [...logs52k353, k] };
+    const numKp1353r = { kind: "apply" as const, head: MUL, args: [...logs52kp1353, kp1] };
+    const gK353r = { kind: "apply" as const, head: DIV, args: [numK353r, k2r] };
+    const gKp1353r = { kind: "apply" as const, head: DIV, args: [numKp1353r, kp1_2r] };
+    const f353r = { kind: "apply" as const, head: SUB, args: [gK353r, gKp1353r] };
+    const result = evaluateSum(f353r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 354 — One-Sqrt × Fifty-One-Log × polynomial numerator", () => {
+  it("√k·log(k)⁵¹·k/k² closes (sqrtHalf=0.5, polyDeg=1 → effective=1.5; denDeg=2 > 1.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const logs51k354 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1354 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK354a = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs51k354, k] };
+    const numKp1354a = { kind: "apply" as const, head: MUL, args: [sqrtKp1, ...logs51kp1354, kp1] };
+    const gK354a = { kind: "apply" as const, head: DIV, args: [numK354a, k2] };
+    const gKp1354a = { kind: "apply" as const, head: DIV, args: [numKp1354a, kp1_2] };
+    const f354a = { kind: "apply" as const, head: SUB, args: [gK354a, gKp1354a] };
+    const result = evaluateSum(f354a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("√k·log(k)⁵²·k/k² refused (52 logs — not Phase 354)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs52k354 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs52kp1354 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK354r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs52k354, k] };
+    const numKp1354r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, ...logs52kp1354, kp1] };
+    const gK354r = { kind: "apply" as const, head: DIV, args: [numK354r, k2r] };
+    const gKp1354r = { kind: "apply" as const, head: DIV, args: [numKp1354r, kp1_2r] };
+    const f354r = { kind: "apply" as const, head: SUB, args: [gK354r, gKp1354r] };
+    const result = evaluateSum(f354r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 355 — Two-Sqrt × Fifty-One-Log × polynomial numerator", () => {
+  it("(√k)²·log(k)⁵¹·k/k³ closes (sqrtHalf=1, polyDeg=1 → effective=2; denDeg=3 > 2)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const logs51k355 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1355 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK355a = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs51k355, k] };
+    const numKp1355a = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, ...logs51kp1355, kp1] };
+    const gK355a = { kind: "apply" as const, head: DIV, args: [numK355a, k3] };
+    const gKp1355a = { kind: "apply" as const, head: DIV, args: [numKp1355a, kp1_3] };
+    const f355a = { kind: "apply" as const, head: SUB, args: [gK355a, gKp1355a] };
+    const result = evaluateSum(f355a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("(√k)²·log(k)⁵²·k/k² refused (52 logs — not Phase 355)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs52k355 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs52kp1355 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK355r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs52k355, k] };
+    const numKp1355r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, ...logs52kp1355, kp1] };
+    const gK355r = { kind: "apply" as const, head: DIV, args: [numK355r, k3r] };
+    const gKp1355r = { kind: "apply" as const, head: DIV, args: [numKp1355r, kp1_3r] };
+    const f355r = { kind: "apply" as const, head: SUB, args: [gK355r, gKp1355r] };
+    const result = evaluateSum(f355r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 356 — Three-Sqrt × Fifty-One-Log × polynomial numerator", () => {
+  it("(√k)³·log(k)⁵¹/k³ closes (sqrtHalf=1.5, polyDeg=0 → effective=1.5; denDeg=3 > 1.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const logs51k356 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1356 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK356a = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs51k356] };
+    const numKp1356a = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, ...logs51kp1356] };
+    const gK356a = { kind: "apply" as const, head: DIV, args: [numK356a, k3] };
+    const gKp1356a = { kind: "apply" as const, head: DIV, args: [numKp1356a, kp1_3] };
+    const f356a = { kind: "apply" as const, head: SUB, args: [gK356a, gKp1356a] };
+    const result = evaluateSum(f356a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("(√k)³·log(k)⁵²·k/k³ refused (52 logs — not Phase 356)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs52k356 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs52kp1356 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK356r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs52k356, k] };
+    const numKp1356r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, ...logs52kp1356, kp1] };
+    const gK356r = { kind: "apply" as const, head: DIV, args: [numK356r, k3r] };
+    const gKp1356r = { kind: "apply" as const, head: DIV, args: [numKp1356r, kp1_3r] };
+    const f356r = { kind: "apply" as const, head: SUB, args: [gK356r, gKp1356r] };
+    const result = evaluateSum(f356r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 357 — Four-Sqrt × Fifty-One-Log × polynomial numerator", () => {
+  it("(√k)⁴·log(k)⁵¹/k³ closes (sqrtHalf=2, polyDeg=0 → effective=2; denDeg=3 > 2)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const logs51k357 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1357 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK357a = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs51k357] };
+    const numKp1357a = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, ...logs51kp1357] };
+    const gK357a = { kind: "apply" as const, head: DIV, args: [numK357a, k3] };
+    const gKp1357a = { kind: "apply" as const, head: DIV, args: [numKp1357a, kp1_3] };
+    const f357a = { kind: "apply" as const, head: SUB, args: [gK357a, gKp1357a] };
+    const result = evaluateSum(f357a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("(√k)⁴·log(k)⁵²·k/k³ refused (52 logs — not Phase 357)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs52k357 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs52kp1357 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK357r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs52k357, k] };
+    const numKp1357r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, ...logs52kp1357, kp1] };
+    const gK357r = { kind: "apply" as const, head: DIV, args: [numK357r, k3r] };
+    const gKp1357r = { kind: "apply" as const, head: DIV, args: [numKp1357r, kp1_3r] };
+    const f357r = { kind: "apply" as const, head: SUB, args: [gK357r, gKp1357r] };
+    const result = evaluateSum(f357r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 358 — Five-Sqrt × Fifty-One-Log × polynomial numerator", () => {
+  it("(√k)^5·log(k)⁵¹/k³ closes (sqrtHalf=2.5, polyDeg=0 → effective=2.5; denDeg=3 > 2.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const logs51k358 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1358 = Array.from({ length: 51 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK358a = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs51k358] };
+    const numKp1358a = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, ...logs51kp1358] };
+    const gK358a = { kind: "apply" as const, head: DIV, args: [numK358a, k3] };
+    const gKp1358a = { kind: "apply" as const, head: DIV, args: [numKp1358a, kp1_3] };
+    const f358a = { kind: "apply" as const, head: SUB, args: [gK358a, gKp1358a] };
+    const result = evaluateSum(f358a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("(√k)^5·log(k)⁵²·k/k³ refused (52 logs — not Phase 358)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs52k358 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs52kp1358 = Array.from({ length: 52 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK358r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs52k358, k] };
+    const numKp1358r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, ...logs52kp1358, kp1] };
+    const gK358r = { kind: "apply" as const, head: DIV, args: [numK358r, k3r] };
+    const gKp1358r = { kind: "apply" as const, head: DIV, args: [numKp1358r, kp1_3r] };
+    const f358r = { kind: "apply" as const, head: SUB, args: [gK358r, gKp1358r] };
+    const result = evaluateSum(f358r, k, int(1), sym("%inf"), evalNode);
     expect(result).toMatchObject({ kind: "apply", head: SUM });
   });
 });


### PR DESCRIPTION
## Summary

Adds Phase 353–358: the Fifty-One-Log convergence recognizer family across Python, Rust, and TypeScript.

Each phase handles summands whose numerator contains exactly **51 logarithmic factors** and **0–5 square-root factors**.

### Phases
| Phase | Description |
|-------|-------------|
| 353 | Zero-Sqrt × Fifty-One-Log × polynomial numerator |
| 354 | One-Sqrt × Fifty-One-Log × polynomial numerator |
| 355 | Two-Sqrt × Fifty-One-Log × polynomial numerator |
| 356 | Three-Sqrt × Fifty-One-Log × polynomial numerator |
| 357 | Four-Sqrt × Fifty-One-Log × polynomial numerator |
| 358 | Five-Sqrt × Fifty-One-Log × polynomial numerator |

### Changes
- **Python**: +6 helpers + dispatch + 12 tests; cascade fix (51→52 logs); 1007 tests pass; 91% coverage
- **Rust**: +6 helpers + dispatch + cascade fix; 900 tests pass
- **TypeScript**: +6 helpers + dispatch + cascade fix; 918 tests pass
- Version bumped 2.289.0 → 2.295.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)