### PR TITLE
feat(cas-summation): add Phase 365-370 (Fifty-Three-Log family, v2.301.0→v2.307.0)

### DIFF
--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 2.307.0 — 2026-05-28
+
+### Added
+
+- **Phase 370 — Five-Sqrt × Fifty-Three-Log × polynomial** (`_five_sqrt_fifty_three_log_poly_effective_x2`):
+  Completes the Fifty-Three-Log family (Phases 365–370).
+- **Phase 369 — Four-Sqrt × Fifty-Three-Log × polynomial** (`_four_sqrt_fifty_three_log_poly_effective_x2`).
+- **Phase 368 — Three-Sqrt × Fifty-Three-Log × polynomial** (`_three_sqrt_fifty_three_log_poly_effective_x2`).
+- **Phase 367 — Two-Sqrt × Fifty-Three-Log × polynomial** (`_two_sqrt_fifty_three_log_poly_effective_x2`).
+- **Phase 366 — One-Sqrt × Fifty-Three-Log × polynomial** (`_one_sqrt_fifty_three_log_poly_effective_x2`).
+- **Phase 365 — Zero-Sqrt × Fifty-Three-Log × polynomial** (`_fifty_three_log_poly_effective_x2`).
+
+### Changed
+
+- Boundary tests in Phases 359–364 updated from 53-log "refused" to 54-log "refused"
+  now that Phases 365–370 handle exactly 53 logs.
+
 ## 2.301.0 — 2026-05-28
 
 ### Added

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "2.301.0"
+version = "2.307.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -1477,6 +1477,60 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
                 return True
         elif _h_diverges_at_infinity(den, k):
             return True
+    # Phase 370: ``Mul(Sqrt(P1)×5, Log(h1)×53, polynomial..., bounded...)`` numerator.
+    s5l53p_x2 = _five_sqrt_fifty_three_log_poly_effective_x2(num, k)
+    if s5l53p_x2 is not None:
+        den_deg_s5l53 = _polynomial_degree_in_k(den, k)
+        if den_deg_s5l53 is not None:
+            if 2 * den_deg_s5l53 > s5l53p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 369: ``Mul(Sqrt(P1)×4, Log(h1)×53, polynomial..., bounded...)`` numerator.
+    s4l53p_x2 = _four_sqrt_fifty_three_log_poly_effective_x2(num, k)
+    if s4l53p_x2 is not None:
+        den_deg_s4l53 = _polynomial_degree_in_k(den, k)
+        if den_deg_s4l53 is not None:
+            if 2 * den_deg_s4l53 > s4l53p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 368: ``Mul(Sqrt(P1)×3, Log(h1)×53, polynomial..., bounded...)`` numerator.
+    s3l53p_x2 = _three_sqrt_fifty_three_log_poly_effective_x2(num, k)
+    if s3l53p_x2 is not None:
+        den_deg_s3l53 = _polynomial_degree_in_k(den, k)
+        if den_deg_s3l53 is not None:
+            if 2 * den_deg_s3l53 > s3l53p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 367: ``Mul(Sqrt(P), Sqrt(P2), Log(h1)×53, polynomial..., bounded...)`` numerator.
+    s2l53p_x2 = _two_sqrt_fifty_three_log_poly_effective_x2(num, k)
+    if s2l53p_x2 is not None:
+        den_deg_s2l53 = _polynomial_degree_in_k(den, k)
+        if den_deg_s2l53 is not None:
+            if 2 * den_deg_s2l53 > s2l53p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 366: ``Mul(Sqrt(P), Log(h1)×53, polynomial..., bounded...)`` numerator.
+    s1l53p_x2 = _one_sqrt_fifty_three_log_poly_effective_x2(num, k)
+    if s1l53p_x2 is not None:
+        den_deg_s1l53 = _polynomial_degree_in_k(den, k)
+        if den_deg_s1l53 is not None:
+            if 2 * den_deg_s1l53 > s1l53p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 365: ``Mul(Log(h1)×53, polynomial..., bounded...)`` numerator.
+    sl53p_x2 = _fifty_three_log_poly_effective_x2(num, k)
+    if sl53p_x2 is not None:
+        den_deg_sl53 = _polynomial_degree_in_k(den, k)
+        if den_deg_sl53 is not None:
+            if 2 * den_deg_sl53 > sl53p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
     # Phase 364: ``Mul(Sqrt(P1)×5, Log(h1)×52, polynomial..., bounded...)`` numerator.
     s5l52p_x2 = _five_sqrt_fifty_two_log_poly_effective_x2(num, k)
     if s5l52p_x2 is not None:
@@ -12802,6 +12856,207 @@ def _five_sqrt_fifty_one_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int
             continue
         return None
     if len(sqrt_degs_x2) != 5 or log_count != 51:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _fifty_three_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 365 — Zero-Sqrt × Fifty-Three-Log × polynomial numerator.
+
+    The Fifty-Three-Log family (Phases 365–370) extends the recogniser to
+    summands whose numerator contains exactly fifty-three logarithmic factors
+    and zero to five square-root factors.  This is Phase 365: zero sqrts.
+
+    Parameters
+    ----------
+    node : IRNode
+        The numerator node.
+    k : IRSymbol
+        The summation variable.
+
+    Returns
+    -------
+    int | None
+        ``2 * poly_deg_sum`` when the shape matches (always even); ``None``
+        when the pattern is not recognised.
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        if _sqrt_effective_half_degree_x2(arg, k) is not None:
+            return None
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 53:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if log_count != 53:
+        return None
+    return 2 * poly_deg_sum
+
+
+def _one_sqrt_fifty_three_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 366 — One-Sqrt × Fifty-Three-Log × polynomial numerator."""
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_deg_x2: int | None = None
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if sqrt_deg_x2 is not None:
+                return None
+            sqrt_deg_x2 = deg_x2
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 53:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if sqrt_deg_x2 is None or log_count != 53:
+        return None
+    return sqrt_deg_x2 + 2 * poly_deg_sum
+
+
+def _two_sqrt_fifty_three_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 367 — Two-Sqrt × Fifty-Three-Log × polynomial numerator."""
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 2:
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 53:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 2 or log_count != 53:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _three_sqrt_fifty_three_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 368 — Three-Sqrt × Fifty-Three-Log × polynomial numerator."""
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 3:
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 53:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 3 or log_count != 53:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _four_sqrt_fifty_three_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 369 — Four-Sqrt × Fifty-Three-Log × polynomial numerator."""
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 4:
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 53:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 4 or log_count != 53:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _five_sqrt_fifty_three_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 370 — Five-Sqrt × Fifty-Three-Log × polynomial numerator.
+    Completes the Fifty-Three-Log family (Phases 365-370).
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 5:
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 53:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 5 or log_count != 53:
         return None
     return sum(sqrt_degs_x2) + 2 * poly_deg_sum
 

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -17474,10 +17474,11 @@ class TestPhase203TwentySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -17514,10 +17515,11 @@ class TestPhase203TwentySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -17652,10 +17654,11 @@ class TestPhase204OneSqrtTwentySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -17693,10 +17696,11 @@ class TestPhase204OneSqrtTwentySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -17831,10 +17835,11 @@ class TestPhase205TwoSqrtTwentySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -17871,10 +17876,11 @@ class TestPhase205TwoSqrtTwentySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -18008,10 +18014,11 @@ class TestPhase206ThreeSqrtTwentySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -18048,10 +18055,11 @@ class TestPhase206ThreeSqrtTwentySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -18190,10 +18198,11 @@ class TestPhase207FourSqrtTwentySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -18231,10 +18240,11 @@ class TestPhase207FourSqrtTwentySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -18373,10 +18383,11 @@ class TestPhase208FiveSqrtTwentySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -18414,10 +18425,11 @@ class TestPhase208FiveSqrtTwentySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -18550,10 +18562,11 @@ class TestPhase209TwentySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -18590,10 +18603,11 @@ class TestPhase209TwentySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -18732,10 +18746,11 @@ class TestPhase210OneSqrtTwentySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -18773,10 +18788,11 @@ class TestPhase210OneSqrtTwentySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -18915,10 +18931,11 @@ class TestPhase211TwoSqrtTwentySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -18955,10 +18972,11 @@ class TestPhase211TwoSqrtTwentySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -19096,10 +19114,11 @@ class TestPhase212ThreeSqrtTwentySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -19136,10 +19155,11 @@ class TestPhase212ThreeSqrtTwentySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -19282,10 +19302,11 @@ class TestPhase213FourSqrtTwentySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -19323,10 +19344,11 @@ class TestPhase213FourSqrtTwentySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -19469,10 +19491,11 @@ class TestPhase214FiveSqrtTwentySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -19510,10 +19533,11 @@ class TestPhase214FiveSqrtTwentySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -19650,10 +19674,11 @@ class TestPhase215TwentyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -19690,10 +19715,11 @@ class TestPhase215TwentyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -19836,10 +19862,11 @@ class TestPhase216OneSqrtTwentyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -19877,10 +19904,11 @@ class TestPhase216OneSqrtTwentyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -20023,10 +20051,11 @@ class TestPhase217TwoSqrtTwentyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -20063,10 +20092,11 @@ class TestPhase217TwoSqrtTwentyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -20208,10 +20238,11 @@ class TestPhase218ThreeSqrtTwentyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -20248,10 +20279,11 @@ class TestPhase218ThreeSqrtTwentyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -20398,10 +20430,11 @@ class TestPhase219FourSqrtTwentyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -20439,10 +20472,11 @@ class TestPhase219FourSqrtTwentyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -20589,10 +20623,11 @@ class TestPhase220FiveSqrtTwentyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -20630,10 +20665,11 @@ class TestPhase220FiveSqrtTwentyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -20775,10 +20811,11 @@ class TestPhase221TwentyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -20815,10 +20852,11 @@ class TestPhase221TwentyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -20965,10 +21003,11 @@ class TestPhase222OneSqrtTwentyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -21006,10 +21045,11 @@ class TestPhase222OneSqrtTwentyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -21156,10 +21196,11 @@ class TestPhase223TwoSqrtTwentyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -21196,10 +21237,11 @@ class TestPhase223TwoSqrtTwentyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -21345,10 +21387,11 @@ class TestPhase224ThreeSqrtTwentyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -21385,10 +21428,11 @@ class TestPhase224ThreeSqrtTwentyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -21539,10 +21583,11 @@ class TestPhase225FourSqrtTwentyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -21580,10 +21625,11 @@ class TestPhase225FourSqrtTwentyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -21734,10 +21780,11 @@ class TestPhase226FiveSqrtTwentyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -21775,10 +21822,11 @@ class TestPhase226FiveSqrtTwentyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -21923,10 +21971,11 @@ class TestPhase227ThirtyLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -21963,10 +22012,11 @@ class TestPhase227ThirtyLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -22117,10 +22167,11 @@ class TestPhase228OneSqrtThirtyLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -22158,10 +22209,11 @@ class TestPhase228OneSqrtThirtyLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -22312,10 +22364,11 @@ class TestPhase229TwoSqrtThirtyLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -22352,10 +22405,11 @@ class TestPhase229TwoSqrtThirtyLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -22505,10 +22559,11 @@ class TestPhase230ThreeSqrtThirtyLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -22545,10 +22600,11 @@ class TestPhase230ThreeSqrtThirtyLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -22698,10 +22754,11 @@ class TestPhase231FourSqrtThirtyLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -22738,10 +22795,11 @@ class TestPhase231FourSqrtThirtyLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -22896,10 +22954,11 @@ class TestPhase232FiveSqrtThirtyLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -22937,10 +22996,11 @@ class TestPhase232FiveSqrtThirtyLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -23089,10 +23149,11 @@ class TestPhase233ThirtyOneLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -23129,10 +23190,11 @@ class TestPhase233ThirtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -23287,10 +23349,11 @@ class TestPhase234OneSqrtThirtyOneLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -23328,10 +23391,11 @@ class TestPhase234OneSqrtThirtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -23486,10 +23550,11 @@ class TestPhase235TwoSqrtThirtyOneLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -23526,10 +23591,11 @@ class TestPhase235TwoSqrtThirtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -23683,10 +23749,11 @@ class TestPhase236ThreeSqrtThirtyOneLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -23723,10 +23790,11 @@ class TestPhase236ThreeSqrtThirtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -23885,10 +23953,11 @@ class TestPhase237FourSqrtThirtyOneLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -23926,10 +23995,11 @@ class TestPhase237FourSqrtThirtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -24088,10 +24158,11 @@ class TestPhase238FiveSqrtThirtyOneLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -24129,10 +24200,11 @@ class TestPhase238FiveSqrtThirtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -24285,10 +24357,11 @@ class TestPhase239ThirtyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -24325,10 +24398,11 @@ class TestPhase239ThirtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -24487,10 +24561,11 @@ class TestPhase240OneSqrtThirtyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -24528,10 +24603,11 @@ class TestPhase240OneSqrtThirtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -24690,10 +24766,11 @@ class TestPhase241TwoSqrtThirtyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -24730,10 +24807,11 @@ class TestPhase241TwoSqrtThirtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -24891,10 +24969,11 @@ class TestPhase242ThreeSqrtThirtyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -24931,10 +25010,11 @@ class TestPhase242ThreeSqrtThirtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -25097,10 +25177,11 @@ class TestPhase243FourSqrtThirtyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -25138,10 +25219,11 @@ class TestPhase243FourSqrtThirtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -25304,10 +25386,11 @@ class TestPhase244FiveSqrtThirtyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -25345,10 +25428,11 @@ class TestPhase244FiveSqrtThirtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -25505,10 +25589,11 @@ class TestPhase245ThirtyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -25545,10 +25630,11 @@ class TestPhase245ThirtyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -25711,10 +25797,11 @@ class TestPhase246OneSqrtThirtyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -25752,10 +25839,11 @@ class TestPhase246OneSqrtThirtyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -25918,10 +26006,11 @@ class TestPhase247TwoSqrtThirtyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -25958,10 +26047,11 @@ class TestPhase247TwoSqrtThirtyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -26123,10 +26213,11 @@ class TestPhase248ThreeSqrtThirtyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -26163,10 +26254,11 @@ class TestPhase248ThreeSqrtThirtyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -26333,10 +26425,11 @@ class TestPhase249FourSqrtThirtyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -26374,10 +26467,11 @@ class TestPhase249FourSqrtThirtyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -26544,10 +26638,11 @@ class TestPhase250FiveSqrtThirtyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -26585,10 +26680,11 @@ class TestPhase250FiveSqrtThirtyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -26749,10 +26845,11 @@ class TestPhase251ThirtyFourLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -26789,10 +26886,11 @@ class TestPhase251ThirtyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -26959,10 +27057,11 @@ class TestPhase252OneSqrtThirtyFourLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -27000,10 +27099,11 @@ class TestPhase252OneSqrtThirtyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -27170,10 +27270,11 @@ class TestPhase253TwoSqrtThirtyFourLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -27210,10 +27311,11 @@ class TestPhase253TwoSqrtThirtyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -27379,10 +27481,11 @@ class TestPhase254ThreeSqrtThirtyFourLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -27419,10 +27522,11 @@ class TestPhase254ThreeSqrtThirtyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -27593,10 +27697,11 @@ class TestPhase255FourSqrtThirtyFourLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -27634,10 +27739,11 @@ class TestPhase255FourSqrtThirtyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -27808,10 +27914,11 @@ class TestPhase256FiveSqrtThirtyFourLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -27849,10 +27956,11 @@ class TestPhase256FiveSqrtThirtyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -28017,10 +28125,11 @@ class TestPhase257ThirtyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -28057,10 +28166,11 @@ class TestPhase257ThirtyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -28231,10 +28341,11 @@ class TestPhase258OneSqrtThirtyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -28272,10 +28383,11 @@ class TestPhase258OneSqrtThirtyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -28446,10 +28558,11 @@ class TestPhase259TwoSqrtThirtyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -28486,10 +28599,11 @@ class TestPhase259TwoSqrtThirtyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -28659,10 +28773,11 @@ class TestPhase260ThreeSqrtThirtyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -28699,10 +28814,11 @@ class TestPhase260ThreeSqrtThirtyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -28877,10 +28993,11 @@ class TestPhase261FourSqrtThirtyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -28918,10 +29035,11 @@ class TestPhase261FourSqrtThirtyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -29096,10 +29214,11 @@ class TestPhase262FiveSqrtThirtyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -29137,10 +29256,11 @@ class TestPhase262FiveSqrtThirtyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -29309,10 +29429,11 @@ class TestPhase263ThirtySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -29349,10 +29470,11 @@ class TestPhase263ThirtySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -29527,10 +29649,11 @@ class TestPhase264OneSqrtThirtySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -29568,10 +29691,11 @@ class TestPhase264OneSqrtThirtySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -29746,10 +29870,11 @@ class TestPhase265TwoSqrtThirtySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -29786,10 +29911,11 @@ class TestPhase265TwoSqrtThirtySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -29963,10 +30089,11 @@ class TestPhase266ThreeSqrtThirtySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -30003,10 +30130,11 @@ class TestPhase266ThreeSqrtThirtySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -30185,10 +30313,11 @@ class TestPhase267FourSqrtThirtySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -30226,10 +30355,11 @@ class TestPhase267FourSqrtThirtySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -30408,10 +30538,11 @@ class TestPhase268FiveSqrtThirtySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -30449,10 +30580,11 @@ class TestPhase268FiveSqrtThirtySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -30627,10 +30759,11 @@ class TestPhase269ThirtySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -30666,10 +30799,11 @@ class TestPhase269ThirtySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -30846,10 +30980,11 @@ class TestPhase270OneSqrtThirtySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -30886,10 +31021,11 @@ class TestPhase270OneSqrtThirtySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -31066,10 +31202,11 @@ class TestPhase271TwoSqrtThirtySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -31106,10 +31243,11 @@ class TestPhase271TwoSqrtThirtySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -31286,10 +31424,11 @@ class TestPhase272ThreeSqrtThirtySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -31326,10 +31465,11 @@ class TestPhase272ThreeSqrtThirtySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -31506,10 +31646,11 @@ class TestPhase273FourSqrtThirtySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -31546,10 +31687,11 @@ class TestPhase273FourSqrtThirtySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -31731,10 +31873,11 @@ class TestPhase274FiveSqrtThirtySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -31772,10 +31915,11 @@ class TestPhase274FiveSqrtThirtySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -31953,10 +32097,11 @@ class TestPhase275ThirtyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -31992,10 +32137,11 @@ class TestPhase275ThirtyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -32176,10 +32322,11 @@ class TestPhase276OneSqrtThirtyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -32216,10 +32363,11 @@ class TestPhase276OneSqrtThirtyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -32400,10 +32548,11 @@ class TestPhase277TwoSqrtThirtyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -32440,10 +32589,11 @@ class TestPhase277TwoSqrtThirtyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -32624,10 +32774,11 @@ class TestPhase278ThreeSqrtThirtyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -32664,10 +32815,11 @@ class TestPhase278ThreeSqrtThirtyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -32853,10 +33005,11 @@ class TestPhase279FourSqrtThirtyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -32894,10 +33047,11 @@ class TestPhase279FourSqrtThirtyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -33083,10 +33237,11 @@ class TestPhase280FiveSqrtThirtyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -33124,10 +33279,11 @@ class TestPhase280FiveSqrtThirtyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -33310,10 +33466,11 @@ class TestPhase281ThirtyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -33349,10 +33506,11 @@ class TestPhase281ThirtyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -33537,10 +33695,11 @@ class TestPhase282OneSqrtThirtyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -33577,10 +33736,11 @@ class TestPhase282OneSqrtThirtyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -33767,10 +33927,11 @@ class TestPhase283TwoSqrtThirtyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -33807,10 +33968,11 @@ class TestPhase283TwoSqrtThirtyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -33997,10 +34159,11 @@ class TestPhase284ThreeSqrtThirtyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -34037,10 +34200,11 @@ class TestPhase284ThreeSqrtThirtyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -34227,10 +34391,11 @@ class TestPhase285FourSqrtThirtyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -34267,10 +34432,11 @@ class TestPhase285FourSqrtThirtyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -34457,10 +34623,11 @@ class TestPhase286FiveSqrtThirtyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -34497,10 +34664,11 @@ class TestPhase286FiveSqrtThirtyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -34687,10 +34855,11 @@ class TestPhase287FortyLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -34726,10 +34895,11 @@ class TestPhase287FortyLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -34918,10 +35088,11 @@ class TestPhase288OneSqrtFortyLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -34958,10 +35129,11 @@ class TestPhase288OneSqrtFortyLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -35152,10 +35324,11 @@ class TestPhase289TwoSqrtFortyLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -35192,10 +35365,11 @@ class TestPhase289TwoSqrtFortyLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -35386,10 +35560,11 @@ class TestPhase290ThreeSqrtFortyLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -35426,10 +35601,11 @@ class TestPhase290ThreeSqrtFortyLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -35620,10 +35796,11 @@ class TestPhase291FourSqrtFortyLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -35660,10 +35837,11 @@ class TestPhase291FourSqrtFortyLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -35854,10 +36032,11 @@ class TestPhase292FiveSqrtFortyLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -35894,10 +36073,11 @@ class TestPhase292FiveSqrtFortyLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -36088,10 +36268,11 @@ class TestPhase293FortyOneLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -36127,10 +36308,11 @@ class TestPhase293FortyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -36252,10 +36434,11 @@ class TestPhase294OneSqrtFortyOneLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -36292,10 +36475,11 @@ class TestPhase294OneSqrtFortyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -36417,10 +36601,11 @@ class TestPhase295TwoSqrtFortyOneLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -36457,10 +36642,11 @@ class TestPhase295TwoSqrtFortyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -36582,10 +36768,11 @@ class TestPhase296ThreeSqrtFortyOneLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -36622,10 +36809,11 @@ class TestPhase296ThreeSqrtFortyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -36747,10 +36935,11 @@ class TestPhase297FourSqrtFortyOneLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -36787,10 +36976,11 @@ class TestPhase297FourSqrtFortyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -36912,10 +37102,11 @@ class TestPhase298FiveSqrtFortyOneLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -36952,10 +37143,11 @@ class TestPhase298FiveSqrtFortyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -37077,10 +37269,11 @@ class TestPhase299FortyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -37116,10 +37309,11 @@ class TestPhase299FortyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -37243,10 +37437,11 @@ class TestPhase300OneSqrtFortyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -37283,10 +37478,11 @@ class TestPhase300OneSqrtFortyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -37410,10 +37606,11 @@ class TestPhase301TwoSqrtFortyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -37450,10 +37647,11 @@ class TestPhase301TwoSqrtFortyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -37577,10 +37775,11 @@ class TestPhase302ThreeSqrtFortyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -37617,10 +37816,11 @@ class TestPhase302ThreeSqrtFortyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -37744,10 +37944,11 @@ class TestPhase303FourSqrtFortyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -37784,10 +37985,11 @@ class TestPhase303FourSqrtFortyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -37911,10 +38113,11 @@ class TestPhase304FiveSqrtFortyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -37951,10 +38154,11 @@ class TestPhase304FiveSqrtFortyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -38078,10 +38282,11 @@ class TestPhase305FortyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -38117,10 +38322,11 @@ class TestPhase305FortyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -38247,10 +38453,11 @@ class TestPhase306OneSqrtFortyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -38287,10 +38494,11 @@ class TestPhase306OneSqrtFortyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -38417,10 +38625,11 @@ class TestPhase307TwoSqrtFortyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -38457,10 +38666,11 @@ class TestPhase307TwoSqrtFortyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -38587,10 +38797,11 @@ class TestPhase308ThreeSqrtFortyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -38627,10 +38838,11 @@ class TestPhase308ThreeSqrtFortyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -38757,10 +38969,11 @@ class TestPhase309FourSqrtFortyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -38797,10 +39010,11 @@ class TestPhase309FourSqrtFortyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -38927,10 +39141,11 @@ class TestPhase310FiveSqrtFortyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -38967,10 +39182,11 @@ class TestPhase310FiveSqrtFortyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -39096,10 +39312,11 @@ class TestPhase311FortyFourLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -39135,10 +39352,11 @@ class TestPhase311FortyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -39267,10 +39485,11 @@ class TestPhase312OneSqrtFortyFourLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -39307,10 +39526,11 @@ class TestPhase312OneSqrtFortyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -39439,10 +39659,11 @@ class TestPhase313TwoSqrtFortyFourLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -39479,10 +39700,11 @@ class TestPhase313TwoSqrtFortyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -39611,10 +39833,11 @@ class TestPhase314ThreeSqrtFortyFourLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -39651,10 +39874,11 @@ class TestPhase314ThreeSqrtFortyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -39783,10 +40007,11 @@ class TestPhase315FourSqrtFortyFourLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -39823,10 +40048,11 @@ class TestPhase315FourSqrtFortyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -39955,10 +40181,11 @@ class TestPhase316FiveSqrtFortyFourLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -39995,10 +40222,11 @@ class TestPhase316FiveSqrtFortyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -40126,10 +40354,11 @@ class TestPhase317FortyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -40165,10 +40394,11 @@ class TestPhase317FortyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -40298,10 +40528,11 @@ class TestPhase318OneSqrtFortyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -40338,10 +40569,11 @@ class TestPhase318OneSqrtFortyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -40471,10 +40703,11 @@ class TestPhase319TwoSqrtFortyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -40511,10 +40744,11 @@ class TestPhase319TwoSqrtFortyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -40644,10 +40878,11 @@ class TestPhase320ThreeSqrtFortyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -40684,10 +40919,11 @@ class TestPhase320ThreeSqrtFortyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -40817,10 +41053,11 @@ class TestPhase321FourSqrtFortyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -40857,10 +41094,11 @@ class TestPhase321FourSqrtFortyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -40990,10 +41228,11 @@ class TestPhase322FiveSqrtFortyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -41030,10 +41269,11 @@ class TestPhase322FiveSqrtFortyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -41163,10 +41403,11 @@ class TestPhase323FortysSixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -41202,10 +41443,11 @@ class TestPhase323FortysSixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -41337,10 +41579,11 @@ class TestPhase324OneSqrtFortySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -41377,10 +41620,11 @@ class TestPhase324OneSqrtFortySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -41512,10 +41756,11 @@ class TestPhase325TwoSqrtFortySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -41552,10 +41797,11 @@ class TestPhase325TwoSqrtFortySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -41687,10 +41933,11 @@ class TestPhase326ThreeSqrtFortySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -41727,10 +41974,11 @@ class TestPhase326ThreeSqrtFortySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -41862,10 +42110,11 @@ class TestPhase327FourSqrtFortySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -41902,10 +42151,11 @@ class TestPhase327FourSqrtFortySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -42037,10 +42287,11 @@ class TestPhase328FiveSqrtFortySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -42077,10 +42328,11 @@ class TestPhase328FiveSqrtFortySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -42212,10 +42464,11 @@ class TestPhase329FortySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -42251,10 +42504,11 @@ class TestPhase329FortySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -42388,10 +42642,11 @@ class TestPhase330OneSqrtFortySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -42428,10 +42683,11 @@ class TestPhase330OneSqrtFortySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -42565,10 +42821,11 @@ class TestPhase331TwoSqrtFortySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -42605,10 +42862,11 @@ class TestPhase331TwoSqrtFortySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -42742,10 +43000,11 @@ class TestPhase332ThreeSqrtFortySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -42782,10 +43041,11 @@ class TestPhase332ThreeSqrtFortySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -42919,10 +43179,11 @@ class TestPhase333FourSqrtFortySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -42959,10 +43220,11 @@ class TestPhase333FourSqrtFortySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -43096,10 +43358,11 @@ class TestPhase334FiveSqrtFortySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -43136,10 +43399,11 @@ class TestPhase334FiveSqrtFortySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -43273,10 +43537,11 @@ class TestPhase335FortyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -43312,10 +43577,11 @@ class TestPhase335FortyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -43452,10 +43718,11 @@ class TestPhase336OneSqrtFortyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -43492,10 +43759,11 @@ class TestPhase336OneSqrtFortyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -43632,10 +43900,11 @@ class TestPhase337TwoSqrtFortyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -43672,10 +43941,11 @@ class TestPhase337TwoSqrtFortyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -43812,10 +44082,11 @@ class TestPhase338ThreeSqrtFortyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -43852,10 +44123,11 @@ class TestPhase338ThreeSqrtFortyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -43992,10 +44264,11 @@ class TestPhase339FourSqrtFortyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -44032,10 +44305,11 @@ class TestPhase339FourSqrtFortyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -44172,10 +44446,11 @@ class TestPhase340FiveSqrtFortyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -44212,10 +44487,11 @@ class TestPhase340FiveSqrtFortyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -44351,10 +44627,11 @@ class TestPhase341FortyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -44390,10 +44667,11 @@ class TestPhase341FortyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -44532,10 +44810,11 @@ class TestPhase342OneSqrtFortyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -44572,10 +44851,11 @@ class TestPhase342OneSqrtFortyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -44714,10 +44994,11 @@ class TestPhase343TwoSqrtFortyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -44754,10 +45035,11 @@ class TestPhase343TwoSqrtFortyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -44896,10 +45178,11 @@ class TestPhase344ThreeSqrtFortyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -44936,10 +45219,11 @@ class TestPhase344ThreeSqrtFortyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -45078,10 +45362,11 @@ class TestPhase345FourSqrtFortyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -45118,10 +45403,11 @@ class TestPhase345FourSqrtFortyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -45260,10 +45546,11 @@ class TestPhase346FiveSqrtFortyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -45300,10 +45587,11 @@ class TestPhase346FiveSqrtFortyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -45442,9 +45730,10 @@ class TestPhase347FiftyLogPoly:
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
             IRApply(LOG, (_k,)),  # 50th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 54th log (over 52; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -45481,9 +45770,10 @@ class TestPhase347FiftyLogPoly:
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
             IRApply(LOG, (kp1,)),  # 50th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 54th log (over 52; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -45625,9 +45915,10 @@ class TestPhase348OneSqrtFiftyLogPoly:
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
             IRApply(LOG, (_k,)),  # 50th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 54th log (over 52; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -45665,9 +45956,10 @@ class TestPhase348OneSqrtFiftyLogPoly:
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
             IRApply(LOG, (kp1,)),  # 50th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 54th log (over 52; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -45809,9 +46101,10 @@ class TestPhase349TwoSqrtFiftyLogPoly:
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
             IRApply(LOG, (_k,)),  # 50th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 54th log (over 52; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -45849,9 +46142,10 @@ class TestPhase349TwoSqrtFiftyLogPoly:
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
             IRApply(LOG, (kp1,)),  # 50th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 54th log (over 52; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -45993,9 +46287,10 @@ class TestPhase350ThreeSqrtFiftyLogPoly:
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
             IRApply(LOG, (_k,)),  # 50th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 54th log (over 52; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -46033,9 +46328,10 @@ class TestPhase350ThreeSqrtFiftyLogPoly:
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
             IRApply(LOG, (kp1,)),  # 50th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 54th log (over 52; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -46177,9 +46473,10 @@ class TestPhase351FourSqrtFiftyLogPoly:
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
             IRApply(LOG, (_k,)),  # 50th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 54th log (over 52; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -46217,9 +46514,10 @@ class TestPhase351FourSqrtFiftyLogPoly:
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
             IRApply(LOG, (kp1,)),  # 50th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 54th log (over 52; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -46361,9 +46659,10 @@ class TestPhase352FiveSqrtFiftyLogPoly:
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
             IRApply(LOG, (_k,)),  # 50th log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 54th log (over 52; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -46401,9 +46700,10 @@ class TestPhase352FiveSqrtFiftyLogPoly:
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
             IRApply(LOG, (kp1,)),  # 50th log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 54th log (over 52; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -46545,8 +46845,9 @@ class TestPhase353FiftyOneLogPoly:
             IRApply(LOG, (_k,)),  # 49th log
             IRApply(LOG, (_k,)),  # 50th log
             IRApply(LOG, (_k,)),  # 51st log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -46584,8 +46885,9 @@ class TestPhase353FiftyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 49th log
             IRApply(LOG, (kp1,)),  # 50th log
             IRApply(LOG, (kp1,)),  # 51st log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -46730,8 +47032,9 @@ class TestPhase354OneSqrtFiftyOneLogPoly:
             IRApply(LOG, (_k,)),  # 49th log
             IRApply(LOG, (_k,)),  # 50th log
             IRApply(LOG, (_k,)),  # 51st log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -46770,8 +47073,9 @@ class TestPhase354OneSqrtFiftyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 49th log
             IRApply(LOG, (kp1,)),  # 50th log
             IRApply(LOG, (kp1,)),  # 51st log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -46916,8 +47220,9 @@ class TestPhase355TwoSqrtFiftyOneLogPoly:
             IRApply(LOG, (_k,)),  # 49th log
             IRApply(LOG, (_k,)),  # 50th log
             IRApply(LOG, (_k,)),  # 51st log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -46956,8 +47261,9 @@ class TestPhase355TwoSqrtFiftyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 49th log
             IRApply(LOG, (kp1,)),  # 50th log
             IRApply(LOG, (kp1,)),  # 51st log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -47102,8 +47408,9 @@ class TestPhase356ThreeSqrtFiftyOneLogPoly:
             IRApply(LOG, (_k,)),  # 49th log
             IRApply(LOG, (_k,)),  # 50th log
             IRApply(LOG, (_k,)),  # 51st log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -47142,8 +47449,9 @@ class TestPhase356ThreeSqrtFiftyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 49th log
             IRApply(LOG, (kp1,)),  # 50th log
             IRApply(LOG, (kp1,)),  # 51st log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -47288,8 +47596,9 @@ class TestPhase357FourSqrtFiftyOneLogPoly:
             IRApply(LOG, (_k,)),  # 49th log
             IRApply(LOG, (_k,)),  # 50th log
             IRApply(LOG, (_k,)),  # 51st log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -47328,8 +47637,9 @@ class TestPhase357FourSqrtFiftyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 49th log
             IRApply(LOG, (kp1,)),  # 50th log
             IRApply(LOG, (kp1,)),  # 51st log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -47474,8 +47784,9 @@ class TestPhase358FiveSqrtFiftyOneLogPoly:
             IRApply(LOG, (_k,)),  # 49th log
             IRApply(LOG, (_k,)),  # 50th log
             IRApply(LOG, (_k,)),  # 51st log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -47514,8 +47825,9 @@ class TestPhase358FiveSqrtFiftyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 49th log
             IRApply(LOG, (kp1,)),  # 50th log
             IRApply(LOG, (kp1,)),  # 51st log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 53rd log (over 51; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -47660,8 +47972,9 @@ class TestPhase359FiftyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 50th log
             IRApply(LOG, (_k,)),  # 51st log
             IRApply(LOG, (_k,)),  # 52nd log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 54th log (over 52; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -47700,8 +48013,9 @@ class TestPhase359FiftyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 50th log
             IRApply(LOG, (kp1,)),  # 51st log
             IRApply(LOG, (kp1,)),  # 52nd log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 54th log (over 52; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -47849,8 +48163,9 @@ class TestPhase360OneSqrtFiftyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 50th log
             IRApply(LOG, (_k,)),  # 51st log
             IRApply(LOG, (_k,)),  # 52nd log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 54th log (over 52; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -47890,8 +48205,9 @@ class TestPhase360OneSqrtFiftyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 50th log
             IRApply(LOG, (kp1,)),  # 51st log
             IRApply(LOG, (kp1,)),  # 52nd log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 54th log (over 52; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -48039,8 +48355,9 @@ class TestPhase361TwoSqrtFiftyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 50th log
             IRApply(LOG, (_k,)),  # 51st log
             IRApply(LOG, (_k,)),  # 52nd log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 54th log (over 52; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -48080,8 +48397,9 @@ class TestPhase361TwoSqrtFiftyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 50th log
             IRApply(LOG, (kp1,)),  # 51st log
             IRApply(LOG, (kp1,)),  # 52nd log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 54th log (over 52; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -48229,8 +48547,9 @@ class TestPhase362ThreeSqrtFiftyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 50th log
             IRApply(LOG, (_k,)),  # 51st log
             IRApply(LOG, (_k,)),  # 52nd log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 54th log (over 52; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -48270,8 +48589,9 @@ class TestPhase362ThreeSqrtFiftyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 50th log
             IRApply(LOG, (kp1,)),  # 51st log
             IRApply(LOG, (kp1,)),  # 52nd log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 54th log (over 52; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -48419,8 +48739,9 @@ class TestPhase363FourSqrtFiftyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 50th log
             IRApply(LOG, (_k,)),  # 51st log
             IRApply(LOG, (_k,)),  # 52nd log
-            IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 54th log (over 52; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -48460,8 +48781,9 @@ class TestPhase363FourSqrtFiftyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 50th log
             IRApply(LOG, (kp1,)),  # 51st log
             IRApply(LOG, (kp1,)),  # 52nd log
-            IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 54th log (over 52; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -48609,8 +48931,1058 @@ class TestPhase364FiveSqrtFiftyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 50th log
             IRApply(LOG, (_k,)),  # 51st log
             IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+class TestPhase365FiftyThreeLogPoly:
+    """Phase 365 -- Zero-Sqrt x Fifty-Three-Log x polynomial numerator."""
+
+    def test_log53_k_over_k2_closes(self):
+        """log(k)^53/k^2: eff_x2=0; 2*2=4 > 0 -> closes"""
+        from symbolic_ir import SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
             IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 54th log (over 52; refused)
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_log54_refused_refused(self):
+        """log(k)^54/k^2: 54 logs -> not Phase 365 -> refused"""
+        from symbolic_ir import SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+class TestPhase366OneSqrtFiftyThreeLogPoly:
+    """Phase 366 -- One-Sqrt x Fifty-Three-Log x polynomial numerator."""
+
+    def test_sqrt_k_log53_k_over_k2_closes(self):
+        """sqrt(k)*log(k)^53/k^2: eff_x2=1; 2*2=4 > 1 -> closes"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_log54_refused_refused(self):
+        """sqrt(k)*log(k)^54/k^2: 54 logs -> not Phase 366 -> refused"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+class TestPhase367TwoSqrtFiftyThreeLogPoly:
+    """Phase 367 -- Two-Sqrt x Fifty-Three-Log x polynomial numerator."""
+
+    def test_2_sqrt_k_log53_k_over_k2_closes(self):
+        """sqrt(k)^2*log(k)^53/k^2: eff_x2=2; 2*2=4 > 2 -> closes"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_2_sqrt_k_log54_refused_refused(self):
+        """sqrt(k)^2*log(k)^54/k^2: 54 logs -> not Phase 367 -> refused"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+class TestPhase368ThreeSqrtFiftyThreeLogPoly:
+    """Phase 368 -- Three-Sqrt x Fifty-Three-Log x polynomial numerator."""
+
+    def test_3_sqrt_k_log53_k_over_k3_closes(self):
+        """sqrt(k)^3*log(k)^53/k^3: eff_x2=3; 2*3=6 > 3 -> closes"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_3_sqrt_k_log54_refused_refused(self):
+        """sqrt(k)^3*log(k)^54/k^3: 54 logs -> not Phase 368 -> refused"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+class TestPhase369FourSqrtFiftyThreeLogPoly:
+    """Phase 369 -- Four-Sqrt x Fifty-Three-Log x polynomial numerator."""
+
+    def test_4_sqrt_k_log53_k_over_k3_closes(self):
+        """sqrt(k)^4*log(k)^53/k^3: eff_x2=4; 2*3=6 > 4 -> closes"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_4_sqrt_k_log54_refused_refused(self):
+        """sqrt(k)^4*log(k)^54/k^3: 54 logs -> not Phase 369 -> refused"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+class TestPhase370FiveSqrtFiftyThreeLogPoly:
+    """Phase 370 -- Five-Sqrt x Fifty-Three-Log x polynomial numerator."""
+
+    def test_5_sqrt_k_log53_k_over_k3_closes(self):
+        """sqrt(k)^5*log(k)^53/k^3: eff_x2=5; 2*3=6 > 5 -> closes"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -48651,7 +50023,101 @@ class TestPhase364FiveSqrtFiftyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 51st log
             IRApply(LOG, (kp1,)),  # 52nd log
             IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 54th log (over 52; refused)
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_5_sqrt_k_log54_refused_refused(self):
+        """sqrt(k)^5*log(k)^54/k^3: 54 logs -> not Phase 370 -> refused"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))

--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 2.307.0 — 2026-05-28
+
+### Added
+
+- **Phase 370 — Five-Sqrt × Fifty-Three-Log × polynomial** (`five_sqrt_fifty_three_log_poly_effective_x2`):
+  Completes the Fifty-Three-Log family (Phases 365–370).
+- **Phase 369 — Four-Sqrt × Fifty-Three-Log × polynomial** (`four_sqrt_fifty_three_log_poly_effective_x2`).
+- **Phase 368 — Three-Sqrt × Fifty-Three-Log × polynomial** (`three_sqrt_fifty_three_log_poly_effective_x2`).
+- **Phase 367 — Two-Sqrt × Fifty-Three-Log × polynomial** (`two_sqrt_fifty_three_log_poly_effective_x2`).
+- **Phase 366 — One-Sqrt × Fifty-Three-Log × polynomial** (`one_sqrt_fifty_three_log_poly_effective_x2`).
+- **Phase 365 — Zero-Sqrt × Fifty-Three-Log × polynomial** (`fifty_three_log_poly_effective_x2`).
+
+### Changed
+
+- Boundary tests in Phases 359–364 updated from 53-log "refused" to 54-log "refused"
+  now that Phases 365–370 handle exactly 53 logs.
+
 ## 2.301.0 — 2026-05-28
 
 ### Added

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "2.301.0"
+version = "2.307.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -7493,6 +7493,170 @@ fn five_sqrt_fifty_one_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Optio
     Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg_sum)
 }
 
+/// Phase 365 — Zero-Sqrt × Fifty-Three-Log × polynomial numerator.
+///
+/// The Fifty-Three-Log family (Phases 365–370) extends the recogniser to
+/// summands whose numerator contains exactly fifty-three logarithmic factors
+/// and zero to five square-root factors.  This is Phase 365: zero sqrts.
+fn fifty_three_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if sqrt_effective_half_degree_x2(arg, k).is_some() { return None; }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 53 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg; continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if log_count != 53 { return None; }
+    Some(2 * poly_deg_sum)
+}
+
+/// Phase 366 — One-Sqrt × Fifty-Three-Log × polynomial numerator.
+fn one_sqrt_fifty_three_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut sqrt_deg: Option<i64> = None;
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_deg.is_some() { return None; }
+            sqrt_deg = Some(d); continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 53 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg; continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    let sd = sqrt_deg?;
+    if log_count != 53 { return None; }
+    Some(sd + 2 * poly_deg_sum)
+}
+
+/// Phase 367 — Two-Sqrt × Fifty-Three-Log × polynomial numerator.
+fn two_sqrt_fifty_three_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut sqrt_degs: Vec<i64> = Vec::new();
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs.len() >= 2 { return None; }
+            sqrt_degs.push(d); continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 53 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg; continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs.len() != 2 || log_count != 53 { return None; }
+    Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg_sum)
+}
+
+/// Phase 368 — Three-Sqrt × Fifty-Three-Log × polynomial numerator.
+fn three_sqrt_fifty_three_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut sqrt_degs: Vec<i64> = Vec::new();
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs.len() >= 3 { return None; }
+            sqrt_degs.push(d); continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 53 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg; continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs.len() != 3 || log_count != 53 { return None; }
+    Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg_sum)
+}
+
+/// Phase 369 — Four-Sqrt × Fifty-Three-Log × polynomial numerator.
+fn four_sqrt_fifty_three_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut sqrt_degs: Vec<i64> = Vec::new();
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs.len() >= 4 { return None; }
+            sqrt_degs.push(d); continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 53 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg; continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs.len() != 4 || log_count != 53 { return None; }
+    Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg_sum)
+}
+
+/// Phase 370 — Five-Sqrt × Fifty-Three-Log × polynomial numerator.
+/// Completes the Fifty-Three-Log family (Phases 365–370).
+fn five_sqrt_fifty_three_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut sqrt_degs: Vec<i64> = Vec::new();
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs.len() >= 5 { return None; }
+            sqrt_degs.push(d); continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 53 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg; continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs.len() != 5 || log_count != 53 { return None; }
+    Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg_sum)
+}
+
 /// Phase 359 — Zero-Sqrt × Fifty-Two-Log × polynomial numerator.
 ///
 /// The Fifty-Two-Log family (Phases 359–364) extends the recogniser to
@@ -10533,6 +10697,42 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
         } else if h_diverges_at_infinity(den, k) {
             return true;
         }
+    }
+    // Phase 370: Mul(Sqrt(P1)×5, Log(h1)×53, ...) numerator.
+    if let Some(s5l53_x2) = five_sqrt_fifty_three_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s5l53) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s5l53 > s5l53_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 369: Mul(Sqrt(P1)×4, Log(h1)×53, ...) numerator.
+    if let Some(s4l53_x2) = four_sqrt_fifty_three_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s4l53) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s4l53 > s4l53_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 368: Mul(Sqrt(P1)×3, Log(h1)×53, ...) numerator.
+    if let Some(s3l53_x2) = three_sqrt_fifty_three_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s3l53) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s3l53 > s3l53_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 367: Mul(Sqrt(P), Sqrt(P2), Log(h1)×53, ...) numerator.
+    if let Some(s2l53_x2) = two_sqrt_fifty_three_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s2l53) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s2l53 > s2l53_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 366: Mul(Sqrt(P), Log(h1)×53, ...) numerator.
+    if let Some(s1l53_x2) = one_sqrt_fifty_three_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s1l53) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s1l53 > s1l53_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 365: Mul(Log(h1)×53, ...) numerator.
+    if let Some(sl53_x2) = fifty_three_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_sl53) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_sl53 > sl53_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
     }
     // Phase 364: Mul(Sqrt(P1)×5, Log(h1)×52, ...) numerator.
     if let Some(s5l52_x2) = five_sqrt_fifty_two_log_poly_effective_x2(num, k) {

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -13269,10 +13269,12 @@ fn phase191_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -13299,10 +13301,12 @@ fn phase191_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -13420,10 +13424,12 @@ fn phase192_sqrt_k_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -13451,10 +13457,12 @@ fn phase192_sqrt_k_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -13985,10 +13993,12 @@ fn phase197_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -14015,10 +14025,12 @@ fn phase197_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -14755,10 +14767,12 @@ fn phase203_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -14785,10 +14799,12 @@ fn phase203_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -15530,10 +15546,12 @@ fn phase209_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -15561,10 +15579,12 @@ fn phase209_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -16336,10 +16356,12 @@ fn phase215_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -16367,10 +16389,12 @@ fn phase215_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -17142,10 +17166,12 @@ fn phase221_log30_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -17173,10 +17199,12 @@ fn phase221_log30_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -17948,10 +17976,12 @@ fn phase227_log31_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -17979,10 +18009,12 @@ fn phase227_log31_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -18754,10 +18786,12 @@ fn phase233_log32_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -18785,10 +18819,12 @@ fn phase233_log32_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -19561,10 +19597,12 @@ fn phase239_log33_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -19591,10 +19629,12 @@ fn phase239_log33_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -20368,10 +20408,12 @@ fn phase245_log34_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -20397,10 +20439,12 @@ fn phase245_log34_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -21173,10 +21217,12 @@ fn phase251_log36_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -21201,10 +21247,12 @@ fn phase251_log36_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -21967,10 +22015,12 @@ fn phase257_log36_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -21995,10 +22045,12 @@ fn phase257_log36_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -23546,10 +23598,12 @@ fn phase269_log38_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -23574,10 +23628,12 @@ fn phase269_log38_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
         kp1.clone(),
     ]);
     let g_k269c = apply(sym(DIV), vec![num_k, k2]);
@@ -23709,10 +23765,12 @@ fn phase270_sqrt_k_log38_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -23738,10 +23796,12 @@ fn phase270_sqrt_k_log38_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
         kp1.clone(),
     ]);
     let g_k270c = apply(sym(DIV), vec![num_k, k2]);
@@ -24426,10 +24486,12 @@ fn phase275_log39_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -24454,10 +24516,12 @@ fn phase275_log39_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
         kp1.clone(),
     ]);
     let g_k275c = apply(sym(DIV), vec![num_k, k2]);
@@ -24593,10 +24657,12 @@ fn phase276_sqrt_k_log39_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -24622,10 +24688,12 @@ fn phase276_sqrt_k_log39_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
         kp1.clone(),
     ]);
     let g_k276c = apply(sym(DIV), vec![num_k, k2]);
@@ -25317,10 +25385,12 @@ fn phase281_log40_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -25341,10 +25411,12 @@ fn phase281_log40_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
         kp1.clone(),
     ]);
     let g_kphase281r = apply(sym(DIV), vec![num_k, k2]);
@@ -25468,10 +25540,12 @@ fn phase282_sqrt1_k_log40_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -25493,10 +25567,12 @@ fn phase282_sqrt1_k_log40_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
         kp1.clone(),
     ]);
     let g_kphase282r = apply(sym(DIV), vec![num_k, k2]);
@@ -26122,10 +26198,12 @@ fn phase287_log42_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -26144,10 +26222,12 @@ fn phase287_log42_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase287r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase287r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -26269,10 +26349,12 @@ fn phase288_sqrt1_k_log42_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -26292,10 +26374,12 @@ fn phase288_sqrt1_k_log42_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase288r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase288r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -26417,10 +26501,12 @@ fn phase289_sqrt2_k_log42_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -26440,10 +26526,12 @@ fn phase289_sqrt2_k_log42_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase289r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase289r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -26565,10 +26653,12 @@ fn phase290_sqrt3_k_log42_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -26588,10 +26678,12 @@ fn phase290_sqrt3_k_log42_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase290r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase290r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -26713,10 +26805,12 @@ fn phase291_sqrt4_k_log42_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -26736,10 +26830,12 @@ fn phase291_sqrt4_k_log42_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase291r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase291r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -26861,10 +26957,12 @@ fn phase292_sqrt5_k_log42_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -26884,10 +26982,12 @@ fn phase292_sqrt5_k_log42_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase292r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase292r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -26962,10 +27062,12 @@ fn phase293_log42_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -26984,10 +27086,12 @@ fn phase293_log42_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase293r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase293r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -27069,10 +27173,12 @@ fn phase294_sqrt1_k_log42_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -27092,10 +27198,12 @@ fn phase294_sqrt1_k_log42_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase294r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase294r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -27177,10 +27285,12 @@ fn phase295_sqrt2_k_log42_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -27200,10 +27310,12 @@ fn phase295_sqrt2_k_log42_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase295r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase295r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -27285,10 +27397,12 @@ fn phase296_sqrt3_k_log42_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -27308,10 +27422,12 @@ fn phase296_sqrt3_k_log42_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase296r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase296r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -27393,10 +27509,12 @@ fn phase297_sqrt4_k_log42_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -27416,10 +27534,12 @@ fn phase297_sqrt4_k_log42_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase297r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase297r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -27501,10 +27621,12 @@ fn phase298_sqrt5_k_log42_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -27524,10 +27646,12 @@ fn phase298_sqrt5_k_log42_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase298r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase298r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -27602,10 +27726,12 @@ fn phase299_log45_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -27624,10 +27750,12 @@ fn phase299_log45_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase299r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase299r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -27709,10 +27837,12 @@ fn phase300_sqrt1_k_log45_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -27732,10 +27862,12 @@ fn phase300_sqrt1_k_log45_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase300r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase300r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -27817,10 +27949,12 @@ fn phase301_sqrt2_k_log45_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -27840,10 +27974,12 @@ fn phase301_sqrt2_k_log45_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase301r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase301r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -27925,10 +28061,12 @@ fn phase302_sqrt3_k_log45_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -27948,10 +28086,12 @@ fn phase302_sqrt3_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase302r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase302r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -28033,10 +28173,12 @@ fn phase303_sqrt4_k_log45_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -28056,10 +28198,12 @@ fn phase303_sqrt4_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase303r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase303r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -28141,10 +28285,12 @@ fn phase304_sqrt5_k_log45_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -28164,10 +28310,12 @@ fn phase304_sqrt5_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase304r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase304r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -28242,10 +28390,12 @@ fn phase305_log45_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -28263,10 +28413,12 @@ fn phase305_log45_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase305r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase305r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -28347,10 +28499,12 @@ fn phase306_sqrt1_k_log45_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -28369,10 +28523,12 @@ fn phase306_sqrt1_k_log45_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase306r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase306r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -28453,10 +28609,12 @@ fn phase307_sqrt2_k_log45_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -28475,10 +28633,12 @@ fn phase307_sqrt2_k_log45_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase307r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase307r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -28559,10 +28719,12 @@ fn phase308_sqrt3_k_log45_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -28581,10 +28743,12 @@ fn phase308_sqrt3_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase308r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase308r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -28665,10 +28829,12 @@ fn phase309_sqrt4_k_log45_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -28687,10 +28853,12 @@ fn phase309_sqrt4_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase309r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase309r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -28771,10 +28939,12 @@ fn phase310_sqrt5_k_log45_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -28793,10 +28963,12 @@ fn phase310_sqrt5_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase310r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase310r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -28869,10 +29041,12 @@ fn phase311_log45_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -28889,10 +29063,12 @@ fn phase311_log45_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase311r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase311r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -28972,10 +29148,12 @@ fn phase312_sqrt1_k_log45_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -28993,10 +29171,12 @@ fn phase312_sqrt1_k_log45_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase312r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase312r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -29076,10 +29256,12 @@ fn phase313_sqrt2_k_log45_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -29097,10 +29279,12 @@ fn phase313_sqrt2_k_log45_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase313r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase313r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -29180,10 +29364,12 @@ fn phase314_sqrt3_k_log45_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -29201,10 +29387,12 @@ fn phase314_sqrt3_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase314r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase314r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -29284,10 +29472,12 @@ fn phase315_sqrt4_k_log45_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -29305,10 +29495,12 @@ fn phase315_sqrt4_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase315r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase315r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -29388,10 +29580,12 @@ fn phase316_sqrt5_k_log45_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -29409,10 +29603,12 @@ fn phase316_sqrt5_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase316r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase316r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -29484,10 +29680,12 @@ fn phase317_log46_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -29503,10 +29701,12 @@ fn phase317_log46_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase317r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase317r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -29585,10 +29785,12 @@ fn phase318_sqrt1_k_log46_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -29605,10 +29807,12 @@ fn phase318_sqrt1_k_log46_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase318r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase318r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -29687,10 +29891,12 @@ fn phase319_sqrt2_k_log46_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -29707,10 +29913,12 @@ fn phase319_sqrt2_k_log46_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase319r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase319r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -29789,10 +29997,12 @@ fn phase320_sqrt3_k_log46_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -29809,10 +30019,12 @@ fn phase320_sqrt3_k_log46_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase320r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase320r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -29891,10 +30103,12 @@ fn phase321_sqrt4_k_log46_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -29911,10 +30125,12 @@ fn phase321_sqrt4_k_log46_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase321r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase321r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -29993,10 +30209,12 @@ fn phase322_sqrt5_k_log46_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -30013,10 +30231,12 @@ fn phase322_sqrt5_k_log46_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase322r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase322r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -30090,10 +30310,12 @@ fn phase323_log47_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -30109,10 +30331,12 @@ fn phase323_log47_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase323r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase323r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -30193,10 +30417,12 @@ fn phase324_sqrt1_k_log47_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -30213,10 +30439,12 @@ fn phase324_sqrt1_k_log47_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase324r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase324r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -30297,10 +30525,12 @@ fn phase325_sqrt2_k_log47_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -30317,10 +30547,12 @@ fn phase325_sqrt2_k_log47_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase325r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase325r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -30401,10 +30633,12 @@ fn phase326_sqrt3_k_log47_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -30421,10 +30655,12 @@ fn phase326_sqrt3_k_log47_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase326r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase326r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -30505,10 +30741,12 @@ fn phase327_sqrt4_k_log47_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -30525,10 +30763,12 @@ fn phase327_sqrt4_k_log47_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase327r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase327r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -30609,10 +30849,12 @@ fn phase328_sqrt5_k_log47_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -30629,10 +30871,12 @@ fn phase328_sqrt5_k_log47_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase328r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase328r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -30687,7 +30931,7 @@ fn phase329_log47_k_over_k2_converges() {
 
 #[test]
 fn phase329_log48_k_over_k2_refused() {
-    // phase329 log48 k over k2 refused: 53 logs → refused (Phase 359 handles exactly 52).
+    // phase329 log48 k over k2 refused: 54 logs → refused (Phase 365 handles exactly 53).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -30708,10 +30952,12 @@ fn phase329_log48_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -30727,10 +30973,12 @@ fn phase329_log48_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase329r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase329r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -30789,7 +31037,7 @@ fn phase330_sqrt1_k_log47_k_over_k2_converges() {
 
 #[test]
 fn phase330_sqrt1_k_log48_k_over_k2_refused() {
-    // phase330 sqrt1 k log48 k over k2 refused: 53 logs → refused (Phase 360 handles exactly 52).
+    // phase330 sqrt1 k log48 k over k2 refused: 54 logs → refused (Phase 366 handles exactly 53).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -30813,10 +31061,12 @@ fn phase330_sqrt1_k_log48_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -30833,10 +31083,12 @@ fn phase330_sqrt1_k_log48_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase330r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase330r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -30895,7 +31147,7 @@ fn phase331_sqrt2_k_log47_k_over_k2_converges() {
 
 #[test]
 fn phase331_sqrt2_k_log48_k_over_k2_refused() {
-    // phase331 sqrt2 k log48 k over k2 refused: 53 logs → refused (Phase 361 handles exactly 52).
+    // phase331 sqrt2 k log48 k over k2 refused: 54 logs → refused (Phase 367 handles exactly 53).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -30919,10 +31171,12 @@ fn phase331_sqrt2_k_log48_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -30939,10 +31193,12 @@ fn phase331_sqrt2_k_log48_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase331r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase331r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -31001,7 +31257,7 @@ fn phase332_sqrt3_k_log47_k_over_k3_converges() {
 
 #[test]
 fn phase332_sqrt3_k_log48_k_over_k3_refused() {
-    // phase332 sqrt3 k log48 k over k3 refused: 53 logs → refused (Phase 362 handles exactly 52).
+    // phase332 sqrt3 k log48 k over k3 refused: 54 logs → refused (Phase 368 handles exactly 53).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -31025,10 +31281,12 @@ fn phase332_sqrt3_k_log48_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -31045,10 +31303,12 @@ fn phase332_sqrt3_k_log48_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase332r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase332r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -31107,7 +31367,7 @@ fn phase333_sqrt4_k_log47_k_over_k3_converges() {
 
 #[test]
 fn phase333_sqrt4_k_log48_k_over_k3_refused() {
-    // phase333 sqrt4 k log48 k over k3 refused: 53 logs → refused (Phase 363 handles exactly 52).
+    // phase333 sqrt4 k log48 k over k3 refused: 54 logs → refused (Phase 369 handles exactly 53).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -31131,10 +31391,12 @@ fn phase333_sqrt4_k_log48_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -31151,10 +31413,12 @@ fn phase333_sqrt4_k_log48_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase333r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase333r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -31213,7 +31477,7 @@ fn phase334_sqrt5_k_log47_k_over_k3_converges() {
 
 #[test]
 fn phase334_sqrt5_k_log48_k_over_k3_refused() {
-    // phase334 sqrt5 k log48 k over k3 refused: 53 logs → refused (Phase 364 handles exactly 52).
+    // phase334 sqrt5 k log48 k over k3 refused: 54 logs → refused (Phase 370 handles exactly 53).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -31237,10 +31501,12 @@ fn phase334_sqrt5_k_log48_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -31257,10 +31523,12 @@ fn phase334_sqrt5_k_log48_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase334r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase334r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -31315,7 +31583,7 @@ fn phase335_log48_k_over_k2_converges() {
 
 #[test]
 fn phase335_log50_k_over_k2_refused() {
-    // log(k)^50 / k2: 53 logs → refused (Phase 359 handles exactly 52).
+    // log(k)^50 / k2: 54 logs → refused (Phase 365 handles exactly 53).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -31336,10 +31604,12 @@ fn phase335_log50_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -31355,10 +31625,12 @@ fn phase335_log50_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase335r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase335r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -31417,7 +31689,7 @@ fn phase336_sqrt1_k_log48_k_over_k2_converges() {
 
 #[test]
 fn phase336_sqrt1_k_log50_k_over_k2_refused() {
-    // sqrt(k)*log(k)^50 / k2: 53 logs → refused (Phase 360 handles exactly 52).
+    // sqrt(k)*log(k)^50 / k2: 54 logs → refused (Phase 366 handles exactly 53).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -31441,10 +31713,12 @@ fn phase336_sqrt1_k_log50_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -31461,10 +31735,12 @@ fn phase336_sqrt1_k_log50_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase336r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase336r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -31523,7 +31799,7 @@ fn phase337_sqrt2_k_log48_k_over_k2_converges() {
 
 #[test]
 fn phase337_sqrt2_k_log50_k_over_k2_refused() {
-    // sqrt(k)^2*log(k)^50 / k2: 53 logs → refused (Phase 361 handles exactly 52).
+    // sqrt(k)^2*log(k)^50 / k2: 54 logs → refused (Phase 367 handles exactly 53).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -31547,10 +31823,12 @@ fn phase337_sqrt2_k_log50_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -31567,10 +31845,12 @@ fn phase337_sqrt2_k_log50_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase337r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase337r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -31629,7 +31909,7 @@ fn phase338_sqrt3_k_log48_k_over_k3_converges() {
 
 #[test]
 fn phase338_sqrt3_k_log50_k_over_k3_refused() {
-    // sqrt(k)^3*log(k)^50 / k3: 53 logs → refused (Phase 362 handles exactly 52).
+    // sqrt(k)^3*log(k)^50 / k3: 54 logs → refused (Phase 368 handles exactly 53).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -31653,10 +31933,12 @@ fn phase338_sqrt3_k_log50_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -31673,10 +31955,12 @@ fn phase338_sqrt3_k_log50_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase338r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase338r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -31735,7 +32019,7 @@ fn phase339_sqrt4_k_log48_k_over_k3_converges() {
 
 #[test]
 fn phase339_sqrt4_k_log50_k_over_k3_refused() {
-    // sqrt(k)^4*log(k)^50 / k3: 53 logs → refused (Phase 363 handles exactly 52).
+    // sqrt(k)^4*log(k)^50 / k3: 54 logs → refused (Phase 369 handles exactly 53).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -31759,10 +32043,12 @@ fn phase339_sqrt4_k_log50_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -31779,10 +32065,12 @@ fn phase339_sqrt4_k_log50_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase339r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase339r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -31841,7 +32129,7 @@ fn phase340_sqrt5_k_log48_k_over_k3_converges() {
 
 #[test]
 fn phase340_sqrt5_k_log50_k_over_k3_refused() {
-    // sqrt(k)^5*log(k)^50 / k3: 53 logs → refused (Phase 364 handles exactly 52).
+    // sqrt(k)^5*log(k)^50 / k3: 54 logs → refused (Phase 370 handles exactly 53).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -31865,10 +32153,12 @@ fn phase340_sqrt5_k_log50_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -31885,10 +32175,12 @@ fn phase340_sqrt5_k_log50_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase340r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase340r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -31945,7 +32237,7 @@ fn phase341_log49_k_over_k2_converges() {
 
 #[test]
 fn phase341_log50_k_over_k2_refused() {
-    // log(k)^50 / k2: 53 logs → refused (Phase 359 handles exactly 52).
+    // log(k)^50 / k2: 54 logs → refused (Phase 365 handles exactly 53).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -31966,10 +32258,12 @@ fn phase341_log50_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -31985,10 +32279,12 @@ fn phase341_log50_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase341r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase341r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -32049,7 +32345,7 @@ fn phase342_sqrt1_k_log49_k_over_k2_converges() {
 
 #[test]
 fn phase342_sqrt1_k_log50_k_over_k2_refused() {
-    // sqrt(k)*log(k)^50 / k2: 53 logs → refused (Phase 360 handles exactly 52).
+    // sqrt(k)*log(k)^50 / k2: 54 logs → refused (Phase 366 handles exactly 53).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -32073,10 +32369,12 @@ fn phase342_sqrt1_k_log50_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -32093,10 +32391,12 @@ fn phase342_sqrt1_k_log50_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase342r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase342r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -32157,7 +32457,7 @@ fn phase343_sqrt2_k_log49_k_over_k3_converges() {
 
 #[test]
 fn phase343_sqrt2_k_log50_k_over_k2_refused() {
-    // sqrt(k)^2*log(k)^50 / k2: 53 logs → refused (Phase 361 handles exactly 52).
+    // sqrt(k)^2*log(k)^50 / k2: 54 logs → refused (Phase 367 handles exactly 53).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -32181,10 +32481,12 @@ fn phase343_sqrt2_k_log50_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -32201,10 +32503,12 @@ fn phase343_sqrt2_k_log50_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase343r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase343r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -32265,7 +32569,7 @@ fn phase344_sqrt3_k_log49_k_over_k3_converges() {
 
 #[test]
 fn phase344_sqrt3_k_log50_k_over_k3_refused() {
-    // sqrt(k)^3*log(k)^50 / k3: 53 logs → refused (Phase 362 handles exactly 52).
+    // sqrt(k)^3*log(k)^50 / k3: 54 logs → refused (Phase 368 handles exactly 53).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -32289,10 +32593,12 @@ fn phase344_sqrt3_k_log50_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -32309,10 +32615,12 @@ fn phase344_sqrt3_k_log50_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase344r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase344r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -32373,7 +32681,7 @@ fn phase345_sqrt4_k_log49_k_over_k3_converges() {
 
 #[test]
 fn phase345_sqrt4_k_log50_k_over_k3_refused() {
-    // sqrt(k)^4*log(k)^50 / k3: 53 logs → refused (Phase 363 handles exactly 52).
+    // sqrt(k)^4*log(k)^50 / k3: 54 logs → refused (Phase 369 handles exactly 53).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -32397,10 +32705,12 @@ fn phase345_sqrt4_k_log50_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -32417,10 +32727,12 @@ fn phase345_sqrt4_k_log50_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase345r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase345r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -32481,7 +32793,7 @@ fn phase346_sqrt5_k_log49_k_over_k3_converges() {
 
 #[test]
 fn phase346_sqrt5_k_log50_k_over_k3_refused() {
-    // sqrt(k)^5*log(k)^50 / k3: 53 logs → refused (Phase 364 handles exactly 52).
+    // sqrt(k)^5*log(k)^50 / k3: 54 logs → refused (Phase 370 handles exactly 53).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -32505,10 +32817,12 @@ fn phase346_sqrt5_k_log50_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -32525,10 +32839,12 @@ fn phase346_sqrt5_k_log50_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase346r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase346r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -32587,7 +32903,7 @@ fn phase347_log50_k_over_k2_converges() {
 
 #[test]
 fn phase347_log51_k_over_k2_refused() {
-    // log(k)^51 / k2: 53 logs → refused (Phase 359 handles exactly 52).
+    // log(k)^51 / k2: 54 logs → refused (Phase 365 handles exactly 53).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -32609,9 +32925,11 @@ fn phase347_log51_k_over_k2_refused() {
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
         log_k.clone(), // 50th log
-        log_k.clone(), // 53rd log
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -32628,9 +32946,11 @@ fn phase347_log51_k_over_k2_refused() {
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
         log_kp1.clone(), // 50th log
-        log_kp1.clone(), // 53rd log
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase347r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase347r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -32693,7 +33013,7 @@ fn phase348_sqrt1_k_log50_k_over_k2_converges() {
 
 #[test]
 fn phase348_sqrt1_k_log51_k_over_k2_refused() {
-    // sqrt(k)*log(k)^51 / k2: 53 logs → refused (Phase 360 handles exactly 52).
+    // sqrt(k)*log(k)^51 / k2: 54 logs → refused (Phase 366 handles exactly 53).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -32718,9 +33038,11 @@ fn phase348_sqrt1_k_log51_k_over_k2_refused() {
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
         log_k.clone(), // 50th log
-        log_k.clone(), // 53rd log
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -32738,9 +33060,11 @@ fn phase348_sqrt1_k_log51_k_over_k2_refused() {
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
         log_kp1.clone(), // 50th log
-        log_kp1.clone(), // 53rd log
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase348r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase348r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -32803,7 +33127,7 @@ fn phase349_sqrt2_k_log50_k_over_k3_converges() {
 
 #[test]
 fn phase349_sqrt2_k_log51_k_over_k2_refused() {
-    // sqrt(k)^2*log(k)^51 / k2: 53 logs → refused (Phase 361 handles exactly 52).
+    // sqrt(k)^2*log(k)^51 / k2: 54 logs → refused (Phase 367 handles exactly 53).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -32828,9 +33152,11 @@ fn phase349_sqrt2_k_log51_k_over_k2_refused() {
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
         log_k.clone(), // 50th log
-        log_k.clone(), // 53rd log
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -32848,9 +33174,11 @@ fn phase349_sqrt2_k_log51_k_over_k2_refused() {
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
         log_kp1.clone(), // 50th log
-        log_kp1.clone(), // 53rd log
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase349r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase349r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -32913,7 +33241,7 @@ fn phase350_sqrt3_k_log50_k_over_k3_converges() {
 
 #[test]
 fn phase350_sqrt3_k_log51_k_over_k3_refused() {
-    // sqrt(k)^3*log(k)^51 / k3: 53 logs → refused (Phase 362 handles exactly 52).
+    // sqrt(k)^3*log(k)^51 / k3: 54 logs → refused (Phase 368 handles exactly 53).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -32938,9 +33266,11 @@ fn phase350_sqrt3_k_log51_k_over_k3_refused() {
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
         log_k.clone(), // 50th log
-        log_k.clone(), // 53rd log
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -32958,9 +33288,11 @@ fn phase350_sqrt3_k_log51_k_over_k3_refused() {
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
         log_kp1.clone(), // 50th log
-        log_kp1.clone(), // 53rd log
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase350r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase350r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -33023,7 +33355,7 @@ fn phase351_sqrt4_k_log50_k_over_k3_converges() {
 
 #[test]
 fn phase351_sqrt4_k_log51_k_over_k3_refused() {
-    // sqrt(k)^4*log(k)^51 / k3: 53 logs → refused (Phase 363 handles exactly 52).
+    // sqrt(k)^4*log(k)^51 / k3: 54 logs → refused (Phase 369 handles exactly 53).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -33048,9 +33380,11 @@ fn phase351_sqrt4_k_log51_k_over_k3_refused() {
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
         log_k.clone(), // 50th log
-        log_k.clone(), // 53rd log
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -33068,9 +33402,11 @@ fn phase351_sqrt4_k_log51_k_over_k3_refused() {
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
         log_kp1.clone(), // 50th log
-        log_kp1.clone(), // 53rd log
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase351r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase351r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -33133,7 +33469,7 @@ fn phase352_sqrt5_k_log50_k_over_k3_converges() {
 
 #[test]
 fn phase352_sqrt5_k_log51_k_over_k3_refused() {
-    // sqrt(k)^5*log(k)^51 / k3: 53 logs → refused (Phase 364 handles exactly 52).
+    // sqrt(k)^5*log(k)^51 / k3: 54 logs → refused (Phase 370 handles exactly 53).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -33158,9 +33494,11 @@ fn phase352_sqrt5_k_log51_k_over_k3_refused() {
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
         log_k.clone(), // 50th log
-        log_k.clone(), // 53rd log
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -33178,9 +33516,11 @@ fn phase352_sqrt5_k_log51_k_over_k3_refused() {
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
         log_kp1.clone(), // 50th log
-        log_kp1.clone(), // 53rd log
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase352r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase352r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -33241,7 +33581,7 @@ fn phase353_log51_k_over_k2_converges() {
 
 #[test]
 fn phase353_log52_k_over_k2_refused() {
-    // log(k)^52 / k2: 53 logs → refused (Phase 359 handles exactly 52).
+    // log(k)^52 / k2: 54 logs → refused (Phase 365 handles exactly 53).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -33264,9 +33604,11 @@ fn phase353_log52_k_over_k2_refused() {
         log_k.clone(), // 49th log
         log_k.clone(), // 50th log
         log_k.clone(), // 51st log
-        log_k.clone(), // 53rd log
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -33284,9 +33626,11 @@ fn phase353_log52_k_over_k2_refused() {
         log_kp1.clone(), // 49th log
         log_kp1.clone(), // 50th log
         log_kp1.clone(), // 51st log
-        log_kp1.clone(), // 53rd log
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase353r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase353r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -33351,7 +33695,7 @@ fn phase354_sqrt1_k_log51_k_over_k2_converges() {
 
 #[test]
 fn phase354_sqrt1_k_log52_k_over_k2_refused() {
-    // sqrt(k)^1*log(k)^52 / k2: 53 logs → refused (Phase 360 handles exactly 52).
+    // sqrt(k)^1*log(k)^52 / k2: 54 logs → refused (Phase 366 handles exactly 53).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -33377,9 +33721,11 @@ fn phase354_sqrt1_k_log52_k_over_k2_refused() {
         log_k.clone(), // 49th log
         log_k.clone(), // 50th log
         log_k.clone(), // 51st log
-        log_k.clone(), // 53rd log
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -33398,9 +33744,11 @@ fn phase354_sqrt1_k_log52_k_over_k2_refused() {
         log_kp1.clone(), // 49th log
         log_kp1.clone(), // 50th log
         log_kp1.clone(), // 51st log
-        log_kp1.clone(), // 53rd log
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase354r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase354r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -33465,7 +33813,7 @@ fn phase355_sqrt2_k_log51_k_over_k3_converges() {
 
 #[test]
 fn phase355_sqrt2_k_log52_k_over_k3_refused() {
-    // sqrt(k)^2*log(k)^52 / k3: 53 logs → refused (Phase 361 handles exactly 52).
+    // sqrt(k)^2*log(k)^52 / k3: 54 logs → refused (Phase 367 handles exactly 53).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -33491,9 +33839,11 @@ fn phase355_sqrt2_k_log52_k_over_k3_refused() {
         log_k.clone(), // 49th log
         log_k.clone(), // 50th log
         log_k.clone(), // 51st log
-        log_k.clone(), // 53rd log
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -33512,9 +33862,11 @@ fn phase355_sqrt2_k_log52_k_over_k3_refused() {
         log_kp1.clone(), // 49th log
         log_kp1.clone(), // 50th log
         log_kp1.clone(), // 51st log
-        log_kp1.clone(), // 53rd log
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase355r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase355r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -33579,7 +33931,7 @@ fn phase356_sqrt3_k_log51_k_over_k3_converges() {
 
 #[test]
 fn phase356_sqrt3_k_log52_k_over_k3_refused() {
-    // sqrt(k)^3*log(k)^52 / k3: 53 logs → refused (Phase 362 handles exactly 52).
+    // sqrt(k)^3*log(k)^52 / k3: 54 logs → refused (Phase 368 handles exactly 53).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -33605,9 +33957,11 @@ fn phase356_sqrt3_k_log52_k_over_k3_refused() {
         log_k.clone(), // 49th log
         log_k.clone(), // 50th log
         log_k.clone(), // 51st log
-        log_k.clone(), // 53rd log
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -33626,9 +33980,11 @@ fn phase356_sqrt3_k_log52_k_over_k3_refused() {
         log_kp1.clone(), // 49th log
         log_kp1.clone(), // 50th log
         log_kp1.clone(), // 51st log
-        log_kp1.clone(), // 53rd log
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase356r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase356r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -33693,7 +34049,7 @@ fn phase357_sqrt4_k_log51_k_over_k3_converges() {
 
 #[test]
 fn phase357_sqrt4_k_log52_k_over_k3_refused() {
-    // sqrt(k)^4*log(k)^52 / k3: 53 logs → refused (Phase 363 handles exactly 52).
+    // sqrt(k)^4*log(k)^52 / k3: 54 logs → refused (Phase 369 handles exactly 53).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -33719,9 +34075,11 @@ fn phase357_sqrt4_k_log52_k_over_k3_refused() {
         log_k.clone(), // 49th log
         log_k.clone(), // 50th log
         log_k.clone(), // 51st log
-        log_k.clone(), // 53rd log
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -33740,9 +34098,11 @@ fn phase357_sqrt4_k_log52_k_over_k3_refused() {
         log_kp1.clone(), // 49th log
         log_kp1.clone(), // 50th log
         log_kp1.clone(), // 51st log
-        log_kp1.clone(), // 53rd log
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase357r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase357r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -33807,7 +34167,7 @@ fn phase358_sqrt5_k_log51_k_over_k3_converges() {
 
 #[test]
 fn phase358_sqrt5_k_log52_k_over_k3_refused() {
-    // sqrt(k)^5*log(k)^52 / k3: 53 logs → refused (Phase 364 handles exactly 52).
+    // sqrt(k)^5*log(k)^52 / k3: 54 logs → refused (Phase 370 handles exactly 53).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -33833,9 +34193,11 @@ fn phase358_sqrt5_k_log52_k_over_k3_refused() {
         log_k.clone(), // 49th log
         log_k.clone(), // 50th log
         log_k.clone(), // 51st log
-        log_k.clone(), // 53rd log
-        log_k.clone(), // 53rd log (over 51; refused)
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -33854,9 +34216,11 @@ fn phase358_sqrt5_k_log52_k_over_k3_refused() {
         log_kp1.clone(), // 49th log
         log_kp1.clone(), // 50th log
         log_kp1.clone(), // 51st log
-        log_kp1.clone(), // 53rd log
-        log_kp1.clone(), // 53rd log (over 51; refused)
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase358r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase358r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -33943,8 +34307,9 @@ fn phase359_log53_k_over_k2_refused() {
         log_k.clone(), // 50th log
         log_k.clone(), // 51st log
         log_k.clone(), // 52nd log
-        log_k.clone(), // 53rd log
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -33963,8 +34328,9 @@ fn phase359_log53_k_over_k2_refused() {
         log_kp1.clone(), // 50th log
         log_kp1.clone(), // 51st log
         log_kp1.clone(), // 52nd log
-        log_kp1.clone(), // 53rd log
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase359r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase359r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -34058,8 +34424,9 @@ fn phase360_sqrt1_k_log53_k_over_k2_refused() {
         log_k.clone(), // 50th log
         log_k.clone(), // 51st log
         log_k.clone(), // 52nd log
-        log_k.clone(), // 53rd log
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -34079,8 +34446,9 @@ fn phase360_sqrt1_k_log53_k_over_k2_refused() {
         log_kp1.clone(), // 50th log
         log_kp1.clone(), // 51st log
         log_kp1.clone(), // 52nd log
-        log_kp1.clone(), // 53rd log
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase360r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase360r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -34174,8 +34542,9 @@ fn phase361_sqrt2_k_log53_k_over_k3_refused() {
         log_k.clone(), // 50th log
         log_k.clone(), // 51st log
         log_k.clone(), // 52nd log
-        log_k.clone(), // 53rd log
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -34195,8 +34564,9 @@ fn phase361_sqrt2_k_log53_k_over_k3_refused() {
         log_kp1.clone(), // 50th log
         log_kp1.clone(), // 51st log
         log_kp1.clone(), // 52nd log
-        log_kp1.clone(), // 53rd log
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase361r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase361r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -34290,8 +34660,9 @@ fn phase362_sqrt3_k_log53_k_over_k3_refused() {
         log_k.clone(), // 50th log
         log_k.clone(), // 51st log
         log_k.clone(), // 52nd log
-        log_k.clone(), // 53rd log
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -34311,8 +34682,9 @@ fn phase362_sqrt3_k_log53_k_over_k3_refused() {
         log_kp1.clone(), // 50th log
         log_kp1.clone(), // 51st log
         log_kp1.clone(), // 52nd log
-        log_kp1.clone(), // 53rd log
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase362r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase362r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -34406,8 +34778,9 @@ fn phase363_sqrt4_k_log53_k_over_k3_refused() {
         log_k.clone(), // 50th log
         log_k.clone(), // 51st log
         log_k.clone(), // 52nd log
-        log_k.clone(), // 53rd log
-        log_k, // 54th log (over 52; refused)
+        log_k.clone(), // 54th log
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -34427,8 +34800,9 @@ fn phase363_sqrt4_k_log53_k_over_k3_refused() {
         log_kp1.clone(), // 50th log
         log_kp1.clone(), // 51st log
         log_kp1.clone(), // 52nd log
-        log_kp1.clone(), // 53rd log
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
     let g_kphase363r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase363r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -34522,8 +34896,709 @@ fn phase364_sqrt5_k_log53_k_over_k3_refused() {
         log_k.clone(), // 50th log
         log_k.clone(), // 51st log
         log_k.clone(), // 52nd log
+        log_k.clone(), // 54th log
+        log_k.clone(), // 54th log (over 53; refused)
+        log_k, // 54th log (over 53; refused)
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 54th log (over 53; refused)
+        log_kp1, // 54th log (over 53; refused)
+    ]);
+    let g_kphase364r = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_phase364r = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let fphase364r = apply(sym(SUB), vec![g_kphase364r, g_kp1_phase364r]);
+    let out = evaluate_sum(fphase364r, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+#[test]
+fn phase365_log53_k_over_k2_converges() {
+    // log53 k over k2: eff_x2=0; 2·2=4 > 0 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k.clone(), // 51st log
+        log_k.clone(), // 52nd log
+        log_k, // 53rd log
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1, // 53rd log
+    ]);
+    let g_k365a = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_365a = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f365a = apply(sym(SUB), vec![g_k365a, g_kp1_365a]);
+    let out = evaluate_sum(f365a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase365_log53_k_over_k2_refused() {
+    // log53 k over k2: 54 logs → refused (Phase 365 handles exactly 53).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k.clone(), // 51st log
+        log_k.clone(), // 52nd log
         log_k.clone(), // 53rd log
-        log_k, // 54th log (over 52; refused)
+        log_k, // 54th log (over 53; refused)
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 53rd log
+        log_kp1, // 54th log (over 53; refused)
+    ]);
+    let g_k365r = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_365r = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f365r = apply(sym(SUB), vec![g_k365r, g_kp1_365r]);
+    let out = evaluate_sum(f365r, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase366_sqrt1_k_log53_k_over_k2_converges() {
+    // sqrt1 k log53 k over k2: eff_x2=1; 2·2=4 > 1 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k.clone(), // 51st log
+        log_k.clone(), // 52nd log
+        log_k, // 53rd log
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1, // 53rd log
+    ]);
+    let g_k366a = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_366a = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f366a = apply(sym(SUB), vec![g_k366a, g_kp1_366a]);
+    let out = evaluate_sum(f366a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase366_sqrt1_k_log53_k_over_k2_refused() {
+    // sqrt1 k log53 k over k2: 54 logs → refused (Phase 366 handles exactly 53).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k.clone(), // 51st log
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 53rd log
+        log_k, // 54th log (over 53; refused)
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 53rd log
+        log_kp1, // 54th log (over 53; refused)
+    ]);
+    let g_k366r = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_366r = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f366r = apply(sym(SUB), vec![g_k366r, g_kp1_366r]);
+    let out = evaluate_sum(f366r, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase367_sqrt2_k_log53_k_over_k2_converges() {
+    // sqrt2 k log53 k over k2: eff_x2=2; 2·2=4 > 2 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k.clone(), // 51st log
+        log_k.clone(), // 52nd log
+        log_k, // 53rd log
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1, // 53rd log
+    ]);
+    let g_k367a = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_367a = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f367a = apply(sym(SUB), vec![g_k367a, g_kp1_367a]);
+    let out = evaluate_sum(f367a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase367_sqrt2_k_log53_k_over_k2_refused() {
+    // sqrt2 k log53 k over k2: 54 logs → refused (Phase 367 handles exactly 53).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k.clone(), // 51st log
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 53rd log
+        log_k, // 54th log (over 53; refused)
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 53rd log
+        log_kp1, // 54th log (over 53; refused)
+    ]);
+    let g_k367r = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_367r = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f367r = apply(sym(SUB), vec![g_k367r, g_kp1_367r]);
+    let out = evaluate_sum(f367r, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase368_sqrt3_k_log53_k_over_k3_converges() {
+    // sqrt3 k log53 k over k3: eff_x2=3; 2·3=6 > 3 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k.clone(), // 51st log
+        log_k.clone(), // 52nd log
+        log_k, // 53rd log
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1, // 53rd log
+    ]);
+    let g_k368a = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_368a = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f368a = apply(sym(SUB), vec![g_k368a, g_kp1_368a]);
+    let out = evaluate_sum(f368a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase368_sqrt3_k_log53_k_over_k3_refused() {
+    // sqrt3 k log53 k over k3: 54 logs → refused (Phase 368 handles exactly 53).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k.clone(), // 51st log
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 53rd log
+        log_k, // 54th log (over 53; refused)
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 53rd log
+        log_kp1, // 54th log (over 53; refused)
+    ]);
+    let g_k368r = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_368r = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f368r = apply(sym(SUB), vec![g_k368r, g_kp1_368r]);
+    let out = evaluate_sum(f368r, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase369_sqrt4_k_log53_k_over_k3_converges() {
+    // sqrt4 k log53 k over k3: eff_x2=4; 2·3=6 > 4 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k.clone(), // 51st log
+        log_k.clone(), // 52nd log
+        log_k, // 53rd log
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1, // 53rd log
+    ]);
+    let g_k369a = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_369a = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f369a = apply(sym(SUB), vec![g_k369a, g_kp1_369a]);
+    let out = evaluate_sum(f369a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase369_sqrt4_k_log53_k_over_k3_refused() {
+    // sqrt4 k log53 k over k3: 54 logs → refused (Phase 369 handles exactly 53).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k.clone(), // 51st log
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 53rd log
+        log_k, // 54th log (over 53; refused)
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 53rd log
+        log_kp1, // 54th log (over 53; refused)
+    ]);
+    let g_k369r = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_369r = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f369r = apply(sym(SUB), vec![g_k369r, g_kp1_369r]);
+    let out = evaluate_sum(f369r, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase370_sqrt5_k_log53_k_over_k3_converges() {
+    // sqrt5 k log53 k over k3: eff_x2=5; 2·3=6 > 5 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k.clone(), // 51st log
+        log_k.clone(), // 52nd log
+        log_k, // 53rd log
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1, // 53rd log
+    ]);
+    let g_k370a = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_370a = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f370a = apply(sym(SUB), vec![g_k370a, g_kp1_370a]);
+    let out = evaluate_sum(f370a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase370_sqrt5_k_log53_k_over_k3_refused() {
+    // sqrt5 k log53 k over k3: 54 logs → refused (Phase 370 handles exactly 53).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k.clone(), // 51st log
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 53rd log
+        log_k, // 54th log (over 53; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -34544,11 +35619,12 @@ fn phase364_sqrt5_k_log53_k_over_k3_refused() {
         log_kp1.clone(), // 51st log
         log_kp1.clone(), // 52nd log
         log_kp1.clone(), // 53rd log
-        log_kp1, // 54th log (over 52; refused)
+        log_kp1, // 54th log (over 53; refused)
     ]);
-    let g_kphase364r = apply(sym(DIV), vec![num_k, k3]);
-    let g_kp1_phase364r = apply(sym(DIV), vec![num_kp1, kp1_3]);
-    let fphase364r = apply(sym(SUB), vec![g_kphase364r, g_kp1_phase364r]);
-    let out = evaluate_sum(fphase364r, k, int(1), sym("%inf"), eval);
+    let g_k370r = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_370r = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f370r = apply(sym(SUB), vec![g_k370r, g_kp1_370r]);
+    let out = evaluate_sum(f370r, k, int(1), sym("%inf"), eval);
     assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }
+

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 2.307.0 — 2026-05-28
+
+### Added
+
+- **Phase 370 — Five-Sqrt × Fifty-Three-Log × polynomial** (`fiveSqrtFiftyThreeLogPolyEffectiveDeg`):
+  Completes the Fifty-Three-Log family (Phases 365–370).
+- **Phase 369 — Four-Sqrt × Fifty-Three-Log × polynomial** (`fourSqrtFiftyThreeLogPolyEffectiveDeg`).
+- **Phase 368 — Three-Sqrt × Fifty-Three-Log × polynomial** (`threeSqrtFiftyThreeLogPolyEffectiveDeg`).
+- **Phase 367 — Two-Sqrt × Fifty-Three-Log × polynomial** (`twoSqrtFiftyThreeLogPolyEffectiveDeg`).
+- **Phase 366 — One-Sqrt × Fifty-Three-Log × polynomial** (`oneSqrtFiftyThreeLogPolyEffectiveDeg`).
+- **Phase 365 — Zero-Sqrt × Fifty-Three-Log × polynomial** (`fiftyThreeLogPolyEffectiveDeg`).
+
+### Changed
+
+- Boundary tests in Phases 359–364 updated from 53-log "refused" to 54-log "refused"
+  now that Phases 365–370 handle exactly 53 logs.
+
 ## 2.301.0 — 2026-05-28
 
 ### Added

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "2.301.0",
+  "version": "2.307.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -6474,6 +6474,162 @@ function oneSqrtFiftyTwoLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | u
   return sqrtHalfDeg + polyDeg;
 }
 
+/** Phase 365 — Zero-Sqrt × Fifty-Three-Log × polynomial numerator.
+ * effectiveDeg = polyDeg (no sqrt factors).
+ * Caller checks `denDeg > fiftyThreeLogPolyEffectiveDeg(num, k)`.
+ */
+function fiftyThreeLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    if (sqrtEffectiveHalfDegree(arg, k) !== undefined) return undefined;
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 53) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (logCount !== 53) return undefined;
+  return polyDeg;
+}
+
+/** Phase 366 — One-Sqrt × Fifty-Three-Log × polynomial numerator. */
+function oneSqrtFiftyThreeLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  let sqrtHalfDeg: number | undefined;
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDeg !== undefined) return undefined;
+      sqrtHalfDeg = hd; continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 53) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDeg === undefined || logCount !== 53) return undefined;
+  return sqrtHalfDeg + polyDeg;
+}
+
+/** Phase 367 — Two-Sqrt × Fifty-Three-Log × polynomial numerator. */
+function twoSqrtFiftyThreeLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDegs.length >= 2) return undefined;
+      sqrtHalfDegs.push(hd); continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 53) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 2 || logCount !== 53) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + polyDeg;
+}
+
+/** Phase 368 — Three-Sqrt × Fifty-Three-Log × polynomial numerator. */
+function threeSqrtFiftyThreeLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDegs.length >= 3) return undefined;
+      sqrtHalfDegs.push(hd); continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 53) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 3 || logCount !== 53) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + polyDeg;
+}
+
+/** Phase 369 — Four-Sqrt × Fifty-Three-Log × polynomial numerator. */
+function fourSqrtFiftyThreeLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDegs.length >= 4) return undefined;
+      sqrtHalfDegs.push(hd); continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 53) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 4 || logCount !== 53) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + sqrtHalfDegs[3] + polyDeg;
+}
+
+/** Phase 370 — Five-Sqrt × Fifty-Three-Log × polynomial numerator.
+ * Completes the Fifty-Three-Log family (Phases 365–370).
+ */
+function fiveSqrtFiftyThreeLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDegs.length >= 5) return undefined;
+      sqrtHalfDegs.push(hd); continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 53) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 5 || logCount !== 53) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + sqrtHalfDegs[3] + sqrtHalfDegs[4] + polyDeg;
+}
+
 /** Phase 359 — Zero-Sqrt × Fifty-Two-Log × polynomial numerator.
  * effectiveDeg = polyDeg (no sqrt factors).
  * Caller checks `denDeg > fiftyTwoLogPolyEffectiveDeg(num, k)`.
@@ -9798,6 +9954,66 @@ function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
     const denDegS2l8 = polynomialDegreeInK(den, k);
     if (denDegS2l8 !== undefined) {
       if (denDegS2l8 > s2l8Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 370: five sqrt + 53 logs
+  const s5l53Deg = fiveSqrtFiftyThreeLogPolyEffectiveDeg(num, k);
+  if (s5l53Deg !== undefined) {
+    const denDegS5l53 = polynomialDegreeInK(den, k);
+    if (denDegS5l53 !== undefined) {
+      if (denDegS5l53 > s5l53Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 369: four sqrt + 53 logs
+  const s4l53Deg = fourSqrtFiftyThreeLogPolyEffectiveDeg(num, k);
+  if (s4l53Deg !== undefined) {
+    const denDegS4l53 = polynomialDegreeInK(den, k);
+    if (denDegS4l53 !== undefined) {
+      if (denDegS4l53 > s4l53Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 368: three sqrt + 53 logs
+  const s3l53Deg = threeSqrtFiftyThreeLogPolyEffectiveDeg(num, k);
+  if (s3l53Deg !== undefined) {
+    const denDegS3l53 = polynomialDegreeInK(den, k);
+    if (denDegS3l53 !== undefined) {
+      if (denDegS3l53 > s3l53Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 367: two sqrt + 53 logs
+  const s2l53Deg = twoSqrtFiftyThreeLogPolyEffectiveDeg(num, k);
+  if (s2l53Deg !== undefined) {
+    const denDegS2l53 = polynomialDegreeInK(den, k);
+    if (denDegS2l53 !== undefined) {
+      if (denDegS2l53 > s2l53Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 366: one sqrt + 53 logs
+  const s1l53Deg = oneSqrtFiftyThreeLogPolyEffectiveDeg(num, k);
+  if (s1l53Deg !== undefined) {
+    const denDegS1l53 = polynomialDegreeInK(den, k);
+    if (denDegS1l53 !== undefined) {
+      if (denDegS1l53 > s1l53Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 365: zero sqrt + 53 logs
+  const s0l53Deg = fiftyThreeLogPolyEffectiveDeg(num, k);
+  if (s0l53Deg !== undefined) {
+    const denDegS0l53 = polynomialDegreeInK(den, k);
+    if (denDegS0l53 !== undefined) {
+      if (denDegS0l53 > s0l53Deg) return true;
     } else if (hDivergesAtInfinity(den, k)) {
       return true;
     }

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -15271,8 +15271,8 @@ describe("Phase 167 — Twenty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK167r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1167r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK167r = { kind: "apply" as const, head: DIV, args: [numK167r, k2] };
@@ -15321,8 +15321,8 @@ describe("Phase 168 — One-Sqrt × Twenty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK168r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [k] }, ...logs29k, k] };
     const numKp1168r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [kp1] }, ...logs29kp1, kp1] };
     const gK168r = { kind: "apply" as const, head: DIV, args: [numK168r, k2] };
@@ -15375,8 +15375,8 @@ describe("Phase 169 — Two-Sqrt × Twenty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK169r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -15431,8 +15431,8 @@ describe("Phase 170 — Three-Sqrt × Twenty-Log × polynomial numerator", () =>
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK170r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15487,8 +15487,8 @@ describe("Phase 171 — Four-Sqrt × Twenty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK171r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15543,8 +15543,8 @@ describe("Phase 172 — Five-Sqrt × Twenty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK172r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15595,8 +15595,8 @@ describe("Phase 173 — Twenty-One-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK173r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1173r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK173r = { kind: "apply" as const, head: DIV, args: [numK173r, k2] };
@@ -15645,8 +15645,8 @@ describe("Phase 174 — One-Sqrt × Twenty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK174r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [k] }, ...logs29k, k] };
     const numKp1174r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [kp1] }, ...logs29kp1, kp1] };
     const gK174r = { kind: "apply" as const, head: DIV, args: [numK174r, k2] };
@@ -15699,8 +15699,8 @@ describe("Phase 175 — Two-Sqrt × Twenty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK175r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -15755,8 +15755,8 @@ describe("Phase 176 — Three-Sqrt × Twenty-One-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK176r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15811,8 +15811,8 @@ describe("Phase 177 — Four-Sqrt × Twenty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK177r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15867,8 +15867,8 @@ describe("Phase 178 — Five-Sqrt × Twenty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK178r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15919,8 +15919,8 @@ describe("Phase 179 — Twenty-Two-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK179r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1179r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK179r = { kind: "apply" as const, head: DIV, args: [numK179r, k2] };
@@ -15969,8 +15969,8 @@ describe("Phase 180 — One-Sqrt × Twenty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK180r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [k] }, ...logs29k, k] };
     const numKp1180r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [kp1] }, ...logs29kp1, kp1] };
     const gK180r = { kind: "apply" as const, head: DIV, args: [numK180r, k2] };
@@ -16023,8 +16023,8 @@ describe("Phase 181 — Two-Sqrt × Twenty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK181r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -16079,8 +16079,8 @@ describe("Phase 182 — Three-Sqrt × Twenty-Two-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK182r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16135,8 +16135,8 @@ describe("Phase 183 — Four-Sqrt × Twenty-Two-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK183r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16191,8 +16191,8 @@ describe("Phase 184 — Five-Sqrt × Twenty-Two-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK184r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16243,8 +16243,8 @@ describe("Phase 185 — Twenty-Three-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK185r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1185r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK185r = { kind: "apply" as const, head: DIV, args: [numK185r, k2] };
@@ -16293,8 +16293,8 @@ describe("Phase 186 — One-Sqrt × Twenty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK186r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [k] }, ...logs29k, k] };
     const numKp1186r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [kp1] }, ...logs29kp1, kp1] };
     const gK186r = { kind: "apply" as const, head: DIV, args: [numK186r, k2] };
@@ -16347,8 +16347,8 @@ describe("Phase 187 — Two-Sqrt × Twenty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK187r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -16403,8 +16403,8 @@ describe("Phase 188 — Three-Sqrt × Twenty-Three-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK188r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16459,8 +16459,8 @@ describe("Phase 189 — Four-Sqrt × Twenty-Three-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK189r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16515,8 +16515,8 @@ describe("Phase 190 — Five-Sqrt × Twenty-Three-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK190r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16567,8 +16567,8 @@ describe("Phase 191 — Twenty-Four-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK191r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1191r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK191r = { kind: "apply" as const, head: DIV, args: [numK191r, k2] };
@@ -16621,8 +16621,8 @@ describe("Phase 192 — One-Sqrt × Twenty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK192r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs29k, k] };
@@ -16677,8 +16677,8 @@ describe("Phase 193 — Two-Sqrt × Twenty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK193r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -16733,8 +16733,8 @@ describe("Phase 194 — Three-Sqrt × Twenty-Four-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK194r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16789,8 +16789,8 @@ describe("Phase 195 — Four-Sqrt × Twenty-Four-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK195r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16845,8 +16845,8 @@ describe("Phase 196 — Five-Sqrt × Twenty-Four-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK196r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16897,8 +16897,8 @@ describe("Phase 197 — Twenty-Five-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK197r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1197r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK197r = { kind: "apply" as const, head: DIV, args: [numK197r, k2] };
@@ -16951,8 +16951,8 @@ describe("Phase 198 — One-Sqrt × Twenty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK198r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs29k, k] };
@@ -17007,8 +17007,8 @@ describe("Phase 199 — Two-Sqrt × Twenty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK199r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -17063,8 +17063,8 @@ describe("Phase 200 — Three-Sqrt × Twenty-Five-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK200r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17119,8 +17119,8 @@ describe("Phase 201 — Four-Sqrt × Twenty-Five-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK201r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17175,8 +17175,8 @@ describe("Phase 202 — Five-Sqrt × Twenty-Five-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK202r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17227,8 +17227,8 @@ describe("Phase 203 — Twenty-Six-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK203r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1203r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK203r = { kind: "apply" as const, head: DIV, args: [numK203r, k2] };
@@ -17279,8 +17279,8 @@ describe("Phase 204 — One-Sqrt × Twenty-Six-Log × polynomial numerator", () 
   it("√k·log(k)²⁹·k/k² refused (30 logs — not Phase 204)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK204r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs29k, k] };
@@ -17333,8 +17333,8 @@ describe("Phase 205 — Two-Sqrt × Twenty-Six-Log × polynomial numerator", () 
   it("√k·√k·log(k)²⁹/k² refused (30 logs — not Phase 205)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK205r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k, k] };
@@ -17387,8 +17387,8 @@ describe("Phase 206 — Three-Sqrt × Twenty-Six-Log × polynomial numerator", (
   it("(√k)³·log(k)²⁹/k² refused (30 logs — not Phase 206)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK206r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k, k] };
@@ -17443,8 +17443,8 @@ describe("Phase 207 — Four-Sqrt × Twenty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK207r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k, k] };
@@ -17499,8 +17499,8 @@ describe("Phase 208 — Five-Sqrt × Twenty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK208r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17551,8 +17551,8 @@ describe("Phase 209 — Zero-Sqrt × Twenty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK209r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1209r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK209r = { kind: "apply" as const, head: DIV, args: [numK209r, k2] };
@@ -17603,8 +17603,8 @@ describe("Phase 210 — One-Sqrt × Twenty-Seven-Log × polynomial numerator", (
   it("√k·log(k)²⁹·k/k² refused (30 logs — not Phase 210)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK210r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs29k, k] };
@@ -17659,8 +17659,8 @@ describe("Phase 211 — Two-Sqrt × Twenty-Seven-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK211r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -17715,8 +17715,8 @@ describe("Phase 212 — Three-Sqrt × Twenty-Seven-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK212r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17771,8 +17771,8 @@ describe("Phase 213 — Four-Sqrt × Twenty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK213r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17827,8 +17827,8 @@ describe("Phase 214 — Five-Sqrt × Twenty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK214r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17879,8 +17879,8 @@ describe("Phase 215 — Zero-Sqrt × Twenty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK215r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1215r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK215r = { kind: "apply" as const, head: DIV, args: [numK215r, k2] };
@@ -17933,8 +17933,8 @@ describe("Phase 216 — One-Sqrt × Twenty-Eight-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK216r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs29k, k] };
@@ -17989,8 +17989,8 @@ describe("Phase 217 — Two-Sqrt × Twenty-Eight-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK217r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -18045,8 +18045,8 @@ describe("Phase 218 — Three-Sqrt × Twenty-Eight-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK218r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -18101,8 +18101,8 @@ describe("Phase 219 — Four-Sqrt × Twenty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK219r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -18157,8 +18157,8 @@ describe("Phase 220 — Five-Sqrt × Twenty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK220r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -18209,8 +18209,8 @@ describe("Phase 221 — Zero-Sqrt × Twenty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK221r = { kind: "apply" as const, head: MUL, args: [...logs30k, k] };
     const numKp1221r = { kind: "apply" as const, head: MUL, args: [...logs30kp1, kp1] };
     const gK221r = { kind: "apply" as const, head: DIV, args: [numK221r, k2] };
@@ -18263,8 +18263,8 @@ describe("Phase 222 — One-Sqrt × Twenty-Nine-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK222r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs30k, k] };
@@ -18319,8 +18319,8 @@ describe("Phase 223 — Two-Sqrt × Twenty-Nine-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK223r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs30k, k] };
@@ -18375,8 +18375,8 @@ describe("Phase 224 — Three-Sqrt × Twenty-Nine-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK224r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs30k, k] };
@@ -18431,8 +18431,8 @@ describe("Phase 225 — Four-Sqrt × Twenty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK225r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs30k, k] };
@@ -18487,8 +18487,8 @@ describe("Phase 226 — Five-Sqrt × Twenty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK226r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs30k, k] };
@@ -18539,8 +18539,8 @@ describe("Phase 227 — Zero-Sqrt × Thirty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK227r = { kind: "apply" as const, head: MUL, args: [...logs31k, k] };
     const numKp1227r = { kind: "apply" as const, head: MUL, args: [...logs31kp1, kp1] };
     const gK227r = { kind: "apply" as const, head: DIV, args: [numK227r, k2] };
@@ -18593,8 +18593,8 @@ describe("Phase 228 — One-Sqrt × Thirty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK228r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs31k, k] };
@@ -18649,8 +18649,8 @@ describe("Phase 229 — Two-Sqrt × Thirty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK229r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs31k, k] };
@@ -18705,8 +18705,8 @@ describe("Phase 230 — Three-Sqrt × Thirty-Log × polynomial numerator", () =>
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK230r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs31k, k] };
@@ -18761,8 +18761,8 @@ describe("Phase 231 — Four-Sqrt × Thirty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK231r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs31k, k] };
@@ -18817,8 +18817,8 @@ describe("Phase 232 — Five-Sqrt × Thirty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK232r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs31k, k] };
@@ -18869,8 +18869,8 @@ describe("Phase 233 — Zero-Sqrt × Thirty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK233r = { kind: "apply" as const, head: MUL, args: [...logs32k, k] };
     const numKp1233r = { kind: "apply" as const, head: MUL, args: [...logs32kp1, kp1] };
     const gK233r = { kind: "apply" as const, head: DIV, args: [numK233r, k2] };
@@ -18923,8 +18923,8 @@ describe("Phase 234 — One-Sqrt × Thirty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK234r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs32k, k] };
@@ -18979,8 +18979,8 @@ describe("Phase 235 — Two-Sqrt × Thirty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK235r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs32k, k] };
@@ -19035,8 +19035,8 @@ describe("Phase 236 — Three-Sqrt × Thirty-One-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK236r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs32k, k] };
@@ -19091,8 +19091,8 @@ describe("Phase 237 — Four-Sqrt × Thirty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK237r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs32k, k] };
@@ -19147,8 +19147,8 @@ describe("Phase 238 — Five-Sqrt × Thirty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK238r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs32k, k] };
@@ -19199,8 +19199,8 @@ describe("Phase 239 — Thirty-Two-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs33k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK239r = { kind: "apply" as const, head: MUL, args: [...logs33k, k] };
     const numKp1239r = { kind: "apply" as const, head: MUL, args: [...logs33kp1, kp1] };
     const gK239r = { kind: "apply" as const, head: DIV, args: [numK239r, k2] };
@@ -19249,8 +19249,8 @@ describe("Phase 240 — One-Sqrt × Thirty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs33k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK240r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [k] }, ...logs33k, k] };
     const numKp1240r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [kp1] }, ...logs33kp1, kp1] };
     const gK240r = { kind: "apply" as const, head: DIV, args: [numK240r, k2] };
@@ -19303,8 +19303,8 @@ describe("Phase 241 — Two-Sqrt × Thirty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs33k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK241r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs33k] };
@@ -19359,8 +19359,8 @@ describe("Phase 242 — Three-Sqrt × Thirty-Two-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs33k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK242r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs33k] };
@@ -19415,8 +19415,8 @@ describe("Phase 243 — Four-Sqrt × Thirty-Two-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs33k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK243r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs33k, k] };
@@ -19471,8 +19471,8 @@ describe("Phase 244 — Five-Sqrt × Thirty-Two-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs33k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK244r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs33k, k] };
@@ -19523,8 +19523,8 @@ describe("Phase 245 — Thirty-Three-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs34k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK245r = { kind: "apply" as const, head: MUL, args: [...logs34k, k] };
     const numKp1245r = { kind: "apply" as const, head: MUL, args: [...logs34kp1, kp1] };
     const gK245r = { kind: "apply" as const, head: DIV, args: [numK245r, k2] };
@@ -19577,8 +19577,8 @@ describe("Phase 246 — One-Sqrt × Thirty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs34k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK246r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs34k, k] };
@@ -19633,8 +19633,8 @@ describe("Phase 247 — Two-Sqrt × Thirty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs34k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK247r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs34k] };
@@ -19689,8 +19689,8 @@ describe("Phase 248 — Three-Sqrt × Thirty-Three-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs34k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK248r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs34k] };
@@ -19745,8 +19745,8 @@ describe("Phase 249 — Four-Sqrt × Thirty-Three-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs34k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK249r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs34k] };
@@ -19801,8 +19801,8 @@ describe("Phase 250 — Five-Sqrt × Thirty-Three-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs34k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK250r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs34k, k] };
@@ -19853,8 +19853,8 @@ describe("Phase 251 — Thirty-Four-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs36k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK251r = { kind: "apply" as const, head: MUL, args: [...logs36k, k] };
     const numKp1251r = { kind: "apply" as const, head: MUL, args: [...logs36kp1, kp1] };
     const gK251r = { kind: "apply" as const, head: DIV, args: [numK251r, k2] };
@@ -19907,8 +19907,8 @@ describe("Phase 252 — One-Sqrt × Thirty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs36k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK252r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs36k, k] };
@@ -19963,8 +19963,8 @@ describe("Phase 253 — Two-Sqrt × Thirty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs36k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK253r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs36k] };
@@ -20019,8 +20019,8 @@ describe("Phase 254 — Three-Sqrt × Thirty-Four-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs36k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK254r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs36k] };
@@ -20075,8 +20075,8 @@ describe("Phase 255 — Four-Sqrt × Thirty-Four-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs36k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK255r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs36k] };
@@ -20131,8 +20131,8 @@ describe("Phase 256 — Five-Sqrt × Thirty-Four-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK256r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs36k, k] };
@@ -20183,8 +20183,8 @@ describe("Phase 257 — Thirty-Five-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK257r = { kind: "apply" as const, head: MUL, args: [...logs36k, k] };
     const numKp1257r = { kind: "apply" as const, head: MUL, args: [...logs36kp1, kp1] };
     const gK257r = { kind: "apply" as const, head: DIV, args: [numK257r, k2] };
@@ -20237,8 +20237,8 @@ describe("Phase 258 — One-Sqrt × Thirty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK258r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs36k, k] };
@@ -20293,8 +20293,8 @@ describe("Phase 259 — Two-Sqrt × Thirty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK259r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs36k, k] };
@@ -20349,8 +20349,8 @@ describe("Phase 260 — Three-Sqrt × Thirty-Five-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK260r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs36k, k] };
@@ -20405,8 +20405,8 @@ describe("Phase 261 — Four-Sqrt × Thirty-Five-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK261r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs36k, k] };
@@ -20461,8 +20461,8 @@ describe("Phase 262 — Five-Sqrt × Thirty-Five-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK262r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs36k, k] };
@@ -20513,8 +20513,8 @@ describe("Phase 263 — Zero-Sqrt × Thirty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK263r = { kind: "apply" as const, head: MUL, args: [...logs37k, k] };
     const numKp1263r = { kind: "apply" as const, head: MUL, args: [...logs37kp1, kp1] };
     const gK263r = { kind: "apply" as const, head: DIV, args: [numK263r, k2] };
@@ -20567,8 +20567,8 @@ describe("Phase 264 — One-Sqrt × Thirty-Six-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK264r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs37k, k] };
@@ -20623,8 +20623,8 @@ describe("Phase 265 — Two-Sqrt × Thirty-Six-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK265r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs37k] };
@@ -20679,8 +20679,8 @@ describe("Phase 266 — Three-Sqrt × Thirty-Six-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK266r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs37k] };
@@ -20735,8 +20735,8 @@ describe("Phase 267 — Four-Sqrt × Thirty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK267r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs37k, k] };
@@ -20791,8 +20791,8 @@ describe("Phase 268 — Five-Sqrt × Thirty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK268r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs37k, k] };
@@ -20843,8 +20843,8 @@ describe("Phase 269 — Zero-Sqrt × Thirty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs38k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs38kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs38k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK269r = { kind: "apply" as const, head: MUL, args: [...logs38k, k] };
     const numKp1269r = { kind: "apply" as const, head: MUL, args: [...logs38kp1, kp1] };
     const gK269r = { kind: "apply" as const, head: DIV, args: [numK269r, k2] };
@@ -20897,8 +20897,8 @@ describe("Phase 270 — One-Sqrt × Thirty-Seven-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs38k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs38kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs38k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK270r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs38k, k] };
@@ -20953,8 +20953,8 @@ describe("Phase 271 — Two-Sqrt × Thirty-Seven-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs38k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs38kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs38k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK271r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs38k, k] };
@@ -21009,8 +21009,8 @@ describe("Phase 272 — Three-Sqrt × Thirty-Seven-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs38k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs38kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs38k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK272r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs38k, k] };
@@ -21065,8 +21065,8 @@ describe("Phase 273 — Four-Sqrt × Thirty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs38k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs38kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs38k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK273r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs38k, k] };
@@ -21121,8 +21121,8 @@ describe("Phase 274 — Five-Sqrt × Thirty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs38k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs38kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs38k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK274r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs38k, k] };
@@ -21173,8 +21173,8 @@ describe("Phase 275 — Zero-Sqrt × Thirty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs39k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs39kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs39k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs39kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK275r = { kind: "apply" as const, head: MUL, args: [...logs39k, k] };
     const numKp1275r = { kind: "apply" as const, head: MUL, args: [...logs39kp1, kp1] };
     const gK275r = { kind: "apply" as const, head: DIV, args: [numK275r, k2] };
@@ -21227,8 +21227,8 @@ describe("Phase 276 — One-Sqrt × Thirty-Eight-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs39k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs39kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs39k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs39kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK276r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs39k, k] };
@@ -21283,8 +21283,8 @@ describe("Phase 277 — Two-Sqrt × Thirty-Eight-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs39k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs39kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs39k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs39kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK277r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs39k, k] };
@@ -21339,8 +21339,8 @@ describe("Phase 278 — Three-Sqrt × Thirty-Eight-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs39k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs39kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs39k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs39kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK278r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs39k, k] };
@@ -21395,8 +21395,8 @@ describe("Phase 279 — Four-Sqrt × Thirty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs39k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs39kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs39k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs39kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK279r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs39k, k] };
@@ -21451,8 +21451,8 @@ describe("Phase 280 — Five-Sqrt × Thirty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs39k = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs39kp1 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs39k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs39kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK280r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs39k, k] };
@@ -21504,8 +21504,8 @@ describe("Phase 281 — Zero-Sqrt × Thirty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs40k281 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs40kp1281 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs40k281 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1281 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK281r = { kind: "apply" as const, head: MUL, args: [...logs40k281, k] };
     const numKp1281r = { kind: "apply" as const, head: MUL, args: [...logs40kp1281, kp1] };
     const gK281r = { kind: "apply" as const, head: DIV, args: [numK281r, k2r] };
@@ -21558,8 +21558,8 @@ describe("Phase 282 — One-Sqrt × Thirty-Nine-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs40k282 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs40kp1282 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs40k282 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1282 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK282r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs40k282, k] };
@@ -21614,8 +21614,8 @@ describe("Phase 283 — Two-Sqrt × Thirty-Nine-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs40k283 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs40kp1283 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs40k283 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1283 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK283r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs40k283, k] };
@@ -21670,8 +21670,8 @@ describe("Phase 284 — Three-Sqrt × Thirty-Nine-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs40k284 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs40kp1284 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs40k284 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1284 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK284r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs40k284, k] };
@@ -21726,8 +21726,8 @@ describe("Phase 285 — Four-Sqrt × Thirty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs40k285 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs40kp1285 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs40k285 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1285 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK285r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs40k285, k] };
@@ -21782,8 +21782,8 @@ describe("Phase 286 — Five-Sqrt × Thirty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs40k286 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs40kp1286 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs40k286 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1286 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK286r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs40k286, k] };
@@ -21834,8 +21834,8 @@ describe("Phase 287 — Zero-Sqrt × Forty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k287 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1287 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k287 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1287 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK287r = { kind: "apply" as const, head: MUL, args: [...logs42k287, k] };
     const numKp1287r = { kind: "apply" as const, head: MUL, args: [...logs42kp1287, kp1] };
     const gK287r = { kind: "apply" as const, head: DIV, args: [numK287r, k2r] };
@@ -21888,8 +21888,8 @@ describe("Phase 288 — One-Sqrt × Forty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k288 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1288 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k288 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1288 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK288r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs42k288, k] };
@@ -21944,8 +21944,8 @@ describe("Phase 289 — Two-Sqrt × Forty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k289 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1289 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k289 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1289 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK289r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs42k289, k] };
@@ -22000,8 +22000,8 @@ describe("Phase 290 — Three-Sqrt × Forty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k290 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1290 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k290 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1290 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK290r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs42k290, k] };
@@ -22056,8 +22056,8 @@ describe("Phase 291 — Four-Sqrt × Forty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k291 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1291 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k291 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1291 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK291r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs42k291, k] };
@@ -22112,8 +22112,8 @@ describe("Phase 292 — Five-Sqrt × Forty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k292 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1292 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k292 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1292 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK292r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs42k292, k] };
@@ -22164,8 +22164,8 @@ describe("Phase 293 — Zero-Sqrt × Forty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k293 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1293 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k293 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1293 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK293r = { kind: "apply" as const, head: MUL, args: [...logs42k293, k] };
     const numKp1293r = { kind: "apply" as const, head: MUL, args: [...logs42kp1293, kp1] };
     const gK293r = { kind: "apply" as const, head: DIV, args: [numK293r, k2r] };
@@ -22200,8 +22200,8 @@ describe("Phase 294 — One-Sqrt × Forty-One-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k294 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1294 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k294 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1294 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK294r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs42k294, k] };
@@ -22238,8 +22238,8 @@ describe("Phase 295 — Two-Sqrt × Forty-One-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k295 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1295 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k295 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1295 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK295r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs42k295, k] };
@@ -22276,8 +22276,8 @@ describe("Phase 296 — Three-Sqrt × Forty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k296 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1296 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k296 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1296 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK296r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs42k296, k] };
@@ -22314,8 +22314,8 @@ describe("Phase 297 — Four-Sqrt × Forty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k297 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1297 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k297 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1297 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK297r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs42k297, k] };
@@ -22352,8 +22352,8 @@ describe("Phase 298 — Five-Sqrt × Forty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k298 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1298 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k298 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1298 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK298r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs42k298, k] };
@@ -22388,8 +22388,8 @@ describe("Phase 299 — Zero-Sqrt × Forty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k299 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1299 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k299 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1299 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK299r = { kind: "apply" as const, head: MUL, args: [...logs44k299, k] };
     const numKp1299r = { kind: "apply" as const, head: MUL, args: [...logs44kp1299, kp1] };
     const gK299r = { kind: "apply" as const, head: DIV, args: [numK299r, k2r] };
@@ -22424,8 +22424,8 @@ describe("Phase 300 — One-Sqrt × Forty-Two-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k300 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1300 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k300 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1300 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK300r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs44k300, k] };
@@ -22462,8 +22462,8 @@ describe("Phase 301 — Two-Sqrt × Forty-Two-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k301 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1301 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k301 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1301 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK301r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs44k301, k] };
@@ -22500,8 +22500,8 @@ describe("Phase 302 — Three-Sqrt × Forty-Two-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k302 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1302 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k302 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1302 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK302r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs44k302, k] };
@@ -22538,8 +22538,8 @@ describe("Phase 303 — Four-Sqrt × Forty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k303 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1303 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k303 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1303 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK303r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs44k303, k] };
@@ -22576,8 +22576,8 @@ describe("Phase 304 — Five-Sqrt × Forty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k304 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1304 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k304 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1304 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK304r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs44k304, k] };
@@ -22612,8 +22612,8 @@ describe("Phase 305 — Zero-Sqrt × Forty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k305 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1305 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k305 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1305 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK305r = { kind: "apply" as const, head: MUL, args: [...logs44k305, k] };
     const numKp1305r = { kind: "apply" as const, head: MUL, args: [...logs44kp1305, kp1] };
     const gK305r = { kind: "apply" as const, head: DIV, args: [numK305r, k2r] };
@@ -22648,8 +22648,8 @@ describe("Phase 306 — One-Sqrt × Forty-Three-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k306 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1306 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k306 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1306 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK306r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs44k306, k] };
@@ -22686,8 +22686,8 @@ describe("Phase 307 — Two-Sqrt × Forty-Three-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k307 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1307 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k307 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1307 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK307r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs44k307, k] };
@@ -22724,8 +22724,8 @@ describe("Phase 308 — Three-Sqrt × Forty-Three-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1, kp1] };
-    const logs44k308 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1308 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k308 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1308 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK308r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs44k308, k] };
@@ -22762,8 +22762,8 @@ describe("Phase 309 — Four-Sqrt × Forty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1, kp1] };
-    const logs44k309 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1309 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k309 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1309 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK309r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs44k309, k] };
@@ -22800,8 +22800,8 @@ describe("Phase 310 — Five-Sqrt × Forty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k310 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1310 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k310 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1310 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK310r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs44k310, k] };
@@ -22836,8 +22836,8 @@ describe("Phase 311 — Forty-Four-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs45k311 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs45kp1311 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs45k311 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs45kp1311 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK311r = { kind: "apply" as const, head: MUL, args: [...logs45k311, k] };
     const numKp1311r = { kind: "apply" as const, head: MUL, args: [...logs45kp1311, kp1] };
     const gK311r = { kind: "apply" as const, head: DIV, args: [numK311r, k2r] };
@@ -22872,8 +22872,8 @@ describe("Phase 312 — One-Sqrt × Forty-Four-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs45k312 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs45kp1312 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs45k312 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs45kp1312 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK312r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs45k312, k] };
@@ -22910,8 +22910,8 @@ describe("Phase 313 — Two-Sqrt × Forty-Four-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs45k313 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs45kp1313 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs45k313 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs45kp1313 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK313r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs45k313, k] };
@@ -22948,8 +22948,8 @@ describe("Phase 314 — Three-Sqrt × Forty-Four-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs45k314 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs45kp1314 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs45k314 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs45kp1314 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK314r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs45k314, k] };
@@ -22986,8 +22986,8 @@ describe("Phase 315 — Four-Sqrt × Forty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs45k315 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs45kp1315 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs45k315 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs45kp1315 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK315r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs45k315, k] };
@@ -23024,8 +23024,8 @@ describe("Phase 316 — Five-Sqrt × Forty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs45k316 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs45kp1316 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs45k316 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs45kp1316 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK316r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs45k316, k] };
@@ -23060,8 +23060,8 @@ describe("Phase 317 — Forty-Five-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs46k317 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs46kp1317 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs46k317 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs46kp1317 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK317r = { kind: "apply" as const, head: MUL, args: [...logs46k317, k] };
     const numKp1317r = { kind: "apply" as const, head: MUL, args: [...logs46kp1317, kp1] };
     const gK317r = { kind: "apply" as const, head: DIV, args: [numK317r, k2r] };
@@ -23096,8 +23096,8 @@ describe("Phase 318 — One-Sqrt × Forty-Five-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs46k318 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs46kp1318 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs46k318 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs46kp1318 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK318r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs46k318, k] };
@@ -23134,8 +23134,8 @@ describe("Phase 319 — Two-Sqrt × Forty-Five-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs46k319 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs46kp1319 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs46k319 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs46kp1319 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK319r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs46k319, k] };
@@ -23172,8 +23172,8 @@ describe("Phase 320 — Three-Sqrt × Forty-Five-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs46k320 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs46kp1320 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs46k320 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs46kp1320 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK320r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs46k320, k] };
@@ -23210,8 +23210,8 @@ describe("Phase 321 — Four-Sqrt × Forty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs46k321 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs46kp1321 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs46k321 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs46kp1321 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK321r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs46k321, k] };
@@ -23248,8 +23248,8 @@ describe("Phase 322 — Five-Sqrt × Forty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs46k322 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs46kp1322 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs46k322 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs46kp1322 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK322r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs46k322, k] };
@@ -23284,8 +23284,8 @@ describe("Phase 323 — Forty-Six-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs47k323 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs47kp1323 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs47k323 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs47kp1323 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK323r = { kind: "apply" as const, head: MUL, args: [...logs47k323, k] };
     const numKp1323r = { kind: "apply" as const, head: MUL, args: [...logs47kp1323, kp1] };
     const gK323r = { kind: "apply" as const, head: DIV, args: [numK323r, k2r] };
@@ -23320,8 +23320,8 @@ describe("Phase 324 — One-Sqrt × Forty-Six-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs47k324 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs47kp1324 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs47k324 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs47kp1324 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK324r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs47k324, k] };
@@ -23358,8 +23358,8 @@ describe("Phase 325 — Two-Sqrt × Forty-Six-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs47k325 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs47kp1325 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs47k325 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs47kp1325 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK325r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs47k325, k] };
@@ -23396,8 +23396,8 @@ describe("Phase 326 — Three-Sqrt × Forty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs47k326 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs47kp1326 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs47k326 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs47kp1326 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK326r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs47k326, k] };
@@ -23434,8 +23434,8 @@ describe("Phase 327 — Four-Sqrt × Forty-Six-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs47k327 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs47kp1327 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs47k327 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs47kp1327 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK327r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs47k327, k] };
@@ -23472,8 +23472,8 @@ describe("Phase 328 — Five-Sqrt × Forty-Six-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs47k328 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs47kp1328 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs47k328 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs47kp1328 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK328r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs47k328, k] };
@@ -23508,8 +23508,8 @@ describe("Phase 329 — Forty-Seven-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k329 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1329 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k329 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1329 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK329r = { kind: "apply" as const, head: MUL, args: [...logs49k329, k] };
     const numKp1329r = { kind: "apply" as const, head: MUL, args: [...logs49kp1329, kp1] };
     const gK329r = { kind: "apply" as const, head: DIV, args: [numK329r, k2r] };
@@ -23544,8 +23544,8 @@ describe("Phase 330 — One-Sqrt × Forty-Seven-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k330 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1330 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k330 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1330 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK330r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs49k330, k] };
@@ -23582,8 +23582,8 @@ describe("Phase 331 — Two-Sqrt × Forty-Seven-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k331 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1331 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k331 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1331 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK331r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs49k331, k] };
@@ -23620,8 +23620,8 @@ describe("Phase 332 — Three-Sqrt × Forty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k332 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1332 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k332 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1332 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK332r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs49k332, k] };
@@ -23658,8 +23658,8 @@ describe("Phase 333 — Four-Sqrt × Forty-Seven-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k333 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1333 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k333 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1333 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK333r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs49k333, k] };
@@ -23696,8 +23696,8 @@ describe("Phase 334 — Five-Sqrt × Forty-Seven-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k334 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1334 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k334 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1334 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK334r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs49k334, k] };
@@ -23727,13 +23727,13 @@ describe("Phase 335 — Zero-Sqrt × Forty-Eight-Log × polynomial numerator", (
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("log(k)⁵¹·k/k² refused (53 logs — not Phase 359)", () => {
+  it("log(k)⁵¹·k/k² refused (54 logs — not Phase 365)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k335 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1335 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k335 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1335 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK335r = { kind: "apply" as const, head: MUL, args: [...logs49k335, k] };
     const numKp1335r = { kind: "apply" as const, head: MUL, args: [...logs49kp1335, kp1] };
     const gK335r = { kind: "apply" as const, head: DIV, args: [numK335r, k2r] };
@@ -23763,13 +23763,13 @@ describe("Phase 336 — One-Sqrt × Forty-Eight-Log × polynomial numerator", ()
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("√k·log(k)⁵¹·k/k² refused (53 logs — not Phase 360)", () => {
+  it("√k·log(k)⁵¹·k/k² refused (54 logs — not Phase 366)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k336 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1336 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k336 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1336 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK336r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs49k336, k] };
@@ -23801,13 +23801,13 @@ describe("Phase 337 — Two-Sqrt × Forty-Eight-Log × polynomial numerator", ()
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)²·log(k)⁵¹·k/k² refused (53 logs — not Phase 361)", () => {
+  it("(√k)²·log(k)⁵¹·k/k² refused (54 logs — not Phase 367)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k337 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1337 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k337 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1337 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK337r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs49k337, k] };
@@ -23839,13 +23839,13 @@ describe("Phase 338 — Three-Sqrt × Forty-Eight-Log × polynomial numerator", 
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)³·log(k)⁵¹·k/k³ refused (53 logs — not Phase 362)", () => {
+  it("(√k)³·log(k)⁵¹·k/k³ refused (54 logs — not Phase 368)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k338 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1338 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k338 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1338 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK338r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs49k338, k] };
@@ -23877,13 +23877,13 @@ describe("Phase 339 — Four-Sqrt × Forty-Eight-Log × polynomial numerator", (
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)⁴·log(k)⁵¹·k/k³ refused (53 logs — not Phase 363)", () => {
+  it("(√k)⁴·log(k)⁵¹·k/k³ refused (54 logs — not Phase 369)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k339 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1339 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k339 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1339 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK339r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs49k339, k] };
@@ -23915,13 +23915,13 @@ describe("Phase 340 — Five-Sqrt × Forty-Eight-Log × polynomial numerator", (
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)^5·log(k)⁵¹·k/k³ refused (53 logs — not Phase 364)", () => {
+  it("(√k)^5·log(k)⁵¹·k/k³ refused (54 logs — not Phase 370)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k340 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1340 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k340 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1340 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK340r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs49k340, k] };
@@ -23951,13 +23951,13 @@ describe("Phase 341 — Zero-Sqrt × Forty-Nine-Log × polynomial numerator", ()
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("log(k)⁵¹·k/k² refused (53 logs — not Phase 359)", () => {
+  it("log(k)⁵¹·k/k² refused (54 logs — not Phase 365)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k341 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1341 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k341 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1341 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK341r = { kind: "apply" as const, head: MUL, args: [...logs51k341, k] };
     const numKp1341r = { kind: "apply" as const, head: MUL, args: [...logs51kp1341, kp1] };
     const gK341r = { kind: "apply" as const, head: DIV, args: [numK341r, k2r] };
@@ -23987,13 +23987,13 @@ describe("Phase 342 — One-Sqrt × Forty-Nine-Log × polynomial numerator", () 
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("√k·log(k)⁵¹·k/k² refused (53 logs — not Phase 360)", () => {
+  it("√k·log(k)⁵¹·k/k² refused (54 logs — not Phase 366)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k342 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1342 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k342 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1342 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK342r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs51k342, k] };
@@ -24025,13 +24025,13 @@ describe("Phase 343 — Two-Sqrt × Forty-Nine-Log × polynomial numerator", () 
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)²·log(k)⁵¹·k/k² refused (53 logs — not Phase 361)", () => {
+  it("(√k)²·log(k)⁵¹·k/k² refused (54 logs — not Phase 367)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k343 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1343 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k343 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1343 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK343r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs51k343, k] };
@@ -24063,13 +24063,13 @@ describe("Phase 344 — Three-Sqrt × Forty-Nine-Log × polynomial numerator", (
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)³·log(k)⁵¹·k/k³ refused (53 logs — not Phase 362)", () => {
+  it("(√k)³·log(k)⁵¹·k/k³ refused (54 logs — not Phase 368)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k344 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1344 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k344 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1344 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK344r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs51k344, k] };
@@ -24101,13 +24101,13 @@ describe("Phase 345 — Four-Sqrt × Forty-Nine-Log × polynomial numerator", ()
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)⁴·log(k)⁵¹·k/k³ refused (53 logs — not Phase 363)", () => {
+  it("(√k)⁴·log(k)⁵¹·k/k³ refused (54 logs — not Phase 369)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k345 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1345 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k345 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1345 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK345r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs51k345, k] };
@@ -24139,13 +24139,13 @@ describe("Phase 346 — Five-Sqrt × Forty-Nine-Log × polynomial numerator", ()
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)^5·log(k)⁵¹·k/k³ refused (53 logs — not Phase 364)", () => {
+  it("(√k)^5·log(k)⁵¹·k/k³ refused (54 logs — not Phase 370)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k346 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1346 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k346 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1346 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK346r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs51k346, k] };
@@ -24175,13 +24175,13 @@ describe("Phase 347 — Zero-Sqrt × Fifty-Log × polynomial numerator", () => {
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("log(k)⁵¹·k/k² refused (53 logs — not Phase 359)", () => {
+  it("log(k)⁵¹·k/k² refused (54 logs — not Phase 365)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k347 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1347 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k347 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1347 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK347r = { kind: "apply" as const, head: MUL, args: [...logs51k347, k] };
     const numKp1347r = { kind: "apply" as const, head: MUL, args: [...logs51kp1347, kp1] };
     const gK347r = { kind: "apply" as const, head: DIV, args: [numK347r, k2r] };
@@ -24211,13 +24211,13 @@ describe("Phase 348 — One-Sqrt × Fifty-Log × polynomial numerator", () => {
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("√k·log(k)⁵¹·k/k² refused (53 logs — not Phase 360)", () => {
+  it("√k·log(k)⁵¹·k/k² refused (54 logs — not Phase 366)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k348 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1348 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k348 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1348 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK348r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs51k348, k] };
@@ -24249,13 +24249,13 @@ describe("Phase 349 — Two-Sqrt × Fifty-Log × polynomial numerator", () => {
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)²·log(k)⁵¹·k/k² refused (53 logs — not Phase 361)", () => {
+  it("(√k)²·log(k)⁵¹·k/k² refused (54 logs — not Phase 367)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k349 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1349 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k349 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1349 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK349r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs51k349, k] };
@@ -24287,13 +24287,13 @@ describe("Phase 350 — Three-Sqrt × Fifty-Log × polynomial numerator", () => 
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)³·log(k)⁵¹·k/k³ refused (53 logs — not Phase 362)", () => {
+  it("(√k)³·log(k)⁵¹·k/k³ refused (54 logs — not Phase 368)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k350 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1350 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k350 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1350 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK350r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs51k350, k] };
@@ -24325,13 +24325,13 @@ describe("Phase 351 — Four-Sqrt × Fifty-Log × polynomial numerator", () => {
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)⁴·log(k)⁵¹·k/k³ refused (53 logs — not Phase 363)", () => {
+  it("(√k)⁴·log(k)⁵¹·k/k³ refused (54 logs — not Phase 369)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k351 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1351 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k351 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1351 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK351r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs51k351, k] };
@@ -24363,13 +24363,13 @@ describe("Phase 352 — Five-Sqrt × Fifty-Log × polynomial numerator", () => {
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)^5·log(k)⁵¹·k/k³ refused (53 logs — not Phase 364)", () => {
+  it("(√k)^5·log(k)⁵¹·k/k³ refused (54 logs — not Phase 370)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k352 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1352 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k352 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1352 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK352r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs51k352, k] };
@@ -24400,13 +24400,13 @@ describe("Phase 353 — Zero-Sqrt × Fifty-One-Log × polynomial numerator", () 
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("log(k)⁵²·k/k² refused (53 logs — not Phase 359)", () => {
+  it("log(k)⁵²·k/k² refused (54 logs — not Phase 365)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs52k353 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs52kp1353 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs52k353 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs52kp1353 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK353r = { kind: "apply" as const, head: MUL, args: [...logs52k353, k] };
     const numKp1353r = { kind: "apply" as const, head: MUL, args: [...logs52kp1353, kp1] };
     const gK353r = { kind: "apply" as const, head: DIV, args: [numK353r, k2r] };
@@ -24436,13 +24436,13 @@ describe("Phase 354 — One-Sqrt × Fifty-One-Log × polynomial numerator", () =
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("√k·log(k)⁵²·k/k² refused (53 logs — not Phase 360)", () => {
+  it("√k·log(k)⁵²·k/k² refused (54 logs — not Phase 366)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs52k354 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs52kp1354 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs52k354 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs52kp1354 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK354r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs52k354, k] };
@@ -24474,13 +24474,13 @@ describe("Phase 355 — Two-Sqrt × Fifty-One-Log × polynomial numerator", () =
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)²·log(k)⁵²·k/k² refused (53 logs — not Phase 361)", () => {
+  it("(√k)²·log(k)⁵²·k/k² refused (54 logs — not Phase 367)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs52k355 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs52kp1355 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs52k355 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs52kp1355 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK355r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs52k355, k] };
@@ -24512,13 +24512,13 @@ describe("Phase 356 — Three-Sqrt × Fifty-One-Log × polynomial numerator", ()
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)³·log(k)⁵²·k/k³ refused (53 logs — not Phase 362)", () => {
+  it("(√k)³·log(k)⁵²·k/k³ refused (54 logs — not Phase 368)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs52k356 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs52kp1356 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs52k356 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs52kp1356 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK356r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs52k356, k] };
@@ -24550,13 +24550,13 @@ describe("Phase 357 — Four-Sqrt × Fifty-One-Log × polynomial numerator", () 
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)⁴·log(k)⁵²·k/k³ refused (53 logs — not Phase 363)", () => {
+  it("(√k)⁴·log(k)⁵²·k/k³ refused (54 logs — not Phase 369)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs52k357 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs52kp1357 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs52k357 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs52kp1357 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK357r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs52k357, k] };
@@ -24588,13 +24588,13 @@ describe("Phase 358 — Five-Sqrt × Fifty-One-Log × polynomial numerator", () 
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)^5·log(k)⁵²·k/k³ refused (53 logs — not Phase 364)", () => {
+  it("(√k)^5·log(k)⁵²·k/k³ refused (54 logs — not Phase 370)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs52k358 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs52kp1358 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs52k358 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs52kp1358 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK358r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs52k358, k] };
@@ -24624,13 +24624,13 @@ describe("Phase 359 — Zero-Sqrt × Fifty-Two-Log × polynomial numerator", () 
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("log(k)⁵³·k/k² refused (53 logs — not Phase 359)", () => {
+  it("log(k)⁵³·k/k² refused (54 logs — not Phase 365)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs53k359 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs53kp1359 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs53k359 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs53kp1359 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK359r = { kind: "apply" as const, head: MUL, args: [...logs53k359, k] };
     const numKp1359r = { kind: "apply" as const, head: MUL, args: [...logs53kp1359, kp1] };
     const gK359r = { kind: "apply" as const, head: DIV, args: [numK359r, k2r] };
@@ -24660,13 +24660,13 @@ describe("Phase 360 — One-Sqrt × Fifty-Two-Log × polynomial numerator", () =
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("√k·log(k)⁵³·k/k² refused (53 logs — not Phase 360)", () => {
+  it("√k·log(k)⁵³·k/k² refused (54 logs — not Phase 366)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs53k360 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs53kp1360 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs53k360 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs53kp1360 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK360r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs53k360, k] };
@@ -24698,13 +24698,13 @@ describe("Phase 361 — Two-Sqrt × Fifty-Two-Log × polynomial numerator", () =
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)²·log(k)⁵³·k/k³ refused (53 logs — not Phase 361)", () => {
+  it("(√k)²·log(k)⁵³·k/k³ refused (54 logs — not Phase 367)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs53k361 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs53kp1361 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs53k361 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs53kp1361 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK361r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs53k361, k] };
@@ -24736,13 +24736,13 @@ describe("Phase 362 — Three-Sqrt × Fifty-Two-Log × polynomial numerator", ()
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)³·log(k)⁵³·k/k³ refused (53 logs — not Phase 362)", () => {
+  it("(√k)³·log(k)⁵³·k/k³ refused (54 logs — not Phase 368)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs53k362 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs53kp1362 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs53k362 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs53kp1362 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK362r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs53k362, k] };
@@ -24774,13 +24774,13 @@ describe("Phase 363 — Four-Sqrt × Fifty-Two-Log × polynomial numerator", () 
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)⁴·log(k)⁵³·k/k³ refused (53 logs — not Phase 363)", () => {
+  it("(√k)⁴·log(k)⁵³·k/k³ refused (54 logs — not Phase 369)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs53k363 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs53kp1363 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs53k363 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs53kp1363 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK363r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs53k363, k] };
@@ -24812,13 +24812,13 @@ describe("Phase 364 — Five-Sqrt × Fifty-Two-Log × polynomial numerator", () 
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)^5·log(k)⁵³·k/k³ refused (53 logs — not Phase 364)", () => {
+  it("(√k)^5·log(k)⁵³·k/k³ refused (54 logs — not Phase 370)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs53k364 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs53kp1364 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs53k364 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs53kp1364 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK364r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs53k364, k] };
@@ -24827,6 +24827,230 @@ describe("Phase 364 — Five-Sqrt × Fifty-Two-Log × polynomial numerator", () 
     const gKp1364r = { kind: "apply" as const, head: DIV, args: [numKp1364r, kp1_3r] };
     const f364r = { kind: "apply" as const, head: SUB, args: [gK364r, gKp1364r] };
     const result = evaluateSum(f364r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 365 — Zero-Sqrt × Fifty-Three-Log × polynomial numerator", () => {
+  it("log(k)⁵³·k/k² closes (polyDeg=1 → effective=1; denDeg=2 > 1)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const logs53k365 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs53kp1365 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const numK365a = { kind: "apply" as const, head: MUL, args: [...logs53k365, k] };
+    const numKp1365a = { kind: "apply" as const, head: MUL, args: [...logs53kp1365, kp1] };
+    const gK365a = { kind: "apply" as const, head: DIV, args: [numK365a, k2] };
+    const gKp1365a = { kind: "apply" as const, head: DIV, args: [numKp1365a, kp1_2] };
+    const f365a = { kind: "apply" as const, head: SUB, args: [gK365a, gKp1365a] };
+    const result = evaluateSum(f365a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("log(k)⁵³·k/k² refused (54 logs — not Phase 365)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs54k365 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs54kp1365 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const numK365r = { kind: "apply" as const, head: MUL, args: [...logs54k365, k] };
+    const numKp1365r = { kind: "apply" as const, head: MUL, args: [...logs54kp1365, kp1] };
+    const gK365r = { kind: "apply" as const, head: DIV, args: [numK365r, k2r] };
+    const gKp1365r = { kind: "apply" as const, head: DIV, args: [numKp1365r, kp1_2r] };
+    const f365r = { kind: "apply" as const, head: SUB, args: [gK365r, gKp1365r] };
+    const result = evaluateSum(f365r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 366 — One-Sqrt × Fifty-Three-Log × polynomial numerator", () => {
+  it("√k·log(k)⁵³·k/k² closes (sqrtHalf=0.5, polyDeg=1 → effective=1.5; denDeg=2 > 1.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const logs53k366 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs53kp1366 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK366a = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs53k366, k] };
+    const numKp1366a = { kind: "apply" as const, head: MUL, args: [sqrtKp1, ...logs53kp1366, kp1] };
+    const gK366a = { kind: "apply" as const, head: DIV, args: [numK366a, k2] };
+    const gKp1366a = { kind: "apply" as const, head: DIV, args: [numKp1366a, kp1_2] };
+    const f366a = { kind: "apply" as const, head: SUB, args: [gK366a, gKp1366a] };
+    const result = evaluateSum(f366a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("√k·log(k)⁵³·k/k² refused (54 logs — not Phase 366)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs54k366 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs54kp1366 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK366r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs54k366, k] };
+    const numKp1366r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, ...logs54kp1366, kp1] };
+    const gK366r = { kind: "apply" as const, head: DIV, args: [numK366r, k2r] };
+    const gKp1366r = { kind: "apply" as const, head: DIV, args: [numKp1366r, kp1_2r] };
+    const f366r = { kind: "apply" as const, head: SUB, args: [gK366r, gKp1366r] };
+    const result = evaluateSum(f366r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 367 — Two-Sqrt × Fifty-Three-Log × polynomial numerator", () => {
+  it("(√k)²·log(k)⁵³·k/k³ closes (sqrtHalf=1.0, polyDeg=1 → effective=2; denDeg=3 > 2)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const logs53k367 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs53kp1367 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK367a = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs53k367, k] };
+    const numKp1367a = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, ...logs53kp1367, kp1] };
+    const gK367a = { kind: "apply" as const, head: DIV, args: [numK367a, k3] };
+    const gKp1367a = { kind: "apply" as const, head: DIV, args: [numKp1367a, kp1_3] };
+    const f367a = { kind: "apply" as const, head: SUB, args: [gK367a, gKp1367a] };
+    const result = evaluateSum(f367a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("(√k)²·log(k)⁵³·k/k² refused (54 logs — not Phase 367)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs54k367 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs54kp1367 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK367r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs54k367, k] };
+    const numKp1367r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, ...logs54kp1367, kp1] };
+    const gK367r = { kind: "apply" as const, head: DIV, args: [numK367r, k2r] };
+    const gKp1367r = { kind: "apply" as const, head: DIV, args: [numKp1367r, kp1_2r] };
+    const f367r = { kind: "apply" as const, head: SUB, args: [gK367r, gKp1367r] };
+    const result = evaluateSum(f367r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 368 — Three-Sqrt × Fifty-Three-Log × polynomial numerator", () => {
+  it("(√k)³·log(k)⁵³·k/k³ closes (sqrtHalf=1.5, polyDeg=1 → effective=2.5; denDeg=3 > 2.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const logs53k368 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs53kp1368 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK368a = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs53k368, k] };
+    const numKp1368a = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, ...logs53kp1368, kp1] };
+    const gK368a = { kind: "apply" as const, head: DIV, args: [numK368a, k3] };
+    const gKp1368a = { kind: "apply" as const, head: DIV, args: [numKp1368a, kp1_3] };
+    const f368a = { kind: "apply" as const, head: SUB, args: [gK368a, gKp1368a] };
+    const result = evaluateSum(f368a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("(√k)³·log(k)⁵³·k/k³ refused (54 logs — not Phase 368)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs54k368 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs54kp1368 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK368r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs54k368, k] };
+    const numKp1368r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, ...logs54kp1368, kp1] };
+    const gK368r = { kind: "apply" as const, head: DIV, args: [numK368r, k3r] };
+    const gKp1368r = { kind: "apply" as const, head: DIV, args: [numKp1368r, kp1_3r] };
+    const f368r = { kind: "apply" as const, head: SUB, args: [gK368r, gKp1368r] };
+    const result = evaluateSum(f368r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 369 — Four-Sqrt × Fifty-Three-Log × polynomial numerator", () => {
+  it("(√k)⁴·log(k)⁵³·k/k⁴ closes (sqrtHalf=2.0, polyDeg=1 → effective=3; denDeg=4 > 3)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k4 = { kind: "apply" as const, head: POW, args: [k, int(4)] };
+    const kp1_4 = { kind: "apply" as const, head: POW, args: [kp1, int(4)] };
+    const logs53k369 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs53kp1369 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK369a = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs53k369, k] };
+    const numKp1369a = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, ...logs53kp1369, kp1] };
+    const gK369a = { kind: "apply" as const, head: DIV, args: [numK369a, k4] };
+    const gKp1369a = { kind: "apply" as const, head: DIV, args: [numKp1369a, kp1_4] };
+    const f369a = { kind: "apply" as const, head: SUB, args: [gK369a, gKp1369a] };
+    const result = evaluateSum(f369a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("(√k)⁴·log(k)⁵³·k/k³ refused (54 logs — not Phase 369)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs54k369 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs54kp1369 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK369r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs54k369, k] };
+    const numKp1369r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, ...logs54kp1369, kp1] };
+    const gK369r = { kind: "apply" as const, head: DIV, args: [numK369r, k3r] };
+    const gKp1369r = { kind: "apply" as const, head: DIV, args: [numKp1369r, kp1_3r] };
+    const f369r = { kind: "apply" as const, head: SUB, args: [gK369r, gKp1369r] };
+    const result = evaluateSum(f369r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 370 — Five-Sqrt × Fifty-Three-Log × polynomial numerator", () => {
+  it("(√k)^5·log(k)⁵³/k³ closes (sqrtHalf=2.5, polyDeg=0 → effective=2.5; denDeg=3 > 2.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const logs53k370 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs53kp1370 = Array.from({ length: 53 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK370a = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs53k370] };
+    const numKp1370a = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, ...logs53kp1370] };
+    const gK370a = { kind: "apply" as const, head: DIV, args: [numK370a, k3] };
+    const gKp1370a = { kind: "apply" as const, head: DIV, args: [numKp1370a, kp1_3] };
+    const f370a = { kind: "apply" as const, head: SUB, args: [gK370a, gKp1370a] };
+    const result = evaluateSum(f370a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("(√k)^5·log(k)⁵³/k³ refused (54 logs — not Phase 370)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs54k370 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs54kp1370 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK370r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs54k370] };
+    const numKp1370r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, ...logs54kp1370] };
+    const gK370r = { kind: "apply" as const, head: DIV, args: [numK370r, k3r] };
+    const gKp1370r = { kind: "apply" as const, head: DIV, args: [numKp1370r, kp1_3r] };
+    const f370r = { kind: "apply" as const, head: SUB, args: [gK370r, gKp1370r] };
+    const result = evaluateSum(f370r, k, int(1), sym("%inf"), evalNode);
     expect(result).toMatchObject({ kind: "apply", head: SUM });
   });
 });


### PR DESCRIPTION
## Summary

Adds Phase 365–370: the Fifty-Three-Log convergence recognizer family across Python, Rust, and TypeScript.

Each phase handles summands whose numerator contains exactly **53 logarithmic factors** and **0–5 square-root factors**.

### Phases
| Phase | Description |
|-------|-------------|
| 365 | Zero-Sqrt × Fifty-Three-Log × polynomial numerator |
| 366 | One-Sqrt × Fifty-Three-Log × polynomial numerator |
| 367 | Two-Sqrt × Fifty-Three-Log × polynomial numerator |
| 368 | Three-Sqrt × Fifty-Three-Log × polynomial numerator |
| 369 | Four-Sqrt × Fifty-Three-Log × polynomial numerator |
| 370 | Five-Sqrt × Fifty-Three-Log × polynomial numerator |

### Changes
- **Python**: +6 helpers + dispatch + 12 tests; cascade fix (53→54 logs); 1031 tests pass; 91% coverage
- **Rust**: +6 helpers + dispatch + cascade fix; 924 tests pass
- **TypeScript**: +6 helpers + dispatch + cascade fix; 942 tests pass
- Version bumped 2.301.0 → 2.307.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)