### PR TITLE
feat(cas-summation): add Phase 371-376 (Fifty-Four-Log family, v2.307.0→v2.313.0)

### DIFF
--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 2.313.0 — 2026-05-28
+
+### Added
+
+- **Phase 376 — Five-Sqrt × Fifty-Four-Log × polynomial** (`_five_sqrt_fifty_four_log_poly_effective_x2`):
+  Completes the Fifty-Four-Log family (Phases 371–376).
+- **Phase 375 — Four-Sqrt × Fifty-Four-Log × polynomial** (`_four_sqrt_fifty_four_log_poly_effective_x2`).
+- **Phase 374 — Three-Sqrt × Fifty-Four-Log × polynomial** (`_three_sqrt_fifty_four_log_poly_effective_x2`).
+- **Phase 373 — Two-Sqrt × Fifty-Four-Log × polynomial** (`_two_sqrt_fifty_four_log_poly_effective_x2`).
+- **Phase 372 — One-Sqrt × Fifty-Four-Log × polynomial** (`_one_sqrt_fifty_four_log_poly_effective_x2`).
+- **Phase 371 — Zero-Sqrt × Fifty-Four-Log × polynomial** (`_fifty_four_log_poly_effective_x2`).
+
+### Changed
+
+- Boundary tests in Phases 365–370 updated from 54-log "refused" to 55-log "refused"
+  now that Phases 371–376 handle exactly 54 logs.
+
 ## 2.307.0 — 2026-05-28
 
 ### Added

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "2.307.0"
+version = "2.313.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -1477,6 +1477,60 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
                 return True
         elif _h_diverges_at_infinity(den, k):
             return True
+    # Phase 376: ``Mul(Sqrt(P1)×5, Log(h1)×54, polynomial..., bounded...)`` numerator.
+    s5l54p_x2 = _five_sqrt_fifty_four_log_poly_effective_x2(num, k)
+    if s5l54p_x2 is not None:
+        den_deg_s5l54 = _polynomial_degree_in_k(den, k)
+        if den_deg_s5l54 is not None:
+            if 2 * den_deg_s5l54 > s5l54p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 375: ``Mul(Sqrt(P1)×4, Log(h1)×54, polynomial..., bounded...)`` numerator.
+    s4l54p_x2 = _four_sqrt_fifty_four_log_poly_effective_x2(num, k)
+    if s4l54p_x2 is not None:
+        den_deg_s4l54 = _polynomial_degree_in_k(den, k)
+        if den_deg_s4l54 is not None:
+            if 2 * den_deg_s4l54 > s4l54p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 374: ``Mul(Sqrt(P1)×3, Log(h1)×54, polynomial..., bounded...)`` numerator.
+    s3l54p_x2 = _three_sqrt_fifty_four_log_poly_effective_x2(num, k)
+    if s3l54p_x2 is not None:
+        den_deg_s3l54 = _polynomial_degree_in_k(den, k)
+        if den_deg_s3l54 is not None:
+            if 2 * den_deg_s3l54 > s3l54p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 373: ``Mul(Sqrt(P), Sqrt(P2), Log(h1)×54, polynomial..., bounded...)`` numerator.
+    s2l54p_x2 = _two_sqrt_fifty_four_log_poly_effective_x2(num, k)
+    if s2l54p_x2 is not None:
+        den_deg_s2l54 = _polynomial_degree_in_k(den, k)
+        if den_deg_s2l54 is not None:
+            if 2 * den_deg_s2l54 > s2l54p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 372: ``Mul(Sqrt(P), Log(h1)×54, polynomial..., bounded...)`` numerator.
+    s1l54p_x2 = _one_sqrt_fifty_four_log_poly_effective_x2(num, k)
+    if s1l54p_x2 is not None:
+        den_deg_s1l54 = _polynomial_degree_in_k(den, k)
+        if den_deg_s1l54 is not None:
+            if 2 * den_deg_s1l54 > s1l54p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 371: ``Mul(Log(h1)×54, polynomial..., bounded...)`` numerator.
+    sl54p_x2 = _fifty_four_log_poly_effective_x2(num, k)
+    if sl54p_x2 is not None:
+        den_deg_sl54 = _polynomial_degree_in_k(den, k)
+        if den_deg_sl54 is not None:
+            if 2 * den_deg_sl54 > sl54p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
     # Phase 370: ``Mul(Sqrt(P1)×5, Log(h1)×53, polynomial..., bounded...)`` numerator.
     s5l53p_x2 = _five_sqrt_fifty_three_log_poly_effective_x2(num, k)
     if s5l53p_x2 is not None:
@@ -13057,6 +13111,207 @@ def _five_sqrt_fifty_three_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> i
             continue
         return None
     if len(sqrt_degs_x2) != 5 or log_count != 53:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _fifty_four_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 371 — Zero-Sqrt × Fifty-Four-Log × polynomial numerator.
+
+    The Fifty-Four-Log family (Phases 371–376) extends the recogniser to
+    summands whose numerator contains exactly fifty-four logarithmic factors
+    and zero to five square-root factors.  This is Phase 371: zero sqrts.
+
+    Parameters
+    ----------
+    node : IRNode
+        The numerator node.
+    k : IRSymbol
+        The summation variable.
+
+    Returns
+    -------
+    int | None
+        ``2 * poly_deg_sum`` when the shape matches (always even); ``None``
+        when the pattern is not recognised.
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        if _sqrt_effective_half_degree_x2(arg, k) is not None:
+            return None
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 54:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if log_count != 54:
+        return None
+    return 2 * poly_deg_sum
+
+
+def _one_sqrt_fifty_four_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 372 — One-Sqrt × Fifty-Four-Log × polynomial numerator."""
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_deg_x2: int | None = None
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if sqrt_deg_x2 is not None:
+                return None
+            sqrt_deg_x2 = deg_x2
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 54:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if sqrt_deg_x2 is None or log_count != 54:
+        return None
+    return sqrt_deg_x2 + 2 * poly_deg_sum
+
+
+def _two_sqrt_fifty_four_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 373 — Two-Sqrt × Fifty-Four-Log × polynomial numerator."""
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 2:
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 54:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 2 or log_count != 54:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _three_sqrt_fifty_four_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 374 — Three-Sqrt × Fifty-Four-Log × polynomial numerator."""
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 3:
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 54:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 3 or log_count != 54:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _four_sqrt_fifty_four_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 375 — Four-Sqrt × Fifty-Four-Log × polynomial numerator."""
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 4:
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 54:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 4 or log_count != 54:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _five_sqrt_fifty_four_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 376 — Five-Sqrt × Fifty-Four-Log × polynomial numerator.
+    Completes the Fifty-Four-Log family (Phases 371-376).
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 5:
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 54:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 5 or log_count != 54:
         return None
     return sum(sqrt_degs_x2) + 2 * poly_deg_sum
 

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -17474,11 +17474,12 @@ class TestPhase203TwentySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -17515,11 +17516,12 @@ class TestPhase203TwentySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -17654,11 +17656,12 @@ class TestPhase204OneSqrtTwentySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -17696,11 +17699,12 @@ class TestPhase204OneSqrtTwentySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -17835,11 +17839,12 @@ class TestPhase205TwoSqrtTwentySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -17876,11 +17881,12 @@ class TestPhase205TwoSqrtTwentySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -18014,11 +18020,12 @@ class TestPhase206ThreeSqrtTwentySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -18055,11 +18062,12 @@ class TestPhase206ThreeSqrtTwentySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -18198,11 +18206,12 @@ class TestPhase207FourSqrtTwentySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -18240,11 +18249,12 @@ class TestPhase207FourSqrtTwentySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -18383,11 +18393,12 @@ class TestPhase208FiveSqrtTwentySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -18425,11 +18436,12 @@ class TestPhase208FiveSqrtTwentySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -18562,11 +18574,12 @@ class TestPhase209TwentySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -18603,11 +18616,12 @@ class TestPhase209TwentySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -18746,11 +18760,12 @@ class TestPhase210OneSqrtTwentySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -18788,11 +18803,12 @@ class TestPhase210OneSqrtTwentySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -18931,11 +18947,12 @@ class TestPhase211TwoSqrtTwentySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -18972,11 +18989,12 @@ class TestPhase211TwoSqrtTwentySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -19114,11 +19132,12 @@ class TestPhase212ThreeSqrtTwentySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -19155,11 +19174,12 @@ class TestPhase212ThreeSqrtTwentySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -19302,11 +19322,12 @@ class TestPhase213FourSqrtTwentySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -19344,11 +19365,12 @@ class TestPhase213FourSqrtTwentySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -19491,11 +19513,12 @@ class TestPhase214FiveSqrtTwentySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -19533,11 +19556,12 @@ class TestPhase214FiveSqrtTwentySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -19674,11 +19698,12 @@ class TestPhase215TwentyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -19715,11 +19740,12 @@ class TestPhase215TwentyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -19862,11 +19888,12 @@ class TestPhase216OneSqrtTwentyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -19904,11 +19931,12 @@ class TestPhase216OneSqrtTwentyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -20051,11 +20079,12 @@ class TestPhase217TwoSqrtTwentyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -20092,11 +20121,12 @@ class TestPhase217TwoSqrtTwentyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -20238,11 +20268,12 @@ class TestPhase218ThreeSqrtTwentyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -20279,11 +20310,12 @@ class TestPhase218ThreeSqrtTwentyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -20430,11 +20462,12 @@ class TestPhase219FourSqrtTwentyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -20472,11 +20505,12 @@ class TestPhase219FourSqrtTwentyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -20623,11 +20657,12 @@ class TestPhase220FiveSqrtTwentyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -20665,11 +20700,12 @@ class TestPhase220FiveSqrtTwentyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -20811,11 +20847,12 @@ class TestPhase221TwentyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -20852,11 +20889,12 @@ class TestPhase221TwentyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -21003,11 +21041,12 @@ class TestPhase222OneSqrtTwentyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -21045,11 +21084,12 @@ class TestPhase222OneSqrtTwentyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -21196,11 +21236,12 @@ class TestPhase223TwoSqrtTwentyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -21237,11 +21278,12 @@ class TestPhase223TwoSqrtTwentyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -21387,11 +21429,12 @@ class TestPhase224ThreeSqrtTwentyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -21428,11 +21471,12 @@ class TestPhase224ThreeSqrtTwentyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -21583,11 +21627,12 @@ class TestPhase225FourSqrtTwentyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -21625,11 +21670,12 @@ class TestPhase225FourSqrtTwentyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -21780,11 +21826,12 @@ class TestPhase226FiveSqrtTwentyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -21822,11 +21869,12 @@ class TestPhase226FiveSqrtTwentyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -21971,11 +22019,12 @@ class TestPhase227ThirtyLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -22012,11 +22061,12 @@ class TestPhase227ThirtyLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -22167,11 +22217,12 @@ class TestPhase228OneSqrtThirtyLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -22209,11 +22260,12 @@ class TestPhase228OneSqrtThirtyLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -22364,11 +22416,12 @@ class TestPhase229TwoSqrtThirtyLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -22405,11 +22458,12 @@ class TestPhase229TwoSqrtThirtyLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -22559,11 +22613,12 @@ class TestPhase230ThreeSqrtThirtyLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -22600,11 +22655,12 @@ class TestPhase230ThreeSqrtThirtyLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -22754,11 +22810,12 @@ class TestPhase231FourSqrtThirtyLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -22795,11 +22852,12 @@ class TestPhase231FourSqrtThirtyLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -22954,11 +23012,12 @@ class TestPhase232FiveSqrtThirtyLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -22996,11 +23055,12 @@ class TestPhase232FiveSqrtThirtyLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -23149,11 +23209,12 @@ class TestPhase233ThirtyOneLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -23190,11 +23251,12 @@ class TestPhase233ThirtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -23349,11 +23411,12 @@ class TestPhase234OneSqrtThirtyOneLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -23391,11 +23454,12 @@ class TestPhase234OneSqrtThirtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -23550,11 +23614,12 @@ class TestPhase235TwoSqrtThirtyOneLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -23591,11 +23656,12 @@ class TestPhase235TwoSqrtThirtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -23749,11 +23815,12 @@ class TestPhase236ThreeSqrtThirtyOneLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -23790,11 +23857,12 @@ class TestPhase236ThreeSqrtThirtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -23953,11 +24021,12 @@ class TestPhase237FourSqrtThirtyOneLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -23995,11 +24064,12 @@ class TestPhase237FourSqrtThirtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -24158,11 +24228,12 @@ class TestPhase238FiveSqrtThirtyOneLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -24200,11 +24271,12 @@ class TestPhase238FiveSqrtThirtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -24357,11 +24429,12 @@ class TestPhase239ThirtyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -24398,11 +24471,12 @@ class TestPhase239ThirtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -24561,11 +24635,12 @@ class TestPhase240OneSqrtThirtyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -24603,11 +24678,12 @@ class TestPhase240OneSqrtThirtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -24766,11 +24842,12 @@ class TestPhase241TwoSqrtThirtyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -24807,11 +24884,12 @@ class TestPhase241TwoSqrtThirtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -24969,11 +25047,12 @@ class TestPhase242ThreeSqrtThirtyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -25010,11 +25089,12 @@ class TestPhase242ThreeSqrtThirtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -25177,11 +25257,12 @@ class TestPhase243FourSqrtThirtyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -25219,11 +25300,12 @@ class TestPhase243FourSqrtThirtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -25386,11 +25468,12 @@ class TestPhase244FiveSqrtThirtyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -25428,11 +25511,12 @@ class TestPhase244FiveSqrtThirtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -25589,11 +25673,12 @@ class TestPhase245ThirtyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -25630,11 +25715,12 @@ class TestPhase245ThirtyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -25797,11 +25883,12 @@ class TestPhase246OneSqrtThirtyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -25839,11 +25926,12 @@ class TestPhase246OneSqrtThirtyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -26006,11 +26094,12 @@ class TestPhase247TwoSqrtThirtyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -26047,11 +26136,12 @@ class TestPhase247TwoSqrtThirtyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -26213,11 +26303,12 @@ class TestPhase248ThreeSqrtThirtyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -26254,11 +26345,12 @@ class TestPhase248ThreeSqrtThirtyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -26425,11 +26517,12 @@ class TestPhase249FourSqrtThirtyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -26467,11 +26560,12 @@ class TestPhase249FourSqrtThirtyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -26638,11 +26732,12 @@ class TestPhase250FiveSqrtThirtyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -26680,11 +26775,12 @@ class TestPhase250FiveSqrtThirtyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -26845,11 +26941,12 @@ class TestPhase251ThirtyFourLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -26886,11 +26983,12 @@ class TestPhase251ThirtyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -27057,11 +27155,12 @@ class TestPhase252OneSqrtThirtyFourLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -27099,11 +27198,12 @@ class TestPhase252OneSqrtThirtyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -27270,11 +27370,12 @@ class TestPhase253TwoSqrtThirtyFourLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -27311,11 +27412,12 @@ class TestPhase253TwoSqrtThirtyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -27481,11 +27583,12 @@ class TestPhase254ThreeSqrtThirtyFourLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -27522,11 +27625,12 @@ class TestPhase254ThreeSqrtThirtyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -27697,11 +27801,12 @@ class TestPhase255FourSqrtThirtyFourLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -27739,11 +27844,12 @@ class TestPhase255FourSqrtThirtyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -27914,11 +28020,12 @@ class TestPhase256FiveSqrtThirtyFourLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -27956,11 +28063,12 @@ class TestPhase256FiveSqrtThirtyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -28125,11 +28233,12 @@ class TestPhase257ThirtyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -28166,11 +28275,12 @@ class TestPhase257ThirtyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -28341,11 +28451,12 @@ class TestPhase258OneSqrtThirtyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -28383,11 +28494,12 @@ class TestPhase258OneSqrtThirtyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -28558,11 +28670,12 @@ class TestPhase259TwoSqrtThirtyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -28599,11 +28712,12 @@ class TestPhase259TwoSqrtThirtyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -28773,11 +28887,12 @@ class TestPhase260ThreeSqrtThirtyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -28814,11 +28929,12 @@ class TestPhase260ThreeSqrtThirtyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -28993,11 +29109,12 @@ class TestPhase261FourSqrtThirtyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -29035,11 +29152,12 @@ class TestPhase261FourSqrtThirtyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -29214,11 +29332,12 @@ class TestPhase262FiveSqrtThirtyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -29256,11 +29375,12 @@ class TestPhase262FiveSqrtThirtyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -29429,11 +29549,12 @@ class TestPhase263ThirtySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -29470,11 +29591,12 @@ class TestPhase263ThirtySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -29649,11 +29771,12 @@ class TestPhase264OneSqrtThirtySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             _k,
         ))
         num_kp1 = IRApply(MUL, (
@@ -29691,11 +29814,12 @@ class TestPhase264OneSqrtThirtySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             kp1,
         ))
         g_k = IRApply(DIV, (num_k, k2))
@@ -29870,11 +29994,12 @@ class TestPhase265TwoSqrtThirtySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -29911,11 +30036,12 @@ class TestPhase265TwoSqrtThirtySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -30089,11 +30215,12 @@ class TestPhase266ThreeSqrtThirtySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -30130,11 +30257,12 @@ class TestPhase266ThreeSqrtThirtySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -30313,11 +30441,12 @@ class TestPhase267FourSqrtThirtySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -30355,11 +30484,12 @@ class TestPhase267FourSqrtThirtySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -30538,11 +30668,12 @@ class TestPhase268FiveSqrtThirtySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -30580,11 +30711,12 @@ class TestPhase268FiveSqrtThirtySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -30759,11 +30891,12 @@ class TestPhase269ThirtySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -30799,11 +30932,12 @@ class TestPhase269ThirtySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -30980,11 +31114,12 @@ class TestPhase270OneSqrtThirtySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -31021,11 +31156,12 @@ class TestPhase270OneSqrtThirtySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -31202,11 +31338,12 @@ class TestPhase271TwoSqrtThirtySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -31243,11 +31380,12 @@ class TestPhase271TwoSqrtThirtySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -31424,11 +31562,12 @@ class TestPhase272ThreeSqrtThirtySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -31465,11 +31604,12 @@ class TestPhase272ThreeSqrtThirtySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -31646,11 +31786,12 @@ class TestPhase273FourSqrtThirtySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -31687,11 +31828,12 @@ class TestPhase273FourSqrtThirtySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -31873,11 +32015,12 @@ class TestPhase274FiveSqrtThirtySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -31915,11 +32058,12 @@ class TestPhase274FiveSqrtThirtySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -32097,11 +32241,12 @@ class TestPhase275ThirtyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -32137,11 +32282,12 @@ class TestPhase275ThirtyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -32322,11 +32468,12 @@ class TestPhase276OneSqrtThirtyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -32363,11 +32510,12 @@ class TestPhase276OneSqrtThirtyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -32548,11 +32696,12 @@ class TestPhase277TwoSqrtThirtyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -32589,11 +32738,12 @@ class TestPhase277TwoSqrtThirtyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -32774,11 +32924,12 @@ class TestPhase278ThreeSqrtThirtyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -32815,11 +32966,12 @@ class TestPhase278ThreeSqrtThirtyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -33005,11 +33157,12 @@ class TestPhase279FourSqrtThirtyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -33047,11 +33200,12 @@ class TestPhase279FourSqrtThirtyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -33237,11 +33391,12 @@ class TestPhase280FiveSqrtThirtyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -33279,11 +33434,12 @@ class TestPhase280FiveSqrtThirtyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -33466,11 +33622,12 @@ class TestPhase281ThirtyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -33506,11 +33663,12 @@ class TestPhase281ThirtyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -33695,11 +33853,12 @@ class TestPhase282OneSqrtThirtyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -33736,11 +33895,12 @@ class TestPhase282OneSqrtThirtyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -33927,11 +34087,12 @@ class TestPhase283TwoSqrtThirtyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -33968,11 +34129,12 @@ class TestPhase283TwoSqrtThirtyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -34159,11 +34321,12 @@ class TestPhase284ThreeSqrtThirtyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -34200,11 +34363,12 @@ class TestPhase284ThreeSqrtThirtyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -34391,11 +34555,12 @@ class TestPhase285FourSqrtThirtyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -34432,11 +34597,12 @@ class TestPhase285FourSqrtThirtyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -34623,11 +34789,12 @@ class TestPhase286FiveSqrtThirtyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -34664,11 +34831,12 @@ class TestPhase286FiveSqrtThirtyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -34855,11 +35023,12 @@ class TestPhase287FortyLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -34895,11 +35064,12 @@ class TestPhase287FortyLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -35088,11 +35258,12 @@ class TestPhase288OneSqrtFortyLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -35129,11 +35300,12 @@ class TestPhase288OneSqrtFortyLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -35324,11 +35496,12 @@ class TestPhase289TwoSqrtFortyLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -35365,11 +35538,12 @@ class TestPhase289TwoSqrtFortyLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -35560,11 +35734,12 @@ class TestPhase290ThreeSqrtFortyLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -35601,11 +35776,12 @@ class TestPhase290ThreeSqrtFortyLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -35796,11 +35972,12 @@ class TestPhase291FourSqrtFortyLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -35837,11 +36014,12 @@ class TestPhase291FourSqrtFortyLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -36032,11 +36210,12 @@ class TestPhase292FiveSqrtFortyLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -36073,11 +36252,12 @@ class TestPhase292FiveSqrtFortyLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -36268,11 +36448,12 @@ class TestPhase293FortyOneLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -36308,11 +36489,12 @@ class TestPhase293FortyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -36434,11 +36616,12 @@ class TestPhase294OneSqrtFortyOneLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -36475,11 +36658,12 @@ class TestPhase294OneSqrtFortyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -36601,11 +36785,12 @@ class TestPhase295TwoSqrtFortyOneLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -36642,11 +36827,12 @@ class TestPhase295TwoSqrtFortyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -36768,11 +36954,12 @@ class TestPhase296ThreeSqrtFortyOneLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -36809,11 +36996,12 @@ class TestPhase296ThreeSqrtFortyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -36935,11 +37123,12 @@ class TestPhase297FourSqrtFortyOneLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -36976,11 +37165,12 @@ class TestPhase297FourSqrtFortyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -37102,11 +37292,12 @@ class TestPhase298FiveSqrtFortyOneLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -37143,11 +37334,12 @@ class TestPhase298FiveSqrtFortyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -37269,11 +37461,12 @@ class TestPhase299FortyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -37309,11 +37502,12 @@ class TestPhase299FortyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -37437,11 +37631,12 @@ class TestPhase300OneSqrtFortyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -37478,11 +37673,12 @@ class TestPhase300OneSqrtFortyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -37606,11 +37802,12 @@ class TestPhase301TwoSqrtFortyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -37647,11 +37844,12 @@ class TestPhase301TwoSqrtFortyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -37775,11 +37973,12 @@ class TestPhase302ThreeSqrtFortyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -37816,11 +38015,12 @@ class TestPhase302ThreeSqrtFortyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -37944,11 +38144,12 @@ class TestPhase303FourSqrtFortyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -37985,11 +38186,12 @@ class TestPhase303FourSqrtFortyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -38113,11 +38315,12 @@ class TestPhase304FiveSqrtFortyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -38154,11 +38357,12 @@ class TestPhase304FiveSqrtFortyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -38282,11 +38486,12 @@ class TestPhase305FortyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -38322,11 +38527,12 @@ class TestPhase305FortyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -38453,11 +38659,12 @@ class TestPhase306OneSqrtFortyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -38494,11 +38701,12 @@ class TestPhase306OneSqrtFortyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -38625,11 +38833,12 @@ class TestPhase307TwoSqrtFortyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -38666,11 +38875,12 @@ class TestPhase307TwoSqrtFortyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -38797,11 +39007,12 @@ class TestPhase308ThreeSqrtFortyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -38838,11 +39049,12 @@ class TestPhase308ThreeSqrtFortyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -38969,11 +39181,12 @@ class TestPhase309FourSqrtFortyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -39010,11 +39223,12 @@ class TestPhase309FourSqrtFortyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -39141,11 +39355,12 @@ class TestPhase310FiveSqrtFortyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -39182,11 +39397,12 @@ class TestPhase310FiveSqrtFortyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -39312,11 +39528,12 @@ class TestPhase311FortyFourLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -39352,11 +39569,12 @@ class TestPhase311FortyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -39485,11 +39703,12 @@ class TestPhase312OneSqrtFortyFourLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -39526,11 +39745,12 @@ class TestPhase312OneSqrtFortyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -39659,11 +39879,12 @@ class TestPhase313TwoSqrtFortyFourLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -39700,11 +39921,12 @@ class TestPhase313TwoSqrtFortyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -39833,11 +40055,12 @@ class TestPhase314ThreeSqrtFortyFourLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -39874,11 +40097,12 @@ class TestPhase314ThreeSqrtFortyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -40007,11 +40231,12 @@ class TestPhase315FourSqrtFortyFourLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -40048,11 +40273,12 @@ class TestPhase315FourSqrtFortyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -40181,11 +40407,12 @@ class TestPhase316FiveSqrtFortyFourLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -40222,11 +40449,12 @@ class TestPhase316FiveSqrtFortyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -40354,11 +40582,12 @@ class TestPhase317FortyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -40394,11 +40623,12 @@ class TestPhase317FortyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -40528,11 +40758,12 @@ class TestPhase318OneSqrtFortyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -40569,11 +40800,12 @@ class TestPhase318OneSqrtFortyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -40703,11 +40935,12 @@ class TestPhase319TwoSqrtFortyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -40744,11 +40977,12 @@ class TestPhase319TwoSqrtFortyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -40878,11 +41112,12 @@ class TestPhase320ThreeSqrtFortyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -40919,11 +41154,12 @@ class TestPhase320ThreeSqrtFortyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -41053,11 +41289,12 @@ class TestPhase321FourSqrtFortyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -41094,11 +41331,12 @@ class TestPhase321FourSqrtFortyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -41228,11 +41466,12 @@ class TestPhase322FiveSqrtFortyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -41269,11 +41508,12 @@ class TestPhase322FiveSqrtFortyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -41403,11 +41643,12 @@ class TestPhase323FortysSixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -41443,11 +41684,12 @@ class TestPhase323FortysSixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -41579,11 +41821,12 @@ class TestPhase324OneSqrtFortySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -41620,11 +41863,12 @@ class TestPhase324OneSqrtFortySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -41756,11 +42000,12 @@ class TestPhase325TwoSqrtFortySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -41797,11 +42042,12 @@ class TestPhase325TwoSqrtFortySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -41933,11 +42179,12 @@ class TestPhase326ThreeSqrtFortySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -41974,11 +42221,12 @@ class TestPhase326ThreeSqrtFortySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -42110,11 +42358,12 @@ class TestPhase327FourSqrtFortySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -42151,11 +42400,12 @@ class TestPhase327FourSqrtFortySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -42287,11 +42537,12 @@ class TestPhase328FiveSqrtFortySixLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -42328,11 +42579,12 @@ class TestPhase328FiveSqrtFortySixLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -42464,11 +42716,12 @@ class TestPhase329FortySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -42504,11 +42757,12 @@ class TestPhase329FortySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -42642,11 +42896,12 @@ class TestPhase330OneSqrtFortySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -42683,11 +42938,12 @@ class TestPhase330OneSqrtFortySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -42821,11 +43077,12 @@ class TestPhase331TwoSqrtFortySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -42862,11 +43119,12 @@ class TestPhase331TwoSqrtFortySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -43000,11 +43258,12 @@ class TestPhase332ThreeSqrtFortySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -43041,11 +43300,12 @@ class TestPhase332ThreeSqrtFortySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -43179,11 +43439,12 @@ class TestPhase333FourSqrtFortySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -43220,11 +43481,12 @@ class TestPhase333FourSqrtFortySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -43358,11 +43620,12 @@ class TestPhase334FiveSqrtFortySevenLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -43399,11 +43662,12 @@ class TestPhase334FiveSqrtFortySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -43537,11 +43801,12 @@ class TestPhase335FortyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -43577,11 +43842,12 @@ class TestPhase335FortyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -43718,11 +43984,12 @@ class TestPhase336OneSqrtFortyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -43759,11 +44026,12 @@ class TestPhase336OneSqrtFortyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -43900,11 +44168,12 @@ class TestPhase337TwoSqrtFortyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -43941,11 +44210,12 @@ class TestPhase337TwoSqrtFortyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -44082,11 +44352,12 @@ class TestPhase338ThreeSqrtFortyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -44123,11 +44394,12 @@ class TestPhase338ThreeSqrtFortyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -44264,11 +44536,12 @@ class TestPhase339FourSqrtFortyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -44305,11 +44578,12 @@ class TestPhase339FourSqrtFortyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -44446,11 +44720,12 @@ class TestPhase340FiveSqrtFortyEightLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -44487,11 +44762,12 @@ class TestPhase340FiveSqrtFortyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -44627,11 +44903,12 @@ class TestPhase341FortyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -44667,11 +44944,12 @@ class TestPhase341FortyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -44810,11 +45088,12 @@ class TestPhase342OneSqrtFortyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -44851,11 +45130,12 @@ class TestPhase342OneSqrtFortyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -44994,11 +45274,12 @@ class TestPhase343TwoSqrtFortyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -45035,11 +45316,12 @@ class TestPhase343TwoSqrtFortyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -45178,11 +45460,12 @@ class TestPhase344ThreeSqrtFortyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -45219,11 +45502,12 @@ class TestPhase344ThreeSqrtFortyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -45362,11 +45646,12 @@ class TestPhase345FourSqrtFortyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -45403,11 +45688,12 @@ class TestPhase345FourSqrtFortyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -45546,11 +45832,12 @@ class TestPhase346FiveSqrtFortyNineLogPoly:
             IRApply(LOG, (_k,)),  # 47th log
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -45587,11 +45874,12 @@ class TestPhase346FiveSqrtFortyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 47th log
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 52nd log (over 50; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -45730,10 +46018,11 @@ class TestPhase347FiftyLogPoly:
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
             IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -45770,10 +46059,11 @@ class TestPhase347FiftyLogPoly:
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
             IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -45915,10 +46205,11 @@ class TestPhase348OneSqrtFiftyLogPoly:
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
             IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -45956,10 +46247,11 @@ class TestPhase348OneSqrtFiftyLogPoly:
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
             IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -46101,10 +46393,11 @@ class TestPhase349TwoSqrtFiftyLogPoly:
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
             IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -46142,10 +46435,11 @@ class TestPhase349TwoSqrtFiftyLogPoly:
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
             IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -46287,10 +46581,11 @@ class TestPhase350ThreeSqrtFiftyLogPoly:
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
             IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -46328,10 +46623,11 @@ class TestPhase350ThreeSqrtFiftyLogPoly:
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
             IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -46473,10 +46769,11 @@ class TestPhase351FourSqrtFiftyLogPoly:
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
             IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -46514,10 +46811,11 @@ class TestPhase351FourSqrtFiftyLogPoly:
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
             IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -46659,10 +46957,11 @@ class TestPhase352FiveSqrtFiftyLogPoly:
             IRApply(LOG, (_k,)),  # 48th log
             IRApply(LOG, (_k,)),  # 49th log
             IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -46700,10 +46999,11 @@ class TestPhase352FiveSqrtFiftyLogPoly:
             IRApply(LOG, (kp1,)),  # 48th log
             IRApply(LOG, (kp1,)),  # 49th log
             IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -46845,9 +47145,10 @@ class TestPhase353FiftyOneLogPoly:
             IRApply(LOG, (_k,)),  # 49th log
             IRApply(LOG, (_k,)),  # 50th log
             IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -46885,9 +47186,10 @@ class TestPhase353FiftyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 49th log
             IRApply(LOG, (kp1,)),  # 50th log
             IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -47032,9 +47334,10 @@ class TestPhase354OneSqrtFiftyOneLogPoly:
             IRApply(LOG, (_k,)),  # 49th log
             IRApply(LOG, (_k,)),  # 50th log
             IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -47073,9 +47376,10 @@ class TestPhase354OneSqrtFiftyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 49th log
             IRApply(LOG, (kp1,)),  # 50th log
             IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -47220,9 +47524,10 @@ class TestPhase355TwoSqrtFiftyOneLogPoly:
             IRApply(LOG, (_k,)),  # 49th log
             IRApply(LOG, (_k,)),  # 50th log
             IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -47261,9 +47566,10 @@ class TestPhase355TwoSqrtFiftyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 49th log
             IRApply(LOG, (kp1,)),  # 50th log
             IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -47408,9 +47714,10 @@ class TestPhase356ThreeSqrtFiftyOneLogPoly:
             IRApply(LOG, (_k,)),  # 49th log
             IRApply(LOG, (_k,)),  # 50th log
             IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -47449,9 +47756,10 @@ class TestPhase356ThreeSqrtFiftyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 49th log
             IRApply(LOG, (kp1,)),  # 50th log
             IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -47596,9 +47904,10 @@ class TestPhase357FourSqrtFiftyOneLogPoly:
             IRApply(LOG, (_k,)),  # 49th log
             IRApply(LOG, (_k,)),  # 50th log
             IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -47637,9 +47946,10 @@ class TestPhase357FourSqrtFiftyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 49th log
             IRApply(LOG, (kp1,)),  # 50th log
             IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -47784,9 +48094,10 @@ class TestPhase358FiveSqrtFiftyOneLogPoly:
             IRApply(LOG, (_k,)),  # 49th log
             IRApply(LOG, (_k,)),  # 50th log
             IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -47825,9 +48136,10 @@ class TestPhase358FiveSqrtFiftyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 49th log
             IRApply(LOG, (kp1,)),  # 50th log
             IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -47972,9 +48284,10 @@ class TestPhase359FiftyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 50th log
             IRApply(LOG, (_k,)),  # 51st log
             IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -48013,9 +48326,10 @@ class TestPhase359FiftyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 50th log
             IRApply(LOG, (kp1,)),  # 51st log
             IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -48163,9 +48477,10 @@ class TestPhase360OneSqrtFiftyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 50th log
             IRApply(LOG, (_k,)),  # 51st log
             IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -48205,9 +48520,10 @@ class TestPhase360OneSqrtFiftyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 50th log
             IRApply(LOG, (kp1,)),  # 51st log
             IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -48355,9 +48671,10 @@ class TestPhase361TwoSqrtFiftyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 50th log
             IRApply(LOG, (_k,)),  # 51st log
             IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -48397,9 +48714,10 @@ class TestPhase361TwoSqrtFiftyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 50th log
             IRApply(LOG, (kp1,)),  # 51st log
             IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -48547,9 +48865,10 @@ class TestPhase362ThreeSqrtFiftyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 50th log
             IRApply(LOG, (_k,)),  # 51st log
             IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -48589,9 +48908,10 @@ class TestPhase362ThreeSqrtFiftyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 50th log
             IRApply(LOG, (kp1,)),  # 51st log
             IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -48739,9 +49059,10 @@ class TestPhase363FourSqrtFiftyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 50th log
             IRApply(LOG, (_k,)),  # 51st log
             IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -48781,9 +49102,10 @@ class TestPhase363FourSqrtFiftyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 50th log
             IRApply(LOG, (kp1,)),  # 51st log
             IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -48931,9 +49253,10 @@ class TestPhase364FiveSqrtFiftyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 50th log
             IRApply(LOG, (_k,)),  # 51st log
             IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 54th log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -48973,9 +49296,10 @@ class TestPhase364FiveSqrtFiftyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 50th log
             IRApply(LOG, (kp1,)),  # 51st log
             IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 54th log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -49077,8 +49401,8 @@ class TestPhase365FiftyThreeLogPoly:
         result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
         assert not (isinstance(result, IRApply) and result.head == SUM)
 
-    def test_log54_refused_refused(self):
-        """log(k)^54/k^2: 54 logs -> not Phase 365 -> refused"""
+    def test_log55_refused_refused(self):
+        """log(k)^55/k^2: 55 logs -> not Phase 371 -> refused"""
         from symbolic_ir import SUB
 
         kp1 = IRApply(ADD, (_k, IRInteger(1)))
@@ -49122,7 +49446,8 @@ class TestPhase365FiftyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 51st log
             IRApply(LOG, (_k,)),  # 52nd log
             IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -49162,7 +49487,8 @@ class TestPhase365FiftyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 51st log
             IRApply(LOG, (kp1,)),  # 52nd log
             IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -49266,8 +49592,8 @@ class TestPhase366OneSqrtFiftyThreeLogPoly:
         result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
         assert not (isinstance(result, IRApply) and result.head == SUM)
 
-    def test_sqrt_k_log54_refused_refused(self):
-        """sqrt(k)*log(k)^54/k^2: 54 logs -> not Phase 366 -> refused"""
+    def test_sqrt_k_log55_refused_refused(self):
+        """sqrt(k)*log(k)^55/k^2: 55 logs -> not Phase 372 -> refused"""
         from symbolic_ir import SQRT, SUB
 
         kp1 = IRApply(ADD, (_k, IRInteger(1)))
@@ -49312,7 +49638,8 @@ class TestPhase366OneSqrtFiftyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 51st log
             IRApply(LOG, (_k,)),  # 52nd log
             IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -49353,7 +49680,8 @@ class TestPhase366OneSqrtFiftyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 51st log
             IRApply(LOG, (kp1,)),  # 52nd log
             IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -49457,8 +49785,8 @@ class TestPhase367TwoSqrtFiftyThreeLogPoly:
         result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
         assert not (isinstance(result, IRApply) and result.head == SUM)
 
-    def test_2_sqrt_k_log54_refused_refused(self):
-        """sqrt(k)^2*log(k)^54/k^2: 54 logs -> not Phase 367 -> refused"""
+    def test_2_sqrt_k_log55_refused_refused(self):
+        """sqrt(k)^2*log(k)^55/k^2: 55 logs -> not Phase 373 -> refused"""
         from symbolic_ir import SQRT, SUB
 
         kp1 = IRApply(ADD, (_k, IRInteger(1)))
@@ -49503,7 +49831,8 @@ class TestPhase367TwoSqrtFiftyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 51st log
             IRApply(LOG, (_k,)),  # 52nd log
             IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -49544,7 +49873,8 @@ class TestPhase367TwoSqrtFiftyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 51st log
             IRApply(LOG, (kp1,)),  # 52nd log
             IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -49648,8 +49978,8 @@ class TestPhase368ThreeSqrtFiftyThreeLogPoly:
         result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
         assert not (isinstance(result, IRApply) and result.head == SUM)
 
-    def test_3_sqrt_k_log54_refused_refused(self):
-        """sqrt(k)^3*log(k)^54/k^3: 54 logs -> not Phase 368 -> refused"""
+    def test_3_sqrt_k_log55_refused_refused(self):
+        """sqrt(k)^3*log(k)^55/k^3: 55 logs -> not Phase 374 -> refused"""
         from symbolic_ir import SQRT, SUB
 
         kp1 = IRApply(ADD, (_k, IRInteger(1)))
@@ -49694,7 +50024,8 @@ class TestPhase368ThreeSqrtFiftyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 51st log
             IRApply(LOG, (_k,)),  # 52nd log
             IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -49735,7 +50066,8 @@ class TestPhase368ThreeSqrtFiftyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 51st log
             IRApply(LOG, (kp1,)),  # 52nd log
             IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -49839,8 +50171,8 @@ class TestPhase369FourSqrtFiftyThreeLogPoly:
         result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
         assert not (isinstance(result, IRApply) and result.head == SUM)
 
-    def test_4_sqrt_k_log54_refused_refused(self):
-        """sqrt(k)^4*log(k)^54/k^3: 54 logs -> not Phase 369 -> refused"""
+    def test_4_sqrt_k_log55_refused_refused(self):
+        """sqrt(k)^4*log(k)^55/k^3: 55 logs -> not Phase 375 -> refused"""
         from symbolic_ir import SQRT, SUB
 
         kp1 = IRApply(ADD, (_k, IRInteger(1)))
@@ -49885,7 +50217,8 @@ class TestPhase369FourSqrtFiftyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 51st log
             IRApply(LOG, (_k,)),  # 52nd log
             IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -49926,7 +50259,8 @@ class TestPhase369FourSqrtFiftyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 51st log
             IRApply(LOG, (kp1,)),  # 52nd log
             IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -50030,8 +50364,8 @@ class TestPhase370FiveSqrtFiftyThreeLogPoly:
         result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
         assert not (isinstance(result, IRApply) and result.head == SUM)
 
-    def test_5_sqrt_k_log54_refused_refused(self):
-        """sqrt(k)^5*log(k)^54/k^3: 54 logs -> not Phase 370 -> refused"""
+    def test_5_sqrt_k_log55_refused_refused(self):
+        """sqrt(k)^5*log(k)^55/k^3: 55 logs -> not Phase 376 -> refused"""
         from symbolic_ir import SQRT, SUB
 
         kp1 = IRApply(ADD, (_k, IRInteger(1)))
@@ -50076,7 +50410,8 @@ class TestPhase370FiveSqrtFiftyThreeLogPoly:
             IRApply(LOG, (_k,)),  # 51st log
             IRApply(LOG, (_k,)),  # 52nd log
             IRApply(LOG, (_k,)),  # 53rd log
-            IRApply(LOG, (_k,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -50117,7 +50452,1174 @@ class TestPhase370FiveSqrtFiftyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 51st log
             IRApply(LOG, (kp1,)),  # 52nd log
             IRApply(LOG, (kp1,)),  # 53rd log
-            IRApply(LOG, (kp1,)),  # 54th log (over 53; refused)
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+class TestPhase371FiftyFourLogPoly:
+    """Phase 371 -- Zero-Sqrt x Fifty-Four-Log x polynomial numerator."""
+
+    def test_log54_k_over_k2_closes(self):
+        """log(k)^54/k^2: eff_x2=0; 2*2=4 > 0 -> closes"""
+        from symbolic_ir import SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_log55_refused_refused(self):
+        """log(k)^55/k^2: 55 logs -> not Phase 371 -> refused"""
+        from symbolic_ir import SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+class TestPhase372OneSqrtFiftyFourLogPoly:
+    """Phase 372 -- One-Sqrt x Fifty-Four-Log x polynomial numerator."""
+
+    def test_sqrt_k_log54_k_over_k2_closes(self):
+        """sqrt(k)*log(k)^54/k^2: eff_x2=1; 2*2=4 > 1 -> closes"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_log55_refused_refused(self):
+        """sqrt(k)*log(k)^55/k^2: 55 logs -> not Phase 372 -> refused"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+class TestPhase373TwoSqrtFiftyFourLogPoly:
+    """Phase 373 -- Two-Sqrt x Fifty-Four-Log x polynomial numerator."""
+
+    def test_2_sqrt_k_log54_k_over_k2_closes(self):
+        """sqrt(k)^2*log(k)^54/k^2: eff_x2=2; 2*2=4 > 2 -> closes"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_2_sqrt_k_log55_refused_refused(self):
+        """sqrt(k)^2*log(k)^55/k^2: 55 logs -> not Phase 373 -> refused"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+class TestPhase374ThreeSqrtFiftyFourLogPoly:
+    """Phase 374 -- Three-Sqrt x Fifty-Four-Log x polynomial numerator."""
+
+    def test_3_sqrt_k_log54_k_over_k3_closes(self):
+        """sqrt(k)^3*log(k)^54/k^3: eff_x2=3; 2*3=6 > 3 -> closes"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_3_sqrt_k_log55_refused_refused(self):
+        """sqrt(k)^3*log(k)^55/k^3: 55 logs -> not Phase 374 -> refused"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+class TestPhase375FourSqrtFiftyFourLogPoly:
+    """Phase 375 -- Four-Sqrt x Fifty-Four-Log x polynomial numerator."""
+
+    def test_4_sqrt_k_log54_k_over_k3_closes(self):
+        """sqrt(k)^4*log(k)^54/k^3: eff_x2=4; 2*3=6 > 4 -> closes"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_4_sqrt_k_log55_refused_refused(self):
+        """sqrt(k)^4*log(k)^55/k^3: 55 logs -> not Phase 375 -> refused"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+class TestPhase376FiveSqrtFiftyFourLogPoly:
+    """Phase 376 -- Five-Sqrt x Fifty-Four-Log x polynomial numerator."""
+
+    def test_5_sqrt_k_log54_k_over_k3_closes(self):
+        """sqrt(k)^5*log(k)^54/k^3: eff_x2=5; 2*3=6 > 5 -> closes"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_5_sqrt_k_log55_refused_refused(self):
+        """sqrt(k)^5*log(k)^55/k^3: 55 logs -> not Phase 376 -> refused"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_k = IRApply(MUL, (
+            IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))

--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 2.313.0 — 2026-05-28
+
+### Added
+
+- **Phase 376 — Five-Sqrt × Fifty-Four-Log × polynomial** (`five_sqrt_fifty_four_log_poly_effective_x2`):
+  Completes the Fifty-Four-Log family (Phases 371–376).
+- **Phase 375 — Four-Sqrt × Fifty-Four-Log × polynomial** (`four_sqrt_fifty_four_log_poly_effective_x2`).
+- **Phase 374 — Three-Sqrt × Fifty-Four-Log × polynomial** (`three_sqrt_fifty_four_log_poly_effective_x2`).
+- **Phase 373 — Two-Sqrt × Fifty-Four-Log × polynomial** (`two_sqrt_fifty_four_log_poly_effective_x2`).
+- **Phase 372 — One-Sqrt × Fifty-Four-Log × polynomial** (`one_sqrt_fifty_four_log_poly_effective_x2`).
+- **Phase 371 — Zero-Sqrt × Fifty-Four-Log × polynomial** (`fifty_four_log_poly_effective_x2`).
+
+### Changed
+
+- Boundary tests in Phases 365–370 updated from 54-log "refused" to 55-log "refused"
+  now that Phases 371–376 handle exactly 54 logs.
+
 ## 2.307.0 — 2026-05-28
 
 ### Added

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "2.307.0"
+version = "2.313.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -7657,6 +7657,170 @@ fn five_sqrt_fifty_three_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Opt
     Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg_sum)
 }
 
+/// Phase 371 — Zero-Sqrt × Fifty-Four-Log × polynomial numerator.
+///
+/// The Fifty-Four-Log family (Phases 371–376) extends the recogniser to
+/// summands whose numerator contains exactly fifty-four logarithmic factors
+/// and zero to five square-root factors.  This is Phase 371: zero sqrts.
+fn fifty_four_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if sqrt_effective_half_degree_x2(arg, k).is_some() { return None; }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 54 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg; continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if log_count != 54 { return None; }
+    Some(2 * poly_deg_sum)
+}
+
+/// Phase 372 — One-Sqrt × Fifty-Four-Log × polynomial numerator.
+fn one_sqrt_fifty_four_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut sqrt_deg: Option<i64> = None;
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_deg.is_some() { return None; }
+            sqrt_deg = Some(d); continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 54 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg; continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    let sd = sqrt_deg?;
+    if log_count != 54 { return None; }
+    Some(sd + 2 * poly_deg_sum)
+}
+
+/// Phase 373 — Two-Sqrt × Fifty-Four-Log × polynomial numerator.
+fn two_sqrt_fifty_four_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut sqrt_degs: Vec<i64> = Vec::new();
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs.len() >= 2 { return None; }
+            sqrt_degs.push(d); continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 54 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg; continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs.len() != 2 || log_count != 54 { return None; }
+    Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg_sum)
+}
+
+/// Phase 374 — Three-Sqrt × Fifty-Four-Log × polynomial numerator.
+fn three_sqrt_fifty_four_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut sqrt_degs: Vec<i64> = Vec::new();
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs.len() >= 3 { return None; }
+            sqrt_degs.push(d); continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 54 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg; continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs.len() != 3 || log_count != 54 { return None; }
+    Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg_sum)
+}
+
+/// Phase 375 — Four-Sqrt × Fifty-Four-Log × polynomial numerator.
+fn four_sqrt_fifty_four_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut sqrt_degs: Vec<i64> = Vec::new();
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs.len() >= 4 { return None; }
+            sqrt_degs.push(d); continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 54 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg; continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs.len() != 4 || log_count != 54 { return None; }
+    Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg_sum)
+}
+
+/// Phase 376 — Five-Sqrt × Fifty-Four-Log × polynomial numerator.
+/// Completes the Fifty-Four-Log family (Phases 371–376).
+fn five_sqrt_fifty_four_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut sqrt_degs: Vec<i64> = Vec::new();
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs.len() >= 5 { return None; }
+            sqrt_degs.push(d); continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 54 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg; continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs.len() != 5 || log_count != 54 { return None; }
+    Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg_sum)
+}
+
 /// Phase 359 — Zero-Sqrt × Fifty-Two-Log × polynomial numerator.
 ///
 /// The Fifty-Two-Log family (Phases 359–364) extends the recogniser to
@@ -10697,6 +10861,42 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
         } else if h_diverges_at_infinity(den, k) {
             return true;
         }
+    }
+    // Phase 376: Mul(Sqrt(P1)×5, Log(h1)×54, ...) numerator.
+    if let Some(s5l54_x2) = five_sqrt_fifty_four_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s5l54) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s5l54 > s5l54_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 375: Mul(Sqrt(P1)×4, Log(h1)×54, ...) numerator.
+    if let Some(s4l54_x2) = four_sqrt_fifty_four_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s4l54) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s4l54 > s4l54_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 374: Mul(Sqrt(P1)×3, Log(h1)×54, ...) numerator.
+    if let Some(s3l54_x2) = three_sqrt_fifty_four_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s3l54) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s3l54 > s3l54_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 373: Mul(Sqrt(P), Sqrt(P2), Log(h1)×54, ...) numerator.
+    if let Some(s2l54_x2) = two_sqrt_fifty_four_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s2l54) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s2l54 > s2l54_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 372: Mul(Sqrt(P), Log(h1)×54, ...) numerator.
+    if let Some(s1l54_x2) = one_sqrt_fifty_four_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s1l54) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s1l54 > s1l54_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 371: Mul(Log(h1)×54, ...) numerator.
+    if let Some(sl54_x2) = fifty_four_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_sl54) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_sl54 > sl54_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
     }
     // Phase 370: Mul(Sqrt(P1)×5, Log(h1)×53, ...) numerator.
     if let Some(s5l53_x2) = five_sqrt_fifty_three_log_poly_effective_x2(num, k) {

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -13269,12 +13269,13 @@ fn phase191_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -13301,12 +13302,13 @@ fn phase191_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -13424,12 +13426,13 @@ fn phase192_sqrt_k_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -13457,12 +13460,13 @@ fn phase192_sqrt_k_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -13993,12 +13997,13 @@ fn phase197_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -14025,12 +14030,13 @@ fn phase197_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -14767,12 +14773,13 @@ fn phase203_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -14799,12 +14806,13 @@ fn phase203_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -15546,12 +15554,13 @@ fn phase209_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -15579,12 +15588,13 @@ fn phase209_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -16356,12 +16366,13 @@ fn phase215_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -16389,12 +16400,13 @@ fn phase215_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -17166,12 +17178,13 @@ fn phase221_log30_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -17199,12 +17212,13 @@ fn phase221_log30_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -17976,12 +17990,13 @@ fn phase227_log31_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -18009,12 +18024,13 @@ fn phase227_log31_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -18786,12 +18802,13 @@ fn phase233_log32_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -18819,12 +18836,13 @@ fn phase233_log32_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -19597,12 +19615,13 @@ fn phase239_log33_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -19629,12 +19648,13 @@ fn phase239_log33_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -20408,12 +20428,13 @@ fn phase245_log34_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -20439,12 +20460,13 @@ fn phase245_log34_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -21217,12 +21239,13 @@ fn phase251_log36_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -21247,12 +21270,13 @@ fn phase251_log36_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -22015,12 +22039,13 @@ fn phase257_log36_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -22045,12 +22070,13 @@ fn phase257_log36_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -23598,12 +23624,13 @@ fn phase269_log38_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -23628,12 +23655,13 @@ fn phase269_log38_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
         kp1.clone(),
     ]);
     let g_k269c = apply(sym(DIV), vec![num_k, k2]);
@@ -23765,12 +23793,13 @@ fn phase270_sqrt_k_log38_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -23796,12 +23825,13 @@ fn phase270_sqrt_k_log38_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
         kp1.clone(),
     ]);
     let g_k270c = apply(sym(DIV), vec![num_k, k2]);
@@ -24486,12 +24516,13 @@ fn phase275_log39_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -24516,12 +24547,13 @@ fn phase275_log39_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
         kp1.clone(),
     ]);
     let g_k275c = apply(sym(DIV), vec![num_k, k2]);
@@ -24657,12 +24689,13 @@ fn phase276_sqrt_k_log39_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -24688,12 +24721,13 @@ fn phase276_sqrt_k_log39_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
         kp1.clone(),
     ]);
     let g_k276c = apply(sym(DIV), vec![num_k, k2]);
@@ -25385,12 +25419,13 @@ fn phase281_log40_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -25411,12 +25446,13 @@ fn phase281_log40_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
         kp1.clone(),
     ]);
     let g_kphase281r = apply(sym(DIV), vec![num_k, k2]);
@@ -25540,12 +25576,13 @@ fn phase282_sqrt1_k_log40_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -25567,12 +25604,13 @@ fn phase282_sqrt1_k_log40_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
         kp1.clone(),
     ]);
     let g_kphase282r = apply(sym(DIV), vec![num_k, k2]);
@@ -26198,12 +26236,13 @@ fn phase287_log42_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -26222,12 +26261,13 @@ fn phase287_log42_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase287r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase287r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -26349,12 +26389,13 @@ fn phase288_sqrt1_k_log42_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -26374,12 +26415,13 @@ fn phase288_sqrt1_k_log42_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase288r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase288r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -26501,12 +26543,13 @@ fn phase289_sqrt2_k_log42_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -26526,12 +26569,13 @@ fn phase289_sqrt2_k_log42_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase289r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase289r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -26653,12 +26697,13 @@ fn phase290_sqrt3_k_log42_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -26678,12 +26723,13 @@ fn phase290_sqrt3_k_log42_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase290r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase290r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -26805,12 +26851,13 @@ fn phase291_sqrt4_k_log42_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -26830,12 +26877,13 @@ fn phase291_sqrt4_k_log42_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase291r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase291r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -26957,12 +27005,13 @@ fn phase292_sqrt5_k_log42_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -26982,12 +27031,13 @@ fn phase292_sqrt5_k_log42_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase292r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase292r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -27062,12 +27112,13 @@ fn phase293_log42_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -27086,12 +27137,13 @@ fn phase293_log42_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase293r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase293r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -27173,12 +27225,13 @@ fn phase294_sqrt1_k_log42_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -27198,12 +27251,13 @@ fn phase294_sqrt1_k_log42_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase294r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase294r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -27285,12 +27339,13 @@ fn phase295_sqrt2_k_log42_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -27310,12 +27365,13 @@ fn phase295_sqrt2_k_log42_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase295r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase295r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -27397,12 +27453,13 @@ fn phase296_sqrt3_k_log42_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -27422,12 +27479,13 @@ fn phase296_sqrt3_k_log42_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase296r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase296r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -27509,12 +27567,13 @@ fn phase297_sqrt4_k_log42_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -27534,12 +27593,13 @@ fn phase297_sqrt4_k_log42_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase297r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase297r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -27621,12 +27681,13 @@ fn phase298_sqrt5_k_log42_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -27646,12 +27707,13 @@ fn phase298_sqrt5_k_log42_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase298r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase298r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -27726,12 +27788,13 @@ fn phase299_log45_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -27750,12 +27813,13 @@ fn phase299_log45_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase299r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase299r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -27837,12 +27901,13 @@ fn phase300_sqrt1_k_log45_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -27862,12 +27927,13 @@ fn phase300_sqrt1_k_log45_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase300r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase300r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -27949,12 +28015,13 @@ fn phase301_sqrt2_k_log45_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -27974,12 +28041,13 @@ fn phase301_sqrt2_k_log45_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase301r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase301r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -28061,12 +28129,13 @@ fn phase302_sqrt3_k_log45_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -28086,12 +28155,13 @@ fn phase302_sqrt3_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase302r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase302r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -28173,12 +28243,13 @@ fn phase303_sqrt4_k_log45_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -28198,12 +28269,13 @@ fn phase303_sqrt4_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase303r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase303r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -28285,12 +28357,13 @@ fn phase304_sqrt5_k_log45_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -28310,12 +28383,13 @@ fn phase304_sqrt5_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase304r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase304r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -28390,12 +28464,13 @@ fn phase305_log45_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -28413,12 +28488,13 @@ fn phase305_log45_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase305r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase305r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -28499,12 +28575,13 @@ fn phase306_sqrt1_k_log45_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -28523,12 +28600,13 @@ fn phase306_sqrt1_k_log45_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase306r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase306r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -28609,12 +28687,13 @@ fn phase307_sqrt2_k_log45_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -28633,12 +28712,13 @@ fn phase307_sqrt2_k_log45_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase307r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase307r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -28719,12 +28799,13 @@ fn phase308_sqrt3_k_log45_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -28743,12 +28824,13 @@ fn phase308_sqrt3_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase308r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase308r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -28829,12 +28911,13 @@ fn phase309_sqrt4_k_log45_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -28853,12 +28936,13 @@ fn phase309_sqrt4_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase309r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase309r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -28939,12 +29023,13 @@ fn phase310_sqrt5_k_log45_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -28963,12 +29048,13 @@ fn phase310_sqrt5_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase310r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase310r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -29041,12 +29127,13 @@ fn phase311_log45_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -29063,12 +29150,13 @@ fn phase311_log45_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase311r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase311r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -29148,12 +29236,13 @@ fn phase312_sqrt1_k_log45_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -29171,12 +29260,13 @@ fn phase312_sqrt1_k_log45_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase312r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase312r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -29256,12 +29346,13 @@ fn phase313_sqrt2_k_log45_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -29279,12 +29370,13 @@ fn phase313_sqrt2_k_log45_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase313r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase313r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -29364,12 +29456,13 @@ fn phase314_sqrt3_k_log45_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -29387,12 +29480,13 @@ fn phase314_sqrt3_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase314r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase314r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -29472,12 +29566,13 @@ fn phase315_sqrt4_k_log45_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -29495,12 +29590,13 @@ fn phase315_sqrt4_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase315r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase315r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -29580,12 +29676,13 @@ fn phase316_sqrt5_k_log45_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -29603,12 +29700,13 @@ fn phase316_sqrt5_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase316r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase316r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -29680,12 +29778,13 @@ fn phase317_log46_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -29701,12 +29800,13 @@ fn phase317_log46_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase317r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase317r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -29785,12 +29885,13 @@ fn phase318_sqrt1_k_log46_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -29807,12 +29908,13 @@ fn phase318_sqrt1_k_log46_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase318r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase318r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -29891,12 +29993,13 @@ fn phase319_sqrt2_k_log46_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -29913,12 +30016,13 @@ fn phase319_sqrt2_k_log46_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase319r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase319r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -29997,12 +30101,13 @@ fn phase320_sqrt3_k_log46_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -30019,12 +30124,13 @@ fn phase320_sqrt3_k_log46_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase320r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase320r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -30103,12 +30209,13 @@ fn phase321_sqrt4_k_log46_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -30125,12 +30232,13 @@ fn phase321_sqrt4_k_log46_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase321r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase321r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -30209,12 +30317,13 @@ fn phase322_sqrt5_k_log46_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -30231,12 +30340,13 @@ fn phase322_sqrt5_k_log46_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase322r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase322r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -30310,12 +30420,13 @@ fn phase323_log47_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -30331,12 +30442,13 @@ fn phase323_log47_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase323r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase323r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -30417,12 +30529,13 @@ fn phase324_sqrt1_k_log47_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -30439,12 +30552,13 @@ fn phase324_sqrt1_k_log47_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase324r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase324r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -30525,12 +30639,13 @@ fn phase325_sqrt2_k_log47_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -30547,12 +30662,13 @@ fn phase325_sqrt2_k_log47_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase325r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase325r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -30633,12 +30749,13 @@ fn phase326_sqrt3_k_log47_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -30655,12 +30772,13 @@ fn phase326_sqrt3_k_log47_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase326r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase326r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -30741,12 +30859,13 @@ fn phase327_sqrt4_k_log47_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -30763,12 +30882,13 @@ fn phase327_sqrt4_k_log47_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase327r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase327r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -30849,12 +30969,13 @@ fn phase328_sqrt5_k_log47_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -30871,12 +30992,13 @@ fn phase328_sqrt5_k_log47_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase328r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase328r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -30931,7 +31053,7 @@ fn phase329_log47_k_over_k2_converges() {
 
 #[test]
 fn phase329_log48_k_over_k2_refused() {
-    // phase329 log48 k over k2 refused: 54 logs → refused (Phase 365 handles exactly 53).
+    // phase329 log48 k over k2 refused: 55 logs → refused (Phase 371 handles exactly 54).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -30952,12 +31074,13 @@ fn phase329_log48_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -30973,12 +31096,13 @@ fn phase329_log48_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase329r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase329r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -31037,7 +31161,7 @@ fn phase330_sqrt1_k_log47_k_over_k2_converges() {
 
 #[test]
 fn phase330_sqrt1_k_log48_k_over_k2_refused() {
-    // phase330 sqrt1 k log48 k over k2 refused: 54 logs → refused (Phase 366 handles exactly 53).
+    // phase330 sqrt1 k log48 k over k2 refused: 55 logs → refused (Phase 372 handles exactly 54).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -31061,12 +31185,13 @@ fn phase330_sqrt1_k_log48_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -31083,12 +31208,13 @@ fn phase330_sqrt1_k_log48_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase330r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase330r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -31147,7 +31273,7 @@ fn phase331_sqrt2_k_log47_k_over_k2_converges() {
 
 #[test]
 fn phase331_sqrt2_k_log48_k_over_k2_refused() {
-    // phase331 sqrt2 k log48 k over k2 refused: 54 logs → refused (Phase 367 handles exactly 53).
+    // phase331 sqrt2 k log48 k over k2 refused: 55 logs → refused (Phase 373 handles exactly 54).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -31171,12 +31297,13 @@ fn phase331_sqrt2_k_log48_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -31193,12 +31320,13 @@ fn phase331_sqrt2_k_log48_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase331r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase331r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -31257,7 +31385,7 @@ fn phase332_sqrt3_k_log47_k_over_k3_converges() {
 
 #[test]
 fn phase332_sqrt3_k_log48_k_over_k3_refused() {
-    // phase332 sqrt3 k log48 k over k3 refused: 54 logs → refused (Phase 368 handles exactly 53).
+    // phase332 sqrt3 k log48 k over k3 refused: 55 logs → refused (Phase 374 handles exactly 54).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -31281,12 +31409,13 @@ fn phase332_sqrt3_k_log48_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -31303,12 +31432,13 @@ fn phase332_sqrt3_k_log48_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase332r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase332r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -31367,7 +31497,7 @@ fn phase333_sqrt4_k_log47_k_over_k3_converges() {
 
 #[test]
 fn phase333_sqrt4_k_log48_k_over_k3_refused() {
-    // phase333 sqrt4 k log48 k over k3 refused: 54 logs → refused (Phase 369 handles exactly 53).
+    // phase333 sqrt4 k log48 k over k3 refused: 55 logs → refused (Phase 375 handles exactly 54).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -31391,12 +31521,13 @@ fn phase333_sqrt4_k_log48_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -31413,12 +31544,13 @@ fn phase333_sqrt4_k_log48_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase333r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase333r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -31477,7 +31609,7 @@ fn phase334_sqrt5_k_log47_k_over_k3_converges() {
 
 #[test]
 fn phase334_sqrt5_k_log48_k_over_k3_refused() {
-    // phase334 sqrt5 k log48 k over k3 refused: 54 logs → refused (Phase 370 handles exactly 53).
+    // phase334 sqrt5 k log48 k over k3 refused: 55 logs → refused (Phase 376 handles exactly 54).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -31501,12 +31633,13 @@ fn phase334_sqrt5_k_log48_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -31523,12 +31656,13 @@ fn phase334_sqrt5_k_log48_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase334r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase334r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -31583,7 +31717,7 @@ fn phase335_log48_k_over_k2_converges() {
 
 #[test]
 fn phase335_log50_k_over_k2_refused() {
-    // log(k)^50 / k2: 54 logs → refused (Phase 365 handles exactly 53).
+    // log(k)^50 / k2: 55 logs → refused (Phase 371 handles exactly 54).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -31604,12 +31738,13 @@ fn phase335_log50_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -31625,12 +31760,13 @@ fn phase335_log50_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase335r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase335r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -31689,7 +31825,7 @@ fn phase336_sqrt1_k_log48_k_over_k2_converges() {
 
 #[test]
 fn phase336_sqrt1_k_log50_k_over_k2_refused() {
-    // sqrt(k)*log(k)^50 / k2: 54 logs → refused (Phase 366 handles exactly 53).
+    // sqrt(k)*log(k)^50 / k2: 55 logs → refused (Phase 372 handles exactly 54).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -31713,12 +31849,13 @@ fn phase336_sqrt1_k_log50_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -31735,12 +31872,13 @@ fn phase336_sqrt1_k_log50_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase336r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase336r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -31799,7 +31937,7 @@ fn phase337_sqrt2_k_log48_k_over_k2_converges() {
 
 #[test]
 fn phase337_sqrt2_k_log50_k_over_k2_refused() {
-    // sqrt(k)^2*log(k)^50 / k2: 54 logs → refused (Phase 367 handles exactly 53).
+    // sqrt(k)^2*log(k)^50 / k2: 55 logs → refused (Phase 373 handles exactly 54).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -31823,12 +31961,13 @@ fn phase337_sqrt2_k_log50_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -31845,12 +31984,13 @@ fn phase337_sqrt2_k_log50_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase337r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase337r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -31909,7 +32049,7 @@ fn phase338_sqrt3_k_log48_k_over_k3_converges() {
 
 #[test]
 fn phase338_sqrt3_k_log50_k_over_k3_refused() {
-    // sqrt(k)^3*log(k)^50 / k3: 54 logs → refused (Phase 368 handles exactly 53).
+    // sqrt(k)^3*log(k)^50 / k3: 55 logs → refused (Phase 374 handles exactly 54).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -31933,12 +32073,13 @@ fn phase338_sqrt3_k_log50_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -31955,12 +32096,13 @@ fn phase338_sqrt3_k_log50_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase338r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase338r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -32019,7 +32161,7 @@ fn phase339_sqrt4_k_log48_k_over_k3_converges() {
 
 #[test]
 fn phase339_sqrt4_k_log50_k_over_k3_refused() {
-    // sqrt(k)^4*log(k)^50 / k3: 54 logs → refused (Phase 369 handles exactly 53).
+    // sqrt(k)^4*log(k)^50 / k3: 55 logs → refused (Phase 375 handles exactly 54).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -32043,12 +32185,13 @@ fn phase339_sqrt4_k_log50_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -32065,12 +32208,13 @@ fn phase339_sqrt4_k_log50_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase339r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase339r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -32129,7 +32273,7 @@ fn phase340_sqrt5_k_log48_k_over_k3_converges() {
 
 #[test]
 fn phase340_sqrt5_k_log50_k_over_k3_refused() {
-    // sqrt(k)^5*log(k)^50 / k3: 54 logs → refused (Phase 370 handles exactly 53).
+    // sqrt(k)^5*log(k)^50 / k3: 55 logs → refused (Phase 376 handles exactly 54).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -32153,12 +32297,13 @@ fn phase340_sqrt5_k_log50_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -32175,12 +32320,13 @@ fn phase340_sqrt5_k_log50_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase340r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase340r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -32237,7 +32383,7 @@ fn phase341_log49_k_over_k2_converges() {
 
 #[test]
 fn phase341_log50_k_over_k2_refused() {
-    // log(k)^50 / k2: 54 logs → refused (Phase 365 handles exactly 53).
+    // log(k)^50 / k2: 55 logs → refused (Phase 371 handles exactly 54).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -32258,12 +32404,13 @@ fn phase341_log50_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -32279,12 +32426,13 @@ fn phase341_log50_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase341r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase341r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -32345,7 +32493,7 @@ fn phase342_sqrt1_k_log49_k_over_k2_converges() {
 
 #[test]
 fn phase342_sqrt1_k_log50_k_over_k2_refused() {
-    // sqrt(k)*log(k)^50 / k2: 54 logs → refused (Phase 366 handles exactly 53).
+    // sqrt(k)*log(k)^50 / k2: 55 logs → refused (Phase 372 handles exactly 54).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -32369,12 +32517,13 @@ fn phase342_sqrt1_k_log50_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -32391,12 +32540,13 @@ fn phase342_sqrt1_k_log50_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase342r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase342r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -32457,7 +32607,7 @@ fn phase343_sqrt2_k_log49_k_over_k3_converges() {
 
 #[test]
 fn phase343_sqrt2_k_log50_k_over_k2_refused() {
-    // sqrt(k)^2*log(k)^50 / k2: 54 logs → refused (Phase 367 handles exactly 53).
+    // sqrt(k)^2*log(k)^50 / k2: 55 logs → refused (Phase 373 handles exactly 54).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -32481,12 +32631,13 @@ fn phase343_sqrt2_k_log50_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -32503,12 +32654,13 @@ fn phase343_sqrt2_k_log50_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase343r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase343r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -32569,7 +32721,7 @@ fn phase344_sqrt3_k_log49_k_over_k3_converges() {
 
 #[test]
 fn phase344_sqrt3_k_log50_k_over_k3_refused() {
-    // sqrt(k)^3*log(k)^50 / k3: 54 logs → refused (Phase 368 handles exactly 53).
+    // sqrt(k)^3*log(k)^50 / k3: 55 logs → refused (Phase 374 handles exactly 54).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -32593,12 +32745,13 @@ fn phase344_sqrt3_k_log50_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -32615,12 +32768,13 @@ fn phase344_sqrt3_k_log50_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase344r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase344r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -32681,7 +32835,7 @@ fn phase345_sqrt4_k_log49_k_over_k3_converges() {
 
 #[test]
 fn phase345_sqrt4_k_log50_k_over_k3_refused() {
-    // sqrt(k)^4*log(k)^50 / k3: 54 logs → refused (Phase 369 handles exactly 53).
+    // sqrt(k)^4*log(k)^50 / k3: 55 logs → refused (Phase 375 handles exactly 54).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -32705,12 +32859,13 @@ fn phase345_sqrt4_k_log50_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -32727,12 +32882,13 @@ fn phase345_sqrt4_k_log50_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase345r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase345r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -32793,7 +32949,7 @@ fn phase346_sqrt5_k_log49_k_over_k3_converges() {
 
 #[test]
 fn phase346_sqrt5_k_log50_k_over_k3_refused() {
-    // sqrt(k)^5*log(k)^50 / k3: 54 logs → refused (Phase 370 handles exactly 53).
+    // sqrt(k)^5*log(k)^50 / k3: 55 logs → refused (Phase 376 handles exactly 54).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -32817,12 +32973,13 @@ fn phase346_sqrt5_k_log50_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
         log_k.clone(), // 52nd log (over 50; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -32839,12 +32996,13 @@ fn phase346_sqrt5_k_log50_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
         log_kp1.clone(), // 52nd log (over 50; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase346r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase346r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -32903,7 +33061,7 @@ fn phase347_log50_k_over_k2_converges() {
 
 #[test]
 fn phase347_log51_k_over_k2_refused() {
-    // log(k)^51 / k2: 54 logs → refused (Phase 365 handles exactly 53).
+    // log(k)^51 / k2: 55 logs → refused (Phase 371 handles exactly 54).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -32925,11 +33083,12 @@ fn phase347_log51_k_over_k2_refused() {
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
         log_k.clone(), // 50th log
+        log_k.clone(), // 55th log
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -32946,11 +33105,12 @@ fn phase347_log51_k_over_k2_refused() {
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
         log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 55th log
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase347r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase347r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -33013,7 +33173,7 @@ fn phase348_sqrt1_k_log50_k_over_k2_converges() {
 
 #[test]
 fn phase348_sqrt1_k_log51_k_over_k2_refused() {
-    // sqrt(k)*log(k)^51 / k2: 54 logs → refused (Phase 366 handles exactly 53).
+    // sqrt(k)*log(k)^51 / k2: 55 logs → refused (Phase 372 handles exactly 54).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -33038,11 +33198,12 @@ fn phase348_sqrt1_k_log51_k_over_k2_refused() {
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
         log_k.clone(), // 50th log
+        log_k.clone(), // 55th log
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -33060,11 +33221,12 @@ fn phase348_sqrt1_k_log51_k_over_k2_refused() {
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
         log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 55th log
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase348r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase348r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -33127,7 +33289,7 @@ fn phase349_sqrt2_k_log50_k_over_k3_converges() {
 
 #[test]
 fn phase349_sqrt2_k_log51_k_over_k2_refused() {
-    // sqrt(k)^2*log(k)^51 / k2: 54 logs → refused (Phase 367 handles exactly 53).
+    // sqrt(k)^2*log(k)^51 / k2: 55 logs → refused (Phase 373 handles exactly 54).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -33152,11 +33314,12 @@ fn phase349_sqrt2_k_log51_k_over_k2_refused() {
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
         log_k.clone(), // 50th log
+        log_k.clone(), // 55th log
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -33174,11 +33337,12 @@ fn phase349_sqrt2_k_log51_k_over_k2_refused() {
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
         log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 55th log
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase349r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase349r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -33241,7 +33405,7 @@ fn phase350_sqrt3_k_log50_k_over_k3_converges() {
 
 #[test]
 fn phase350_sqrt3_k_log51_k_over_k3_refused() {
-    // sqrt(k)^3*log(k)^51 / k3: 54 logs → refused (Phase 368 handles exactly 53).
+    // sqrt(k)^3*log(k)^51 / k3: 55 logs → refused (Phase 374 handles exactly 54).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -33266,11 +33430,12 @@ fn phase350_sqrt3_k_log51_k_over_k3_refused() {
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
         log_k.clone(), // 50th log
+        log_k.clone(), // 55th log
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -33288,11 +33453,12 @@ fn phase350_sqrt3_k_log51_k_over_k3_refused() {
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
         log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 55th log
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase350r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase350r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -33355,7 +33521,7 @@ fn phase351_sqrt4_k_log50_k_over_k3_converges() {
 
 #[test]
 fn phase351_sqrt4_k_log51_k_over_k3_refused() {
-    // sqrt(k)^4*log(k)^51 / k3: 54 logs → refused (Phase 369 handles exactly 53).
+    // sqrt(k)^4*log(k)^51 / k3: 55 logs → refused (Phase 375 handles exactly 54).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -33380,11 +33546,12 @@ fn phase351_sqrt4_k_log51_k_over_k3_refused() {
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
         log_k.clone(), // 50th log
+        log_k.clone(), // 55th log
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -33402,11 +33569,12 @@ fn phase351_sqrt4_k_log51_k_over_k3_refused() {
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
         log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 55th log
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase351r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase351r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -33469,7 +33637,7 @@ fn phase352_sqrt5_k_log50_k_over_k3_converges() {
 
 #[test]
 fn phase352_sqrt5_k_log51_k_over_k3_refused() {
-    // sqrt(k)^5*log(k)^51 / k3: 54 logs → refused (Phase 370 handles exactly 53).
+    // sqrt(k)^5*log(k)^51 / k3: 55 logs → refused (Phase 376 handles exactly 54).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -33494,11 +33662,12 @@ fn phase352_sqrt5_k_log51_k_over_k3_refused() {
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
         log_k.clone(), // 50th log
+        log_k.clone(), // 55th log
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -33516,11 +33685,12 @@ fn phase352_sqrt5_k_log51_k_over_k3_refused() {
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
         log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 55th log
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase352r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase352r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -33581,7 +33751,7 @@ fn phase353_log51_k_over_k2_converges() {
 
 #[test]
 fn phase353_log52_k_over_k2_refused() {
-    // log(k)^52 / k2: 54 logs → refused (Phase 365 handles exactly 53).
+    // log(k)^52 / k2: 55 logs → refused (Phase 371 handles exactly 54).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -33604,11 +33774,12 @@ fn phase353_log52_k_over_k2_refused() {
         log_k.clone(), // 49th log
         log_k.clone(), // 50th log
         log_k.clone(), // 51st log
+        log_k.clone(), // 55th log
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -33626,11 +33797,12 @@ fn phase353_log52_k_over_k2_refused() {
         log_kp1.clone(), // 49th log
         log_kp1.clone(), // 50th log
         log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 55th log
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase353r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase353r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -33695,7 +33867,7 @@ fn phase354_sqrt1_k_log51_k_over_k2_converges() {
 
 #[test]
 fn phase354_sqrt1_k_log52_k_over_k2_refused() {
-    // sqrt(k)^1*log(k)^52 / k2: 54 logs → refused (Phase 366 handles exactly 53).
+    // sqrt(k)^1*log(k)^52 / k2: 55 logs → refused (Phase 372 handles exactly 54).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -33721,11 +33893,12 @@ fn phase354_sqrt1_k_log52_k_over_k2_refused() {
         log_k.clone(), // 49th log
         log_k.clone(), // 50th log
         log_k.clone(), // 51st log
+        log_k.clone(), // 55th log
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -33744,11 +33917,12 @@ fn phase354_sqrt1_k_log52_k_over_k2_refused() {
         log_kp1.clone(), // 49th log
         log_kp1.clone(), // 50th log
         log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 55th log
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase354r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase354r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -33813,7 +33987,7 @@ fn phase355_sqrt2_k_log51_k_over_k3_converges() {
 
 #[test]
 fn phase355_sqrt2_k_log52_k_over_k3_refused() {
-    // sqrt(k)^2*log(k)^52 / k3: 54 logs → refused (Phase 367 handles exactly 53).
+    // sqrt(k)^2*log(k)^52 / k3: 55 logs → refused (Phase 373 handles exactly 54).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -33839,11 +34013,12 @@ fn phase355_sqrt2_k_log52_k_over_k3_refused() {
         log_k.clone(), // 49th log
         log_k.clone(), // 50th log
         log_k.clone(), // 51st log
+        log_k.clone(), // 55th log
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -33862,11 +34037,12 @@ fn phase355_sqrt2_k_log52_k_over_k3_refused() {
         log_kp1.clone(), // 49th log
         log_kp1.clone(), // 50th log
         log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 55th log
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase355r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase355r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -33931,7 +34107,7 @@ fn phase356_sqrt3_k_log51_k_over_k3_converges() {
 
 #[test]
 fn phase356_sqrt3_k_log52_k_over_k3_refused() {
-    // sqrt(k)^3*log(k)^52 / k3: 54 logs → refused (Phase 368 handles exactly 53).
+    // sqrt(k)^3*log(k)^52 / k3: 55 logs → refused (Phase 374 handles exactly 54).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -33957,11 +34133,12 @@ fn phase356_sqrt3_k_log52_k_over_k3_refused() {
         log_k.clone(), // 49th log
         log_k.clone(), // 50th log
         log_k.clone(), // 51st log
+        log_k.clone(), // 55th log
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -33980,11 +34157,12 @@ fn phase356_sqrt3_k_log52_k_over_k3_refused() {
         log_kp1.clone(), // 49th log
         log_kp1.clone(), // 50th log
         log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 55th log
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase356r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase356r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -34049,7 +34227,7 @@ fn phase357_sqrt4_k_log51_k_over_k3_converges() {
 
 #[test]
 fn phase357_sqrt4_k_log52_k_over_k3_refused() {
-    // sqrt(k)^4*log(k)^52 / k3: 54 logs → refused (Phase 369 handles exactly 53).
+    // sqrt(k)^4*log(k)^52 / k3: 55 logs → refused (Phase 375 handles exactly 54).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -34075,11 +34253,12 @@ fn phase357_sqrt4_k_log52_k_over_k3_refused() {
         log_k.clone(), // 49th log
         log_k.clone(), // 50th log
         log_k.clone(), // 51st log
+        log_k.clone(), // 55th log
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -34098,11 +34277,12 @@ fn phase357_sqrt4_k_log52_k_over_k3_refused() {
         log_kp1.clone(), // 49th log
         log_kp1.clone(), // 50th log
         log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 55th log
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase357r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase357r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -34167,7 +34347,7 @@ fn phase358_sqrt5_k_log51_k_over_k3_converges() {
 
 #[test]
 fn phase358_sqrt5_k_log52_k_over_k3_refused() {
-    // sqrt(k)^5*log(k)^52 / k3: 54 logs → refused (Phase 370 handles exactly 53).
+    // sqrt(k)^5*log(k)^52 / k3: 55 logs → refused (Phase 376 handles exactly 54).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -34193,11 +34373,12 @@ fn phase358_sqrt5_k_log52_k_over_k3_refused() {
         log_k.clone(), // 49th log
         log_k.clone(), // 50th log
         log_k.clone(), // 51st log
+        log_k.clone(), // 55th log
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -34216,11 +34397,12 @@ fn phase358_sqrt5_k_log52_k_over_k3_refused() {
         log_kp1.clone(), // 49th log
         log_kp1.clone(), // 50th log
         log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 55th log
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase358r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase358r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -34307,9 +34489,10 @@ fn phase359_log53_k_over_k2_refused() {
         log_k.clone(), // 50th log
         log_k.clone(), // 51st log
         log_k.clone(), // 52nd log
+        log_k.clone(), // 55th log
+        log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -34328,9 +34511,10 @@ fn phase359_log53_k_over_k2_refused() {
         log_kp1.clone(), // 50th log
         log_kp1.clone(), // 51st log
         log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 55th log
+        log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase359r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase359r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -34424,9 +34608,10 @@ fn phase360_sqrt1_k_log53_k_over_k2_refused() {
         log_k.clone(), // 50th log
         log_k.clone(), // 51st log
         log_k.clone(), // 52nd log
+        log_k.clone(), // 55th log
+        log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -34446,9 +34631,10 @@ fn phase360_sqrt1_k_log53_k_over_k2_refused() {
         log_kp1.clone(), // 50th log
         log_kp1.clone(), // 51st log
         log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 55th log
+        log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase360r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase360r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -34542,9 +34728,10 @@ fn phase361_sqrt2_k_log53_k_over_k3_refused() {
         log_k.clone(), // 50th log
         log_k.clone(), // 51st log
         log_k.clone(), // 52nd log
+        log_k.clone(), // 55th log
+        log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -34564,9 +34751,10 @@ fn phase361_sqrt2_k_log53_k_over_k3_refused() {
         log_kp1.clone(), // 50th log
         log_kp1.clone(), // 51st log
         log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 55th log
+        log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase361r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase361r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -34660,9 +34848,10 @@ fn phase362_sqrt3_k_log53_k_over_k3_refused() {
         log_k.clone(), // 50th log
         log_k.clone(), // 51st log
         log_k.clone(), // 52nd log
+        log_k.clone(), // 55th log
+        log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -34682,9 +34871,10 @@ fn phase362_sqrt3_k_log53_k_over_k3_refused() {
         log_kp1.clone(), // 50th log
         log_kp1.clone(), // 51st log
         log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 55th log
+        log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase362r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase362r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -34778,9 +34968,10 @@ fn phase363_sqrt4_k_log53_k_over_k3_refused() {
         log_k.clone(), // 50th log
         log_k.clone(), // 51st log
         log_k.clone(), // 52nd log
+        log_k.clone(), // 55th log
+        log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -34800,9 +34991,10 @@ fn phase363_sqrt4_k_log53_k_over_k3_refused() {
         log_kp1.clone(), // 50th log
         log_kp1.clone(), // 51st log
         log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 55th log
+        log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase363r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase363r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -34896,9 +35088,10 @@ fn phase364_sqrt5_k_log53_k_over_k3_refused() {
         log_k.clone(), // 50th log
         log_k.clone(), // 51st log
         log_k.clone(), // 52nd log
+        log_k.clone(), // 55th log
+        log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
-        log_k.clone(), // 54th log (over 53; refused)
-        log_k, // 54th log (over 53; refused)
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -34918,9 +35111,10 @@ fn phase364_sqrt5_k_log53_k_over_k3_refused() {
         log_kp1.clone(), // 50th log
         log_kp1.clone(), // 51st log
         log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 55th log
+        log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
-        log_kp1.clone(), // 54th log (over 53; refused)
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_kphase364r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase364r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -34984,7 +35178,7 @@ fn phase365_log53_k_over_k2_converges() {
 
 #[test]
 fn phase365_log53_k_over_k2_refused() {
-    // log53 k over k2: 54 logs → refused (Phase 365 handles exactly 53).
+    // log53 k over k2: 55 logs → refused (Phase 371 handles exactly 54).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -35009,7 +35203,8 @@ fn phase365_log53_k_over_k2_refused() {
         log_k.clone(), // 51st log
         log_k.clone(), // 52nd log
         log_k.clone(), // 53rd log
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -35029,7 +35224,8 @@ fn phase365_log53_k_over_k2_refused() {
         log_kp1.clone(), // 51st log
         log_kp1.clone(), // 52nd log
         log_kp1.clone(), // 53rd log
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_k365r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_365r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -35098,7 +35294,7 @@ fn phase366_sqrt1_k_log53_k_over_k2_converges() {
 
 #[test]
 fn phase366_sqrt1_k_log53_k_over_k2_refused() {
-    // sqrt1 k log53 k over k2: 54 logs → refused (Phase 366 handles exactly 53).
+    // sqrt1 k log53 k over k2: 55 logs → refused (Phase 372 handles exactly 54).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -35126,7 +35322,8 @@ fn phase366_sqrt1_k_log53_k_over_k2_refused() {
         log_k.clone(), // 51st log
         log_k.clone(), // 52nd log
         log_k.clone(), // 53rd log
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -35147,7 +35344,8 @@ fn phase366_sqrt1_k_log53_k_over_k2_refused() {
         log_kp1.clone(), // 51st log
         log_kp1.clone(), // 52nd log
         log_kp1.clone(), // 53rd log
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_k366r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_366r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -35216,7 +35414,7 @@ fn phase367_sqrt2_k_log53_k_over_k2_converges() {
 
 #[test]
 fn phase367_sqrt2_k_log53_k_over_k2_refused() {
-    // sqrt2 k log53 k over k2: 54 logs → refused (Phase 367 handles exactly 53).
+    // sqrt2 k log53 k over k2: 55 logs → refused (Phase 373 handles exactly 54).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -35244,7 +35442,8 @@ fn phase367_sqrt2_k_log53_k_over_k2_refused() {
         log_k.clone(), // 51st log
         log_k.clone(), // 52nd log
         log_k.clone(), // 53rd log
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -35265,7 +35464,8 @@ fn phase367_sqrt2_k_log53_k_over_k2_refused() {
         log_kp1.clone(), // 51st log
         log_kp1.clone(), // 52nd log
         log_kp1.clone(), // 53rd log
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_k367r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_367r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -35334,7 +35534,7 @@ fn phase368_sqrt3_k_log53_k_over_k3_converges() {
 
 #[test]
 fn phase368_sqrt3_k_log53_k_over_k3_refused() {
-    // sqrt3 k log53 k over k3: 54 logs → refused (Phase 368 handles exactly 53).
+    // sqrt3 k log53 k over k3: 55 logs → refused (Phase 374 handles exactly 54).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -35362,7 +35562,8 @@ fn phase368_sqrt3_k_log53_k_over_k3_refused() {
         log_k.clone(), // 51st log
         log_k.clone(), // 52nd log
         log_k.clone(), // 53rd log
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -35383,7 +35584,8 @@ fn phase368_sqrt3_k_log53_k_over_k3_refused() {
         log_kp1.clone(), // 51st log
         log_kp1.clone(), // 52nd log
         log_kp1.clone(), // 53rd log
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_k368r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_368r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -35452,7 +35654,7 @@ fn phase369_sqrt4_k_log53_k_over_k3_converges() {
 
 #[test]
 fn phase369_sqrt4_k_log53_k_over_k3_refused() {
-    // sqrt4 k log53 k over k3: 54 logs → refused (Phase 369 handles exactly 53).
+    // sqrt4 k log53 k over k3: 55 logs → refused (Phase 375 handles exactly 54).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -35480,7 +35682,8 @@ fn phase369_sqrt4_k_log53_k_over_k3_refused() {
         log_k.clone(), // 51st log
         log_k.clone(), // 52nd log
         log_k.clone(), // 53rd log
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -35501,7 +35704,8 @@ fn phase369_sqrt4_k_log53_k_over_k3_refused() {
         log_kp1.clone(), // 51st log
         log_kp1.clone(), // 52nd log
         log_kp1.clone(), // 53rd log
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_k369r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_369r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -35570,7 +35774,7 @@ fn phase370_sqrt5_k_log53_k_over_k3_converges() {
 
 #[test]
 fn phase370_sqrt5_k_log53_k_over_k3_refused() {
-    // sqrt5 k log53 k over k3: 54 logs → refused (Phase 370 handles exactly 53).
+    // sqrt5 k log53 k over k3: 55 logs → refused (Phase 376 handles exactly 54).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -35598,7 +35802,8 @@ fn phase370_sqrt5_k_log53_k_over_k3_refused() {
         log_k.clone(), // 51st log
         log_k.clone(), // 52nd log
         log_k.clone(), // 53rd log
-        log_k, // 54th log (over 53; refused)
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -35619,7 +35824,8 @@ fn phase370_sqrt5_k_log53_k_over_k3_refused() {
         log_kp1.clone(), // 51st log
         log_kp1.clone(), // 52nd log
         log_kp1.clone(), // 53rd log
-        log_kp1, // 54th log (over 53; refused)
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
     ]);
     let g_k370r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_370r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -35628,3 +35834,726 @@ fn phase370_sqrt5_k_log53_k_over_k3_refused() {
     assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }
 
+#[test]
+fn phase371_log54_k_over_k2_converges() {
+    // log54 k over k2: eff_x2=0; 2·2=4 > 0 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k.clone(), // 51st log
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 53rd log
+        log_k, // 54th log
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 53rd log
+        log_kp1, // 54th log
+    ]);
+    let g_k371a = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_371a = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f371a = apply(sym(SUB), vec![g_k371a, g_kp1_371a]);
+    let out = evaluate_sum(f371a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase371_log54_k_over_k2_refused() {
+    // log54 k over k2: 55 logs → refused (Phase 371 handles exactly 54).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k.clone(), // 51st log
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
+    ]);
+    let g_k371r = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_371r = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f371r = apply(sym(SUB), vec![g_k371r, g_kp1_371r]);
+    let out = evaluate_sum(f371r, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase372_sqrt1_k_log54_k_over_k2_converges() {
+    // sqrt1 k log54 k over k2: eff_x2=1; 2·2=4 > 1 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k.clone(), // 51st log
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 53rd log
+        log_k, // 54th log
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 53rd log
+        log_kp1, // 54th log
+    ]);
+    let g_k372a = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_372a = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f372a = apply(sym(SUB), vec![g_k372a, g_kp1_372a]);
+    let out = evaluate_sum(f372a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase372_sqrt1_k_log54_k_over_k2_refused() {
+    // sqrt1 k log54 k over k2: 55 logs → refused (Phase 372 handles exactly 54).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k.clone(), // 51st log
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
+    ]);
+    let g_k372r = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_372r = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f372r = apply(sym(SUB), vec![g_k372r, g_kp1_372r]);
+    let out = evaluate_sum(f372r, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase373_sqrt2_k_log54_k_over_k2_converges() {
+    // sqrt2 k log54 k over k2: eff_x2=2; 2·2=4 > 2 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k.clone(), // 51st log
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 53rd log
+        log_k, // 54th log
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 53rd log
+        log_kp1, // 54th log
+    ]);
+    let g_k373a = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_373a = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f373a = apply(sym(SUB), vec![g_k373a, g_kp1_373a]);
+    let out = evaluate_sum(f373a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase373_sqrt2_k_log54_k_over_k2_refused() {
+    // sqrt2 k log54 k over k2: 55 logs → refused (Phase 373 handles exactly 54).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k.clone(), // 51st log
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
+    ]);
+    let g_k373r = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_373r = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f373r = apply(sym(SUB), vec![g_k373r, g_kp1_373r]);
+    let out = evaluate_sum(f373r, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase374_sqrt3_k_log54_k_over_k3_converges() {
+    // sqrt3 k log54 k over k3: eff_x2=3; 2·3=6 > 3 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k.clone(), // 51st log
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 53rd log
+        log_k, // 54th log
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 53rd log
+        log_kp1, // 54th log
+    ]);
+    let g_k374a = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_374a = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f374a = apply(sym(SUB), vec![g_k374a, g_kp1_374a]);
+    let out = evaluate_sum(f374a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase374_sqrt3_k_log54_k_over_k3_refused() {
+    // sqrt3 k log54 k over k3: 55 logs → refused (Phase 374 handles exactly 54).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k.clone(), // 51st log
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
+    ]);
+    let g_k374r = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_374r = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f374r = apply(sym(SUB), vec![g_k374r, g_kp1_374r]);
+    let out = evaluate_sum(f374r, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase375_sqrt4_k_log54_k_over_k3_converges() {
+    // sqrt4 k log54 k over k3: eff_x2=4; 2·3=6 > 4 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k.clone(), // 51st log
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 53rd log
+        log_k, // 54th log
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 53rd log
+        log_kp1, // 54th log
+    ]);
+    let g_k375a = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_375a = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f375a = apply(sym(SUB), vec![g_k375a, g_kp1_375a]);
+    let out = evaluate_sum(f375a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase375_sqrt4_k_log54_k_over_k3_refused() {
+    // sqrt4 k log54 k over k3: 55 logs → refused (Phase 375 handles exactly 54).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k.clone(), // 51st log
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
+    ]);
+    let g_k375r = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_375r = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f375r = apply(sym(SUB), vec![g_k375r, g_kp1_375r]);
+    let out = evaluate_sum(f375r, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase376_sqrt5_k_log54_k_over_k3_converges() {
+    // sqrt5 k log54 k over k3: eff_x2=5; 2·3=6 > 5 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k.clone(), // 51st log
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 53rd log
+        log_k, // 54th log
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 53rd log
+        log_kp1, // 54th log
+    ]);
+    let g_k376a = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_376a = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f376a = apply(sym(SUB), vec![g_k376a, g_kp1_376a]);
+    let out = evaluate_sum(f376a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase376_sqrt5_k_log54_k_over_k3_refused() {
+    // sqrt5 k log54 k over k3: 55 logs → refused (Phase 376 handles exactly 54).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k.clone(), // 51st log
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
+        log_k, // 55th log (over 54; refused)
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 41st, 42nd, 43rd, 44th, 45th log
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
+        log_kp1, // 55th log (over 54; refused)
+    ]);
+    let g_k376r = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_376r = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f376r = apply(sym(SUB), vec![g_k376r, g_kp1_376r]);
+    let out = evaluate_sum(f376r, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 2.313.0 — 2026-05-28
+
+### Added
+
+- **Phase 376 — Five-Sqrt × Fifty-Four-Log × polynomial** (`fiveSqrtFiftyFourLogPolyEffectiveDeg`):
+  Completes the Fifty-Four-Log family (Phases 371–376).
+- **Phase 375 — Four-Sqrt × Fifty-Four-Log × polynomial** (`fourSqrtFiftyFourLogPolyEffectiveDeg`).
+- **Phase 374 — Three-Sqrt × Fifty-Four-Log × polynomial** (`threeSqrtFiftyFourLogPolyEffectiveDeg`).
+- **Phase 373 — Two-Sqrt × Fifty-Four-Log × polynomial** (`twoSqrtFiftyFourLogPolyEffectiveDeg`).
+- **Phase 372 — One-Sqrt × Fifty-Four-Log × polynomial** (`oneSqrtFiftyFourLogPolyEffectiveDeg`).
+- **Phase 371 — Zero-Sqrt × Fifty-Four-Log × polynomial** (`fiftyFourLogPolyEffectiveDeg`).
+
+### Changed
+
+- Boundary tests in Phases 365–370 updated from 54-log "refused" to 55-log "refused"
+  now that Phases 371–376 handle exactly 54 logs.
+
 ## 2.307.0 — 2026-05-28
 
 ### Added

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "2.307.0",
+  "version": "2.313.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -6630,6 +6630,162 @@ function fiveSqrtFiftyThreeLogPolyEffectiveDeg(node: IRNode, k: IRNode): number 
   return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + sqrtHalfDegs[3] + sqrtHalfDegs[4] + polyDeg;
 }
 
+/** Phase 371 — Zero-Sqrt × Fifty-Four-Log × polynomial numerator.
+ * effectiveDeg = polyDeg (no sqrt factors).
+ * Caller checks `denDeg > fiftyFourLogPolyEffectiveDeg(num, k)`.
+ */
+function fiftyFourLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    if (sqrtEffectiveHalfDegree(arg, k) !== undefined) return undefined;
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 54) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (logCount !== 54) return undefined;
+  return polyDeg;
+}
+
+/** Phase 372 — One-Sqrt × Fifty-Four-Log × polynomial numerator. */
+function oneSqrtFiftyFourLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  let sqrtHalfDeg: number | undefined;
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDeg !== undefined) return undefined;
+      sqrtHalfDeg = hd; continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 54) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDeg === undefined || logCount !== 54) return undefined;
+  return sqrtHalfDeg + polyDeg;
+}
+
+/** Phase 373 — Two-Sqrt × Fifty-Four-Log × polynomial numerator. */
+function twoSqrtFiftyFourLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDegs.length >= 2) return undefined;
+      sqrtHalfDegs.push(hd); continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 54) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 2 || logCount !== 54) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + polyDeg;
+}
+
+/** Phase 374 — Three-Sqrt × Fifty-Four-Log × polynomial numerator. */
+function threeSqrtFiftyFourLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDegs.length >= 3) return undefined;
+      sqrtHalfDegs.push(hd); continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 54) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 3 || logCount !== 54) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + polyDeg;
+}
+
+/** Phase 375 — Four-Sqrt × Fifty-Four-Log × polynomial numerator. */
+function fourSqrtFiftyFourLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDegs.length >= 4) return undefined;
+      sqrtHalfDegs.push(hd); continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 54) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 4 || logCount !== 54) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + sqrtHalfDegs[3] + polyDeg;
+}
+
+/** Phase 376 — Five-Sqrt × Fifty-Four-Log × polynomial numerator.
+ * Completes the Fifty-Four-Log family (Phases 371–376).
+ */
+function fiveSqrtFiftyFourLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDegs.length >= 5) return undefined;
+      sqrtHalfDegs.push(hd); continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 54) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 5 || logCount !== 54) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + sqrtHalfDegs[3] + sqrtHalfDegs[4] + polyDeg;
+}
+
 /** Phase 359 — Zero-Sqrt × Fifty-Two-Log × polynomial numerator.
  * effectiveDeg = polyDeg (no sqrt factors).
  * Caller checks `denDeg > fiftyTwoLogPolyEffectiveDeg(num, k)`.
@@ -9954,6 +10110,66 @@ function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
     const denDegS2l8 = polynomialDegreeInK(den, k);
     if (denDegS2l8 !== undefined) {
       if (denDegS2l8 > s2l8Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 376: five sqrt + 54 logs
+  const s5l54Deg = fiveSqrtFiftyFourLogPolyEffectiveDeg(num, k);
+  if (s5l54Deg !== undefined) {
+    const denDegS5l54 = polynomialDegreeInK(den, k);
+    if (denDegS5l54 !== undefined) {
+      if (denDegS5l54 > s5l54Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 375: four sqrt + 54 logs
+  const s4l54Deg = fourSqrtFiftyFourLogPolyEffectiveDeg(num, k);
+  if (s4l54Deg !== undefined) {
+    const denDegS4l54 = polynomialDegreeInK(den, k);
+    if (denDegS4l54 !== undefined) {
+      if (denDegS4l54 > s4l54Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 374: three sqrt + 54 logs
+  const s3l54Deg = threeSqrtFiftyFourLogPolyEffectiveDeg(num, k);
+  if (s3l54Deg !== undefined) {
+    const denDegS3l54 = polynomialDegreeInK(den, k);
+    if (denDegS3l54 !== undefined) {
+      if (denDegS3l54 > s3l54Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 373: two sqrt + 54 logs
+  const s2l54Deg = twoSqrtFiftyFourLogPolyEffectiveDeg(num, k);
+  if (s2l54Deg !== undefined) {
+    const denDegS2l54 = polynomialDegreeInK(den, k);
+    if (denDegS2l54 !== undefined) {
+      if (denDegS2l54 > s2l54Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 372: one sqrt + 54 logs
+  const s1l54Deg = oneSqrtFiftyFourLogPolyEffectiveDeg(num, k);
+  if (s1l54Deg !== undefined) {
+    const denDegS1l54 = polynomialDegreeInK(den, k);
+    if (denDegS1l54 !== undefined) {
+      if (denDegS1l54 > s1l54Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 371: zero sqrt + 54 logs
+  const s0l54Deg = fiftyFourLogPolyEffectiveDeg(num, k);
+  if (s0l54Deg !== undefined) {
+    const denDegS0l54 = polynomialDegreeInK(den, k);
+    if (denDegS0l54 !== undefined) {
+      if (denDegS0l54 > s0l54Deg) return true;
     } else if (hDivergesAtInfinity(den, k)) {
       return true;
     }

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -15271,8 +15271,8 @@ describe("Phase 167 — Twenty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK167r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1167r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK167r = { kind: "apply" as const, head: DIV, args: [numK167r, k2] };
@@ -15321,8 +15321,8 @@ describe("Phase 168 — One-Sqrt × Twenty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK168r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [k] }, ...logs29k, k] };
     const numKp1168r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [kp1] }, ...logs29kp1, kp1] };
     const gK168r = { kind: "apply" as const, head: DIV, args: [numK168r, k2] };
@@ -15375,8 +15375,8 @@ describe("Phase 169 — Two-Sqrt × Twenty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK169r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -15431,8 +15431,8 @@ describe("Phase 170 — Three-Sqrt × Twenty-Log × polynomial numerator", () =>
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK170r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15487,8 +15487,8 @@ describe("Phase 171 — Four-Sqrt × Twenty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK171r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15543,8 +15543,8 @@ describe("Phase 172 — Five-Sqrt × Twenty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK172r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15595,8 +15595,8 @@ describe("Phase 173 — Twenty-One-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK173r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1173r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK173r = { kind: "apply" as const, head: DIV, args: [numK173r, k2] };
@@ -15645,8 +15645,8 @@ describe("Phase 174 — One-Sqrt × Twenty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK174r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [k] }, ...logs29k, k] };
     const numKp1174r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [kp1] }, ...logs29kp1, kp1] };
     const gK174r = { kind: "apply" as const, head: DIV, args: [numK174r, k2] };
@@ -15699,8 +15699,8 @@ describe("Phase 175 — Two-Sqrt × Twenty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK175r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -15755,8 +15755,8 @@ describe("Phase 176 — Three-Sqrt × Twenty-One-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK176r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15811,8 +15811,8 @@ describe("Phase 177 — Four-Sqrt × Twenty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK177r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15867,8 +15867,8 @@ describe("Phase 178 — Five-Sqrt × Twenty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK178r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15919,8 +15919,8 @@ describe("Phase 179 — Twenty-Two-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK179r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1179r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK179r = { kind: "apply" as const, head: DIV, args: [numK179r, k2] };
@@ -15969,8 +15969,8 @@ describe("Phase 180 — One-Sqrt × Twenty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK180r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [k] }, ...logs29k, k] };
     const numKp1180r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [kp1] }, ...logs29kp1, kp1] };
     const gK180r = { kind: "apply" as const, head: DIV, args: [numK180r, k2] };
@@ -16023,8 +16023,8 @@ describe("Phase 181 — Two-Sqrt × Twenty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK181r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -16079,8 +16079,8 @@ describe("Phase 182 — Three-Sqrt × Twenty-Two-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK182r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16135,8 +16135,8 @@ describe("Phase 183 — Four-Sqrt × Twenty-Two-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK183r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16191,8 +16191,8 @@ describe("Phase 184 — Five-Sqrt × Twenty-Two-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK184r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16243,8 +16243,8 @@ describe("Phase 185 — Twenty-Three-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK185r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1185r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK185r = { kind: "apply" as const, head: DIV, args: [numK185r, k2] };
@@ -16293,8 +16293,8 @@ describe("Phase 186 — One-Sqrt × Twenty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK186r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [k] }, ...logs29k, k] };
     const numKp1186r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [kp1] }, ...logs29kp1, kp1] };
     const gK186r = { kind: "apply" as const, head: DIV, args: [numK186r, k2] };
@@ -16347,8 +16347,8 @@ describe("Phase 187 — Two-Sqrt × Twenty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK187r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -16403,8 +16403,8 @@ describe("Phase 188 — Three-Sqrt × Twenty-Three-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK188r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16459,8 +16459,8 @@ describe("Phase 189 — Four-Sqrt × Twenty-Three-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK189r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16515,8 +16515,8 @@ describe("Phase 190 — Five-Sqrt × Twenty-Three-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK190r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16567,8 +16567,8 @@ describe("Phase 191 — Twenty-Four-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK191r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1191r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK191r = { kind: "apply" as const, head: DIV, args: [numK191r, k2] };
@@ -16621,8 +16621,8 @@ describe("Phase 192 — One-Sqrt × Twenty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK192r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs29k, k] };
@@ -16677,8 +16677,8 @@ describe("Phase 193 — Two-Sqrt × Twenty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK193r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -16733,8 +16733,8 @@ describe("Phase 194 — Three-Sqrt × Twenty-Four-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK194r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16789,8 +16789,8 @@ describe("Phase 195 — Four-Sqrt × Twenty-Four-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK195r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16845,8 +16845,8 @@ describe("Phase 196 — Five-Sqrt × Twenty-Four-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK196r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16897,8 +16897,8 @@ describe("Phase 197 — Twenty-Five-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK197r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1197r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK197r = { kind: "apply" as const, head: DIV, args: [numK197r, k2] };
@@ -16951,8 +16951,8 @@ describe("Phase 198 — One-Sqrt × Twenty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK198r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs29k, k] };
@@ -17007,8 +17007,8 @@ describe("Phase 199 — Two-Sqrt × Twenty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK199r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -17063,8 +17063,8 @@ describe("Phase 200 — Three-Sqrt × Twenty-Five-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK200r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17119,8 +17119,8 @@ describe("Phase 201 — Four-Sqrt × Twenty-Five-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK201r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17175,8 +17175,8 @@ describe("Phase 202 — Five-Sqrt × Twenty-Five-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK202r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17227,8 +17227,8 @@ describe("Phase 203 — Twenty-Six-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK203r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1203r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK203r = { kind: "apply" as const, head: DIV, args: [numK203r, k2] };
@@ -17279,8 +17279,8 @@ describe("Phase 204 — One-Sqrt × Twenty-Six-Log × polynomial numerator", () 
   it("√k·log(k)²⁹·k/k² refused (30 logs — not Phase 204)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK204r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs29k, k] };
@@ -17333,8 +17333,8 @@ describe("Phase 205 — Two-Sqrt × Twenty-Six-Log × polynomial numerator", () 
   it("√k·√k·log(k)²⁹/k² refused (30 logs — not Phase 205)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK205r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k, k] };
@@ -17387,8 +17387,8 @@ describe("Phase 206 — Three-Sqrt × Twenty-Six-Log × polynomial numerator", (
   it("(√k)³·log(k)²⁹/k² refused (30 logs — not Phase 206)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK206r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k, k] };
@@ -17443,8 +17443,8 @@ describe("Phase 207 — Four-Sqrt × Twenty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK207r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k, k] };
@@ -17499,8 +17499,8 @@ describe("Phase 208 — Five-Sqrt × Twenty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK208r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17551,8 +17551,8 @@ describe("Phase 209 — Zero-Sqrt × Twenty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK209r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1209r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK209r = { kind: "apply" as const, head: DIV, args: [numK209r, k2] };
@@ -17603,8 +17603,8 @@ describe("Phase 210 — One-Sqrt × Twenty-Seven-Log × polynomial numerator", (
   it("√k·log(k)²⁹·k/k² refused (30 logs — not Phase 210)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK210r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs29k, k] };
@@ -17659,8 +17659,8 @@ describe("Phase 211 — Two-Sqrt × Twenty-Seven-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK211r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -17715,8 +17715,8 @@ describe("Phase 212 — Three-Sqrt × Twenty-Seven-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK212r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17771,8 +17771,8 @@ describe("Phase 213 — Four-Sqrt × Twenty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK213r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17827,8 +17827,8 @@ describe("Phase 214 — Five-Sqrt × Twenty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK214r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17879,8 +17879,8 @@ describe("Phase 215 — Zero-Sqrt × Twenty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK215r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1215r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK215r = { kind: "apply" as const, head: DIV, args: [numK215r, k2] };
@@ -17933,8 +17933,8 @@ describe("Phase 216 — One-Sqrt × Twenty-Eight-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK216r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs29k, k] };
@@ -17989,8 +17989,8 @@ describe("Phase 217 — Two-Sqrt × Twenty-Eight-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK217r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -18045,8 +18045,8 @@ describe("Phase 218 — Three-Sqrt × Twenty-Eight-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK218r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -18101,8 +18101,8 @@ describe("Phase 219 — Four-Sqrt × Twenty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK219r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -18157,8 +18157,8 @@ describe("Phase 220 — Five-Sqrt × Twenty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK220r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -18209,8 +18209,8 @@ describe("Phase 221 — Zero-Sqrt × Twenty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK221r = { kind: "apply" as const, head: MUL, args: [...logs30k, k] };
     const numKp1221r = { kind: "apply" as const, head: MUL, args: [...logs30kp1, kp1] };
     const gK221r = { kind: "apply" as const, head: DIV, args: [numK221r, k2] };
@@ -18263,8 +18263,8 @@ describe("Phase 222 — One-Sqrt × Twenty-Nine-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK222r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs30k, k] };
@@ -18319,8 +18319,8 @@ describe("Phase 223 — Two-Sqrt × Twenty-Nine-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK223r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs30k, k] };
@@ -18375,8 +18375,8 @@ describe("Phase 224 — Three-Sqrt × Twenty-Nine-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK224r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs30k, k] };
@@ -18431,8 +18431,8 @@ describe("Phase 225 — Four-Sqrt × Twenty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK225r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs30k, k] };
@@ -18487,8 +18487,8 @@ describe("Phase 226 — Five-Sqrt × Twenty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK226r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs30k, k] };
@@ -18539,8 +18539,8 @@ describe("Phase 227 — Zero-Sqrt × Thirty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK227r = { kind: "apply" as const, head: MUL, args: [...logs31k, k] };
     const numKp1227r = { kind: "apply" as const, head: MUL, args: [...logs31kp1, kp1] };
     const gK227r = { kind: "apply" as const, head: DIV, args: [numK227r, k2] };
@@ -18593,8 +18593,8 @@ describe("Phase 228 — One-Sqrt × Thirty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK228r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs31k, k] };
@@ -18649,8 +18649,8 @@ describe("Phase 229 — Two-Sqrt × Thirty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK229r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs31k, k] };
@@ -18705,8 +18705,8 @@ describe("Phase 230 — Three-Sqrt × Thirty-Log × polynomial numerator", () =>
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK230r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs31k, k] };
@@ -18761,8 +18761,8 @@ describe("Phase 231 — Four-Sqrt × Thirty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK231r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs31k, k] };
@@ -18817,8 +18817,8 @@ describe("Phase 232 — Five-Sqrt × Thirty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK232r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs31k, k] };
@@ -18869,8 +18869,8 @@ describe("Phase 233 — Zero-Sqrt × Thirty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK233r = { kind: "apply" as const, head: MUL, args: [...logs32k, k] };
     const numKp1233r = { kind: "apply" as const, head: MUL, args: [...logs32kp1, kp1] };
     const gK233r = { kind: "apply" as const, head: DIV, args: [numK233r, k2] };
@@ -18923,8 +18923,8 @@ describe("Phase 234 — One-Sqrt × Thirty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK234r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs32k, k] };
@@ -18979,8 +18979,8 @@ describe("Phase 235 — Two-Sqrt × Thirty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK235r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs32k, k] };
@@ -19035,8 +19035,8 @@ describe("Phase 236 — Three-Sqrt × Thirty-One-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK236r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs32k, k] };
@@ -19091,8 +19091,8 @@ describe("Phase 237 — Four-Sqrt × Thirty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK237r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs32k, k] };
@@ -19147,8 +19147,8 @@ describe("Phase 238 — Five-Sqrt × Thirty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK238r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs32k, k] };
@@ -19199,8 +19199,8 @@ describe("Phase 239 — Thirty-Two-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs33k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK239r = { kind: "apply" as const, head: MUL, args: [...logs33k, k] };
     const numKp1239r = { kind: "apply" as const, head: MUL, args: [...logs33kp1, kp1] };
     const gK239r = { kind: "apply" as const, head: DIV, args: [numK239r, k2] };
@@ -19249,8 +19249,8 @@ describe("Phase 240 — One-Sqrt × Thirty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs33k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK240r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [k] }, ...logs33k, k] };
     const numKp1240r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [kp1] }, ...logs33kp1, kp1] };
     const gK240r = { kind: "apply" as const, head: DIV, args: [numK240r, k2] };
@@ -19303,8 +19303,8 @@ describe("Phase 241 — Two-Sqrt × Thirty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs33k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK241r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs33k] };
@@ -19359,8 +19359,8 @@ describe("Phase 242 — Three-Sqrt × Thirty-Two-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs33k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK242r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs33k] };
@@ -19415,8 +19415,8 @@ describe("Phase 243 — Four-Sqrt × Thirty-Two-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs33k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK243r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs33k, k] };
@@ -19471,8 +19471,8 @@ describe("Phase 244 — Five-Sqrt × Thirty-Two-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs33k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK244r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs33k, k] };
@@ -19523,8 +19523,8 @@ describe("Phase 245 — Thirty-Three-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs34k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK245r = { kind: "apply" as const, head: MUL, args: [...logs34k, k] };
     const numKp1245r = { kind: "apply" as const, head: MUL, args: [...logs34kp1, kp1] };
     const gK245r = { kind: "apply" as const, head: DIV, args: [numK245r, k2] };
@@ -19577,8 +19577,8 @@ describe("Phase 246 — One-Sqrt × Thirty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs34k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK246r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs34k, k] };
@@ -19633,8 +19633,8 @@ describe("Phase 247 — Two-Sqrt × Thirty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs34k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK247r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs34k] };
@@ -19689,8 +19689,8 @@ describe("Phase 248 — Three-Sqrt × Thirty-Three-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs34k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK248r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs34k] };
@@ -19745,8 +19745,8 @@ describe("Phase 249 — Four-Sqrt × Thirty-Three-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs34k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK249r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs34k] };
@@ -19801,8 +19801,8 @@ describe("Phase 250 — Five-Sqrt × Thirty-Three-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs34k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK250r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs34k, k] };
@@ -19853,8 +19853,8 @@ describe("Phase 251 — Thirty-Four-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs36k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK251r = { kind: "apply" as const, head: MUL, args: [...logs36k, k] };
     const numKp1251r = { kind: "apply" as const, head: MUL, args: [...logs36kp1, kp1] };
     const gK251r = { kind: "apply" as const, head: DIV, args: [numK251r, k2] };
@@ -19907,8 +19907,8 @@ describe("Phase 252 — One-Sqrt × Thirty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs36k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK252r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs36k, k] };
@@ -19963,8 +19963,8 @@ describe("Phase 253 — Two-Sqrt × Thirty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs36k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK253r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs36k] };
@@ -20019,8 +20019,8 @@ describe("Phase 254 — Three-Sqrt × Thirty-Four-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs36k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK254r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs36k] };
@@ -20075,8 +20075,8 @@ describe("Phase 255 — Four-Sqrt × Thirty-Four-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs36k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK255r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs36k] };
@@ -20131,8 +20131,8 @@ describe("Phase 256 — Five-Sqrt × Thirty-Four-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK256r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs36k, k] };
@@ -20183,8 +20183,8 @@ describe("Phase 257 — Thirty-Five-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK257r = { kind: "apply" as const, head: MUL, args: [...logs36k, k] };
     const numKp1257r = { kind: "apply" as const, head: MUL, args: [...logs36kp1, kp1] };
     const gK257r = { kind: "apply" as const, head: DIV, args: [numK257r, k2] };
@@ -20237,8 +20237,8 @@ describe("Phase 258 — One-Sqrt × Thirty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK258r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs36k, k] };
@@ -20293,8 +20293,8 @@ describe("Phase 259 — Two-Sqrt × Thirty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK259r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs36k, k] };
@@ -20349,8 +20349,8 @@ describe("Phase 260 — Three-Sqrt × Thirty-Five-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK260r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs36k, k] };
@@ -20405,8 +20405,8 @@ describe("Phase 261 — Four-Sqrt × Thirty-Five-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK261r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs36k, k] };
@@ -20461,8 +20461,8 @@ describe("Phase 262 — Five-Sqrt × Thirty-Five-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK262r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs36k, k] };
@@ -20513,8 +20513,8 @@ describe("Phase 263 — Zero-Sqrt × Thirty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK263r = { kind: "apply" as const, head: MUL, args: [...logs37k, k] };
     const numKp1263r = { kind: "apply" as const, head: MUL, args: [...logs37kp1, kp1] };
     const gK263r = { kind: "apply" as const, head: DIV, args: [numK263r, k2] };
@@ -20567,8 +20567,8 @@ describe("Phase 264 — One-Sqrt × Thirty-Six-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK264r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs37k, k] };
@@ -20623,8 +20623,8 @@ describe("Phase 265 — Two-Sqrt × Thirty-Six-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK265r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs37k] };
@@ -20679,8 +20679,8 @@ describe("Phase 266 — Three-Sqrt × Thirty-Six-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK266r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs37k] };
@@ -20735,8 +20735,8 @@ describe("Phase 267 — Four-Sqrt × Thirty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK267r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs37k, k] };
@@ -20791,8 +20791,8 @@ describe("Phase 268 — Five-Sqrt × Thirty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK268r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs37k, k] };
@@ -20843,8 +20843,8 @@ describe("Phase 269 — Zero-Sqrt × Thirty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs38k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs38kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs38k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK269r = { kind: "apply" as const, head: MUL, args: [...logs38k, k] };
     const numKp1269r = { kind: "apply" as const, head: MUL, args: [...logs38kp1, kp1] };
     const gK269r = { kind: "apply" as const, head: DIV, args: [numK269r, k2] };
@@ -20897,8 +20897,8 @@ describe("Phase 270 — One-Sqrt × Thirty-Seven-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs38k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs38kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs38k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK270r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs38k, k] };
@@ -20953,8 +20953,8 @@ describe("Phase 271 — Two-Sqrt × Thirty-Seven-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs38k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs38kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs38k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK271r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs38k, k] };
@@ -21009,8 +21009,8 @@ describe("Phase 272 — Three-Sqrt × Thirty-Seven-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs38k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs38kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs38k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK272r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs38k, k] };
@@ -21065,8 +21065,8 @@ describe("Phase 273 — Four-Sqrt × Thirty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs38k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs38kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs38k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK273r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs38k, k] };
@@ -21121,8 +21121,8 @@ describe("Phase 274 — Five-Sqrt × Thirty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs38k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs38kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs38k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK274r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs38k, k] };
@@ -21173,8 +21173,8 @@ describe("Phase 275 — Zero-Sqrt × Thirty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs39k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs39kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs39k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs39kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK275r = { kind: "apply" as const, head: MUL, args: [...logs39k, k] };
     const numKp1275r = { kind: "apply" as const, head: MUL, args: [...logs39kp1, kp1] };
     const gK275r = { kind: "apply" as const, head: DIV, args: [numK275r, k2] };
@@ -21227,8 +21227,8 @@ describe("Phase 276 — One-Sqrt × Thirty-Eight-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs39k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs39kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs39k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs39kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK276r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs39k, k] };
@@ -21283,8 +21283,8 @@ describe("Phase 277 — Two-Sqrt × Thirty-Eight-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs39k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs39kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs39k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs39kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK277r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs39k, k] };
@@ -21339,8 +21339,8 @@ describe("Phase 278 — Three-Sqrt × Thirty-Eight-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs39k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs39kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs39k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs39kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK278r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs39k, k] };
@@ -21395,8 +21395,8 @@ describe("Phase 279 — Four-Sqrt × Thirty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs39k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs39kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs39k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs39kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK279r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs39k, k] };
@@ -21451,8 +21451,8 @@ describe("Phase 280 — Five-Sqrt × Thirty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs39k = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs39kp1 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs39k = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs39kp1 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK280r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs39k, k] };
@@ -21504,8 +21504,8 @@ describe("Phase 281 — Zero-Sqrt × Thirty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs40k281 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs40kp1281 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs40k281 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1281 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK281r = { kind: "apply" as const, head: MUL, args: [...logs40k281, k] };
     const numKp1281r = { kind: "apply" as const, head: MUL, args: [...logs40kp1281, kp1] };
     const gK281r = { kind: "apply" as const, head: DIV, args: [numK281r, k2r] };
@@ -21558,8 +21558,8 @@ describe("Phase 282 — One-Sqrt × Thirty-Nine-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs40k282 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs40kp1282 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs40k282 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1282 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK282r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs40k282, k] };
@@ -21614,8 +21614,8 @@ describe("Phase 283 — Two-Sqrt × Thirty-Nine-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs40k283 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs40kp1283 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs40k283 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1283 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK283r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs40k283, k] };
@@ -21670,8 +21670,8 @@ describe("Phase 284 — Three-Sqrt × Thirty-Nine-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs40k284 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs40kp1284 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs40k284 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1284 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK284r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs40k284, k] };
@@ -21726,8 +21726,8 @@ describe("Phase 285 — Four-Sqrt × Thirty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs40k285 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs40kp1285 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs40k285 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1285 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK285r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs40k285, k] };
@@ -21782,8 +21782,8 @@ describe("Phase 286 — Five-Sqrt × Thirty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs40k286 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs40kp1286 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs40k286 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1286 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK286r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs40k286, k] };
@@ -21834,8 +21834,8 @@ describe("Phase 287 — Zero-Sqrt × Forty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k287 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1287 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k287 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1287 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK287r = { kind: "apply" as const, head: MUL, args: [...logs42k287, k] };
     const numKp1287r = { kind: "apply" as const, head: MUL, args: [...logs42kp1287, kp1] };
     const gK287r = { kind: "apply" as const, head: DIV, args: [numK287r, k2r] };
@@ -21888,8 +21888,8 @@ describe("Phase 288 — One-Sqrt × Forty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k288 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1288 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k288 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1288 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK288r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs42k288, k] };
@@ -21944,8 +21944,8 @@ describe("Phase 289 — Two-Sqrt × Forty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k289 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1289 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k289 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1289 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK289r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs42k289, k] };
@@ -22000,8 +22000,8 @@ describe("Phase 290 — Three-Sqrt × Forty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k290 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1290 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k290 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1290 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK290r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs42k290, k] };
@@ -22056,8 +22056,8 @@ describe("Phase 291 — Four-Sqrt × Forty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k291 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1291 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k291 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1291 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK291r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs42k291, k] };
@@ -22112,8 +22112,8 @@ describe("Phase 292 — Five-Sqrt × Forty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k292 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1292 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k292 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1292 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK292r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs42k292, k] };
@@ -22164,8 +22164,8 @@ describe("Phase 293 — Zero-Sqrt × Forty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k293 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1293 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k293 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1293 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK293r = { kind: "apply" as const, head: MUL, args: [...logs42k293, k] };
     const numKp1293r = { kind: "apply" as const, head: MUL, args: [...logs42kp1293, kp1] };
     const gK293r = { kind: "apply" as const, head: DIV, args: [numK293r, k2r] };
@@ -22200,8 +22200,8 @@ describe("Phase 294 — One-Sqrt × Forty-One-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k294 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1294 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k294 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1294 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK294r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs42k294, k] };
@@ -22238,8 +22238,8 @@ describe("Phase 295 — Two-Sqrt × Forty-One-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k295 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1295 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k295 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1295 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK295r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs42k295, k] };
@@ -22276,8 +22276,8 @@ describe("Phase 296 — Three-Sqrt × Forty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k296 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1296 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k296 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1296 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK296r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs42k296, k] };
@@ -22314,8 +22314,8 @@ describe("Phase 297 — Four-Sqrt × Forty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k297 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1297 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k297 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1297 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK297r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs42k297, k] };
@@ -22352,8 +22352,8 @@ describe("Phase 298 — Five-Sqrt × Forty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k298 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1298 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k298 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1298 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK298r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs42k298, k] };
@@ -22388,8 +22388,8 @@ describe("Phase 299 — Zero-Sqrt × Forty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k299 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1299 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k299 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1299 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK299r = { kind: "apply" as const, head: MUL, args: [...logs44k299, k] };
     const numKp1299r = { kind: "apply" as const, head: MUL, args: [...logs44kp1299, kp1] };
     const gK299r = { kind: "apply" as const, head: DIV, args: [numK299r, k2r] };
@@ -22424,8 +22424,8 @@ describe("Phase 300 — One-Sqrt × Forty-Two-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k300 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1300 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k300 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1300 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK300r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs44k300, k] };
@@ -22462,8 +22462,8 @@ describe("Phase 301 — Two-Sqrt × Forty-Two-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k301 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1301 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k301 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1301 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK301r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs44k301, k] };
@@ -22500,8 +22500,8 @@ describe("Phase 302 — Three-Sqrt × Forty-Two-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k302 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1302 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k302 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1302 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK302r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs44k302, k] };
@@ -22538,8 +22538,8 @@ describe("Phase 303 — Four-Sqrt × Forty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k303 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1303 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k303 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1303 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK303r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs44k303, k] };
@@ -22576,8 +22576,8 @@ describe("Phase 304 — Five-Sqrt × Forty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k304 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1304 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k304 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1304 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK304r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs44k304, k] };
@@ -22612,8 +22612,8 @@ describe("Phase 305 — Zero-Sqrt × Forty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k305 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1305 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k305 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1305 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK305r = { kind: "apply" as const, head: MUL, args: [...logs44k305, k] };
     const numKp1305r = { kind: "apply" as const, head: MUL, args: [...logs44kp1305, kp1] };
     const gK305r = { kind: "apply" as const, head: DIV, args: [numK305r, k2r] };
@@ -22648,8 +22648,8 @@ describe("Phase 306 — One-Sqrt × Forty-Three-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k306 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1306 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k306 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1306 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK306r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs44k306, k] };
@@ -22686,8 +22686,8 @@ describe("Phase 307 — Two-Sqrt × Forty-Three-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k307 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1307 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k307 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1307 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK307r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs44k307, k] };
@@ -22724,8 +22724,8 @@ describe("Phase 308 — Three-Sqrt × Forty-Three-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1, kp1] };
-    const logs44k308 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1308 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k308 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1308 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK308r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs44k308, k] };
@@ -22762,8 +22762,8 @@ describe("Phase 309 — Four-Sqrt × Forty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1, kp1] };
-    const logs44k309 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1309 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k309 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1309 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK309r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs44k309, k] };
@@ -22800,8 +22800,8 @@ describe("Phase 310 — Five-Sqrt × Forty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k310 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1310 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k310 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1310 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK310r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs44k310, k] };
@@ -22836,8 +22836,8 @@ describe("Phase 311 — Forty-Four-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs45k311 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs45kp1311 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs45k311 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs45kp1311 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK311r = { kind: "apply" as const, head: MUL, args: [...logs45k311, k] };
     const numKp1311r = { kind: "apply" as const, head: MUL, args: [...logs45kp1311, kp1] };
     const gK311r = { kind: "apply" as const, head: DIV, args: [numK311r, k2r] };
@@ -22872,8 +22872,8 @@ describe("Phase 312 — One-Sqrt × Forty-Four-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs45k312 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs45kp1312 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs45k312 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs45kp1312 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK312r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs45k312, k] };
@@ -22910,8 +22910,8 @@ describe("Phase 313 — Two-Sqrt × Forty-Four-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs45k313 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs45kp1313 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs45k313 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs45kp1313 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK313r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs45k313, k] };
@@ -22948,8 +22948,8 @@ describe("Phase 314 — Three-Sqrt × Forty-Four-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs45k314 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs45kp1314 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs45k314 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs45kp1314 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK314r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs45k314, k] };
@@ -22986,8 +22986,8 @@ describe("Phase 315 — Four-Sqrt × Forty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs45k315 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs45kp1315 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs45k315 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs45kp1315 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK315r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs45k315, k] };
@@ -23024,8 +23024,8 @@ describe("Phase 316 — Five-Sqrt × Forty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs45k316 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs45kp1316 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs45k316 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs45kp1316 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK316r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs45k316, k] };
@@ -23060,8 +23060,8 @@ describe("Phase 317 — Forty-Five-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs46k317 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs46kp1317 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs46k317 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs46kp1317 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK317r = { kind: "apply" as const, head: MUL, args: [...logs46k317, k] };
     const numKp1317r = { kind: "apply" as const, head: MUL, args: [...logs46kp1317, kp1] };
     const gK317r = { kind: "apply" as const, head: DIV, args: [numK317r, k2r] };
@@ -23096,8 +23096,8 @@ describe("Phase 318 — One-Sqrt × Forty-Five-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs46k318 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs46kp1318 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs46k318 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs46kp1318 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK318r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs46k318, k] };
@@ -23134,8 +23134,8 @@ describe("Phase 319 — Two-Sqrt × Forty-Five-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs46k319 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs46kp1319 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs46k319 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs46kp1319 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK319r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs46k319, k] };
@@ -23172,8 +23172,8 @@ describe("Phase 320 — Three-Sqrt × Forty-Five-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs46k320 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs46kp1320 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs46k320 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs46kp1320 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK320r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs46k320, k] };
@@ -23210,8 +23210,8 @@ describe("Phase 321 — Four-Sqrt × Forty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs46k321 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs46kp1321 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs46k321 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs46kp1321 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK321r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs46k321, k] };
@@ -23248,8 +23248,8 @@ describe("Phase 322 — Five-Sqrt × Forty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs46k322 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs46kp1322 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs46k322 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs46kp1322 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK322r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs46k322, k] };
@@ -23284,8 +23284,8 @@ describe("Phase 323 — Forty-Six-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs47k323 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs47kp1323 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs47k323 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs47kp1323 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK323r = { kind: "apply" as const, head: MUL, args: [...logs47k323, k] };
     const numKp1323r = { kind: "apply" as const, head: MUL, args: [...logs47kp1323, kp1] };
     const gK323r = { kind: "apply" as const, head: DIV, args: [numK323r, k2r] };
@@ -23320,8 +23320,8 @@ describe("Phase 324 — One-Sqrt × Forty-Six-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs47k324 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs47kp1324 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs47k324 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs47kp1324 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK324r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs47k324, k] };
@@ -23358,8 +23358,8 @@ describe("Phase 325 — Two-Sqrt × Forty-Six-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs47k325 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs47kp1325 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs47k325 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs47kp1325 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK325r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs47k325, k] };
@@ -23396,8 +23396,8 @@ describe("Phase 326 — Three-Sqrt × Forty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs47k326 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs47kp1326 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs47k326 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs47kp1326 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK326r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs47k326, k] };
@@ -23434,8 +23434,8 @@ describe("Phase 327 — Four-Sqrt × Forty-Six-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs47k327 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs47kp1327 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs47k327 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs47kp1327 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK327r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs47k327, k] };
@@ -23472,8 +23472,8 @@ describe("Phase 328 — Five-Sqrt × Forty-Six-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs47k328 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs47kp1328 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs47k328 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs47kp1328 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK328r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs47k328, k] };
@@ -23508,8 +23508,8 @@ describe("Phase 329 — Forty-Seven-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k329 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1329 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k329 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1329 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK329r = { kind: "apply" as const, head: MUL, args: [...logs49k329, k] };
     const numKp1329r = { kind: "apply" as const, head: MUL, args: [...logs49kp1329, kp1] };
     const gK329r = { kind: "apply" as const, head: DIV, args: [numK329r, k2r] };
@@ -23544,8 +23544,8 @@ describe("Phase 330 — One-Sqrt × Forty-Seven-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k330 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1330 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k330 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1330 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK330r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs49k330, k] };
@@ -23582,8 +23582,8 @@ describe("Phase 331 — Two-Sqrt × Forty-Seven-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k331 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1331 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k331 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1331 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK331r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs49k331, k] };
@@ -23620,8 +23620,8 @@ describe("Phase 332 — Three-Sqrt × Forty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k332 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1332 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k332 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1332 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK332r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs49k332, k] };
@@ -23658,8 +23658,8 @@ describe("Phase 333 — Four-Sqrt × Forty-Seven-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k333 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1333 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k333 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1333 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK333r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs49k333, k] };
@@ -23696,8 +23696,8 @@ describe("Phase 334 — Five-Sqrt × Forty-Seven-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k334 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1334 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k334 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1334 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK334r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs49k334, k] };
@@ -23727,13 +23727,13 @@ describe("Phase 335 — Zero-Sqrt × Forty-Eight-Log × polynomial numerator", (
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("log(k)⁵¹·k/k² refused (54 logs — not Phase 365)", () => {
+  it("log(k)⁵¹·k/k² refused (55 logs — not Phase 371)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k335 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1335 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k335 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1335 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK335r = { kind: "apply" as const, head: MUL, args: [...logs49k335, k] };
     const numKp1335r = { kind: "apply" as const, head: MUL, args: [...logs49kp1335, kp1] };
     const gK335r = { kind: "apply" as const, head: DIV, args: [numK335r, k2r] };
@@ -23763,13 +23763,13 @@ describe("Phase 336 — One-Sqrt × Forty-Eight-Log × polynomial numerator", ()
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("√k·log(k)⁵¹·k/k² refused (54 logs — not Phase 366)", () => {
+  it("√k·log(k)⁵¹·k/k² refused (55 logs — not Phase 372)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k336 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1336 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k336 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1336 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK336r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs49k336, k] };
@@ -23801,13 +23801,13 @@ describe("Phase 337 — Two-Sqrt × Forty-Eight-Log × polynomial numerator", ()
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)²·log(k)⁵¹·k/k² refused (54 logs — not Phase 367)", () => {
+  it("(√k)²·log(k)⁵¹·k/k² refused (55 logs — not Phase 373)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k337 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1337 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k337 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1337 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK337r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs49k337, k] };
@@ -23839,13 +23839,13 @@ describe("Phase 338 — Three-Sqrt × Forty-Eight-Log × polynomial numerator", 
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)³·log(k)⁵¹·k/k³ refused (54 logs — not Phase 368)", () => {
+  it("(√k)³·log(k)⁵¹·k/k³ refused (55 logs — not Phase 374)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k338 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1338 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k338 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1338 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK338r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs49k338, k] };
@@ -23877,13 +23877,13 @@ describe("Phase 339 — Four-Sqrt × Forty-Eight-Log × polynomial numerator", (
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)⁴·log(k)⁵¹·k/k³ refused (54 logs — not Phase 369)", () => {
+  it("(√k)⁴·log(k)⁵¹·k/k³ refused (55 logs — not Phase 375)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k339 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1339 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k339 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1339 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK339r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs49k339, k] };
@@ -23915,13 +23915,13 @@ describe("Phase 340 — Five-Sqrt × Forty-Eight-Log × polynomial numerator", (
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)^5·log(k)⁵¹·k/k³ refused (54 logs — not Phase 370)", () => {
+  it("(√k)^5·log(k)⁵¹·k/k³ refused (55 logs — not Phase 376)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k340 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1340 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k340 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1340 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK340r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs49k340, k] };
@@ -23951,13 +23951,13 @@ describe("Phase 341 — Zero-Sqrt × Forty-Nine-Log × polynomial numerator", ()
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("log(k)⁵¹·k/k² refused (54 logs — not Phase 365)", () => {
+  it("log(k)⁵¹·k/k² refused (55 logs — not Phase 371)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k341 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1341 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k341 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1341 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK341r = { kind: "apply" as const, head: MUL, args: [...logs51k341, k] };
     const numKp1341r = { kind: "apply" as const, head: MUL, args: [...logs51kp1341, kp1] };
     const gK341r = { kind: "apply" as const, head: DIV, args: [numK341r, k2r] };
@@ -23987,13 +23987,13 @@ describe("Phase 342 — One-Sqrt × Forty-Nine-Log × polynomial numerator", () 
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("√k·log(k)⁵¹·k/k² refused (54 logs — not Phase 366)", () => {
+  it("√k·log(k)⁵¹·k/k² refused (55 logs — not Phase 372)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k342 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1342 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k342 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1342 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK342r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs51k342, k] };
@@ -24025,13 +24025,13 @@ describe("Phase 343 — Two-Sqrt × Forty-Nine-Log × polynomial numerator", () 
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)²·log(k)⁵¹·k/k² refused (54 logs — not Phase 367)", () => {
+  it("(√k)²·log(k)⁵¹·k/k² refused (55 logs — not Phase 373)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k343 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1343 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k343 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1343 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK343r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs51k343, k] };
@@ -24063,13 +24063,13 @@ describe("Phase 344 — Three-Sqrt × Forty-Nine-Log × polynomial numerator", (
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)³·log(k)⁵¹·k/k³ refused (54 logs — not Phase 368)", () => {
+  it("(√k)³·log(k)⁵¹·k/k³ refused (55 logs — not Phase 374)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k344 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1344 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k344 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1344 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK344r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs51k344, k] };
@@ -24101,13 +24101,13 @@ describe("Phase 345 — Four-Sqrt × Forty-Nine-Log × polynomial numerator", ()
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)⁴·log(k)⁵¹·k/k³ refused (54 logs — not Phase 369)", () => {
+  it("(√k)⁴·log(k)⁵¹·k/k³ refused (55 logs — not Phase 375)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k345 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1345 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k345 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1345 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK345r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs51k345, k] };
@@ -24139,13 +24139,13 @@ describe("Phase 346 — Five-Sqrt × Forty-Nine-Log × polynomial numerator", ()
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)^5·log(k)⁵¹·k/k³ refused (54 logs — not Phase 370)", () => {
+  it("(√k)^5·log(k)⁵¹·k/k³ refused (55 logs — not Phase 376)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k346 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1346 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k346 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1346 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK346r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs51k346, k] };
@@ -24175,13 +24175,13 @@ describe("Phase 347 — Zero-Sqrt × Fifty-Log × polynomial numerator", () => {
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("log(k)⁵¹·k/k² refused (54 logs — not Phase 365)", () => {
+  it("log(k)⁵¹·k/k² refused (55 logs — not Phase 371)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k347 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1347 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k347 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1347 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK347r = { kind: "apply" as const, head: MUL, args: [...logs51k347, k] };
     const numKp1347r = { kind: "apply" as const, head: MUL, args: [...logs51kp1347, kp1] };
     const gK347r = { kind: "apply" as const, head: DIV, args: [numK347r, k2r] };
@@ -24211,13 +24211,13 @@ describe("Phase 348 — One-Sqrt × Fifty-Log × polynomial numerator", () => {
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("√k·log(k)⁵¹·k/k² refused (54 logs — not Phase 366)", () => {
+  it("√k·log(k)⁵¹·k/k² refused (55 logs — not Phase 372)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k348 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1348 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k348 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1348 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK348r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs51k348, k] };
@@ -24249,13 +24249,13 @@ describe("Phase 349 — Two-Sqrt × Fifty-Log × polynomial numerator", () => {
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)²·log(k)⁵¹·k/k² refused (54 logs — not Phase 367)", () => {
+  it("(√k)²·log(k)⁵¹·k/k² refused (55 logs — not Phase 373)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k349 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1349 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k349 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1349 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK349r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs51k349, k] };
@@ -24287,13 +24287,13 @@ describe("Phase 350 — Three-Sqrt × Fifty-Log × polynomial numerator", () => 
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)³·log(k)⁵¹·k/k³ refused (54 logs — not Phase 368)", () => {
+  it("(√k)³·log(k)⁵¹·k/k³ refused (55 logs — not Phase 374)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k350 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1350 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k350 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1350 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK350r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs51k350, k] };
@@ -24325,13 +24325,13 @@ describe("Phase 351 — Four-Sqrt × Fifty-Log × polynomial numerator", () => {
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)⁴·log(k)⁵¹·k/k³ refused (54 logs — not Phase 369)", () => {
+  it("(√k)⁴·log(k)⁵¹·k/k³ refused (55 logs — not Phase 375)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k351 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1351 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k351 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1351 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK351r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs51k351, k] };
@@ -24363,13 +24363,13 @@ describe("Phase 352 — Five-Sqrt × Fifty-Log × polynomial numerator", () => {
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)^5·log(k)⁵¹·k/k³ refused (54 logs — not Phase 370)", () => {
+  it("(√k)^5·log(k)⁵¹·k/k³ refused (55 logs — not Phase 376)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k352 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1352 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k352 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1352 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK352r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs51k352, k] };
@@ -24400,13 +24400,13 @@ describe("Phase 353 — Zero-Sqrt × Fifty-One-Log × polynomial numerator", () 
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("log(k)⁵²·k/k² refused (54 logs — not Phase 365)", () => {
+  it("log(k)⁵²·k/k² refused (55 logs — not Phase 371)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs52k353 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs52kp1353 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs52k353 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs52kp1353 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK353r = { kind: "apply" as const, head: MUL, args: [...logs52k353, k] };
     const numKp1353r = { kind: "apply" as const, head: MUL, args: [...logs52kp1353, kp1] };
     const gK353r = { kind: "apply" as const, head: DIV, args: [numK353r, k2r] };
@@ -24436,13 +24436,13 @@ describe("Phase 354 — One-Sqrt × Fifty-One-Log × polynomial numerator", () =
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("√k·log(k)⁵²·k/k² refused (54 logs — not Phase 366)", () => {
+  it("√k·log(k)⁵²·k/k² refused (55 logs — not Phase 372)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs52k354 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs52kp1354 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs52k354 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs52kp1354 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK354r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs52k354, k] };
@@ -24474,13 +24474,13 @@ describe("Phase 355 — Two-Sqrt × Fifty-One-Log × polynomial numerator", () =
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)²·log(k)⁵²·k/k² refused (54 logs — not Phase 367)", () => {
+  it("(√k)²·log(k)⁵²·k/k² refused (55 logs — not Phase 373)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs52k355 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs52kp1355 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs52k355 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs52kp1355 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK355r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs52k355, k] };
@@ -24512,13 +24512,13 @@ describe("Phase 356 — Three-Sqrt × Fifty-One-Log × polynomial numerator", ()
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)³·log(k)⁵²·k/k³ refused (54 logs — not Phase 368)", () => {
+  it("(√k)³·log(k)⁵²·k/k³ refused (55 logs — not Phase 374)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs52k356 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs52kp1356 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs52k356 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs52kp1356 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK356r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs52k356, k] };
@@ -24550,13 +24550,13 @@ describe("Phase 357 — Four-Sqrt × Fifty-One-Log × polynomial numerator", () 
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)⁴·log(k)⁵²·k/k³ refused (54 logs — not Phase 369)", () => {
+  it("(√k)⁴·log(k)⁵²·k/k³ refused (55 logs — not Phase 375)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs52k357 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs52kp1357 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs52k357 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs52kp1357 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK357r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs52k357, k] };
@@ -24588,13 +24588,13 @@ describe("Phase 358 — Five-Sqrt × Fifty-One-Log × polynomial numerator", () 
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)^5·log(k)⁵²·k/k³ refused (54 logs — not Phase 370)", () => {
+  it("(√k)^5·log(k)⁵²·k/k³ refused (55 logs — not Phase 376)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs52k358 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs52kp1358 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs52k358 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs52kp1358 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK358r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs52k358, k] };
@@ -24624,13 +24624,13 @@ describe("Phase 359 — Zero-Sqrt × Fifty-Two-Log × polynomial numerator", () 
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("log(k)⁵³·k/k² refused (54 logs — not Phase 365)", () => {
+  it("log(k)⁵³·k/k² refused (55 logs — not Phase 371)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs53k359 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs53kp1359 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs53k359 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs53kp1359 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK359r = { kind: "apply" as const, head: MUL, args: [...logs53k359, k] };
     const numKp1359r = { kind: "apply" as const, head: MUL, args: [...logs53kp1359, kp1] };
     const gK359r = { kind: "apply" as const, head: DIV, args: [numK359r, k2r] };
@@ -24660,13 +24660,13 @@ describe("Phase 360 — One-Sqrt × Fifty-Two-Log × polynomial numerator", () =
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("√k·log(k)⁵³·k/k² refused (54 logs — not Phase 366)", () => {
+  it("√k·log(k)⁵³·k/k² refused (55 logs — not Phase 372)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs53k360 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs53kp1360 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs53k360 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs53kp1360 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK360r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs53k360, k] };
@@ -24698,13 +24698,13 @@ describe("Phase 361 — Two-Sqrt × Fifty-Two-Log × polynomial numerator", () =
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)²·log(k)⁵³·k/k³ refused (54 logs — not Phase 367)", () => {
+  it("(√k)²·log(k)⁵³·k/k³ refused (55 logs — not Phase 373)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs53k361 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs53kp1361 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs53k361 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs53kp1361 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK361r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs53k361, k] };
@@ -24736,13 +24736,13 @@ describe("Phase 362 — Three-Sqrt × Fifty-Two-Log × polynomial numerator", ()
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)³·log(k)⁵³·k/k³ refused (54 logs — not Phase 368)", () => {
+  it("(√k)³·log(k)⁵³·k/k³ refused (55 logs — not Phase 374)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs53k362 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs53kp1362 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs53k362 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs53kp1362 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK362r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs53k362, k] };
@@ -24774,13 +24774,13 @@ describe("Phase 363 — Four-Sqrt × Fifty-Two-Log × polynomial numerator", () 
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)⁴·log(k)⁵³·k/k³ refused (54 logs — not Phase 369)", () => {
+  it("(√k)⁴·log(k)⁵³·k/k³ refused (55 logs — not Phase 375)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs53k363 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs53kp1363 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs53k363 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs53kp1363 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK363r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs53k363, k] };
@@ -24812,13 +24812,13 @@ describe("Phase 364 — Five-Sqrt × Fifty-Two-Log × polynomial numerator", () 
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)^5·log(k)⁵³·k/k³ refused (54 logs — not Phase 370)", () => {
+  it("(√k)^5·log(k)⁵³·k/k³ refused (55 logs — not Phase 376)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs53k364 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs53kp1364 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs53k364 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs53kp1364 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK364r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs53k364, k] };
@@ -24848,13 +24848,13 @@ describe("Phase 365 — Zero-Sqrt × Fifty-Three-Log × polynomial numerator", (
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("log(k)⁵³·k/k² refused (54 logs — not Phase 365)", () => {
+  it("log(k)⁵³·k/k² refused (55 logs — not Phase 371)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs54k365 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs54kp1365 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs54k365 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs54kp1365 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK365r = { kind: "apply" as const, head: MUL, args: [...logs54k365, k] };
     const numKp1365r = { kind: "apply" as const, head: MUL, args: [...logs54kp1365, kp1] };
     const gK365r = { kind: "apply" as const, head: DIV, args: [numK365r, k2r] };
@@ -24884,13 +24884,13 @@ describe("Phase 366 — One-Sqrt × Fifty-Three-Log × polynomial numerator", ()
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("√k·log(k)⁵³·k/k² refused (54 logs — not Phase 366)", () => {
+  it("√k·log(k)⁵³·k/k² refused (55 logs — not Phase 372)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs54k366 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs54kp1366 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs54k366 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs54kp1366 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK366r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs54k366, k] };
@@ -24922,13 +24922,13 @@ describe("Phase 367 — Two-Sqrt × Fifty-Three-Log × polynomial numerator", ()
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)²·log(k)⁵³·k/k² refused (54 logs — not Phase 367)", () => {
+  it("(√k)²·log(k)⁵³·k/k² refused (55 logs — not Phase 373)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs54k367 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs54kp1367 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs54k367 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs54kp1367 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK367r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs54k367, k] };
@@ -24960,13 +24960,13 @@ describe("Phase 368 — Three-Sqrt × Fifty-Three-Log × polynomial numerator", 
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)³·log(k)⁵³·k/k³ refused (54 logs — not Phase 368)", () => {
+  it("(√k)³·log(k)⁵³·k/k³ refused (55 logs — not Phase 374)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs54k368 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs54kp1368 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs54k368 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs54kp1368 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK368r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs54k368, k] };
@@ -24998,13 +24998,13 @@ describe("Phase 369 — Four-Sqrt × Fifty-Three-Log × polynomial numerator", (
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)⁴·log(k)⁵³·k/k³ refused (54 logs — not Phase 369)", () => {
+  it("(√k)⁴·log(k)⁵³·k/k³ refused (55 logs — not Phase 375)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs54k369 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs54kp1369 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs54k369 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs54kp1369 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK369r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs54k369, k] };
@@ -25036,13 +25036,13 @@ describe("Phase 370 — Five-Sqrt × Fifty-Three-Log × polynomial numerator", (
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)^5·log(k)⁵³/k³ refused (54 logs — not Phase 370)", () => {
+  it("(√k)^5·log(k)⁵³/k³ refused (55 logs — not Phase 376)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs54k370 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs54kp1370 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs54k370 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs54kp1370 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK370r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs54k370] };
@@ -25051,6 +25051,230 @@ describe("Phase 370 — Five-Sqrt × Fifty-Three-Log × polynomial numerator", (
     const gKp1370r = { kind: "apply" as const, head: DIV, args: [numKp1370r, kp1_3r] };
     const f370r = { kind: "apply" as const, head: SUB, args: [gK370r, gKp1370r] };
     const result = evaluateSum(f370r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 371 — Zero-Sqrt × Fifty-Four-Log × polynomial numerator", () => {
+  it("log(k)⁵⁴·k/k² closes (polyDeg=1 → effective=1; denDeg=2 > 1)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const logs54k371 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs54kp1371 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const numK371a = { kind: "apply" as const, head: MUL, args: [...logs54k371, k] };
+    const numKp1371a = { kind: "apply" as const, head: MUL, args: [...logs54kp1371, kp1] };
+    const gK371a = { kind: "apply" as const, head: DIV, args: [numK371a, k2] };
+    const gKp1371a = { kind: "apply" as const, head: DIV, args: [numKp1371a, kp1_2] };
+    const f371a = { kind: "apply" as const, head: SUB, args: [gK371a, gKp1371a] };
+    const result = evaluateSum(f371a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("log(k)⁵⁴·k/k² refused (55 logs — not Phase 371)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs55k371 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs55kp1371 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const numK371r = { kind: "apply" as const, head: MUL, args: [...logs55k371, k] };
+    const numKp1371r = { kind: "apply" as const, head: MUL, args: [...logs55kp1371, kp1] };
+    const gK371r = { kind: "apply" as const, head: DIV, args: [numK371r, k2r] };
+    const gKp1371r = { kind: "apply" as const, head: DIV, args: [numKp1371r, kp1_2r] };
+    const f371r = { kind: "apply" as const, head: SUB, args: [gK371r, gKp1371r] };
+    const result = evaluateSum(f371r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 372 — One-Sqrt × Fifty-Four-Log × polynomial numerator", () => {
+  it("√k·log(k)⁵⁴·k/k² closes (sqrtHalf=0.5, polyDeg=1 → effective=1.5; denDeg=2 > 1.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const logs54k372 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs54kp1372 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK372a = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs54k372, k] };
+    const numKp1372a = { kind: "apply" as const, head: MUL, args: [sqrtKp1, ...logs54kp1372, kp1] };
+    const gK372a = { kind: "apply" as const, head: DIV, args: [numK372a, k2] };
+    const gKp1372a = { kind: "apply" as const, head: DIV, args: [numKp1372a, kp1_2] };
+    const f372a = { kind: "apply" as const, head: SUB, args: [gK372a, gKp1372a] };
+    const result = evaluateSum(f372a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("√k·log(k)⁵⁴·k/k² refused (55 logs — not Phase 372)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs55k372 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs55kp1372 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK372r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs55k372, k] };
+    const numKp1372r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, ...logs55kp1372, kp1] };
+    const gK372r = { kind: "apply" as const, head: DIV, args: [numK372r, k2r] };
+    const gKp1372r = { kind: "apply" as const, head: DIV, args: [numKp1372r, kp1_2r] };
+    const f372r = { kind: "apply" as const, head: SUB, args: [gK372r, gKp1372r] };
+    const result = evaluateSum(f372r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 373 — Two-Sqrt × Fifty-Four-Log × polynomial numerator", () => {
+  it("(√k)²·log(k)⁵⁴·k/k³ closes (sqrtHalf=1.0, polyDeg=1 → effective=2; denDeg=3 > 2)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const logs54k373 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs54kp1373 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK373a = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs54k373, k] };
+    const numKp1373a = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, ...logs54kp1373, kp1] };
+    const gK373a = { kind: "apply" as const, head: DIV, args: [numK373a, k3] };
+    const gKp1373a = { kind: "apply" as const, head: DIV, args: [numKp1373a, kp1_3] };
+    const f373a = { kind: "apply" as const, head: SUB, args: [gK373a, gKp1373a] };
+    const result = evaluateSum(f373a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("(√k)²·log(k)⁵⁴·k/k² refused (55 logs — not Phase 373)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs55k373 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs55kp1373 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK373r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs55k373, k] };
+    const numKp1373r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, ...logs55kp1373, kp1] };
+    const gK373r = { kind: "apply" as const, head: DIV, args: [numK373r, k2r] };
+    const gKp1373r = { kind: "apply" as const, head: DIV, args: [numKp1373r, kp1_2r] };
+    const f373r = { kind: "apply" as const, head: SUB, args: [gK373r, gKp1373r] };
+    const result = evaluateSum(f373r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 374 — Three-Sqrt × Fifty-Four-Log × polynomial numerator", () => {
+  it("(√k)³·log(k)⁵⁴·k/k³ closes (sqrtHalf=1.5, polyDeg=1 → effective=2.5; denDeg=3 > 2.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const logs54k374 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs54kp1374 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK374a = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs54k374, k] };
+    const numKp1374a = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, ...logs54kp1374, kp1] };
+    const gK374a = { kind: "apply" as const, head: DIV, args: [numK374a, k3] };
+    const gKp1374a = { kind: "apply" as const, head: DIV, args: [numKp1374a, kp1_3] };
+    const f374a = { kind: "apply" as const, head: SUB, args: [gK374a, gKp1374a] };
+    const result = evaluateSum(f374a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("(√k)³·log(k)⁵⁴·k/k³ refused (55 logs — not Phase 374)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs55k374 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs55kp1374 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK374r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs55k374, k] };
+    const numKp1374r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, ...logs55kp1374, kp1] };
+    const gK374r = { kind: "apply" as const, head: DIV, args: [numK374r, k3r] };
+    const gKp1374r = { kind: "apply" as const, head: DIV, args: [numKp1374r, kp1_3r] };
+    const f374r = { kind: "apply" as const, head: SUB, args: [gK374r, gKp1374r] };
+    const result = evaluateSum(f374r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 375 — Four-Sqrt × Fifty-Four-Log × polynomial numerator", () => {
+  it("(√k)⁴·log(k)⁵⁴·k/k⁴ closes (sqrtHalf=2.0, polyDeg=1 → effective=3; denDeg=4 > 3)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k4 = { kind: "apply" as const, head: POW, args: [k, int(4)] };
+    const kp1_4 = { kind: "apply" as const, head: POW, args: [kp1, int(4)] };
+    const logs54k375 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs54kp1375 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK375a = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs54k375, k] };
+    const numKp1375a = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, ...logs54kp1375, kp1] };
+    const gK375a = { kind: "apply" as const, head: DIV, args: [numK375a, k4] };
+    const gKp1375a = { kind: "apply" as const, head: DIV, args: [numKp1375a, kp1_4] };
+    const f375a = { kind: "apply" as const, head: SUB, args: [gK375a, gKp1375a] };
+    const result = evaluateSum(f375a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("(√k)⁴·log(k)⁵⁴·k/k³ refused (55 logs — not Phase 375)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs55k375 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs55kp1375 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK375r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs55k375, k] };
+    const numKp1375r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, ...logs55kp1375, kp1] };
+    const gK375r = { kind: "apply" as const, head: DIV, args: [numK375r, k3r] };
+    const gKp1375r = { kind: "apply" as const, head: DIV, args: [numKp1375r, kp1_3r] };
+    const f375r = { kind: "apply" as const, head: SUB, args: [gK375r, gKp1375r] };
+    const result = evaluateSum(f375r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 376 — Five-Sqrt × Fifty-Four-Log × polynomial numerator", () => {
+  it("(√k)^5·log(k)⁵⁴/k³ closes (sqrtHalf=2.5, polyDeg=0 → effective=2.5; denDeg=3 > 2.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const logs54k376 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs54kp1376 = Array.from({ length: 54 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK376a = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs54k376] };
+    const numKp1376a = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, ...logs54kp1376] };
+    const gK376a = { kind: "apply" as const, head: DIV, args: [numK376a, k3] };
+    const gKp1376a = { kind: "apply" as const, head: DIV, args: [numKp1376a, kp1_3] };
+    const f376a = { kind: "apply" as const, head: SUB, args: [gK376a, gKp1376a] };
+    const result = evaluateSum(f376a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("(√k)^5·log(k)⁵⁴/k³ refused (55 logs — not Phase 376)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs55k376 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs55kp1376 = Array.from({ length: 55 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK376r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs55k376] };
+    const numKp1376r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, ...logs55kp1376] };
+    const gK376r = { kind: "apply" as const, head: DIV, args: [numK376r, k3r] };
+    const gKp1376r = { kind: "apply" as const, head: DIV, args: [numKp1376r, kp1_3r] };
+    const f376r = { kind: "apply" as const, head: SUB, args: [gK376r, gKp1376r] };
+    const result = evaluateSum(f376r, k, int(1), sym("%inf"), evalNode);
     expect(result).toMatchObject({ kind: "apply", head: SUM });
   });
 });


### PR DESCRIPTION
## Summary

Adds Phase 371–376: the Fifty-Four-Log convergence recognizer family across Python, Rust, and TypeScript.

Each phase handles summands whose numerator contains exactly **54 logarithmic factors** and **0–5 square-root factors**.

### Phases
| Phase | Description |
|-------|-------------|
| 371 | Zero-Sqrt × Fifty-Four-Log × polynomial numerator |
| 372 | One-Sqrt × Fifty-Four-Log × polynomial numerator |
| 373 | Two-Sqrt × Fifty-Four-Log × polynomial numerator |
| 374 | Three-Sqrt × Fifty-Four-Log × polynomial numerator |
| 375 | Four-Sqrt × Fifty-Four-Log × polynomial numerator |
| 376 | Five-Sqrt × Fifty-Four-Log × polynomial numerator |

### Changes
- **Python**: +6 helpers + dispatch + 12 tests; cascade fix (54→55 logs); 1043 tests pass; 91% coverage
- **Rust**: +6 helpers + dispatch + cascade fix; 936 tests pass
- **TypeScript**: +6 helpers + dispatch + cascade fix; 954 tests pass
- Version bumped 2.307.0 → 2.313.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)