### PR TITLE
feat(cas-summation): add Phase 389-394 (Fifty-Seven-Log family, v2.325.0→v2.331.0)

### DIFF
--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 2.331.0 — 2026-05-28
+
+### Added
+
+- **Phase 394 — Five-Sqrt × Fifty-Seven-Log × polynomial** (`_five_sqrt_fifty_seven_log_poly_effective_x2`):
+  Completes the Fifty-Seven-Log family (Phases 389–394).
+- **Phase 393 — Four-Sqrt × Fifty-Seven-Log × polynomial** (`_four_sqrt_fifty_seven_log_poly_effective_x2`).
+- **Phase 392 — Three-Sqrt × Fifty-Seven-Log × polynomial** (`_three_sqrt_fifty_seven_log_poly_effective_x2`).
+- **Phase 391 — Two-Sqrt × Fifty-Seven-Log × polynomial** (`_two_sqrt_fifty_seven_log_poly_effective_x2`).
+- **Phase 390 — One-Sqrt × Fifty-Seven-Log × polynomial** (`_one_sqrt_fifty_seven_log_poly_effective_x2`).
+- **Phase 389 — Zero-Sqrt × Fifty-Seven-Log × polynomial** (`_fifty_seven_log_poly_effective_x2`).
+
+### Changed
+
+- Boundary tests in Phases 383–388 updated from 57-log "refused" to 58-log "refused"
+  now that Phases 389–394 handle exactly 57 logs.
+
 ## 2.325.0 — 2026-05-28
 
 ### Added

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "2.325.0"
+version = "2.331.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -1477,6 +1477,60 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
                 return True
         elif _h_diverges_at_infinity(den, k):
             return True
+    # Phase 394: ``Mul(Sqrt(P1)×5, Log(h1)×57, polynomial..., bounded...)`` numerator.
+    s5l57p_x2 = _five_sqrt_fifty_seven_log_poly_effective_x2(num, k)
+    if s5l57p_x2 is not None:
+        den_deg_s5l57 = _polynomial_degree_in_k(den, k)
+        if den_deg_s5l57 is not None:
+            if 2 * den_deg_s5l57 > s5l57p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 393: ``Mul(Sqrt(P1)×4, Log(h1)×57, polynomial..., bounded...)`` numerator.
+    s4l57p_x2 = _four_sqrt_fifty_seven_log_poly_effective_x2(num, k)
+    if s4l57p_x2 is not None:
+        den_deg_s4l57 = _polynomial_degree_in_k(den, k)
+        if den_deg_s4l57 is not None:
+            if 2 * den_deg_s4l57 > s4l57p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 392: ``Mul(Sqrt(P1)×3, Log(h1)×57, polynomial..., bounded...)`` numerator.
+    s3l57p_x2 = _three_sqrt_fifty_seven_log_poly_effective_x2(num, k)
+    if s3l57p_x2 is not None:
+        den_deg_s3l57 = _polynomial_degree_in_k(den, k)
+        if den_deg_s3l57 is not None:
+            if 2 * den_deg_s3l57 > s3l57p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 391: ``Mul(Sqrt(P), Sqrt(P2), Log(h1)×57, polynomial..., bounded...)`` numerator.
+    s2l57p_x2 = _two_sqrt_fifty_seven_log_poly_effective_x2(num, k)
+    if s2l57p_x2 is not None:
+        den_deg_s2l57 = _polynomial_degree_in_k(den, k)
+        if den_deg_s2l57 is not None:
+            if 2 * den_deg_s2l57 > s2l57p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 390: ``Mul(Sqrt(P), Log(h1)×57, polynomial..., bounded...)`` numerator.
+    s1l57p_x2 = _one_sqrt_fifty_seven_log_poly_effective_x2(num, k)
+    if s1l57p_x2 is not None:
+        den_deg_s1l57 = _polynomial_degree_in_k(den, k)
+        if den_deg_s1l57 is not None:
+            if 2 * den_deg_s1l57 > s1l57p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 389: ``Mul(Log(h1)×57, polynomial..., bounded...)`` numerator.
+    sl57p_x2 = _fifty_seven_log_poly_effective_x2(num, k)
+    if sl57p_x2 is not None:
+        den_deg_sl57 = _polynomial_degree_in_k(den, k)
+        if den_deg_sl57 is not None:
+            if 2 * den_deg_sl57 > sl57p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
     # Phase 388: ``Mul(Sqrt(P1)×5, Log(h1)×56, polynomial..., bounded...)`` numerator.
     s5l56p_x2 = _five_sqrt_fifty_six_log_poly_effective_x2(num, k)
     if s5l56p_x2 is not None:
@@ -13420,6 +13474,207 @@ def _five_sqrt_fifty_six_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int
             continue
         return None
     if len(sqrt_degs_x2) != 5 or log_count != 56:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _fifty_seven_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 389 — Zero-Sqrt × Fifty-Seven-Log × polynomial numerator.
+
+    The Fifty-Seven-Log family (Phases 389–394) extends the recogniser to
+    summands whose numerator contains exactly fifty-seven logarithmic factors
+    and zero to five square-root factors.  This is Phase 389: zero sqrts.
+
+    Parameters
+    ----------
+    node : IRNode
+        The numerator node.
+    k : IRSymbol
+        The summation variable.
+
+    Returns
+    -------
+    int | None
+        ``2 * poly_deg_sum`` when the shape matches (always even); ``None``
+        when the pattern is not recognised.
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        if _sqrt_effective_half_degree_x2(arg, k) is not None:
+            return None
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 57:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if log_count != 57:
+        return None
+    return 2 * poly_deg_sum
+
+
+def _one_sqrt_fifty_seven_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 390 — One-Sqrt × Fifty-Seven-Log × polynomial numerator."""
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_deg_x2: int | None = None
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if sqrt_deg_x2 is not None:
+                return None
+            sqrt_deg_x2 = deg_x2
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 57:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if sqrt_deg_x2 is None or log_count != 57:
+        return None
+    return sqrt_deg_x2 + 2 * poly_deg_sum
+
+
+def _two_sqrt_fifty_seven_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 391 — Two-Sqrt × Fifty-Seven-Log × polynomial numerator."""
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 2:
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 57:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 2 or log_count != 57:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _three_sqrt_fifty_seven_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 392 — Three-Sqrt × Fifty-Seven-Log × polynomial numerator."""
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 3:
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 57:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 3 or log_count != 57:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _four_sqrt_fifty_seven_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 393 — Four-Sqrt × Fifty-Seven-Log × polynomial numerator."""
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 4:
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 57:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 4 or log_count != 57:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _five_sqrt_fifty_seven_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 394 — Five-Sqrt × Fifty-Seven-Log × polynomial numerator.
+    Completes the Fifty-Seven-Log family (Phases 389-394).
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 5:
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 57:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 5 or log_count != 57:
         return None
     return sum(sqrt_degs_x2) + 2 * poly_deg_sum
 

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -17891,6 +17891,7 @@ class TestPhase205TwoSqrtTwentySixLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -18074,6 +18075,7 @@ class TestPhase206ThreeSqrtTwentySixLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -18263,6 +18265,7 @@ class TestPhase207FourSqrtTwentySixLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -18452,6 +18455,7 @@ class TestPhase208FiveSqrtTwentySixLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -19009,6 +19013,7 @@ class TestPhase211TwoSqrtTwentySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -19196,6 +19201,7 @@ class TestPhase212ThreeSqrtTwentySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -19389,6 +19395,7 @@ class TestPhase213FourSqrtTwentySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -19582,6 +19589,7 @@ class TestPhase214FiveSqrtTwentySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -20151,6 +20159,7 @@ class TestPhase217TwoSqrtTwentyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -20342,6 +20351,7 @@ class TestPhase218ThreeSqrtTwentyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -20539,6 +20549,7 @@ class TestPhase219FourSqrtTwentyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -20736,6 +20747,7 @@ class TestPhase220FiveSqrtTwentyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -21318,6 +21330,7 @@ class TestPhase223TwoSqrtTwentyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -21513,6 +21526,7 @@ class TestPhase224ThreeSqrtTwentyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -21714,6 +21728,7 @@ class TestPhase225FourSqrtTwentyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -21915,6 +21930,7 @@ class TestPhase226FiveSqrtTwentyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -22508,6 +22524,7 @@ class TestPhase229TwoSqrtThirtyLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -22707,6 +22724,7 @@ class TestPhase230ThreeSqrtThirtyLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -22906,6 +22924,7 @@ class TestPhase231FourSqrtThirtyLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -23111,6 +23130,7 @@ class TestPhase232FiveSqrtThirtyLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -23716,6 +23736,7 @@ class TestPhase235TwoSqrtThirtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -23919,6 +23940,7 @@ class TestPhase236ThreeSqrtThirtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -24128,6 +24150,7 @@ class TestPhase237FourSqrtThirtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -24337,6 +24360,7 @@ class TestPhase238FiveSqrtThirtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -24954,6 +24978,7 @@ class TestPhase241TwoSqrtThirtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -25161,6 +25186,7 @@ class TestPhase242ThreeSqrtThirtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -25374,6 +25400,7 @@ class TestPhase243FourSqrtThirtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -25587,6 +25614,7 @@ class TestPhase244FiveSqrtThirtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -26216,6 +26244,7 @@ class TestPhase247TwoSqrtThirtyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -26427,6 +26456,7 @@ class TestPhase248ThreeSqrtThirtyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -26644,6 +26674,7 @@ class TestPhase249FourSqrtThirtyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -26861,6 +26892,7 @@ class TestPhase250FiveSqrtThirtyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -27502,6 +27534,7 @@ class TestPhase253TwoSqrtThirtyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -27717,6 +27750,7 @@ class TestPhase254ThreeSqrtThirtyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -27938,6 +27972,7 @@ class TestPhase255FourSqrtThirtyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -28159,6 +28194,7 @@ class TestPhase256FiveSqrtThirtyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -28812,6 +28848,7 @@ class TestPhase259TwoSqrtThirtyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -29031,6 +29068,7 @@ class TestPhase260ThreeSqrtThirtyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -29256,6 +29294,7 @@ class TestPhase261FourSqrtThirtyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -29481,6 +29520,7 @@ class TestPhase262FiveSqrtThirtyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -30146,6 +30186,7 @@ class TestPhase265TwoSqrtThirtySixLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -30369,6 +30410,7 @@ class TestPhase266ThreeSqrtThirtySixLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -30598,6 +30640,7 @@ class TestPhase267FourSqrtThirtySixLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -30827,6 +30870,7 @@ class TestPhase268FiveSqrtThirtySixLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -31050,6 +31094,7 @@ class TestPhase269ThirtySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -31276,6 +31321,7 @@ class TestPhase270OneSqrtThirtySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -31502,6 +31548,7 @@ class TestPhase271TwoSqrtThirtySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -31728,6 +31775,7 @@ class TestPhase272ThreeSqrtThirtySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -31954,6 +32002,7 @@ class TestPhase273FourSqrtThirtySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -32186,6 +32235,7 @@ class TestPhase274FiveSqrtThirtySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -32412,6 +32462,7 @@ class TestPhase275ThirtyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -32642,6 +32693,7 @@ class TestPhase276OneSqrtThirtyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -32872,6 +32924,7 @@ class TestPhase277TwoSqrtThirtyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -33102,6 +33155,7 @@ class TestPhase278ThreeSqrtThirtyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -33338,6 +33392,7 @@ class TestPhase279FourSqrtThirtyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -33574,6 +33629,7 @@ class TestPhase280FiveSqrtThirtyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -33805,6 +33861,7 @@ class TestPhase281ThirtyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -34039,6 +34096,7 @@ class TestPhase282OneSqrtThirtyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -34275,6 +34333,7 @@ class TestPhase283TwoSqrtThirtyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -34511,6 +34570,7 @@ class TestPhase284ThreeSqrtThirtyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -34747,6 +34807,7 @@ class TestPhase285FourSqrtThirtyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -34983,6 +35044,7 @@ class TestPhase286FiveSqrtThirtyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -35218,6 +35280,7 @@ class TestPhase287FortyLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -35456,6 +35519,7 @@ class TestPhase288OneSqrtFortyLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -35696,6 +35760,7 @@ class TestPhase289TwoSqrtFortyLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -35936,6 +36001,7 @@ class TestPhase290ThreeSqrtFortyLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -36176,6 +36242,7 @@ class TestPhase291FourSqrtFortyLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -36416,6 +36483,7 @@ class TestPhase292FiveSqrtFortyLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -36655,6 +36723,7 @@ class TestPhase293FortyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -36826,6 +36895,7 @@ class TestPhase294OneSqrtFortyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -36997,6 +37067,7 @@ class TestPhase295TwoSqrtFortyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -37168,6 +37239,7 @@ class TestPhase296ThreeSqrtFortyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -37339,6 +37411,7 @@ class TestPhase297FourSqrtFortyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -37510,6 +37583,7 @@ class TestPhase298FiveSqrtFortyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -37680,6 +37754,7 @@ class TestPhase299FortyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -37853,6 +37928,7 @@ class TestPhase300OneSqrtFortyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -38026,6 +38102,7 @@ class TestPhase301TwoSqrtFortyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -38199,6 +38276,7 @@ class TestPhase302ThreeSqrtFortyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -38372,6 +38450,7 @@ class TestPhase303FourSqrtFortyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -38545,6 +38624,7 @@ class TestPhase304FiveSqrtFortyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -38717,6 +38797,7 @@ class TestPhase305FortyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -38893,6 +38974,7 @@ class TestPhase306OneSqrtFortyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -39069,6 +39151,7 @@ class TestPhase307TwoSqrtFortyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -39245,6 +39328,7 @@ class TestPhase308ThreeSqrtFortyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -39421,6 +39505,7 @@ class TestPhase309FourSqrtFortyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -39597,6 +39682,7 @@ class TestPhase310FiveSqrtFortyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -39771,6 +39857,7 @@ class TestPhase311FortyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -39949,6 +40036,7 @@ class TestPhase312OneSqrtFortyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -40127,6 +40215,7 @@ class TestPhase313TwoSqrtFortyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -40305,6 +40394,7 @@ class TestPhase314ThreeSqrtFortyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -40483,6 +40573,7 @@ class TestPhase315FourSqrtFortyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -40661,6 +40752,7 @@ class TestPhase316FiveSqrtFortyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -40837,6 +40929,7 @@ class TestPhase317FortyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -41016,6 +41109,7 @@ class TestPhase318OneSqrtFortyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -41195,6 +41289,7 @@ class TestPhase319TwoSqrtFortyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -41374,6 +41469,7 @@ class TestPhase320ThreeSqrtFortyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -41553,6 +41649,7 @@ class TestPhase321FourSqrtFortyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -41732,6 +41829,7 @@ class TestPhase322FiveSqrtFortyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -41910,6 +42008,7 @@ class TestPhase323FortysSixLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -42091,6 +42190,7 @@ class TestPhase324OneSqrtFortySixLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -42272,6 +42372,7 @@ class TestPhase325TwoSqrtFortySixLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -42453,6 +42554,7 @@ class TestPhase326ThreeSqrtFortySixLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -42634,6 +42736,7 @@ class TestPhase327FourSqrtFortySixLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -42815,6 +42918,7 @@ class TestPhase328FiveSqrtFortySixLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -42995,6 +43099,7 @@ class TestPhase329FortySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -43178,6 +43283,7 @@ class TestPhase330OneSqrtFortySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -43361,6 +43467,7 @@ class TestPhase331TwoSqrtFortySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -43544,6 +43651,7 @@ class TestPhase332ThreeSqrtFortySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -43727,6 +43835,7 @@ class TestPhase333FourSqrtFortySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -43910,6 +44019,7 @@ class TestPhase334FiveSqrtFortySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -44092,6 +44202,7 @@ class TestPhase335FortyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -44278,6 +44389,7 @@ class TestPhase336OneSqrtFortyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -44464,6 +44576,7 @@ class TestPhase337TwoSqrtFortyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -44650,6 +44763,7 @@ class TestPhase338ThreeSqrtFortyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -44836,6 +44950,7 @@ class TestPhase339FourSqrtFortyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -45022,6 +45137,7 @@ class TestPhase340FiveSqrtFortyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -45206,6 +45322,7 @@ class TestPhase341FortyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -45394,6 +45511,7 @@ class TestPhase342OneSqrtFortyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -45582,6 +45700,7 @@ class TestPhase343TwoSqrtFortyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -45770,6 +45889,7 @@ class TestPhase344ThreeSqrtFortyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -45958,6 +46078,7 @@ class TestPhase345FourSqrtFortyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -46146,6 +46267,7 @@ class TestPhase346FiveSqrtFortyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -46332,6 +46454,7 @@ class TestPhase347FiftyLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -46522,6 +46645,7 @@ class TestPhase348OneSqrtFiftyLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -46712,6 +46836,7 @@ class TestPhase349TwoSqrtFiftyLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -46902,6 +47027,7 @@ class TestPhase350ThreeSqrtFiftyLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -47092,6 +47218,7 @@ class TestPhase351FourSqrtFiftyLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -47282,6 +47409,7 @@ class TestPhase352FiveSqrtFiftyLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -47470,6 +47598,7 @@ class TestPhase353FiftyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -47662,6 +47791,7 @@ class TestPhase354OneSqrtFiftyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -47854,6 +47984,7 @@ class TestPhase355TwoSqrtFiftyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -48046,6 +48177,7 @@ class TestPhase356ThreeSqrtFiftyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -48238,6 +48370,7 @@ class TestPhase357FourSqrtFiftyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -48430,6 +48563,7 @@ class TestPhase358FiveSqrtFiftyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -48579,6 +48713,7 @@ class TestPhase359FiftyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 54th log
             IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (_k,)),  # 58th log (over 57; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -48622,6 +48757,7 @@ class TestPhase359FiftyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 54th log
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -48774,6 +48910,7 @@ class TestPhase360OneSqrtFiftyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 54th log
             IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (_k,)),  # 58th log (over 57; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -48818,6 +48955,7 @@ class TestPhase360OneSqrtFiftyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 54th log
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -48970,6 +49108,7 @@ class TestPhase361TwoSqrtFiftyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 54th log
             IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (_k,)),  # 58th log (over 57; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -49014,6 +49153,7 @@ class TestPhase361TwoSqrtFiftyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 54th log
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -49166,6 +49306,7 @@ class TestPhase362ThreeSqrtFiftyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 54th log
             IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (_k,)),  # 58th log (over 57; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -49210,6 +49351,7 @@ class TestPhase362ThreeSqrtFiftyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 54th log
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -49362,6 +49504,7 @@ class TestPhase363FourSqrtFiftyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 54th log
             IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (_k,)),  # 58th log (over 57; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -49406,6 +49549,7 @@ class TestPhase363FourSqrtFiftyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 54th log
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -49558,6 +49702,7 @@ class TestPhase364FiveSqrtFiftyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 54th log
             IRApply(LOG, (_k,)),  # 55th log (over 54; refused)
             IRApply(LOG, (_k,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (_k,)),  # 58th log (over 57; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -49602,6 +49747,7 @@ class TestPhase364FiveSqrtFiftyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 54th log
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -49793,6 +49939,7 @@ class TestPhase365FiftyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -49988,6 +50135,7 @@ class TestPhase366OneSqrtFiftyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -50183,6 +50331,7 @@ class TestPhase367TwoSqrtFiftyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -50378,6 +50527,7 @@ class TestPhase368ThreeSqrtFiftyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -50573,6 +50723,7 @@ class TestPhase369FourSqrtFiftyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -50768,6 +50919,7 @@ class TestPhase370FiveSqrtFiftyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -50961,6 +51113,7 @@ class TestPhase371FiftyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -51158,6 +51311,7 @@ class TestPhase372OneSqrtFiftyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -51355,6 +51509,7 @@ class TestPhase373TwoSqrtFiftyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -51552,6 +51707,7 @@ class TestPhase374ThreeSqrtFiftyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -51749,6 +51905,7 @@ class TestPhase375FourSqrtFiftyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -51946,6 +52103,7 @@ class TestPhase376FiveSqrtFiftyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log (over 54; refused)
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -52101,6 +52259,7 @@ class TestPhase377FiftyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 55th log
             IRApply(LOG, (_k,)),  # 56th log (over 55; refused)
             IRApply(LOG, (_k,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (_k,)),  # 58th log (over 57; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -52144,6 +52303,7 @@ class TestPhase377FiftyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -52302,6 +52462,7 @@ class TestPhase378OneSqrtFiftyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 55th log
             IRApply(LOG, (_k,)),  # 56th log (over 55; refused)
             IRApply(LOG, (_k,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (_k,)),  # 58th log (over 57; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -52346,6 +52507,7 @@ class TestPhase378OneSqrtFiftyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -52504,6 +52666,7 @@ class TestPhase379TwoSqrtFiftyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 55th log
             IRApply(LOG, (_k,)),  # 56th log (over 55; refused)
             IRApply(LOG, (_k,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (_k,)),  # 58th log (over 57; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -52548,6 +52711,7 @@ class TestPhase379TwoSqrtFiftyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -52706,6 +52870,7 @@ class TestPhase380ThreeSqrtFiftyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 55th log
             IRApply(LOG, (_k,)),  # 56th log (over 55; refused)
             IRApply(LOG, (_k,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (_k,)),  # 58th log (over 57; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -52750,6 +52915,7 @@ class TestPhase380ThreeSqrtFiftyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -52908,6 +53074,7 @@ class TestPhase381FourSqrtFiftyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 55th log
             IRApply(LOG, (_k,)),  # 56th log (over 55; refused)
             IRApply(LOG, (_k,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (_k,)),  # 58th log (over 57; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -52952,6 +53119,7 @@ class TestPhase381FourSqrtFiftyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -53110,6 +53278,7 @@ class TestPhase382FiveSqrtFiftyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 55th log
             IRApply(LOG, (_k,)),  # 56th log (over 55; refused)
             IRApply(LOG, (_k,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (_k,)),  # 58th log (over 57; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -53154,6 +53323,7 @@ class TestPhase382FiveSqrtFiftyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -53263,7 +53433,7 @@ class TestPhase383ZeroSqrtFiftySixLogPoly:
         assert not (isinstance(result, IRApply) and result.head == SUM)
 
     def test_log56_k_over_k2_refused_refused(self):
-        """log(k)^57/k2: 57 logs -> not Phase 383 -> refused"""
+        """log(k)^58/k2: 58 logs -> not Phase 383 -> refused"""
         from symbolic_ir import SUB
 
         kp1 = IRApply(ADD, (_k, IRInteger(1)))
@@ -53311,6 +53481,7 @@ class TestPhase383ZeroSqrtFiftySixLogPoly:
             IRApply(LOG, (_k,)),  # 55th log
             IRApply(LOG, (_k,)),  # 56th log
             IRApply(LOG, (_k,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (_k,)),  # 58th log (over 57; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -53354,6 +53525,7 @@ class TestPhase383ZeroSqrtFiftySixLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log
             IRApply(LOG, (kp1,)),  # 56th log
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -53467,7 +53639,7 @@ class TestPhase384OneSqrtFiftySixLogPoly:
         assert not (isinstance(result, IRApply) and result.head == SUM)
 
     def test_sqrt_k_log56_k_over_k2_refused_refused(self):
-        """log(k)^57/k2: 57 logs -> not Phase 384 -> refused"""
+        """log(k)^58/k2: 58 logs -> not Phase 384 -> refused"""
         from symbolic_ir import SQRT, SUB
 
         kp1 = IRApply(ADD, (_k, IRInteger(1)))
@@ -53518,6 +53690,7 @@ class TestPhase384OneSqrtFiftySixLogPoly:
             IRApply(LOG, (_k,)),  # 55th log
             IRApply(LOG, (_k,)),  # 56th log
             IRApply(LOG, (_k,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (_k,)),  # 58th log (over 57; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1,
@@ -53562,6 +53735,7 @@ class TestPhase384OneSqrtFiftySixLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log
             IRApply(LOG, (kp1,)),  # 56th log
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -53675,7 +53849,7 @@ class TestPhase385TwoSqrtFiftySixLogPoly:
         assert not (isinstance(result, IRApply) and result.head == SUM)
 
     def test_2_sqrt_k_log56_k_over_k2_refused_refused(self):
-        """log(k)^57/k2: 57 logs -> not Phase 385 -> refused"""
+        """log(k)^58/k2: 58 logs -> not Phase 385 -> refused"""
         from symbolic_ir import SQRT, SUB
 
         kp1 = IRApply(ADD, (_k, IRInteger(1)))
@@ -53726,6 +53900,7 @@ class TestPhase385TwoSqrtFiftySixLogPoly:
             IRApply(LOG, (_k,)),  # 55th log
             IRApply(LOG, (_k,)),  # 56th log
             IRApply(LOG, (_k,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (_k,)),  # 58th log (over 57; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1,
@@ -53770,6 +53945,7 @@ class TestPhase385TwoSqrtFiftySixLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log
             IRApply(LOG, (kp1,)),  # 56th log
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -53883,7 +54059,7 @@ class TestPhase386ThreeSqrtFiftySixLogPoly:
         assert not (isinstance(result, IRApply) and result.head == SUM)
 
     def test_3_sqrt_k_log56_k_over_k3_refused_refused(self):
-        """log(k)^57/k3: 57 logs -> not Phase 386 -> refused"""
+        """log(k)^58/k3: 58 logs -> not Phase 386 -> refused"""
         from symbolic_ir import SQRT, SUB
 
         kp1 = IRApply(ADD, (_k, IRInteger(1)))
@@ -53934,6 +54110,7 @@ class TestPhase386ThreeSqrtFiftySixLogPoly:
             IRApply(LOG, (_k,)),  # 55th log
             IRApply(LOG, (_k,)),  # 56th log
             IRApply(LOG, (_k,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (_k,)),  # 58th log (over 57; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -53978,6 +54155,7 @@ class TestPhase386ThreeSqrtFiftySixLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log
             IRApply(LOG, (kp1,)),  # 56th log
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -54091,7 +54269,7 @@ class TestPhase387FourSqrtFiftySixLogPoly:
         assert not (isinstance(result, IRApply) and result.head == SUM)
 
     def test_4_sqrt_k_log56_k_over_k3_refused_refused(self):
-        """log(k)^57/k3: 57 logs -> not Phase 387 -> refused"""
+        """log(k)^58/k3: 58 logs -> not Phase 387 -> refused"""
         from symbolic_ir import SQRT, SUB
 
         kp1 = IRApply(ADD, (_k, IRInteger(1)))
@@ -54142,6 +54320,7 @@ class TestPhase387FourSqrtFiftySixLogPoly:
             IRApply(LOG, (_k,)),  # 55th log
             IRApply(LOG, (_k,)),  # 56th log
             IRApply(LOG, (_k,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (_k,)),  # 58th log (over 57; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -54186,6 +54365,7 @@ class TestPhase387FourSqrtFiftySixLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log
             IRApply(LOG, (kp1,)),  # 56th log
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -54299,7 +54479,7 @@ class TestPhase388FiveSqrtFiftySixLogPoly:
         assert not (isinstance(result, IRApply) and result.head == SUM)
 
     def test_5_sqrt_k_log56_k_over_k3_refused_refused(self):
-        """log(k)^57/k3: 57 logs -> not Phase 388 -> refused"""
+        """log(k)^58/k3: 58 logs -> not Phase 388 -> refused"""
         from symbolic_ir import SQRT, SUB
 
         kp1 = IRApply(ADD, (_k, IRInteger(1)))
@@ -54350,6 +54530,7 @@ class TestPhase388FiveSqrtFiftySixLogPoly:
             IRApply(LOG, (_k,)),  # 55th log
             IRApply(LOG, (_k,)),  # 56th log
             IRApply(LOG, (_k,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (_k,)),  # 58th log (over 57; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -54394,6 +54575,1271 @@ class TestPhase388FiveSqrtFiftySixLogPoly:
             IRApply(LOG, (kp1,)),  # 55th log
             IRApply(LOG, (kp1,)),  # 56th log
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase389ZeroSqrtFiftySevenLogPoly:
+    """Phase 389 -- Zero-Sqrt x Fifty-Seven-Log x polynomial numerator."""
+
+    def test_log57_k_over_k2_closes(self):
+        """log(k)^57/k^2: eff_x2=0; 2*2=4 > 0 -> closes"""
+        from symbolic_ir import SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_log57_k_over_k2_refused_refused(self):
+        """log(k)^58/k2: 58 logs -> not Phase 389 -> refused"""
+        from symbolic_ir import SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+            IRApply(LOG, (_k,)),  # 58th log (over 57; refused)
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase390OneSqrtFiftySevenLogPoly:
+    """Phase 390 -- One-Sqrt x Fifty-Seven-Log x polynomial numerator."""
+
+    def test_sqrt_k_log57_k_over_k2_closes(self):
+        """sqrt(k)*log(k)^57/k^2: eff_x2=1; 2*2=4 > 1 -> closes"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        sqrt_k = IRApply(SQRT, (_k,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_k = IRApply(MUL, (
+            sqrt_k,
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+        ))
+        num_kp1 = IRApply(MUL, (
+            sqrt_kp1,
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_log57_k_over_k2_refused_refused(self):
+        """log(k)^58/k2: 58 logs -> not Phase 390 -> refused"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        sqrt_k = IRApply(SQRT, (_k,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_k = IRApply(MUL, (
+            sqrt_k,
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+            IRApply(LOG, (_k,)),  # 58th log (over 57; refused)
+        ))
+        num_kp1 = IRApply(MUL, (
+            sqrt_kp1,
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase391TwoSqrtFiftySevenLogPoly:
+    """Phase 391 -- Two-Sqrt x Fifty-Seven-Log x polynomial numerator."""
+
+    def test_2_sqrt_k_log57_k_over_k2_closes(self):
+        """sqrt(k)^2*log(k)^57/k^2: eff_x2=2; 2*2=4 > 2 -> closes"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        sqrt_k = IRApply(SQRT, (_k,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_k = IRApply(MUL, (
+            sqrt_k, sqrt_k,
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+        ))
+        num_kp1 = IRApply(MUL, (
+            sqrt_kp1, sqrt_kp1,
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_2_sqrt_k_log57_k_over_k2_refused_refused(self):
+        """log(k)^58/k2: 58 logs -> not Phase 391 -> refused"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        sqrt_k = IRApply(SQRT, (_k,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_k = IRApply(MUL, (
+            sqrt_k, sqrt_k,
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+            IRApply(LOG, (_k,)),  # 58th log (over 57; refused)
+        ))
+        num_kp1 = IRApply(MUL, (
+            sqrt_kp1, sqrt_kp1,
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase392ThreeSqrtFiftySevenLogPoly:
+    """Phase 392 -- Three-Sqrt x Fifty-Seven-Log x polynomial numerator."""
+
+    def test_3_sqrt_k_log57_k_over_k3_closes(self):
+        """sqrt(k)^3*log(k)^57/k^3: eff_x2=3; 2*3=6 > 3 -> closes"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        sqrt_k = IRApply(SQRT, (_k,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_k = IRApply(MUL, (
+            sqrt_k, sqrt_k, sqrt_k,
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+        ))
+        num_kp1 = IRApply(MUL, (
+            sqrt_kp1, sqrt_kp1, sqrt_kp1,
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_3_sqrt_k_log57_k_over_k3_refused_refused(self):
+        """log(k)^58/k3: 58 logs -> not Phase 392 -> refused"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        sqrt_k = IRApply(SQRT, (_k,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_k = IRApply(MUL, (
+            sqrt_k, sqrt_k, sqrt_k,
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+            IRApply(LOG, (_k,)),  # 58th log (over 57; refused)
+        ))
+        num_kp1 = IRApply(MUL, (
+            sqrt_kp1, sqrt_kp1, sqrt_kp1,
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase393FourSqrtFiftySevenLogPoly:
+    """Phase 393 -- Four-Sqrt x Fifty-Seven-Log x polynomial numerator."""
+
+    def test_4_sqrt_k_log57_k_over_k3_closes(self):
+        """sqrt(k)^4*log(k)^57/k^3: eff_x2=4; 2*3=6 > 4 -> closes"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        sqrt_k = IRApply(SQRT, (_k,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_k = IRApply(MUL, (
+            sqrt_k, sqrt_k, sqrt_k, sqrt_k,
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+        ))
+        num_kp1 = IRApply(MUL, (
+            sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_4_sqrt_k_log57_k_over_k3_refused_refused(self):
+        """log(k)^58/k3: 58 logs -> not Phase 393 -> refused"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        sqrt_k = IRApply(SQRT, (_k,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_k = IRApply(MUL, (
+            sqrt_k, sqrt_k, sqrt_k, sqrt_k,
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+            IRApply(LOG, (_k,)),  # 58th log (over 57; refused)
+        ))
+        num_kp1 = IRApply(MUL, (
+            sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase394FiveSqrtFiftySevenLogPoly:
+    """Phase 394 -- Five-Sqrt x Fifty-Seven-Log x polynomial numerator."""
+
+    def test_5_sqrt_k_log57_k_over_k3_closes(self):
+        """sqrt(k)^5*log(k)^57/k^3: eff_x2=5; 2*3=6 > 5 -> closes"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        sqrt_k = IRApply(SQRT, (_k,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_k = IRApply(MUL, (
+            sqrt_k, sqrt_k, sqrt_k, sqrt_k, sqrt_k,
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+        ))
+        num_kp1 = IRApply(MUL, (
+            sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_5_sqrt_k_log57_k_over_k3_refused_refused(self):
+        """log(k)^58/k3: 58 logs -> not Phase 394 -> refused"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        sqrt_k = IRApply(SQRT, (_k,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_k = IRApply(MUL, (
+            sqrt_k, sqrt_k, sqrt_k, sqrt_k, sqrt_k,
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+            IRApply(LOG, (_k,)),  # 58th log (over 57; refused)
+        ))
+        num_kp1 = IRApply(MUL, (
+            sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+            IRApply(LOG, (kp1,)),  # 58th log (over 57; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))

--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 2.331.0 — 2026-05-28
+
+### Added
+
+- **Phase 394 — Five-Sqrt × Fifty-Seven-Log × polynomial** (`five_sqrt_fifty_seven_log_poly_effective_x2`):
+  Completes the Fifty-Seven-Log family (Phases 389–394).
+- **Phase 393 — Four-Sqrt × Fifty-Seven-Log × polynomial** (`four_sqrt_fifty_seven_log_poly_effective_x2`).
+- **Phase 392 — Three-Sqrt × Fifty-Seven-Log × polynomial** (`three_sqrt_fifty_seven_log_poly_effective_x2`).
+- **Phase 391 — Two-Sqrt × Fifty-Seven-Log × polynomial** (`two_sqrt_fifty_seven_log_poly_effective_x2`).
+- **Phase 390 — One-Sqrt × Fifty-Seven-Log × polynomial** (`one_sqrt_fifty_seven_log_poly_effective_x2`).
+- **Phase 389 — Zero-Sqrt × Fifty-Seven-Log × polynomial** (`fifty_seven_log_poly_effective_x2`).
+
+### Changed
+
+- Boundary tests in Phases 383–388 updated from 57-log "refused" to 58-log "refused"
+  now that Phases 389–394 handle exactly 57 logs.
+
 ## 2.325.0 — 2026-05-28
 
 ### Added

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "2.325.0"
+version = "2.331.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -7820,6 +7820,169 @@ fn five_sqrt_fifty_six_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Optio
     Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg_sum)
 }
 
+/// Phase 389 — Zero-Sqrt × Fifty-Seven-Log × polynomial numerator.
+///
+/// The Fifty-Seven-Log family (Phases 389–394) extends the recogniser to
+/// summands whose numerator contains exactly fifty-seven logarithmic factors
+/// and zero to five square-root factors.  This is Phase 389: zero sqrts.
+fn fifty_seven_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if sqrt_effective_half_degree_x2(arg, k).is_some() { return None; }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 57 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg; continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if log_count != 57 { return None; }
+    Some(2 * poly_deg_sum)
+}
+
+/// Phase 390 — One-Sqrt × Fifty-Seven-Log × polynomial numerator.
+fn one_sqrt_fifty_seven_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut sqrt_deg: Option<i64> = None;
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if let Some(hd) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_deg.is_some() { return None; }
+            sqrt_deg = Some(hd); continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 57 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg; continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_deg.is_none() || log_count != 57 { return None; }
+    Some(sqrt_deg.unwrap() + 2 * poly_deg_sum)
+}
+
+/// Phase 391 — Two-Sqrt × Fifty-Seven-Log × polynomial numerator.
+fn two_sqrt_fifty_seven_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut sqrt_degs: Vec<i64> = Vec::new();
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if let Some(hd) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs.len() >= 2 { return None; }
+            sqrt_degs.push(hd); continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 57 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg; continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs.len() != 2 || log_count != 57 { return None; }
+    Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg_sum)
+}
+
+/// Phase 392 — Three-Sqrt × Fifty-Seven-Log × polynomial numerator.
+fn three_sqrt_fifty_seven_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut sqrt_degs: Vec<i64> = Vec::new();
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if let Some(hd) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs.len() >= 3 { return None; }
+            sqrt_degs.push(hd); continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 57 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg; continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs.len() != 3 || log_count != 57 { return None; }
+    Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg_sum)
+}
+
+/// Phase 393 — Four-Sqrt × Fifty-Seven-Log × polynomial numerator.
+fn four_sqrt_fifty_seven_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut sqrt_degs: Vec<i64> = Vec::new();
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if let Some(hd) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs.len() >= 4 { return None; }
+            sqrt_degs.push(hd); continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 57 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg; continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs.len() != 4 || log_count != 57 { return None; }
+    Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg_sum)
+}
+
+/// Phase 394 — Five-Sqrt × Fifty-Seven-Log × polynomial numerator.
+/// Completes the Fifty-Seven-Log family (Phases 389–394).
+fn five_sqrt_fifty_seven_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut sqrt_degs: Vec<i64> = Vec::new();
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if let Some(hd) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs.len() >= 5 { return None; }
+            sqrt_degs.push(hd); continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 57 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg; continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs.len() != 5 || log_count != 57 { return None; }
+    Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg_sum)
+}
+
 /// Phase 377 — Zero-Sqrt × Fifty-Five-Log × polynomial numerator.
 ///
 /// The Fifty-Five-Log family (Phases 377–382) extends the recogniser to
@@ -11188,6 +11351,42 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
         } else if h_diverges_at_infinity(den, k) {
             return true;
         }
+    }
+    // Phase 394: Mul(Sqrt(P1)×5, Log(h1)×57, ...) numerator.
+    if let Some(s5l57_x2) = five_sqrt_fifty_seven_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s5l57) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s5l57 > s5l57_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 393: Mul(Sqrt(P1)×4, Log(h1)×57, ...) numerator.
+    if let Some(s4l57_x2) = four_sqrt_fifty_seven_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s4l57) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s4l57 > s4l57_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 392: Mul(Sqrt(P1)×3, Log(h1)×57, ...) numerator.
+    if let Some(s3l57_x2) = three_sqrt_fifty_seven_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s3l57) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s3l57 > s3l57_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 391: Mul(Sqrt(P), Sqrt(P2), Log(h1)×57, ...) numerator.
+    if let Some(s2l57_x2) = two_sqrt_fifty_seven_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s2l57) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s2l57 > s2l57_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 390: Mul(Sqrt(P), Log(h1)×57, ...) numerator.
+    if let Some(s1l57_x2) = one_sqrt_fifty_seven_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s1l57) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s1l57 > s1l57_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 389: Mul(Log(h1)×57, ...) numerator.
+    if let Some(sl57_x2) = fifty_seven_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_sl57) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_sl57 > sl57_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
     }
     // Phase 388: Mul(Sqrt(P1)×5, Log(h1)×56, ...) numerator.
     if let Some(s5l56_x2) = five_sqrt_fifty_six_log_poly_effective_x2(num, k) {

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -13269,14 +13269,15 @@ fn phase191_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -13303,14 +13304,15 @@ fn phase191_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -13428,14 +13430,15 @@ fn phase192_sqrt_k_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -13463,14 +13466,15 @@ fn phase192_sqrt_k_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -14001,14 +14005,15 @@ fn phase197_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -14035,14 +14040,15 @@ fn phase197_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -14779,14 +14785,15 @@ fn phase203_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -14813,14 +14820,15 @@ fn phase203_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -15562,14 +15570,15 @@ fn phase209_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -15597,14 +15606,15 @@ fn phase209_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -16376,14 +16386,15 @@ fn phase215_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -16411,14 +16422,15 @@ fn phase215_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -17190,14 +17202,15 @@ fn phase221_log30_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -17225,14 +17238,15 @@ fn phase221_log30_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -18004,14 +18018,15 @@ fn phase227_log31_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -18039,14 +18054,15 @@ fn phase227_log31_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -18818,14 +18834,15 @@ fn phase233_log32_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -18853,14 +18870,15 @@ fn phase233_log32_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -19633,14 +19651,15 @@ fn phase239_log33_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -19667,14 +19686,15 @@ fn phase239_log33_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -20448,14 +20468,15 @@ fn phase245_log34_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -20481,14 +20502,15 @@ fn phase245_log34_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -21261,14 +21283,15 @@ fn phase251_log36_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -21293,14 +21316,15 @@ fn phase251_log36_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -22063,14 +22087,15 @@ fn phase257_log36_k_times_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -22095,14 +22120,15 @@ fn phase257_log36_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -23650,14 +23676,15 @@ fn phase269_log38_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -23682,14 +23709,15 @@ fn phase269_log38_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
         kp1.clone(),
     ]);
     let g_k269c = apply(sym(DIV), vec![num_k, k2]);
@@ -23821,14 +23849,15 @@ fn phase270_sqrt_k_log38_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -23854,14 +23883,15 @@ fn phase270_sqrt_k_log38_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
         kp1.clone(),
     ]);
     let g_k270c = apply(sym(DIV), vec![num_k, k2]);
@@ -24546,14 +24576,15 @@ fn phase275_log39_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -24578,14 +24609,15 @@ fn phase275_log39_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
         kp1.clone(),
     ]);
     let g_k275c = apply(sym(DIV), vec![num_k, k2]);
@@ -24721,14 +24753,15 @@ fn phase276_sqrt_k_log39_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -24754,14 +24787,15 @@ fn phase276_sqrt_k_log39_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
         kp1.clone(),
     ]);
     let g_k276c = apply(sym(DIV), vec![num_k, k2]);
@@ -25453,14 +25487,15 @@ fn phase281_log40_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -25481,14 +25516,15 @@ fn phase281_log40_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
         kp1.clone(),
     ]);
     let g_kphase281r = apply(sym(DIV), vec![num_k, k2]);
@@ -25612,14 +25648,15 @@ fn phase282_sqrt1_k_log40_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -25641,14 +25678,15 @@ fn phase282_sqrt1_k_log40_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
         kp1.clone(),
     ]);
     let g_kphase282r = apply(sym(DIV), vec![num_k, k2]);
@@ -26274,14 +26312,15 @@ fn phase287_log42_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -26300,14 +26339,15 @@ fn phase287_log42_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase287r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase287r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -26429,14 +26469,15 @@ fn phase288_sqrt1_k_log42_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -26456,14 +26497,15 @@ fn phase288_sqrt1_k_log42_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase288r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase288r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -26585,14 +26627,15 @@ fn phase289_sqrt2_k_log42_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -26612,14 +26655,15 @@ fn phase289_sqrt2_k_log42_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase289r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase289r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -26741,14 +26785,15 @@ fn phase290_sqrt3_k_log42_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -26768,14 +26813,15 @@ fn phase290_sqrt3_k_log42_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase290r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase290r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -26897,14 +26943,15 @@ fn phase291_sqrt4_k_log42_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -26924,14 +26971,15 @@ fn phase291_sqrt4_k_log42_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase291r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase291r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -27053,14 +27101,15 @@ fn phase292_sqrt5_k_log42_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -27080,14 +27129,15 @@ fn phase292_sqrt5_k_log42_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase292r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase292r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -27162,14 +27212,15 @@ fn phase293_log42_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -27188,14 +27239,15 @@ fn phase293_log42_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase293r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase293r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -27277,14 +27329,15 @@ fn phase294_sqrt1_k_log42_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -27304,14 +27357,15 @@ fn phase294_sqrt1_k_log42_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase294r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase294r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -27393,14 +27447,15 @@ fn phase295_sqrt2_k_log42_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -27420,14 +27475,15 @@ fn phase295_sqrt2_k_log42_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase295r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase295r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -27509,14 +27565,15 @@ fn phase296_sqrt3_k_log42_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -27536,14 +27593,15 @@ fn phase296_sqrt3_k_log42_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase296r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase296r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -27625,14 +27683,15 @@ fn phase297_sqrt4_k_log42_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -27652,14 +27711,15 @@ fn phase297_sqrt4_k_log42_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase297r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase297r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -27741,14 +27801,15 @@ fn phase298_sqrt5_k_log42_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -27768,14 +27829,15 @@ fn phase298_sqrt5_k_log42_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase298r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase298r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -27850,14 +27912,15 @@ fn phase299_log45_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -27876,14 +27939,15 @@ fn phase299_log45_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase299r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase299r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -27965,14 +28029,15 @@ fn phase300_sqrt1_k_log45_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -27992,14 +28057,15 @@ fn phase300_sqrt1_k_log45_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase300r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase300r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -28081,14 +28147,15 @@ fn phase301_sqrt2_k_log45_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -28108,14 +28175,15 @@ fn phase301_sqrt2_k_log45_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase301r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase301r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -28197,14 +28265,15 @@ fn phase302_sqrt3_k_log45_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -28224,14 +28293,15 @@ fn phase302_sqrt3_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase302r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase302r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -28313,14 +28383,15 @@ fn phase303_sqrt4_k_log45_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -28340,14 +28411,15 @@ fn phase303_sqrt4_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase303r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase303r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -28429,14 +28501,15 @@ fn phase304_sqrt5_k_log45_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -28456,14 +28529,15 @@ fn phase304_sqrt5_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase304r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase304r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -28538,14 +28612,15 @@ fn phase305_log45_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -28563,14 +28638,15 @@ fn phase305_log45_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase305r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase305r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -28651,14 +28727,15 @@ fn phase306_sqrt1_k_log45_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -28677,14 +28754,15 @@ fn phase306_sqrt1_k_log45_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase306r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase306r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -28765,14 +28843,15 @@ fn phase307_sqrt2_k_log45_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -28791,14 +28870,15 @@ fn phase307_sqrt2_k_log45_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase307r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase307r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -28879,14 +28959,15 @@ fn phase308_sqrt3_k_log45_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -28905,14 +28986,15 @@ fn phase308_sqrt3_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase308r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase308r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -28993,14 +29075,15 @@ fn phase309_sqrt4_k_log45_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -29019,14 +29102,15 @@ fn phase309_sqrt4_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase309r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase309r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -29107,14 +29191,15 @@ fn phase310_sqrt5_k_log45_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -29133,14 +29218,15 @@ fn phase310_sqrt5_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase310r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase310r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -29213,14 +29299,15 @@ fn phase311_log45_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -29237,14 +29324,15 @@ fn phase311_log45_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase311r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase311r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -29324,14 +29412,15 @@ fn phase312_sqrt1_k_log45_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -29349,14 +29438,15 @@ fn phase312_sqrt1_k_log45_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase312r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase312r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -29436,14 +29526,15 @@ fn phase313_sqrt2_k_log45_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -29461,14 +29552,15 @@ fn phase313_sqrt2_k_log45_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase313r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase313r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -29548,14 +29640,15 @@ fn phase314_sqrt3_k_log45_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -29573,14 +29666,15 @@ fn phase314_sqrt3_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase314r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase314r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -29660,14 +29754,15 @@ fn phase315_sqrt4_k_log45_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -29685,14 +29780,15 @@ fn phase315_sqrt4_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase315r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase315r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -29772,14 +29868,15 @@ fn phase316_sqrt5_k_log45_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -29797,14 +29894,15 @@ fn phase316_sqrt5_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase316r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase316r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -29876,14 +29974,15 @@ fn phase317_log46_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -29899,14 +29998,15 @@ fn phase317_log46_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase317r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase317r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -29985,14 +30085,15 @@ fn phase318_sqrt1_k_log46_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -30009,14 +30110,15 @@ fn phase318_sqrt1_k_log46_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase318r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase318r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -30095,14 +30197,15 @@ fn phase319_sqrt2_k_log46_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -30119,14 +30222,15 @@ fn phase319_sqrt2_k_log46_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase319r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase319r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -30205,14 +30309,15 @@ fn phase320_sqrt3_k_log46_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -30229,14 +30334,15 @@ fn phase320_sqrt3_k_log46_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase320r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase320r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -30315,14 +30421,15 @@ fn phase321_sqrt4_k_log46_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -30339,14 +30446,15 @@ fn phase321_sqrt4_k_log46_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase321r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase321r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -30425,14 +30533,15 @@ fn phase322_sqrt5_k_log46_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -30449,14 +30558,15 @@ fn phase322_sqrt5_k_log46_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase322r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase322r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -30530,14 +30640,15 @@ fn phase323_log47_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -30553,14 +30664,15 @@ fn phase323_log47_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase323r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase323r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -30641,14 +30753,15 @@ fn phase324_sqrt1_k_log47_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -30665,14 +30778,15 @@ fn phase324_sqrt1_k_log47_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase324r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase324r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -30753,14 +30867,15 @@ fn phase325_sqrt2_k_log47_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -30777,14 +30892,15 @@ fn phase325_sqrt2_k_log47_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase325r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase325r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -30865,14 +30981,15 @@ fn phase326_sqrt3_k_log47_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -30889,14 +31006,15 @@ fn phase326_sqrt3_k_log47_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase326r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase326r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -30977,14 +31095,15 @@ fn phase327_sqrt4_k_log47_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -31001,14 +31120,15 @@ fn phase327_sqrt4_k_log47_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase327r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase327r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -31089,14 +31209,15 @@ fn phase328_sqrt5_k_log47_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -31113,14 +31234,15 @@ fn phase328_sqrt5_k_log47_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase328r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase328r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -31175,7 +31297,7 @@ fn phase329_log47_k_over_k2_converges() {
 
 #[test]
 fn phase329_log48_k_over_k2_refused() {
-    // phase329 log48 k over k2 refused: 57 logs → refused (Phase 383 handles exactly 56).
+    // phase329 log48 k over k2 refused: 58 logs → refused (Phase 389 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -31196,14 +31318,15 @@ fn phase329_log48_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -31219,14 +31342,15 @@ fn phase329_log48_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase329r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase329r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -31285,7 +31409,7 @@ fn phase330_sqrt1_k_log47_k_over_k2_converges() {
 
 #[test]
 fn phase330_sqrt1_k_log48_k_over_k2_refused() {
-    // phase330 sqrt1 k log48 k over k2 refused: 57 logs → refused (Phase 384 handles exactly 56).
+    // phase330 sqrt1 k log48 k over k2 refused: 58 logs → refused (Phase 390 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -31309,14 +31433,15 @@ fn phase330_sqrt1_k_log48_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -31333,14 +31458,15 @@ fn phase330_sqrt1_k_log48_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase330r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase330r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -31399,7 +31525,7 @@ fn phase331_sqrt2_k_log47_k_over_k2_converges() {
 
 #[test]
 fn phase331_sqrt2_k_log48_k_over_k2_refused() {
-    // phase331 sqrt2 k log48 k over k2 refused: 57 logs → refused (Phase 385 handles exactly 56).
+    // phase331 sqrt2 k log48 k over k2 refused: 58 logs → refused (Phase 391 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -31423,14 +31549,15 @@ fn phase331_sqrt2_k_log48_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -31447,14 +31574,15 @@ fn phase331_sqrt2_k_log48_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase331r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase331r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -31513,7 +31641,7 @@ fn phase332_sqrt3_k_log47_k_over_k3_converges() {
 
 #[test]
 fn phase332_sqrt3_k_log48_k_over_k3_refused() {
-    // phase332 sqrt3 k log48 k over k3 refused: 57 logs → refused (Phase 386 handles exactly 56).
+    // phase332 sqrt3 k log48 k over k3 refused: 58 logs → refused (Phase 392 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -31537,14 +31665,15 @@ fn phase332_sqrt3_k_log48_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -31561,14 +31690,15 @@ fn phase332_sqrt3_k_log48_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase332r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase332r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -31627,7 +31757,7 @@ fn phase333_sqrt4_k_log47_k_over_k3_converges() {
 
 #[test]
 fn phase333_sqrt4_k_log48_k_over_k3_refused() {
-    // phase333 sqrt4 k log48 k over k3 refused: 57 logs → refused (Phase 387 handles exactly 56).
+    // phase333 sqrt4 k log48 k over k3 refused: 58 logs → refused (Phase 393 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -31651,14 +31781,15 @@ fn phase333_sqrt4_k_log48_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -31675,14 +31806,15 @@ fn phase333_sqrt4_k_log48_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase333r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase333r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -31741,7 +31873,7 @@ fn phase334_sqrt5_k_log47_k_over_k3_converges() {
 
 #[test]
 fn phase334_sqrt5_k_log48_k_over_k3_refused() {
-    // phase334 sqrt5 k log48 k over k3 refused: 57 logs → refused (Phase 388 handles exactly 56).
+    // phase334 sqrt5 k log48 k over k3 refused: 58 logs → refused (Phase 394 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -31765,14 +31897,15 @@ fn phase334_sqrt5_k_log48_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -31789,14 +31922,15 @@ fn phase334_sqrt5_k_log48_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase334r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase334r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -31851,7 +31985,7 @@ fn phase335_log48_k_over_k2_converges() {
 
 #[test]
 fn phase335_log50_k_over_k2_refused() {
-    // log(k)^50 / k2: 57 logs → refused (Phase 383 handles exactly 56).
+    // log(k)^50 / k2: 58 logs → refused (Phase 389 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -31872,14 +32006,15 @@ fn phase335_log50_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -31895,14 +32030,15 @@ fn phase335_log50_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase335r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase335r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -31961,7 +32097,7 @@ fn phase336_sqrt1_k_log48_k_over_k2_converges() {
 
 #[test]
 fn phase336_sqrt1_k_log50_k_over_k2_refused() {
-    // sqrt(k)*log(k)^50 / k2: 57 logs → refused (Phase 384 handles exactly 56).
+    // sqrt(k)*log(k)^50 / k2: 58 logs → refused (Phase 390 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -31985,14 +32121,15 @@ fn phase336_sqrt1_k_log50_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -32009,14 +32146,15 @@ fn phase336_sqrt1_k_log50_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase336r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase336r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -32075,7 +32213,7 @@ fn phase337_sqrt2_k_log48_k_over_k2_converges() {
 
 #[test]
 fn phase337_sqrt2_k_log50_k_over_k2_refused() {
-    // sqrt(k)^2*log(k)^50 / k2: 57 logs → refused (Phase 385 handles exactly 56).
+    // sqrt(k)^2*log(k)^50 / k2: 58 logs → refused (Phase 391 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -32099,14 +32237,15 @@ fn phase337_sqrt2_k_log50_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -32123,14 +32262,15 @@ fn phase337_sqrt2_k_log50_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase337r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase337r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -32189,7 +32329,7 @@ fn phase338_sqrt3_k_log48_k_over_k3_converges() {
 
 #[test]
 fn phase338_sqrt3_k_log50_k_over_k3_refused() {
-    // sqrt(k)^3*log(k)^50 / k3: 57 logs → refused (Phase 386 handles exactly 56).
+    // sqrt(k)^3*log(k)^50 / k3: 58 logs → refused (Phase 392 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -32213,14 +32353,15 @@ fn phase338_sqrt3_k_log50_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -32237,14 +32378,15 @@ fn phase338_sqrt3_k_log50_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase338r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase338r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -32303,7 +32445,7 @@ fn phase339_sqrt4_k_log48_k_over_k3_converges() {
 
 #[test]
 fn phase339_sqrt4_k_log50_k_over_k3_refused() {
-    // sqrt(k)^4*log(k)^50 / k3: 57 logs → refused (Phase 387 handles exactly 56).
+    // sqrt(k)^4*log(k)^50 / k3: 58 logs → refused (Phase 393 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -32327,14 +32469,15 @@ fn phase339_sqrt4_k_log50_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -32351,14 +32494,15 @@ fn phase339_sqrt4_k_log50_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase339r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase339r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -32417,7 +32561,7 @@ fn phase340_sqrt5_k_log48_k_over_k3_converges() {
 
 #[test]
 fn phase340_sqrt5_k_log50_k_over_k3_refused() {
-    // sqrt(k)^5*log(k)^50 / k3: 57 logs → refused (Phase 388 handles exactly 56).
+    // sqrt(k)^5*log(k)^50 / k3: 58 logs → refused (Phase 394 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -32441,14 +32585,15 @@ fn phase340_sqrt5_k_log50_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -32465,14 +32610,15 @@ fn phase340_sqrt5_k_log50_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase340r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase340r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -32529,7 +32675,7 @@ fn phase341_log49_k_over_k2_converges() {
 
 #[test]
 fn phase341_log50_k_over_k2_refused() {
-    // log(k)^50 / k2: 57 logs → refused (Phase 383 handles exactly 56).
+    // log(k)^50 / k2: 58 logs → refused (Phase 389 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -32550,14 +32696,15 @@ fn phase341_log50_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -32573,14 +32720,15 @@ fn phase341_log50_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase341r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase341r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -32641,7 +32789,7 @@ fn phase342_sqrt1_k_log49_k_over_k2_converges() {
 
 #[test]
 fn phase342_sqrt1_k_log50_k_over_k2_refused() {
-    // sqrt(k)*log(k)^50 / k2: 57 logs → refused (Phase 384 handles exactly 56).
+    // sqrt(k)*log(k)^50 / k2: 58 logs → refused (Phase 390 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -32665,14 +32813,15 @@ fn phase342_sqrt1_k_log50_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -32689,14 +32838,15 @@ fn phase342_sqrt1_k_log50_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase342r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase342r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -32757,7 +32907,7 @@ fn phase343_sqrt2_k_log49_k_over_k3_converges() {
 
 #[test]
 fn phase343_sqrt2_k_log50_k_over_k2_refused() {
-    // sqrt(k)^2*log(k)^50 / k2: 57 logs → refused (Phase 385 handles exactly 56).
+    // sqrt(k)^2*log(k)^50 / k2: 58 logs → refused (Phase 391 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -32781,14 +32931,15 @@ fn phase343_sqrt2_k_log50_k_over_k2_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -32805,14 +32956,15 @@ fn phase343_sqrt2_k_log50_k_over_k2_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase343r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase343r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -32873,7 +33025,7 @@ fn phase344_sqrt3_k_log49_k_over_k3_converges() {
 
 #[test]
 fn phase344_sqrt3_k_log50_k_over_k3_refused() {
-    // sqrt(k)^3*log(k)^50 / k3: 57 logs → refused (Phase 386 handles exactly 56).
+    // sqrt(k)^3*log(k)^50 / k3: 58 logs → refused (Phase 392 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -32897,14 +33049,15 @@ fn phase344_sqrt3_k_log50_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -32921,14 +33074,15 @@ fn phase344_sqrt3_k_log50_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase344r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase344r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -32989,7 +33143,7 @@ fn phase345_sqrt4_k_log49_k_over_k3_converges() {
 
 #[test]
 fn phase345_sqrt4_k_log50_k_over_k3_refused() {
-    // sqrt(k)^4*log(k)^50 / k3: 57 logs → refused (Phase 387 handles exactly 56).
+    // sqrt(k)^4*log(k)^50 / k3: 58 logs → refused (Phase 393 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -33013,14 +33167,15 @@ fn phase345_sqrt4_k_log50_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -33037,14 +33192,15 @@ fn phase345_sqrt4_k_log50_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase345r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase345r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -33105,7 +33261,7 @@ fn phase346_sqrt5_k_log49_k_over_k3_converges() {
 
 #[test]
 fn phase346_sqrt5_k_log50_k_over_k3_refused() {
-    // sqrt(k)^5*log(k)^50 / k3: 57 logs → refused (Phase 388 handles exactly 56).
+    // sqrt(k)^5*log(k)^50 / k3: 58 logs → refused (Phase 394 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -33129,14 +33285,15 @@ fn phase346_sqrt5_k_log50_k_over_k3_refused() {
         log_k.clone(), // 47th log
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 52nd log (over 50; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -33153,14 +33310,15 @@ fn phase346_sqrt5_k_log50_k_over_k3_refused() {
         log_kp1.clone(), // 47th log
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 52nd log (over 50; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase346r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase346r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -33219,7 +33377,7 @@ fn phase347_log50_k_over_k2_converges() {
 
 #[test]
 fn phase347_log51_k_over_k2_refused() {
-    // log(k)^51 / k2: 57 logs → refused (Phase 383 handles exactly 56).
+    // log(k)^51 / k2: 58 logs → refused (Phase 389 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -33241,13 +33399,14 @@ fn phase347_log51_k_over_k2_refused() {
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
         log_k.clone(), // 50th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -33264,13 +33423,14 @@ fn phase347_log51_k_over_k2_refused() {
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
         log_kp1.clone(), // 50th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase347r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase347r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -33333,7 +33493,7 @@ fn phase348_sqrt1_k_log50_k_over_k2_converges() {
 
 #[test]
 fn phase348_sqrt1_k_log51_k_over_k2_refused() {
-    // sqrt(k)*log(k)^51 / k2: 57 logs → refused (Phase 384 handles exactly 56).
+    // sqrt(k)*log(k)^51 / k2: 58 logs → refused (Phase 390 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -33358,13 +33518,14 @@ fn phase348_sqrt1_k_log51_k_over_k2_refused() {
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
         log_k.clone(), // 50th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -33382,13 +33543,14 @@ fn phase348_sqrt1_k_log51_k_over_k2_refused() {
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
         log_kp1.clone(), // 50th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase348r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase348r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -33451,7 +33613,7 @@ fn phase349_sqrt2_k_log50_k_over_k3_converges() {
 
 #[test]
 fn phase349_sqrt2_k_log51_k_over_k2_refused() {
-    // sqrt(k)^2*log(k)^51 / k2: 57 logs → refused (Phase 385 handles exactly 56).
+    // sqrt(k)^2*log(k)^51 / k2: 58 logs → refused (Phase 391 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -33476,13 +33638,14 @@ fn phase349_sqrt2_k_log51_k_over_k2_refused() {
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
         log_k.clone(), // 50th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -33500,13 +33663,14 @@ fn phase349_sqrt2_k_log51_k_over_k2_refused() {
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
         log_kp1.clone(), // 50th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase349r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase349r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -33569,7 +33733,7 @@ fn phase350_sqrt3_k_log50_k_over_k3_converges() {
 
 #[test]
 fn phase350_sqrt3_k_log51_k_over_k3_refused() {
-    // sqrt(k)^3*log(k)^51 / k3: 57 logs → refused (Phase 386 handles exactly 56).
+    // sqrt(k)^3*log(k)^51 / k3: 58 logs → refused (Phase 392 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -33594,13 +33758,14 @@ fn phase350_sqrt3_k_log51_k_over_k3_refused() {
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
         log_k.clone(), // 50th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -33618,13 +33783,14 @@ fn phase350_sqrt3_k_log51_k_over_k3_refused() {
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
         log_kp1.clone(), // 50th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase350r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase350r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -33687,7 +33853,7 @@ fn phase351_sqrt4_k_log50_k_over_k3_converges() {
 
 #[test]
 fn phase351_sqrt4_k_log51_k_over_k3_refused() {
-    // sqrt(k)^4*log(k)^51 / k3: 57 logs → refused (Phase 387 handles exactly 56).
+    // sqrt(k)^4*log(k)^51 / k3: 58 logs → refused (Phase 393 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -33712,13 +33878,14 @@ fn phase351_sqrt4_k_log51_k_over_k3_refused() {
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
         log_k.clone(), // 50th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -33736,13 +33903,14 @@ fn phase351_sqrt4_k_log51_k_over_k3_refused() {
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
         log_kp1.clone(), // 50th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase351r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase351r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -33805,7 +33973,7 @@ fn phase352_sqrt5_k_log50_k_over_k3_converges() {
 
 #[test]
 fn phase352_sqrt5_k_log51_k_over_k3_refused() {
-    // sqrt(k)^5*log(k)^51 / k3: 57 logs → refused (Phase 388 handles exactly 56).
+    // sqrt(k)^5*log(k)^51 / k3: 58 logs → refused (Phase 394 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -33830,13 +33998,14 @@ fn phase352_sqrt5_k_log51_k_over_k3_refused() {
         log_k.clone(), // 48th log
         log_k.clone(), // 49th log
         log_k.clone(), // 50th log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -33854,13 +34023,14 @@ fn phase352_sqrt5_k_log51_k_over_k3_refused() {
         log_kp1.clone(), // 48th log
         log_kp1.clone(), // 49th log
         log_kp1.clone(), // 50th log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase352r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase352r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -33921,7 +34091,7 @@ fn phase353_log51_k_over_k2_converges() {
 
 #[test]
 fn phase353_log52_k_over_k2_refused() {
-    // log(k)^52 / k2: 57 logs → refused (Phase 383 handles exactly 56).
+    // log(k)^52 / k2: 58 logs → refused (Phase 389 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -33944,12 +34114,13 @@ fn phase353_log52_k_over_k2_refused() {
         log_k.clone(), // 49th log
         log_k.clone(), // 50th log
         log_k.clone(), // 51st log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
-        log_k, // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -33967,12 +34138,13 @@ fn phase353_log52_k_over_k2_refused() {
         log_kp1.clone(), // 49th log
         log_kp1.clone(), // 50th log
         log_kp1.clone(), // 51st log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
-        log_kp1, // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase353r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase353r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -34037,7 +34209,7 @@ fn phase354_sqrt1_k_log51_k_over_k2_converges() {
 
 #[test]
 fn phase354_sqrt1_k_log52_k_over_k2_refused() {
-    // sqrt(k)^1*log(k)^52 / k2: 57 logs → refused (Phase 384 handles exactly 56).
+    // sqrt(k)^1*log(k)^52 / k2: 58 logs → refused (Phase 390 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -34063,12 +34235,13 @@ fn phase354_sqrt1_k_log52_k_over_k2_refused() {
         log_k.clone(), // 49th log
         log_k.clone(), // 50th log
         log_k.clone(), // 51st log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
-        log_k, // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -34087,12 +34260,13 @@ fn phase354_sqrt1_k_log52_k_over_k2_refused() {
         log_kp1.clone(), // 49th log
         log_kp1.clone(), // 50th log
         log_kp1.clone(), // 51st log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
-        log_kp1, // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase354r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase354r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -34157,7 +34331,7 @@ fn phase355_sqrt2_k_log51_k_over_k3_converges() {
 
 #[test]
 fn phase355_sqrt2_k_log52_k_over_k3_refused() {
-    // sqrt(k)^2*log(k)^52 / k3: 57 logs → refused (Phase 385 handles exactly 56).
+    // sqrt(k)^2*log(k)^52 / k3: 58 logs → refused (Phase 391 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -34183,12 +34357,13 @@ fn phase355_sqrt2_k_log52_k_over_k3_refused() {
         log_k.clone(), // 49th log
         log_k.clone(), // 50th log
         log_k.clone(), // 51st log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
-        log_k, // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -34207,12 +34382,13 @@ fn phase355_sqrt2_k_log52_k_over_k3_refused() {
         log_kp1.clone(), // 49th log
         log_kp1.clone(), // 50th log
         log_kp1.clone(), // 51st log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
-        log_kp1, // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase355r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase355r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -34277,7 +34453,7 @@ fn phase356_sqrt3_k_log51_k_over_k3_converges() {
 
 #[test]
 fn phase356_sqrt3_k_log52_k_over_k3_refused() {
-    // sqrt(k)^3*log(k)^52 / k3: 57 logs → refused (Phase 386 handles exactly 56).
+    // sqrt(k)^3*log(k)^52 / k3: 58 logs → refused (Phase 392 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -34303,12 +34479,13 @@ fn phase356_sqrt3_k_log52_k_over_k3_refused() {
         log_k.clone(), // 49th log
         log_k.clone(), // 50th log
         log_k.clone(), // 51st log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
-        log_k, // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -34327,12 +34504,13 @@ fn phase356_sqrt3_k_log52_k_over_k3_refused() {
         log_kp1.clone(), // 49th log
         log_kp1.clone(), // 50th log
         log_kp1.clone(), // 51st log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
-        log_kp1, // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase356r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase356r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -34397,7 +34575,7 @@ fn phase357_sqrt4_k_log51_k_over_k3_converges() {
 
 #[test]
 fn phase357_sqrt4_k_log52_k_over_k3_refused() {
-    // sqrt(k)^4*log(k)^52 / k3: 57 logs → refused (Phase 387 handles exactly 56).
+    // sqrt(k)^4*log(k)^52 / k3: 58 logs → refused (Phase 393 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -34423,12 +34601,13 @@ fn phase357_sqrt4_k_log52_k_over_k3_refused() {
         log_k.clone(), // 49th log
         log_k.clone(), // 50th log
         log_k.clone(), // 51st log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
-        log_k, // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -34447,12 +34626,13 @@ fn phase357_sqrt4_k_log52_k_over_k3_refused() {
         log_kp1.clone(), // 49th log
         log_kp1.clone(), // 50th log
         log_kp1.clone(), // 51st log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
-        log_kp1, // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase357r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase357r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -34517,7 +34697,7 @@ fn phase358_sqrt5_k_log51_k_over_k3_converges() {
 
 #[test]
 fn phase358_sqrt5_k_log52_k_over_k3_refused() {
-    // sqrt(k)^5*log(k)^52 / k3: 57 logs → refused (Phase 388 handles exactly 56).
+    // sqrt(k)^5*log(k)^52 / k3: 58 logs → refused (Phase 394 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -34543,12 +34723,13 @@ fn phase358_sqrt5_k_log52_k_over_k3_refused() {
         log_k.clone(), // 49th log
         log_k.clone(), // 50th log
         log_k.clone(), // 51st log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
-        log_k, // 55th log (over 54; refused)
+        log_k.clone(), // 55th log (over 54; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -34567,12 +34748,13 @@ fn phase358_sqrt5_k_log52_k_over_k3_refused() {
         log_kp1.clone(), // 49th log
         log_kp1.clone(), // 50th log
         log_kp1.clone(), // 51st log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
-        log_kp1, // 55th log (over 54; refused)
+        log_kp1.clone(), // 55th log (over 54; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase358r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase358r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -34659,11 +34841,12 @@ fn phase359_log53_k_over_k2_refused() {
         log_k.clone(), // 50th log
         log_k.clone(), // 51st log
         log_k.clone(), // 52nd log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -34682,11 +34865,12 @@ fn phase359_log53_k_over_k2_refused() {
         log_kp1.clone(), // 50th log
         log_kp1.clone(), // 51st log
         log_kp1.clone(), // 52nd log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase359r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase359r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -34780,11 +34964,12 @@ fn phase360_sqrt1_k_log53_k_over_k2_refused() {
         log_k.clone(), // 50th log
         log_k.clone(), // 51st log
         log_k.clone(), // 52nd log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -34804,11 +34989,12 @@ fn phase360_sqrt1_k_log53_k_over_k2_refused() {
         log_kp1.clone(), // 50th log
         log_kp1.clone(), // 51st log
         log_kp1.clone(), // 52nd log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase360r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase360r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -34902,11 +35088,12 @@ fn phase361_sqrt2_k_log53_k_over_k3_refused() {
         log_k.clone(), // 50th log
         log_k.clone(), // 51st log
         log_k.clone(), // 52nd log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -34926,11 +35113,12 @@ fn phase361_sqrt2_k_log53_k_over_k3_refused() {
         log_kp1.clone(), // 50th log
         log_kp1.clone(), // 51st log
         log_kp1.clone(), // 52nd log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase361r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase361r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -35024,11 +35212,12 @@ fn phase362_sqrt3_k_log53_k_over_k3_refused() {
         log_k.clone(), // 50th log
         log_k.clone(), // 51st log
         log_k.clone(), // 52nd log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -35048,11 +35237,12 @@ fn phase362_sqrt3_k_log53_k_over_k3_refused() {
         log_kp1.clone(), // 50th log
         log_kp1.clone(), // 51st log
         log_kp1.clone(), // 52nd log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase362r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase362r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -35146,11 +35336,12 @@ fn phase363_sqrt4_k_log53_k_over_k3_refused() {
         log_k.clone(), // 50th log
         log_k.clone(), // 51st log
         log_k.clone(), // 52nd log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -35170,11 +35361,12 @@ fn phase363_sqrt4_k_log53_k_over_k3_refused() {
         log_kp1.clone(), // 50th log
         log_kp1.clone(), // 51st log
         log_kp1.clone(), // 52nd log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase363r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase363r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -35268,11 +35460,12 @@ fn phase364_sqrt5_k_log53_k_over_k3_refused() {
         log_k.clone(), // 50th log
         log_k.clone(), // 51st log
         log_k.clone(), // 52nd log
-        log_k.clone(), // 57th log
+        log_k.clone(), // 58th log
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 54th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -35292,11 +35485,12 @@ fn phase364_sqrt5_k_log53_k_over_k3_refused() {
         log_kp1.clone(), // 50th log
         log_kp1.clone(), // 51st log
         log_kp1.clone(), // 52nd log
-        log_kp1.clone(), // 57th log
+        log_kp1.clone(), // 58th log
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_kphase364r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase364r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -35360,7 +35554,7 @@ fn phase365_log53_k_over_k2_converges() {
 
 #[test]
 fn phase365_log53_k_over_k2_refused() {
-    // log53 k over k2: 57 logs → refused (Phase 383 handles exactly 56).
+    // log53 k over k2: 58 logs → refused (Phase 389 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -35388,7 +35582,8 @@ fn phase365_log53_k_over_k2_refused() {
         log_k.clone(), // 54th log
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -35411,7 +35606,8 @@ fn phase365_log53_k_over_k2_refused() {
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_k365r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_365r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -35480,7 +35676,7 @@ fn phase366_sqrt1_k_log53_k_over_k2_converges() {
 
 #[test]
 fn phase366_sqrt1_k_log53_k_over_k2_refused() {
-    // sqrt1 k log53 k over k2: 57 logs → refused (Phase 384 handles exactly 56).
+    // sqrt1 k log53 k over k2: 58 logs → refused (Phase 390 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -35511,7 +35707,8 @@ fn phase366_sqrt1_k_log53_k_over_k2_refused() {
         log_k.clone(), // 54th log
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -35535,7 +35732,8 @@ fn phase366_sqrt1_k_log53_k_over_k2_refused() {
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_k366r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_366r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -35604,7 +35802,7 @@ fn phase367_sqrt2_k_log53_k_over_k2_converges() {
 
 #[test]
 fn phase367_sqrt2_k_log53_k_over_k2_refused() {
-    // sqrt2 k log53 k over k2: 57 logs → refused (Phase 385 handles exactly 56).
+    // sqrt2 k log53 k over k2: 58 logs → refused (Phase 391 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -35635,7 +35833,8 @@ fn phase367_sqrt2_k_log53_k_over_k2_refused() {
         log_k.clone(), // 54th log
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -35659,7 +35858,8 @@ fn phase367_sqrt2_k_log53_k_over_k2_refused() {
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_k367r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_367r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -35728,7 +35928,7 @@ fn phase368_sqrt3_k_log53_k_over_k3_converges() {
 
 #[test]
 fn phase368_sqrt3_k_log53_k_over_k3_refused() {
-    // sqrt3 k log53 k over k3: 57 logs → refused (Phase 386 handles exactly 56).
+    // sqrt3 k log53 k over k3: 58 logs → refused (Phase 392 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -35759,7 +35959,8 @@ fn phase368_sqrt3_k_log53_k_over_k3_refused() {
         log_k.clone(), // 54th log
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -35783,7 +35984,8 @@ fn phase368_sqrt3_k_log53_k_over_k3_refused() {
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_k368r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_368r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -35852,7 +36054,7 @@ fn phase369_sqrt4_k_log53_k_over_k3_converges() {
 
 #[test]
 fn phase369_sqrt4_k_log53_k_over_k3_refused() {
-    // sqrt4 k log53 k over k3: 57 logs → refused (Phase 387 handles exactly 56).
+    // sqrt4 k log53 k over k3: 58 logs → refused (Phase 393 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -35883,7 +36085,8 @@ fn phase369_sqrt4_k_log53_k_over_k3_refused() {
         log_k.clone(), // 54th log
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -35907,7 +36110,8 @@ fn phase369_sqrt4_k_log53_k_over_k3_refused() {
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_k369r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_369r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -35976,7 +36180,7 @@ fn phase370_sqrt5_k_log53_k_over_k3_converges() {
 
 #[test]
 fn phase370_sqrt5_k_log53_k_over_k3_refused() {
-    // sqrt5 k log53 k over k3: 57 logs → refused (Phase 388 handles exactly 56).
+    // sqrt5 k log53 k over k3: 58 logs → refused (Phase 394 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -36007,7 +36211,8 @@ fn phase370_sqrt5_k_log53_k_over_k3_refused() {
         log_k.clone(), // 54th log
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -36031,7 +36236,8 @@ fn phase370_sqrt5_k_log53_k_over_k3_refused() {
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_k370r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_370r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -36098,7 +36304,7 @@ fn phase371_log54_k_over_k2_converges() {
 
 #[test]
 fn phase371_log54_k_over_k2_refused() {
-    // log54 k over k2: 57 logs → refused (Phase 383 handles exactly 56).
+    // log54 k over k2: 58 logs → refused (Phase 389 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -36126,7 +36332,8 @@ fn phase371_log54_k_over_k2_refused() {
         log_k.clone(), // 54th log
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -36149,7 +36356,8 @@ fn phase371_log54_k_over_k2_refused() {
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_k371r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_371r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -36220,7 +36428,7 @@ fn phase372_sqrt1_k_log54_k_over_k2_converges() {
 
 #[test]
 fn phase372_sqrt1_k_log54_k_over_k2_refused() {
-    // sqrt1 k log54 k over k2: 57 logs → refused (Phase 384 handles exactly 56).
+    // sqrt1 k log54 k over k2: 58 logs → refused (Phase 390 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -36251,7 +36459,8 @@ fn phase372_sqrt1_k_log54_k_over_k2_refused() {
         log_k.clone(), // 54th log
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -36275,7 +36484,8 @@ fn phase372_sqrt1_k_log54_k_over_k2_refused() {
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_k372r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_372r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -36346,7 +36556,7 @@ fn phase373_sqrt2_k_log54_k_over_k2_converges() {
 
 #[test]
 fn phase373_sqrt2_k_log54_k_over_k2_refused() {
-    // sqrt2 k log54 k over k2: 57 logs → refused (Phase 385 handles exactly 56).
+    // sqrt2 k log54 k over k2: 58 logs → refused (Phase 391 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -36377,7 +36587,8 @@ fn phase373_sqrt2_k_log54_k_over_k2_refused() {
         log_k.clone(), // 54th log
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -36401,7 +36612,8 @@ fn phase373_sqrt2_k_log54_k_over_k2_refused() {
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_k373r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_373r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -36472,7 +36684,7 @@ fn phase374_sqrt3_k_log54_k_over_k3_converges() {
 
 #[test]
 fn phase374_sqrt3_k_log54_k_over_k3_refused() {
-    // sqrt3 k log54 k over k3: 57 logs → refused (Phase 386 handles exactly 56).
+    // sqrt3 k log54 k over k3: 58 logs → refused (Phase 392 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -36503,7 +36715,8 @@ fn phase374_sqrt3_k_log54_k_over_k3_refused() {
         log_k.clone(), // 54th log
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -36527,7 +36740,8 @@ fn phase374_sqrt3_k_log54_k_over_k3_refused() {
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_k374r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_374r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -36598,7 +36812,7 @@ fn phase375_sqrt4_k_log54_k_over_k3_converges() {
 
 #[test]
 fn phase375_sqrt4_k_log54_k_over_k3_refused() {
-    // sqrt4 k log54 k over k3: 57 logs → refused (Phase 387 handles exactly 56).
+    // sqrt4 k log54 k over k3: 58 logs → refused (Phase 393 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -36629,7 +36843,8 @@ fn phase375_sqrt4_k_log54_k_over_k3_refused() {
         log_k.clone(), // 54th log
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -36653,7 +36868,8 @@ fn phase375_sqrt4_k_log54_k_over_k3_refused() {
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_k375r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_375r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -36724,7 +36940,7 @@ fn phase376_sqrt5_k_log54_k_over_k3_converges() {
 
 #[test]
 fn phase376_sqrt5_k_log54_k_over_k3_refused() {
-    // sqrt5 k log54 k over k3: 57 logs → refused (Phase 388 handles exactly 56).
+    // sqrt5 k log54 k over k3: 58 logs → refused (Phase 394 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -36755,7 +36971,8 @@ fn phase376_sqrt5_k_log54_k_over_k3_refused() {
         log_k.clone(), // 54th log
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -36779,7 +36996,8 @@ fn phase376_sqrt5_k_log54_k_over_k3_refused() {
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_k376r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_376r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -36848,7 +37066,7 @@ fn phase377_log55_k_over_k2_converges() {
 
 #[test]
 fn phase377_log55_k_over_k2_refused() {
-    // log55 k over k2: 57 logs → refused (Phase 383 handles exactly 56).
+    // log55 k over k2: 58 logs → refused (Phase 389 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -36876,7 +37094,8 @@ fn phase377_log55_k_over_k2_refused() {
         log_k.clone(), // 54th log
         log_k.clone(), // 55th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -36899,7 +37118,8 @@ fn phase377_log55_k_over_k2_refused() {
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 55th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_k377r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_377r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -36972,7 +37192,7 @@ fn phase378_sqrt1_k_log55_k_over_k2_converges() {
 
 #[test]
 fn phase378_sqrt1_k_log55_k_over_k2_refused() {
-    // sqrt1 k log55 k over k2: 57 logs → refused (Phase 384 handles exactly 56).
+    // sqrt1 k log55 k over k2: 58 logs → refused (Phase 390 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -37003,7 +37223,8 @@ fn phase378_sqrt1_k_log55_k_over_k2_refused() {
         log_k.clone(), // 54th log
         log_k.clone(), // 55th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -37027,7 +37248,8 @@ fn phase378_sqrt1_k_log55_k_over_k2_refused() {
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 55th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_k378r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_378r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -37100,7 +37322,7 @@ fn phase379_sqrt2_k_log55_k_over_k2_converges() {
 
 #[test]
 fn phase379_sqrt2_k_log55_k_over_k2_refused() {
-    // sqrt2 k log55 k over k2: 57 logs → refused (Phase 385 handles exactly 56).
+    // sqrt2 k log55 k over k2: 58 logs → refused (Phase 391 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -37131,7 +37353,8 @@ fn phase379_sqrt2_k_log55_k_over_k2_refused() {
         log_k.clone(), // 54th log
         log_k.clone(), // 55th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -37155,7 +37378,8 @@ fn phase379_sqrt2_k_log55_k_over_k2_refused() {
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 55th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_k379r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_379r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -37228,7 +37452,7 @@ fn phase380_sqrt3_k_log55_k_over_k3_converges() {
 
 #[test]
 fn phase380_sqrt3_k_log55_k_over_k3_refused() {
-    // sqrt3 k log55 k over k3: 57 logs → refused (Phase 386 handles exactly 56).
+    // sqrt3 k log55 k over k3: 58 logs → refused (Phase 392 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -37259,7 +37483,8 @@ fn phase380_sqrt3_k_log55_k_over_k3_refused() {
         log_k.clone(), // 54th log
         log_k.clone(), // 55th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -37283,7 +37508,8 @@ fn phase380_sqrt3_k_log55_k_over_k3_refused() {
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 55th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_k380r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_380r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -37356,7 +37582,7 @@ fn phase381_sqrt4_k_log55_k_over_k3_converges() {
 
 #[test]
 fn phase381_sqrt4_k_log55_k_over_k3_refused() {
-    // sqrt4 k log55 k over k3: 57 logs → refused (Phase 387 handles exactly 56).
+    // sqrt4 k log55 k over k3: 58 logs → refused (Phase 393 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -37387,7 +37613,8 @@ fn phase381_sqrt4_k_log55_k_over_k3_refused() {
         log_k.clone(), // 54th log
         log_k.clone(), // 55th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -37411,7 +37638,8 @@ fn phase381_sqrt4_k_log55_k_over_k3_refused() {
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 55th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_k381r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_381r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -37484,7 +37712,7 @@ fn phase382_sqrt5_k_log55_k_over_k3_converges() {
 
 #[test]
 fn phase382_sqrt5_k_log55_k_over_k3_refused() {
-    // sqrt5 k log55 k over k3: 57 logs → refused (Phase 388 handles exactly 56).
+    // sqrt5 k log55 k over k3: 58 logs → refused (Phase 394 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -37515,7 +37743,8 @@ fn phase382_sqrt5_k_log55_k_over_k3_refused() {
         log_k.clone(), // 54th log
         log_k.clone(), // 55th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -37539,7 +37768,8 @@ fn phase382_sqrt5_k_log55_k_over_k3_refused() {
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 55th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_k382r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_382r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -37612,7 +37842,7 @@ fn phase383_log56_k_over_k2_converges() {
 
 #[test]
 fn phase383_log56_k_over_k2_refused() {
-    // log56 k over k2: 57 logs → refused (Phase 383 handles exactly 56).
+    // log56 k over k2: 58 logs → refused (Phase 389 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -37640,7 +37870,8 @@ fn phase383_log56_k_over_k2_refused() {
         log_k.clone(), // 54th log
         log_k.clone(), // 55th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -37663,7 +37894,8 @@ fn phase383_log56_k_over_k2_refused() {
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 55th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_k383r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_383r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -37738,7 +37970,7 @@ fn phase384_sqrt1_k_log56_k_over_k2_converges() {
 
 #[test]
 fn phase384_sqrt1_k_log56_k_over_k2_refused() {
-    // sqrt1 k log56 k over k2: 57 logs → refused (Phase 384 handles exactly 56).
+    // sqrt1 k log56 k over k2: 58 logs → refused (Phase 390 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -37769,7 +38001,8 @@ fn phase384_sqrt1_k_log56_k_over_k2_refused() {
         log_k.clone(), // 54th log
         log_k.clone(), // 55th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -37793,7 +38026,8 @@ fn phase384_sqrt1_k_log56_k_over_k2_refused() {
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 55th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_k384r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_384r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -37868,7 +38102,7 @@ fn phase385_sqrt2_k_log56_k_over_k2_converges() {
 
 #[test]
 fn phase385_sqrt2_k_log56_k_over_k2_refused() {
-    // sqrt2 k log56 k over k2: 57 logs → refused (Phase 385 handles exactly 56).
+    // sqrt2 k log56 k over k2: 58 logs → refused (Phase 391 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -37899,7 +38133,8 @@ fn phase385_sqrt2_k_log56_k_over_k2_refused() {
         log_k.clone(), // 54th log
         log_k.clone(), // 55th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -37923,7 +38158,8 @@ fn phase385_sqrt2_k_log56_k_over_k2_refused() {
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 55th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_k385r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_385r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -37998,7 +38234,7 @@ fn phase386_sqrt3_k_log56_k_over_k3_converges() {
 
 #[test]
 fn phase386_sqrt3_k_log56_k_over_k3_refused() {
-    // sqrt3 k log56 k over k3: 57 logs → refused (Phase 386 handles exactly 56).
+    // sqrt3 k log56 k over k3: 58 logs → refused (Phase 392 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -38029,7 +38265,8 @@ fn phase386_sqrt3_k_log56_k_over_k3_refused() {
         log_k.clone(), // 54th log
         log_k.clone(), // 55th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -38053,7 +38290,8 @@ fn phase386_sqrt3_k_log56_k_over_k3_refused() {
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 55th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_k386r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_386r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -38128,7 +38366,7 @@ fn phase387_sqrt4_k_log56_k_over_k3_converges() {
 
 #[test]
 fn phase387_sqrt4_k_log56_k_over_k3_refused() {
-    // sqrt4 k log56 k over k3: 57 logs → refused (Phase 387 handles exactly 56).
+    // sqrt4 k log56 k over k3: 58 logs → refused (Phase 393 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -38159,7 +38397,8 @@ fn phase387_sqrt4_k_log56_k_over_k3_refused() {
         log_k.clone(), // 54th log
         log_k.clone(), // 55th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -38183,7 +38422,8 @@ fn phase387_sqrt4_k_log56_k_over_k3_refused() {
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 55th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_k387r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_387r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -38258,7 +38498,7 @@ fn phase388_sqrt5_k_log56_k_over_k3_converges() {
 
 #[test]
 fn phase388_sqrt5_k_log56_k_over_k3_refused() {
-    // sqrt5 k log56 k over k3: 57 logs → refused (Phase 388 handles exactly 56).
+    // sqrt5 k log56 k over k3: 58 logs → refused (Phase 394 handles exactly 57).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -38289,7 +38529,8 @@ fn phase388_sqrt5_k_log56_k_over_k3_refused() {
         log_k.clone(), // 54th log
         log_k.clone(), // 55th log
         log_k.clone(), // 56th log
-        log_k, // 57th log (over 56; refused)
+        log_k.clone(), // 57th log (over 56; refused)
+        log_k, // 58th log (over 57; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -38313,11 +38554,808 @@ fn phase388_sqrt5_k_log56_k_over_k3_refused() {
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 55th log
         log_kp1.clone(), // 56th log
-        log_kp1, // 57th log (over 56; refused)
+        log_kp1.clone(), // 57th log (over 56; refused)
+        log_kp1, // 58th log (over 57; refused)
     ]);
     let g_k388r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_388r = apply(sym(DIV), vec![num_kp1, kp1_3]);
     let f388r = apply(sym(SUB), vec![g_k388r, g_kp1_388r]);
     let out = evaluate_sum(f388r, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase389_log57_k_over_k2_converges() {
+    // log57 k over k2: eff_x2=0; 2·2=4 > 0 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 45 logs
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k.clone(), // 51st log
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
+        log_k.clone(), // 56th log
+        log_k, // 57th log
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 45 logs
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
+        log_kp1.clone(), // 56th log
+        log_kp1, // 57th log
+    ]);
+    let g_k389a = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_389a = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f389a = apply(sym(SUB), vec![g_k389a, g_kp1_389a]);
+    let out = evaluate_sum(f389a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase389_log57_k_over_k2_refused() {
+    // log57 k over k2: 58 logs → refused (Phase 389 handles exactly 57).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 45 logs
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k.clone(), // 51st log
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
+        log_k.clone(), // 56th log
+        log_k.clone(), // 57th log
+        log_k, // 58th log (over 57; refused)
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 45 logs
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
+        log_kp1.clone(), // 56th log
+        log_kp1.clone(), // 57th log
+        log_kp1, // 58th log (over 57; refused)
+    ]);
+    let g_k389r = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_389r = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f389r = apply(sym(SUB), vec![g_k389r, g_kp1_389r]);
+    let out = evaluate_sum(f389r, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase390_sqrt1_k_log57_k_over_k2_converges() {
+    // sqrt1 k log57 k over k2: eff_x2=1; 2·2=4 > 1 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 45 logs
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k.clone(), // 51st log
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
+        log_k.clone(), // 56th log
+        log_k, // 57th log
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 45 logs
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
+        log_kp1.clone(), // 56th log
+        log_kp1, // 57th log
+    ]);
+    let g_k390a = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_390a = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f390a = apply(sym(SUB), vec![g_k390a, g_kp1_390a]);
+    let out = evaluate_sum(f390a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase390_sqrt1_k_log57_k_over_k2_refused() {
+    // sqrt1 k log57 k over k2: 58 logs → refused (Phase 390 handles exactly 57).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 45 logs
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k.clone(), // 51st log
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
+        log_k.clone(), // 56th log
+        log_k.clone(), // 57th log
+        log_k, // 58th log (over 57; refused)
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 45 logs
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
+        log_kp1.clone(), // 56th log
+        log_kp1.clone(), // 57th log
+        log_kp1, // 58th log (over 57; refused)
+    ]);
+    let g_k390r = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_390r = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f390r = apply(sym(SUB), vec![g_k390r, g_kp1_390r]);
+    let out = evaluate_sum(f390r, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase391_sqrt2_k_log57_k_over_k2_converges() {
+    // sqrt2 k log57 k over k2: eff_x2=2; 2·2=4 > 2 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 45 logs
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k.clone(), // 51st log
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
+        log_k.clone(), // 56th log
+        log_k, // 57th log
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 45 logs
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
+        log_kp1.clone(), // 56th log
+        log_kp1, // 57th log
+    ]);
+    let g_k391a = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_391a = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f391a = apply(sym(SUB), vec![g_k391a, g_kp1_391a]);
+    let out = evaluate_sum(f391a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase391_sqrt2_k_log57_k_over_k2_refused() {
+    // sqrt2 k log57 k over k2: 58 logs → refused (Phase 391 handles exactly 57).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 45 logs
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k.clone(), // 51st log
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
+        log_k.clone(), // 56th log
+        log_k.clone(), // 57th log
+        log_k, // 58th log (over 57; refused)
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 45 logs
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
+        log_kp1.clone(), // 56th log
+        log_kp1.clone(), // 57th log
+        log_kp1, // 58th log (over 57; refused)
+    ]);
+    let g_k391r = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_391r = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f391r = apply(sym(SUB), vec![g_k391r, g_kp1_391r]);
+    let out = evaluate_sum(f391r, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase392_sqrt3_k_log57_k_over_k3_converges() {
+    // sqrt3 k log57 k over k3: eff_x2=3; 2·3=6 > 3 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 45 logs
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k.clone(), // 51st log
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
+        log_k.clone(), // 56th log
+        log_k, // 57th log
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 45 logs
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
+        log_kp1.clone(), // 56th log
+        log_kp1, // 57th log
+    ]);
+    let g_k392a = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_392a = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f392a = apply(sym(SUB), vec![g_k392a, g_kp1_392a]);
+    let out = evaluate_sum(f392a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase392_sqrt3_k_log57_k_over_k3_refused() {
+    // sqrt3 k log57 k over k3: 58 logs → refused (Phase 392 handles exactly 57).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 45 logs
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k.clone(), // 51st log
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
+        log_k.clone(), // 56th log
+        log_k.clone(), // 57th log
+        log_k, // 58th log (over 57; refused)
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 45 logs
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
+        log_kp1.clone(), // 56th log
+        log_kp1.clone(), // 57th log
+        log_kp1, // 58th log (over 57; refused)
+    ]);
+    let g_k392r = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_392r = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f392r = apply(sym(SUB), vec![g_k392r, g_kp1_392r]);
+    let out = evaluate_sum(f392r, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase393_sqrt4_k_log57_k_over_k3_converges() {
+    // sqrt4 k log57 k over k3: eff_x2=4; 2·3=6 > 4 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 45 logs
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k.clone(), // 51st log
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
+        log_k.clone(), // 56th log
+        log_k, // 57th log
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 45 logs
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
+        log_kp1.clone(), // 56th log
+        log_kp1, // 57th log
+    ]);
+    let g_k393a = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_393a = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f393a = apply(sym(SUB), vec![g_k393a, g_kp1_393a]);
+    let out = evaluate_sum(f393a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase393_sqrt4_k_log57_k_over_k3_refused() {
+    // sqrt4 k log57 k over k3: 58 logs → refused (Phase 393 handles exactly 57).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 45 logs
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k.clone(), // 51st log
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
+        log_k.clone(), // 56th log
+        log_k.clone(), // 57th log
+        log_k, // 58th log (over 57; refused)
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 45 logs
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
+        log_kp1.clone(), // 56th log
+        log_kp1.clone(), // 57th log
+        log_kp1, // 58th log (over 57; refused)
+    ]);
+    let g_k393r = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_393r = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f393r = apply(sym(SUB), vec![g_k393r, g_kp1_393r]);
+    let out = evaluate_sum(f393r, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase394_sqrt5_k_log57_k_over_k3_converges() {
+    // sqrt5 k log57 k over k3: eff_x2=5; 2·3=6 > 5 → converges.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 45 logs
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k.clone(), // 51st log
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
+        log_k.clone(), // 56th log
+        log_k, // 57th log
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 45 logs
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
+        log_kp1.clone(), // 56th log
+        log_kp1, // 57th log
+    ]);
+    let g_k394a = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_394a = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f394a = apply(sym(SUB), vec![g_k394a, g_kp1_394a]);
+    let out = evaluate_sum(f394a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase394_sqrt5_k_log57_k_over_k3_refused() {
+    // sqrt5 k log57 k over k3: 58 logs → refused (Phase 394 handles exactly 57).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40 logs
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 45 logs
+        log_k.clone(), // 46th log
+        log_k.clone(), // 47th log
+        log_k.clone(), // 48th log
+        log_k.clone(), // 49th log
+        log_k.clone(), // 50th log
+        log_k.clone(), // 51st log
+        log_k.clone(), // 52nd log
+        log_k.clone(), // 53rd log
+        log_k.clone(), // 54th log
+        log_k.clone(), // 55th log
+        log_k.clone(), // 56th log
+        log_k.clone(), // 57th log
+        log_k, // 58th log (over 57; refused)
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40 logs
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 45 logs
+        log_kp1.clone(), // 46th log
+        log_kp1.clone(), // 47th log
+        log_kp1.clone(), // 48th log
+        log_kp1.clone(), // 49th log
+        log_kp1.clone(), // 50th log
+        log_kp1.clone(), // 51st log
+        log_kp1.clone(), // 52nd log
+        log_kp1.clone(), // 53rd log
+        log_kp1.clone(), // 54th log
+        log_kp1.clone(), // 55th log
+        log_kp1.clone(), // 56th log
+        log_kp1.clone(), // 57th log
+        log_kp1, // 58th log (over 57; refused)
+    ]);
+    let g_k394r = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_394r = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f394r = apply(sym(SUB), vec![g_k394r, g_kp1_394r]);
+    let out = evaluate_sum(f394r, k, int(1), sym("%inf"), eval);
     assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 2.331.0 — 2026-05-28
+
+### Added
+
+- **Phase 394 — Five-Sqrt × Fifty-Seven-Log × polynomial** (`fiveSqrtFiftySevenLogPolyEffectiveDeg`):
+  Completes the Fifty-Seven-Log family (Phases 389–394).
+- **Phase 393 — Four-Sqrt × Fifty-Seven-Log × polynomial** (`fourSqrtFiftySevenLogPolyEffectiveDeg`).
+- **Phase 392 — Three-Sqrt × Fifty-Seven-Log × polynomial** (`threeSqrtFiftySevenLogPolyEffectiveDeg`).
+- **Phase 391 — Two-Sqrt × Fifty-Seven-Log × polynomial** (`twoSqrtFiftySevenLogPolyEffectiveDeg`).
+- **Phase 390 — One-Sqrt × Fifty-Seven-Log × polynomial** (`oneSqrtFiftySevenLogPolyEffectiveDeg`).
+- **Phase 389 — Zero-Sqrt × Fifty-Seven-Log × polynomial** (`fiftySevenLogPolyEffectiveDeg`).
+
+### Changed
+
+- Boundary tests in Phases 383–388 updated from 57-log "refused" to 58-log "refused"
+  now that Phases 389–394 handle exactly 57 logs.
+
 ## 2.325.0 — 2026-05-28
 
 ### Added

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "2.325.0",
+  "version": "2.331.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -6942,6 +6942,162 @@ function fiveSqrtFiftySixLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | 
   return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + sqrtHalfDegs[3] + sqrtHalfDegs[4] + polyDeg;
 }
 
+/** Phase 389 — Zero-Sqrt × Fifty-Seven-Log × polynomial numerator.
+ * effectiveDeg = polyDeg (no sqrt factors).
+ * Caller checks `denDeg > fiftySevenLogPolyEffectiveDeg(num, k)`.
+ */
+function fiftySevenLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    if (sqrtEffectiveHalfDegree(arg, k) !== undefined) return undefined;
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 57) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (logCount !== 57) return undefined;
+  return polyDeg;
+}
+
+/** Phase 390 — One-Sqrt × Fifty-Seven-Log × polynomial numerator. */
+function oneSqrtFiftySevenLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  let sqrtHalfDeg: number | undefined;
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDeg !== undefined) return undefined;
+      sqrtHalfDeg = hd; continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 57) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDeg === undefined || logCount !== 57) return undefined;
+  return sqrtHalfDeg + polyDeg;
+}
+
+/** Phase 391 — Two-Sqrt × Fifty-Seven-Log × polynomial numerator. */
+function twoSqrtFiftySevenLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDegs.length >= 2) return undefined;
+      sqrtHalfDegs.push(hd); continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 57) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 2 || logCount !== 57) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + polyDeg;
+}
+
+/** Phase 392 — Three-Sqrt × Fifty-Seven-Log × polynomial numerator. */
+function threeSqrtFiftySevenLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDegs.length >= 3) return undefined;
+      sqrtHalfDegs.push(hd); continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 57) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 3 || logCount !== 57) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + polyDeg;
+}
+
+/** Phase 393 — Four-Sqrt × Fifty-Seven-Log × polynomial numerator. */
+function fourSqrtFiftySevenLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDegs.length >= 4) return undefined;
+      sqrtHalfDegs.push(hd); continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 57) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 4 || logCount !== 57) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + sqrtHalfDegs[3] + polyDeg;
+}
+
+/** Phase 394 — Five-Sqrt × Fifty-Seven-Log × polynomial numerator.
+ * Completes the Fifty-Seven-Log family (Phases 389–394).
+ */
+function fiveSqrtFiftySevenLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDegs.length >= 5) return undefined;
+      sqrtHalfDegs.push(hd); continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 57) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 5 || logCount !== 57) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + sqrtHalfDegs[3] + sqrtHalfDegs[4] + polyDeg;
+}
+
 /** Phase 371 — Zero-Sqrt × Fifty-Four-Log × polynomial numerator.
  * effectiveDeg = polyDeg (no sqrt factors).
  * Caller checks `denDeg > fiftyFourLogPolyEffectiveDeg(num, k)`.
@@ -10422,6 +10578,66 @@ function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
     const denDegS2l8 = polynomialDegreeInK(den, k);
     if (denDegS2l8 !== undefined) {
       if (denDegS2l8 > s2l8Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 394: five sqrt + 57 logs
+  const s5l57Deg = fiveSqrtFiftySevenLogPolyEffectiveDeg(num, k);
+  if (s5l57Deg !== undefined) {
+    const denDegS5l57 = polynomialDegreeInK(den, k);
+    if (denDegS5l57 !== undefined) {
+      if (denDegS5l57 > s5l57Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 393: four sqrt + 57 logs
+  const s4l57Deg = fourSqrtFiftySevenLogPolyEffectiveDeg(num, k);
+  if (s4l57Deg !== undefined) {
+    const denDegS4l57 = polynomialDegreeInK(den, k);
+    if (denDegS4l57 !== undefined) {
+      if (denDegS4l57 > s4l57Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 392: three sqrt + 57 logs
+  const s3l57Deg = threeSqrtFiftySevenLogPolyEffectiveDeg(num, k);
+  if (s3l57Deg !== undefined) {
+    const denDegS3l57 = polynomialDegreeInK(den, k);
+    if (denDegS3l57 !== undefined) {
+      if (denDegS3l57 > s3l57Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 391: two sqrt + 57 logs
+  const s2l57Deg = twoSqrtFiftySevenLogPolyEffectiveDeg(num, k);
+  if (s2l57Deg !== undefined) {
+    const denDegS2l57 = polynomialDegreeInK(den, k);
+    if (denDegS2l57 !== undefined) {
+      if (denDegS2l57 > s2l57Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 390: one sqrt + 57 logs
+  const s1l57Deg = oneSqrtFiftySevenLogPolyEffectiveDeg(num, k);
+  if (s1l57Deg !== undefined) {
+    const denDegS1l57 = polynomialDegreeInK(den, k);
+    if (denDegS1l57 !== undefined) {
+      if (denDegS1l57 > s1l57Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 389: zero sqrt + 57 logs
+  const s0l57Deg = fiftySevenLogPolyEffectiveDeg(num, k);
+  if (s0l57Deg !== undefined) {
+    const denDegS0l57 = polynomialDegreeInK(den, k);
+    if (denDegS0l57 !== undefined) {
+      if (denDegS0l57 > s0l57Deg) return true;
     } else if (hDivergesAtInfinity(den, k)) {
       return true;
     }

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -15271,8 +15271,8 @@ describe("Phase 167 — Twenty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK167r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1167r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK167r = { kind: "apply" as const, head: DIV, args: [numK167r, k2] };
@@ -15321,8 +15321,8 @@ describe("Phase 168 — One-Sqrt × Twenty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK168r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [k] }, ...logs29k, k] };
     const numKp1168r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [kp1] }, ...logs29kp1, kp1] };
     const gK168r = { kind: "apply" as const, head: DIV, args: [numK168r, k2] };
@@ -15375,8 +15375,8 @@ describe("Phase 169 — Two-Sqrt × Twenty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK169r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -15431,8 +15431,8 @@ describe("Phase 170 — Three-Sqrt × Twenty-Log × polynomial numerator", () =>
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK170r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15487,8 +15487,8 @@ describe("Phase 171 — Four-Sqrt × Twenty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK171r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15543,8 +15543,8 @@ describe("Phase 172 — Five-Sqrt × Twenty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK172r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15595,8 +15595,8 @@ describe("Phase 173 — Twenty-One-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK173r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1173r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK173r = { kind: "apply" as const, head: DIV, args: [numK173r, k2] };
@@ -15645,8 +15645,8 @@ describe("Phase 174 — One-Sqrt × Twenty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK174r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [k] }, ...logs29k, k] };
     const numKp1174r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [kp1] }, ...logs29kp1, kp1] };
     const gK174r = { kind: "apply" as const, head: DIV, args: [numK174r, k2] };
@@ -15699,8 +15699,8 @@ describe("Phase 175 — Two-Sqrt × Twenty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK175r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -15755,8 +15755,8 @@ describe("Phase 176 — Three-Sqrt × Twenty-One-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK176r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15811,8 +15811,8 @@ describe("Phase 177 — Four-Sqrt × Twenty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK177r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15867,8 +15867,8 @@ describe("Phase 178 — Five-Sqrt × Twenty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK178r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15919,8 +15919,8 @@ describe("Phase 179 — Twenty-Two-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK179r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1179r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK179r = { kind: "apply" as const, head: DIV, args: [numK179r, k2] };
@@ -15969,8 +15969,8 @@ describe("Phase 180 — One-Sqrt × Twenty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK180r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [k] }, ...logs29k, k] };
     const numKp1180r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [kp1] }, ...logs29kp1, kp1] };
     const gK180r = { kind: "apply" as const, head: DIV, args: [numK180r, k2] };
@@ -16023,8 +16023,8 @@ describe("Phase 181 — Two-Sqrt × Twenty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK181r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -16079,8 +16079,8 @@ describe("Phase 182 — Three-Sqrt × Twenty-Two-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK182r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16135,8 +16135,8 @@ describe("Phase 183 — Four-Sqrt × Twenty-Two-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK183r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16191,8 +16191,8 @@ describe("Phase 184 — Five-Sqrt × Twenty-Two-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK184r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16243,8 +16243,8 @@ describe("Phase 185 — Twenty-Three-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK185r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1185r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK185r = { kind: "apply" as const, head: DIV, args: [numK185r, k2] };
@@ -16293,8 +16293,8 @@ describe("Phase 186 — One-Sqrt × Twenty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK186r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [k] }, ...logs29k, k] };
     const numKp1186r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [kp1] }, ...logs29kp1, kp1] };
     const gK186r = { kind: "apply" as const, head: DIV, args: [numK186r, k2] };
@@ -16347,8 +16347,8 @@ describe("Phase 187 — Two-Sqrt × Twenty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK187r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -16403,8 +16403,8 @@ describe("Phase 188 — Three-Sqrt × Twenty-Three-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK188r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16459,8 +16459,8 @@ describe("Phase 189 — Four-Sqrt × Twenty-Three-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK189r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16515,8 +16515,8 @@ describe("Phase 190 — Five-Sqrt × Twenty-Three-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK190r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16567,8 +16567,8 @@ describe("Phase 191 — Twenty-Four-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK191r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1191r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK191r = { kind: "apply" as const, head: DIV, args: [numK191r, k2] };
@@ -16621,8 +16621,8 @@ describe("Phase 192 — One-Sqrt × Twenty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK192r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs29k, k] };
@@ -16677,8 +16677,8 @@ describe("Phase 193 — Two-Sqrt × Twenty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK193r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -16733,8 +16733,8 @@ describe("Phase 194 — Three-Sqrt × Twenty-Four-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK194r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16789,8 +16789,8 @@ describe("Phase 195 — Four-Sqrt × Twenty-Four-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK195r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16845,8 +16845,8 @@ describe("Phase 196 — Five-Sqrt × Twenty-Four-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK196r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16897,8 +16897,8 @@ describe("Phase 197 — Twenty-Five-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK197r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1197r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK197r = { kind: "apply" as const, head: DIV, args: [numK197r, k2] };
@@ -16951,8 +16951,8 @@ describe("Phase 198 — One-Sqrt × Twenty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK198r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs29k, k] };
@@ -17007,8 +17007,8 @@ describe("Phase 199 — Two-Sqrt × Twenty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK199r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -17063,8 +17063,8 @@ describe("Phase 200 — Three-Sqrt × Twenty-Five-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK200r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17119,8 +17119,8 @@ describe("Phase 201 — Four-Sqrt × Twenty-Five-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK201r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17175,8 +17175,8 @@ describe("Phase 202 — Five-Sqrt × Twenty-Five-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK202r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17227,8 +17227,8 @@ describe("Phase 203 — Twenty-Six-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK203r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1203r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK203r = { kind: "apply" as const, head: DIV, args: [numK203r, k2] };
@@ -17279,8 +17279,8 @@ describe("Phase 204 — One-Sqrt × Twenty-Six-Log × polynomial numerator", () 
   it("√k·log(k)²⁹·k/k² refused (30 logs — not Phase 204)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK204r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs29k, k] };
@@ -17333,8 +17333,8 @@ describe("Phase 205 — Two-Sqrt × Twenty-Six-Log × polynomial numerator", () 
   it("√k·√k·log(k)²⁹/k² refused (30 logs — not Phase 205)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK205r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k, k] };
@@ -17387,8 +17387,8 @@ describe("Phase 206 — Three-Sqrt × Twenty-Six-Log × polynomial numerator", (
   it("(√k)³·log(k)²⁹/k² refused (30 logs — not Phase 206)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK206r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k, k] };
@@ -17443,8 +17443,8 @@ describe("Phase 207 — Four-Sqrt × Twenty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK207r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k, k] };
@@ -17499,8 +17499,8 @@ describe("Phase 208 — Five-Sqrt × Twenty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK208r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17551,8 +17551,8 @@ describe("Phase 209 — Zero-Sqrt × Twenty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK209r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1209r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK209r = { kind: "apply" as const, head: DIV, args: [numK209r, k2] };
@@ -17603,8 +17603,8 @@ describe("Phase 210 — One-Sqrt × Twenty-Seven-Log × polynomial numerator", (
   it("√k·log(k)²⁹·k/k² refused (30 logs — not Phase 210)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK210r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs29k, k] };
@@ -17659,8 +17659,8 @@ describe("Phase 211 — Two-Sqrt × Twenty-Seven-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK211r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -17715,8 +17715,8 @@ describe("Phase 212 — Three-Sqrt × Twenty-Seven-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK212r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17771,8 +17771,8 @@ describe("Phase 213 — Four-Sqrt × Twenty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK213r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17827,8 +17827,8 @@ describe("Phase 214 — Five-Sqrt × Twenty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK214r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17879,8 +17879,8 @@ describe("Phase 215 — Zero-Sqrt × Twenty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK215r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1215r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK215r = { kind: "apply" as const, head: DIV, args: [numK215r, k2] };
@@ -17933,8 +17933,8 @@ describe("Phase 216 — One-Sqrt × Twenty-Eight-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK216r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs29k, k] };
@@ -17989,8 +17989,8 @@ describe("Phase 217 — Two-Sqrt × Twenty-Eight-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK217r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -18045,8 +18045,8 @@ describe("Phase 218 — Three-Sqrt × Twenty-Eight-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK218r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -18101,8 +18101,8 @@ describe("Phase 219 — Four-Sqrt × Twenty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK219r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -18157,8 +18157,8 @@ describe("Phase 220 — Five-Sqrt × Twenty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK220r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -18209,8 +18209,8 @@ describe("Phase 221 — Zero-Sqrt × Twenty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK221r = { kind: "apply" as const, head: MUL, args: [...logs30k, k] };
     const numKp1221r = { kind: "apply" as const, head: MUL, args: [...logs30kp1, kp1] };
     const gK221r = { kind: "apply" as const, head: DIV, args: [numK221r, k2] };
@@ -18263,8 +18263,8 @@ describe("Phase 222 — One-Sqrt × Twenty-Nine-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK222r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs30k, k] };
@@ -18319,8 +18319,8 @@ describe("Phase 223 — Two-Sqrt × Twenty-Nine-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK223r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs30k, k] };
@@ -18375,8 +18375,8 @@ describe("Phase 224 — Three-Sqrt × Twenty-Nine-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK224r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs30k, k] };
@@ -18431,8 +18431,8 @@ describe("Phase 225 — Four-Sqrt × Twenty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK225r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs30k, k] };
@@ -18487,8 +18487,8 @@ describe("Phase 226 — Five-Sqrt × Twenty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK226r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs30k, k] };
@@ -18539,8 +18539,8 @@ describe("Phase 227 — Zero-Sqrt × Thirty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK227r = { kind: "apply" as const, head: MUL, args: [...logs31k, k] };
     const numKp1227r = { kind: "apply" as const, head: MUL, args: [...logs31kp1, kp1] };
     const gK227r = { kind: "apply" as const, head: DIV, args: [numK227r, k2] };
@@ -18593,8 +18593,8 @@ describe("Phase 228 — One-Sqrt × Thirty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK228r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs31k, k] };
@@ -18649,8 +18649,8 @@ describe("Phase 229 — Two-Sqrt × Thirty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK229r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs31k, k] };
@@ -18705,8 +18705,8 @@ describe("Phase 230 — Three-Sqrt × Thirty-Log × polynomial numerator", () =>
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK230r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs31k, k] };
@@ -18761,8 +18761,8 @@ describe("Phase 231 — Four-Sqrt × Thirty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK231r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs31k, k] };
@@ -18817,8 +18817,8 @@ describe("Phase 232 — Five-Sqrt × Thirty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK232r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs31k, k] };
@@ -18869,8 +18869,8 @@ describe("Phase 233 — Zero-Sqrt × Thirty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK233r = { kind: "apply" as const, head: MUL, args: [...logs32k, k] };
     const numKp1233r = { kind: "apply" as const, head: MUL, args: [...logs32kp1, kp1] };
     const gK233r = { kind: "apply" as const, head: DIV, args: [numK233r, k2] };
@@ -18923,8 +18923,8 @@ describe("Phase 234 — One-Sqrt × Thirty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK234r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs32k, k] };
@@ -18979,8 +18979,8 @@ describe("Phase 235 — Two-Sqrt × Thirty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK235r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs32k, k] };
@@ -19035,8 +19035,8 @@ describe("Phase 236 — Three-Sqrt × Thirty-One-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK236r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs32k, k] };
@@ -19091,8 +19091,8 @@ describe("Phase 237 — Four-Sqrt × Thirty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK237r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs32k, k] };
@@ -19147,8 +19147,8 @@ describe("Phase 238 — Five-Sqrt × Thirty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK238r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs32k, k] };
@@ -19199,8 +19199,8 @@ describe("Phase 239 — Thirty-Two-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs33k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK239r = { kind: "apply" as const, head: MUL, args: [...logs33k, k] };
     const numKp1239r = { kind: "apply" as const, head: MUL, args: [...logs33kp1, kp1] };
     const gK239r = { kind: "apply" as const, head: DIV, args: [numK239r, k2] };
@@ -19249,8 +19249,8 @@ describe("Phase 240 — One-Sqrt × Thirty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs33k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK240r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [k] }, ...logs33k, k] };
     const numKp1240r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [kp1] }, ...logs33kp1, kp1] };
     const gK240r = { kind: "apply" as const, head: DIV, args: [numK240r, k2] };
@@ -19303,8 +19303,8 @@ describe("Phase 241 — Two-Sqrt × Thirty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs33k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK241r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs33k] };
@@ -19359,8 +19359,8 @@ describe("Phase 242 — Three-Sqrt × Thirty-Two-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs33k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK242r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs33k] };
@@ -19415,8 +19415,8 @@ describe("Phase 243 — Four-Sqrt × Thirty-Two-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs33k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK243r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs33k, k] };
@@ -19471,8 +19471,8 @@ describe("Phase 244 — Five-Sqrt × Thirty-Two-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs33k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK244r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs33k, k] };
@@ -19523,8 +19523,8 @@ describe("Phase 245 — Thirty-Three-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs34k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK245r = { kind: "apply" as const, head: MUL, args: [...logs34k, k] };
     const numKp1245r = { kind: "apply" as const, head: MUL, args: [...logs34kp1, kp1] };
     const gK245r = { kind: "apply" as const, head: DIV, args: [numK245r, k2] };
@@ -19577,8 +19577,8 @@ describe("Phase 246 — One-Sqrt × Thirty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs34k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK246r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs34k, k] };
@@ -19633,8 +19633,8 @@ describe("Phase 247 — Two-Sqrt × Thirty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs34k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK247r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs34k] };
@@ -19689,8 +19689,8 @@ describe("Phase 248 — Three-Sqrt × Thirty-Three-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs34k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK248r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs34k] };
@@ -19745,8 +19745,8 @@ describe("Phase 249 — Four-Sqrt × Thirty-Three-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs34k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK249r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs34k] };
@@ -19801,8 +19801,8 @@ describe("Phase 250 — Five-Sqrt × Thirty-Three-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs34k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK250r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs34k, k] };
@@ -19853,8 +19853,8 @@ describe("Phase 251 — Thirty-Four-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs36k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK251r = { kind: "apply" as const, head: MUL, args: [...logs36k, k] };
     const numKp1251r = { kind: "apply" as const, head: MUL, args: [...logs36kp1, kp1] };
     const gK251r = { kind: "apply" as const, head: DIV, args: [numK251r, k2] };
@@ -19907,8 +19907,8 @@ describe("Phase 252 — One-Sqrt × Thirty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs36k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK252r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs36k, k] };
@@ -19963,8 +19963,8 @@ describe("Phase 253 — Two-Sqrt × Thirty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs36k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK253r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs36k] };
@@ -20019,8 +20019,8 @@ describe("Phase 254 — Three-Sqrt × Thirty-Four-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs36k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK254r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs36k] };
@@ -20075,8 +20075,8 @@ describe("Phase 255 — Four-Sqrt × Thirty-Four-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs36k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK255r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs36k] };
@@ -20131,8 +20131,8 @@ describe("Phase 256 — Five-Sqrt × Thirty-Four-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK256r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs36k, k] };
@@ -20183,8 +20183,8 @@ describe("Phase 257 — Thirty-Five-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK257r = { kind: "apply" as const, head: MUL, args: [...logs36k, k] };
     const numKp1257r = { kind: "apply" as const, head: MUL, args: [...logs36kp1, kp1] };
     const gK257r = { kind: "apply" as const, head: DIV, args: [numK257r, k2] };
@@ -20237,8 +20237,8 @@ describe("Phase 258 — One-Sqrt × Thirty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK258r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs36k, k] };
@@ -20293,8 +20293,8 @@ describe("Phase 259 — Two-Sqrt × Thirty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK259r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs36k, k] };
@@ -20349,8 +20349,8 @@ describe("Phase 260 — Three-Sqrt × Thirty-Five-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK260r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs36k, k] };
@@ -20405,8 +20405,8 @@ describe("Phase 261 — Four-Sqrt × Thirty-Five-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK261r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs36k, k] };
@@ -20461,8 +20461,8 @@ describe("Phase 262 — Five-Sqrt × Thirty-Five-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK262r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs36k, k] };
@@ -20513,8 +20513,8 @@ describe("Phase 263 — Zero-Sqrt × Thirty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK263r = { kind: "apply" as const, head: MUL, args: [...logs37k, k] };
     const numKp1263r = { kind: "apply" as const, head: MUL, args: [...logs37kp1, kp1] };
     const gK263r = { kind: "apply" as const, head: DIV, args: [numK263r, k2] };
@@ -20567,8 +20567,8 @@ describe("Phase 264 — One-Sqrt × Thirty-Six-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK264r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs37k, k] };
@@ -20623,8 +20623,8 @@ describe("Phase 265 — Two-Sqrt × Thirty-Six-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK265r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs37k] };
@@ -20679,8 +20679,8 @@ describe("Phase 266 — Three-Sqrt × Thirty-Six-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK266r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs37k] };
@@ -20735,8 +20735,8 @@ describe("Phase 267 — Four-Sqrt × Thirty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK267r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs37k, k] };
@@ -20791,8 +20791,8 @@ describe("Phase 268 — Five-Sqrt × Thirty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK268r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs37k, k] };
@@ -20843,8 +20843,8 @@ describe("Phase 269 — Zero-Sqrt × Thirty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs38k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs38kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs38k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK269r = { kind: "apply" as const, head: MUL, args: [...logs38k, k] };
     const numKp1269r = { kind: "apply" as const, head: MUL, args: [...logs38kp1, kp1] };
     const gK269r = { kind: "apply" as const, head: DIV, args: [numK269r, k2] };
@@ -20897,8 +20897,8 @@ describe("Phase 270 — One-Sqrt × Thirty-Seven-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs38k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs38kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs38k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK270r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs38k, k] };
@@ -20953,8 +20953,8 @@ describe("Phase 271 — Two-Sqrt × Thirty-Seven-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs38k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs38kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs38k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK271r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs38k, k] };
@@ -21009,8 +21009,8 @@ describe("Phase 272 — Three-Sqrt × Thirty-Seven-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs38k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs38kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs38k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK272r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs38k, k] };
@@ -21065,8 +21065,8 @@ describe("Phase 273 — Four-Sqrt × Thirty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs38k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs38kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs38k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK273r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs38k, k] };
@@ -21121,8 +21121,8 @@ describe("Phase 274 — Five-Sqrt × Thirty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs38k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs38kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs38k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK274r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs38k, k] };
@@ -21173,8 +21173,8 @@ describe("Phase 275 — Zero-Sqrt × Thirty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs39k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs39kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs39k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs39kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK275r = { kind: "apply" as const, head: MUL, args: [...logs39k, k] };
     const numKp1275r = { kind: "apply" as const, head: MUL, args: [...logs39kp1, kp1] };
     const gK275r = { kind: "apply" as const, head: DIV, args: [numK275r, k2] };
@@ -21227,8 +21227,8 @@ describe("Phase 276 — One-Sqrt × Thirty-Eight-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs39k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs39kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs39k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs39kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK276r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs39k, k] };
@@ -21283,8 +21283,8 @@ describe("Phase 277 — Two-Sqrt × Thirty-Eight-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs39k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs39kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs39k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs39kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK277r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs39k, k] };
@@ -21339,8 +21339,8 @@ describe("Phase 278 — Three-Sqrt × Thirty-Eight-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs39k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs39kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs39k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs39kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK278r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs39k, k] };
@@ -21395,8 +21395,8 @@ describe("Phase 279 — Four-Sqrt × Thirty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs39k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs39kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs39k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs39kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK279r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs39k, k] };
@@ -21451,8 +21451,8 @@ describe("Phase 280 — Five-Sqrt × Thirty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs39k = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs39kp1 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs39k = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs39kp1 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK280r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs39k, k] };
@@ -21504,8 +21504,8 @@ describe("Phase 281 — Zero-Sqrt × Thirty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs40k281 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs40kp1281 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs40k281 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1281 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK281r = { kind: "apply" as const, head: MUL, args: [...logs40k281, k] };
     const numKp1281r = { kind: "apply" as const, head: MUL, args: [...logs40kp1281, kp1] };
     const gK281r = { kind: "apply" as const, head: DIV, args: [numK281r, k2r] };
@@ -21558,8 +21558,8 @@ describe("Phase 282 — One-Sqrt × Thirty-Nine-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs40k282 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs40kp1282 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs40k282 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1282 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK282r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs40k282, k] };
@@ -21614,8 +21614,8 @@ describe("Phase 283 — Two-Sqrt × Thirty-Nine-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs40k283 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs40kp1283 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs40k283 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1283 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK283r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs40k283, k] };
@@ -21670,8 +21670,8 @@ describe("Phase 284 — Three-Sqrt × Thirty-Nine-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs40k284 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs40kp1284 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs40k284 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1284 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK284r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs40k284, k] };
@@ -21726,8 +21726,8 @@ describe("Phase 285 — Four-Sqrt × Thirty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs40k285 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs40kp1285 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs40k285 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1285 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK285r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs40k285, k] };
@@ -21782,8 +21782,8 @@ describe("Phase 286 — Five-Sqrt × Thirty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs40k286 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs40kp1286 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs40k286 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1286 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK286r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs40k286, k] };
@@ -21834,8 +21834,8 @@ describe("Phase 287 — Zero-Sqrt × Forty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k287 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1287 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k287 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1287 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK287r = { kind: "apply" as const, head: MUL, args: [...logs42k287, k] };
     const numKp1287r = { kind: "apply" as const, head: MUL, args: [...logs42kp1287, kp1] };
     const gK287r = { kind: "apply" as const, head: DIV, args: [numK287r, k2r] };
@@ -21888,8 +21888,8 @@ describe("Phase 288 — One-Sqrt × Forty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k288 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1288 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k288 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1288 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK288r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs42k288, k] };
@@ -21944,8 +21944,8 @@ describe("Phase 289 — Two-Sqrt × Forty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k289 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1289 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k289 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1289 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK289r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs42k289, k] };
@@ -22000,8 +22000,8 @@ describe("Phase 290 — Three-Sqrt × Forty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k290 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1290 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k290 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1290 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK290r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs42k290, k] };
@@ -22056,8 +22056,8 @@ describe("Phase 291 — Four-Sqrt × Forty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k291 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1291 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k291 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1291 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK291r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs42k291, k] };
@@ -22112,8 +22112,8 @@ describe("Phase 292 — Five-Sqrt × Forty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k292 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1292 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k292 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1292 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK292r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs42k292, k] };
@@ -22164,8 +22164,8 @@ describe("Phase 293 — Zero-Sqrt × Forty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k293 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1293 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k293 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1293 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK293r = { kind: "apply" as const, head: MUL, args: [...logs42k293, k] };
     const numKp1293r = { kind: "apply" as const, head: MUL, args: [...logs42kp1293, kp1] };
     const gK293r = { kind: "apply" as const, head: DIV, args: [numK293r, k2r] };
@@ -22200,8 +22200,8 @@ describe("Phase 294 — One-Sqrt × Forty-One-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k294 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1294 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k294 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1294 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK294r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs42k294, k] };
@@ -22238,8 +22238,8 @@ describe("Phase 295 — Two-Sqrt × Forty-One-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k295 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1295 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k295 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1295 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK295r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs42k295, k] };
@@ -22276,8 +22276,8 @@ describe("Phase 296 — Three-Sqrt × Forty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k296 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1296 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k296 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1296 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK296r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs42k296, k] };
@@ -22314,8 +22314,8 @@ describe("Phase 297 — Four-Sqrt × Forty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k297 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1297 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k297 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1297 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK297r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs42k297, k] };
@@ -22352,8 +22352,8 @@ describe("Phase 298 — Five-Sqrt × Forty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k298 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1298 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k298 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1298 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK298r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs42k298, k] };
@@ -22388,8 +22388,8 @@ describe("Phase 299 — Zero-Sqrt × Forty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k299 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1299 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k299 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1299 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK299r = { kind: "apply" as const, head: MUL, args: [...logs44k299, k] };
     const numKp1299r = { kind: "apply" as const, head: MUL, args: [...logs44kp1299, kp1] };
     const gK299r = { kind: "apply" as const, head: DIV, args: [numK299r, k2r] };
@@ -22424,8 +22424,8 @@ describe("Phase 300 — One-Sqrt × Forty-Two-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k300 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1300 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k300 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1300 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK300r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs44k300, k] };
@@ -22462,8 +22462,8 @@ describe("Phase 301 — Two-Sqrt × Forty-Two-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k301 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1301 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k301 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1301 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK301r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs44k301, k] };
@@ -22500,8 +22500,8 @@ describe("Phase 302 — Three-Sqrt × Forty-Two-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k302 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1302 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k302 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1302 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK302r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs44k302, k] };
@@ -22538,8 +22538,8 @@ describe("Phase 303 — Four-Sqrt × Forty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k303 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1303 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k303 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1303 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK303r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs44k303, k] };
@@ -22576,8 +22576,8 @@ describe("Phase 304 — Five-Sqrt × Forty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k304 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1304 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k304 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1304 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK304r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs44k304, k] };
@@ -22612,8 +22612,8 @@ describe("Phase 305 — Zero-Sqrt × Forty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k305 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1305 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k305 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1305 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK305r = { kind: "apply" as const, head: MUL, args: [...logs44k305, k] };
     const numKp1305r = { kind: "apply" as const, head: MUL, args: [...logs44kp1305, kp1] };
     const gK305r = { kind: "apply" as const, head: DIV, args: [numK305r, k2r] };
@@ -22648,8 +22648,8 @@ describe("Phase 306 — One-Sqrt × Forty-Three-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k306 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1306 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k306 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1306 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK306r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs44k306, k] };
@@ -22686,8 +22686,8 @@ describe("Phase 307 — Two-Sqrt × Forty-Three-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k307 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1307 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k307 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1307 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK307r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs44k307, k] };
@@ -22724,8 +22724,8 @@ describe("Phase 308 — Three-Sqrt × Forty-Three-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1, kp1] };
-    const logs44k308 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1308 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k308 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1308 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK308r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs44k308, k] };
@@ -22762,8 +22762,8 @@ describe("Phase 309 — Four-Sqrt × Forty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1, kp1] };
-    const logs44k309 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1309 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k309 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1309 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK309r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs44k309, k] };
@@ -22800,8 +22800,8 @@ describe("Phase 310 — Five-Sqrt × Forty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k310 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1310 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k310 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1310 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK310r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs44k310, k] };
@@ -22836,8 +22836,8 @@ describe("Phase 311 — Forty-Four-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs45k311 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs45kp1311 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs45k311 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs45kp1311 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK311r = { kind: "apply" as const, head: MUL, args: [...logs45k311, k] };
     const numKp1311r = { kind: "apply" as const, head: MUL, args: [...logs45kp1311, kp1] };
     const gK311r = { kind: "apply" as const, head: DIV, args: [numK311r, k2r] };
@@ -22872,8 +22872,8 @@ describe("Phase 312 — One-Sqrt × Forty-Four-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs45k312 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs45kp1312 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs45k312 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs45kp1312 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK312r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs45k312, k] };
@@ -22910,8 +22910,8 @@ describe("Phase 313 — Two-Sqrt × Forty-Four-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs45k313 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs45kp1313 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs45k313 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs45kp1313 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK313r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs45k313, k] };
@@ -22948,8 +22948,8 @@ describe("Phase 314 — Three-Sqrt × Forty-Four-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs45k314 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs45kp1314 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs45k314 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs45kp1314 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK314r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs45k314, k] };
@@ -22986,8 +22986,8 @@ describe("Phase 315 — Four-Sqrt × Forty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs45k315 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs45kp1315 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs45k315 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs45kp1315 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK315r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs45k315, k] };
@@ -23024,8 +23024,8 @@ describe("Phase 316 — Five-Sqrt × Forty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs45k316 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs45kp1316 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs45k316 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs45kp1316 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK316r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs45k316, k] };
@@ -23060,8 +23060,8 @@ describe("Phase 317 — Forty-Five-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs46k317 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs46kp1317 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs46k317 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs46kp1317 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK317r = { kind: "apply" as const, head: MUL, args: [...logs46k317, k] };
     const numKp1317r = { kind: "apply" as const, head: MUL, args: [...logs46kp1317, kp1] };
     const gK317r = { kind: "apply" as const, head: DIV, args: [numK317r, k2r] };
@@ -23096,8 +23096,8 @@ describe("Phase 318 — One-Sqrt × Forty-Five-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs46k318 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs46kp1318 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs46k318 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs46kp1318 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK318r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs46k318, k] };
@@ -23134,8 +23134,8 @@ describe("Phase 319 — Two-Sqrt × Forty-Five-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs46k319 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs46kp1319 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs46k319 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs46kp1319 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK319r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs46k319, k] };
@@ -23172,8 +23172,8 @@ describe("Phase 320 — Three-Sqrt × Forty-Five-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs46k320 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs46kp1320 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs46k320 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs46kp1320 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK320r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs46k320, k] };
@@ -23210,8 +23210,8 @@ describe("Phase 321 — Four-Sqrt × Forty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs46k321 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs46kp1321 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs46k321 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs46kp1321 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK321r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs46k321, k] };
@@ -23248,8 +23248,8 @@ describe("Phase 322 — Five-Sqrt × Forty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs46k322 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs46kp1322 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs46k322 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs46kp1322 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK322r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs46k322, k] };
@@ -23284,8 +23284,8 @@ describe("Phase 323 — Forty-Six-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs47k323 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs47kp1323 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs47k323 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs47kp1323 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK323r = { kind: "apply" as const, head: MUL, args: [...logs47k323, k] };
     const numKp1323r = { kind: "apply" as const, head: MUL, args: [...logs47kp1323, kp1] };
     const gK323r = { kind: "apply" as const, head: DIV, args: [numK323r, k2r] };
@@ -23320,8 +23320,8 @@ describe("Phase 324 — One-Sqrt × Forty-Six-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs47k324 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs47kp1324 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs47k324 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs47kp1324 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK324r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs47k324, k] };
@@ -23358,8 +23358,8 @@ describe("Phase 325 — Two-Sqrt × Forty-Six-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs47k325 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs47kp1325 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs47k325 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs47kp1325 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK325r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs47k325, k] };
@@ -23396,8 +23396,8 @@ describe("Phase 326 — Three-Sqrt × Forty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs47k326 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs47kp1326 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs47k326 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs47kp1326 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK326r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs47k326, k] };
@@ -23434,8 +23434,8 @@ describe("Phase 327 — Four-Sqrt × Forty-Six-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs47k327 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs47kp1327 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs47k327 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs47kp1327 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK327r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs47k327, k] };
@@ -23472,8 +23472,8 @@ describe("Phase 328 — Five-Sqrt × Forty-Six-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs47k328 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs47kp1328 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs47k328 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs47kp1328 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK328r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs47k328, k] };
@@ -23508,8 +23508,8 @@ describe("Phase 329 — Forty-Seven-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k329 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1329 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k329 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1329 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK329r = { kind: "apply" as const, head: MUL, args: [...logs49k329, k] };
     const numKp1329r = { kind: "apply" as const, head: MUL, args: [...logs49kp1329, kp1] };
     const gK329r = { kind: "apply" as const, head: DIV, args: [numK329r, k2r] };
@@ -23544,8 +23544,8 @@ describe("Phase 330 — One-Sqrt × Forty-Seven-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k330 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1330 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k330 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1330 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK330r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs49k330, k] };
@@ -23582,8 +23582,8 @@ describe("Phase 331 — Two-Sqrt × Forty-Seven-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k331 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1331 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k331 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1331 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK331r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs49k331, k] };
@@ -23620,8 +23620,8 @@ describe("Phase 332 — Three-Sqrt × Forty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k332 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1332 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k332 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1332 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK332r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs49k332, k] };
@@ -23658,8 +23658,8 @@ describe("Phase 333 — Four-Sqrt × Forty-Seven-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k333 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1333 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k333 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1333 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK333r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs49k333, k] };
@@ -23696,8 +23696,8 @@ describe("Phase 334 — Five-Sqrt × Forty-Seven-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k334 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1334 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k334 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1334 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK334r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs49k334, k] };
@@ -23732,8 +23732,8 @@ describe("Phase 335 — Zero-Sqrt × Forty-Eight-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k335 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1335 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k335 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1335 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK335r = { kind: "apply" as const, head: MUL, args: [...logs49k335, k] };
     const numKp1335r = { kind: "apply" as const, head: MUL, args: [...logs49kp1335, kp1] };
     const gK335r = { kind: "apply" as const, head: DIV, args: [numK335r, k2r] };
@@ -23768,8 +23768,8 @@ describe("Phase 336 — One-Sqrt × Forty-Eight-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k336 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1336 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k336 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1336 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK336r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs49k336, k] };
@@ -23806,8 +23806,8 @@ describe("Phase 337 — Two-Sqrt × Forty-Eight-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k337 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1337 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k337 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1337 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK337r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs49k337, k] };
@@ -23844,8 +23844,8 @@ describe("Phase 338 — Three-Sqrt × Forty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k338 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1338 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k338 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1338 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK338r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs49k338, k] };
@@ -23882,8 +23882,8 @@ describe("Phase 339 — Four-Sqrt × Forty-Eight-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k339 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1339 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k339 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1339 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK339r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs49k339, k] };
@@ -23920,8 +23920,8 @@ describe("Phase 340 — Five-Sqrt × Forty-Eight-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k340 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1340 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k340 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1340 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK340r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs49k340, k] };
@@ -23956,8 +23956,8 @@ describe("Phase 341 — Zero-Sqrt × Forty-Nine-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k341 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1341 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k341 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1341 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK341r = { kind: "apply" as const, head: MUL, args: [...logs51k341, k] };
     const numKp1341r = { kind: "apply" as const, head: MUL, args: [...logs51kp1341, kp1] };
     const gK341r = { kind: "apply" as const, head: DIV, args: [numK341r, k2r] };
@@ -23992,8 +23992,8 @@ describe("Phase 342 — One-Sqrt × Forty-Nine-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k342 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1342 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k342 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1342 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK342r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs51k342, k] };
@@ -24030,8 +24030,8 @@ describe("Phase 343 — Two-Sqrt × Forty-Nine-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k343 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1343 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k343 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1343 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK343r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs51k343, k] };
@@ -24068,8 +24068,8 @@ describe("Phase 344 — Three-Sqrt × Forty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k344 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1344 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k344 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1344 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK344r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs51k344, k] };
@@ -24106,8 +24106,8 @@ describe("Phase 345 — Four-Sqrt × Forty-Nine-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k345 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1345 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k345 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1345 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK345r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs51k345, k] };
@@ -24144,8 +24144,8 @@ describe("Phase 346 — Five-Sqrt × Forty-Nine-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k346 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1346 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k346 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1346 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK346r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs51k346, k] };
@@ -24180,8 +24180,8 @@ describe("Phase 347 — Zero-Sqrt × Fifty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k347 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1347 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k347 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1347 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK347r = { kind: "apply" as const, head: MUL, args: [...logs51k347, k] };
     const numKp1347r = { kind: "apply" as const, head: MUL, args: [...logs51kp1347, kp1] };
     const gK347r = { kind: "apply" as const, head: DIV, args: [numK347r, k2r] };
@@ -24216,8 +24216,8 @@ describe("Phase 348 — One-Sqrt × Fifty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k348 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1348 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k348 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1348 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK348r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs51k348, k] };
@@ -24254,8 +24254,8 @@ describe("Phase 349 — Two-Sqrt × Fifty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k349 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1349 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k349 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1349 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK349r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs51k349, k] };
@@ -24292,8 +24292,8 @@ describe("Phase 350 — Three-Sqrt × Fifty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k350 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1350 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k350 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1350 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK350r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs51k350, k] };
@@ -24330,8 +24330,8 @@ describe("Phase 351 — Four-Sqrt × Fifty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k351 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1351 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k351 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1351 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK351r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs51k351, k] };
@@ -24368,8 +24368,8 @@ describe("Phase 352 — Five-Sqrt × Fifty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k352 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1352 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k352 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1352 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK352r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs51k352, k] };
@@ -24405,8 +24405,8 @@ describe("Phase 353 — Zero-Sqrt × Fifty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs52k353 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs52kp1353 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs52k353 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs52kp1353 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK353r = { kind: "apply" as const, head: MUL, args: [...logs52k353, k] };
     const numKp1353r = { kind: "apply" as const, head: MUL, args: [...logs52kp1353, kp1] };
     const gK353r = { kind: "apply" as const, head: DIV, args: [numK353r, k2r] };
@@ -24441,8 +24441,8 @@ describe("Phase 354 — One-Sqrt × Fifty-One-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs52k354 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs52kp1354 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs52k354 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs52kp1354 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK354r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs52k354, k] };
@@ -24479,8 +24479,8 @@ describe("Phase 355 — Two-Sqrt × Fifty-One-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs52k355 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs52kp1355 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs52k355 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs52kp1355 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK355r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs52k355, k] };
@@ -24517,8 +24517,8 @@ describe("Phase 356 — Three-Sqrt × Fifty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs52k356 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs52kp1356 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs52k356 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs52kp1356 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK356r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs52k356, k] };
@@ -24555,8 +24555,8 @@ describe("Phase 357 — Four-Sqrt × Fifty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs52k357 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs52kp1357 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs52k357 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs52kp1357 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK357r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs52k357, k] };
@@ -24593,8 +24593,8 @@ describe("Phase 358 — Five-Sqrt × Fifty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs52k358 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs52kp1358 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs52k358 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs52kp1358 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK358r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs52k358, k] };
@@ -24629,8 +24629,8 @@ describe("Phase 359 — Zero-Sqrt × Fifty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs53k359 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs53kp1359 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs53k359 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs53kp1359 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK359r = { kind: "apply" as const, head: MUL, args: [...logs53k359, k] };
     const numKp1359r = { kind: "apply" as const, head: MUL, args: [...logs53kp1359, kp1] };
     const gK359r = { kind: "apply" as const, head: DIV, args: [numK359r, k2r] };
@@ -24665,8 +24665,8 @@ describe("Phase 360 — One-Sqrt × Fifty-Two-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs53k360 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs53kp1360 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs53k360 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs53kp1360 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK360r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs53k360, k] };
@@ -24703,8 +24703,8 @@ describe("Phase 361 — Two-Sqrt × Fifty-Two-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs53k361 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs53kp1361 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs53k361 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs53kp1361 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK361r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs53k361, k] };
@@ -24741,8 +24741,8 @@ describe("Phase 362 — Three-Sqrt × Fifty-Two-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs53k362 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs53kp1362 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs53k362 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs53kp1362 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK362r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs53k362, k] };
@@ -24779,8 +24779,8 @@ describe("Phase 363 — Four-Sqrt × Fifty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs53k363 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs53kp1363 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs53k363 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs53kp1363 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK363r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs53k363, k] };
@@ -24817,8 +24817,8 @@ describe("Phase 364 — Five-Sqrt × Fifty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs53k364 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs53kp1364 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs53k364 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs53kp1364 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK364r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs53k364, k] };
@@ -24853,8 +24853,8 @@ describe("Phase 365 — Zero-Sqrt × Fifty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs54k365 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs54kp1365 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs54k365 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs54kp1365 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK365r = { kind: "apply" as const, head: MUL, args: [...logs54k365, k] };
     const numKp1365r = { kind: "apply" as const, head: MUL, args: [...logs54kp1365, kp1] };
     const gK365r = { kind: "apply" as const, head: DIV, args: [numK365r, k2r] };
@@ -24889,8 +24889,8 @@ describe("Phase 366 — One-Sqrt × Fifty-Three-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs54k366 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs54kp1366 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs54k366 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs54kp1366 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK366r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs54k366, k] };
@@ -24927,8 +24927,8 @@ describe("Phase 367 — Two-Sqrt × Fifty-Three-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs54k367 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs54kp1367 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs54k367 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs54kp1367 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK367r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs54k367, k] };
@@ -24965,8 +24965,8 @@ describe("Phase 368 — Three-Sqrt × Fifty-Three-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs54k368 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs54kp1368 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs54k368 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs54kp1368 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK368r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs54k368, k] };
@@ -25003,8 +25003,8 @@ describe("Phase 369 — Four-Sqrt × Fifty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs54k369 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs54kp1369 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs54k369 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs54kp1369 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK369r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs54k369, k] };
@@ -25041,8 +25041,8 @@ describe("Phase 370 — Five-Sqrt × Fifty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs54k370 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs54kp1370 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs54k370 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs54kp1370 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK370r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs54k370] };
@@ -25077,8 +25077,8 @@ describe("Phase 371 — Zero-Sqrt × Fifty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs56k371 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs56kp1371 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs56k371 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs56kp1371 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK371r = { kind: "apply" as const, head: MUL, args: [...logs56k371, k] };
     const numKp1371r = { kind: "apply" as const, head: MUL, args: [...logs56kp1371, kp1] };
     const gK371r = { kind: "apply" as const, head: DIV, args: [numK371r, k2r] };
@@ -25113,8 +25113,8 @@ describe("Phase 372 — One-Sqrt × Fifty-Four-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs56k372 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs56kp1372 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs56k372 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs56kp1372 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK372r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs56k372, k] };
@@ -25151,8 +25151,8 @@ describe("Phase 373 — Two-Sqrt × Fifty-Four-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs56k373 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs56kp1373 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs56k373 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs56kp1373 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK373r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs56k373, k] };
@@ -25189,8 +25189,8 @@ describe("Phase 374 — Three-Sqrt × Fifty-Four-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs56k374 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs56kp1374 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs56k374 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs56kp1374 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK374r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs56k374, k] };
@@ -25227,8 +25227,8 @@ describe("Phase 375 — Four-Sqrt × Fifty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs56k375 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs56kp1375 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs56k375 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs56kp1375 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK375r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs56k375, k] };
@@ -25265,8 +25265,8 @@ describe("Phase 376 — Five-Sqrt × Fifty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs56k376 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs56kp1376 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs56k376 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs56kp1376 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK376r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs56k376] };
@@ -25301,8 +25301,8 @@ describe("Phase 377 — Zero-Sqrt × Fifty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs56k377 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs56kp1377 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs56k377 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs56kp1377 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK377r = { kind: "apply" as const, head: MUL, args: [...logs56k377] };
     const numKp1377r = { kind: "apply" as const, head: MUL, args: [...logs56kp1377] };
     const gK377r = { kind: "apply" as const, head: DIV, args: [numK377r, k2r] };
@@ -25337,8 +25337,8 @@ describe("Phase 378 — One-Sqrt × Fifty-Five-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs56k378 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs56kp1378 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs56k378 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs56kp1378 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK378r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs56k378] };
@@ -25375,8 +25375,8 @@ describe("Phase 379 — Two-Sqrt × Fifty-Five-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs56k379 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs56kp1379 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs56k379 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs56kp1379 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK379r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs56k379] };
@@ -25413,8 +25413,8 @@ describe("Phase 380 — Three-Sqrt × Fifty-Five-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs56k380 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs56kp1380 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs56k380 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs56kp1380 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK380r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs56k380] };
@@ -25451,8 +25451,8 @@ describe("Phase 381 — Four-Sqrt × Fifty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs56k381 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs56kp1381 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs56k381 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs56kp1381 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK381r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs56k381] };
@@ -25489,8 +25489,8 @@ describe("Phase 382 — Five-Sqrt × Fifty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs56k382 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs56kp1382 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs56k382 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs56kp1382 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK382r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs56k382] };
@@ -25520,13 +25520,13 @@ describe("Phase 383 — Zero-Sqrt × Fifty-Six-Log × polynomial numerator", () 
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("log(k)⁵⁶/k² refused (57 logs — not Phase 383)", () => {
+  it("log(k)⁵⁶/k² refused (58 logs — not Phase 383)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs57k383 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs57kp1383 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs57k383 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs57kp1383 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK383r = { kind: "apply" as const, head: MUL, args: [...logs57k383] };
     const numKp1383r = { kind: "apply" as const, head: MUL, args: [...logs57kp1383] };
     const gK383r = { kind: "apply" as const, head: DIV, args: [numK383r, k2r] };
@@ -25556,13 +25556,13 @@ describe("Phase 384 — One-Sqrt × Fifty-Six-Log × polynomial numerator", () =
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("√k·log(k)⁵⁶/k² refused (57 logs — not Phase 384)", () => {
+  it("√k·log(k)⁵⁶/k² refused (58 logs — not Phase 384)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs57k384 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs57kp1384 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs57k384 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs57kp1384 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK384r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs57k384] };
@@ -25594,13 +25594,13 @@ describe("Phase 385 — Two-Sqrt × Fifty-Six-Log × polynomial numerator", () =
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)²·log(k)⁵⁶/k² refused (57 logs — not Phase 385)", () => {
+  it("(√k)²·log(k)⁵⁶/k² refused (58 logs — not Phase 385)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs57k385 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs57kp1385 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs57k385 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs57kp1385 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK385r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs57k385] };
@@ -25632,13 +25632,13 @@ describe("Phase 386 — Three-Sqrt × Fifty-Six-Log × polynomial numerator", ()
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)³·log(k)⁵⁶/k³ refused (57 logs — not Phase 386)", () => {
+  it("(√k)³·log(k)⁵⁶/k³ refused (58 logs — not Phase 386)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs57k386 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs57kp1386 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs57k386 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs57kp1386 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK386r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs57k386] };
@@ -25670,13 +25670,13 @@ describe("Phase 387 — Four-Sqrt × Fifty-Six-Log × polynomial numerator", () 
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)⁴·log(k)⁵⁶/k³ refused (57 logs — not Phase 387)", () => {
+  it("(√k)⁴·log(k)⁵⁶/k³ refused (58 logs — not Phase 387)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs57k387 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs57kp1387 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs57k387 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs57kp1387 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK387r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs57k387] };
@@ -25708,13 +25708,13 @@ describe("Phase 388 — Five-Sqrt × Fifty-Six-Log × polynomial numerator", () 
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)^5·log(k)⁵⁶/k³ refused (57 logs — not Phase 388)", () => {
+  it("(√k)^5·log(k)⁵⁶/k³ refused (58 logs — not Phase 388)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs57k388 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs57kp1388 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs57k388 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs57kp1388 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK388r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs57k388] };
@@ -25723,6 +25723,230 @@ describe("Phase 388 — Five-Sqrt × Fifty-Six-Log × polynomial numerator", () 
     const gKp1388r = { kind: "apply" as const, head: DIV, args: [numKp1388r, kp1_3r] };
     const f388r = { kind: "apply" as const, head: SUB, args: [gK388r, gKp1388r] };
     const result = evaluateSum(f388r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 389 — Zero-Sqrt × Fifty-Seven-Log × polynomial numerator", () => {
+  it("log(k)⁵⁷/k² closes (polyDeg=0 → effective=0; denDeg=2 > 0)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const logs57k389 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs57kp1389 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const numK389a = { kind: "apply" as const, head: MUL, args: [...logs57k389] };
+    const numKp1389a = { kind: "apply" as const, head: MUL, args: [...logs57kp1389] };
+    const gK389a = { kind: "apply" as const, head: DIV, args: [numK389a, k2] };
+    const gKp1389a = { kind: "apply" as const, head: DIV, args: [numKp1389a, kp1_2] };
+    const f389a = { kind: "apply" as const, head: SUB, args: [gK389a, gKp1389a] };
+    const result = evaluateSum(f389a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("log(k)⁵⁷/k² refused (58 logs — not Phase 389)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs58k389 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs58kp1389 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const numK389r = { kind: "apply" as const, head: MUL, args: [...logs58k389] };
+    const numKp1389r = { kind: "apply" as const, head: MUL, args: [...logs58kp1389] };
+    const gK389r = { kind: "apply" as const, head: DIV, args: [numK389r, k2r] };
+    const gKp1389r = { kind: "apply" as const, head: DIV, args: [numKp1389r, kp1_2r] };
+    const f389r = { kind: "apply" as const, head: SUB, args: [gK389r, gKp1389r] };
+    const result = evaluateSum(f389r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 390 — One-Sqrt × Fifty-Seven-Log × polynomial numerator", () => {
+  it("√k·log(k)⁵⁷/k² closes (sqrtHalf=0.5, polyDeg=0 → effective=0.5; denDeg=2 > 0.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const logs57k390 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs57kp1390 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK390a = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs57k390] };
+    const numKp1390a = { kind: "apply" as const, head: MUL, args: [sqrtKp1, ...logs57kp1390] };
+    const gK390a = { kind: "apply" as const, head: DIV, args: [numK390a, k2] };
+    const gKp1390a = { kind: "apply" as const, head: DIV, args: [numKp1390a, kp1_2] };
+    const f390a = { kind: "apply" as const, head: SUB, args: [gK390a, gKp1390a] };
+    const result = evaluateSum(f390a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("√k·log(k)⁵⁷/k² refused (58 logs — not Phase 390)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs58k390 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs58kp1390 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK390r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs58k390] };
+    const numKp1390r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, ...logs58kp1390] };
+    const gK390r = { kind: "apply" as const, head: DIV, args: [numK390r, k2r] };
+    const gKp1390r = { kind: "apply" as const, head: DIV, args: [numKp1390r, kp1_2r] };
+    const f390r = { kind: "apply" as const, head: SUB, args: [gK390r, gKp1390r] };
+    const result = evaluateSum(f390r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 391 — Two-Sqrt × Fifty-Seven-Log × polynomial numerator", () => {
+  it("(√k)²·log(k)⁵⁷/k² closes (sqrtHalf=1.0, polyDeg=0 → effective=1; denDeg=2 > 1)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const logs57k391 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs57kp1391 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK391a = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs57k391] };
+    const numKp1391a = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, ...logs57kp1391] };
+    const gK391a = { kind: "apply" as const, head: DIV, args: [numK391a, k2] };
+    const gKp1391a = { kind: "apply" as const, head: DIV, args: [numKp1391a, kp1_2] };
+    const f391a = { kind: "apply" as const, head: SUB, args: [gK391a, gKp1391a] };
+    const result = evaluateSum(f391a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("(√k)²·log(k)⁵⁷/k² refused (58 logs — not Phase 391)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs58k391 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs58kp1391 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK391r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs58k391] };
+    const numKp1391r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, ...logs58kp1391] };
+    const gK391r = { kind: "apply" as const, head: DIV, args: [numK391r, k2r] };
+    const gKp1391r = { kind: "apply" as const, head: DIV, args: [numKp1391r, kp1_2r] };
+    const f391r = { kind: "apply" as const, head: SUB, args: [gK391r, gKp1391r] };
+    const result = evaluateSum(f391r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 392 — Three-Sqrt × Fifty-Seven-Log × polynomial numerator", () => {
+  it("(√k)³·log(k)⁵⁷/k³ closes (sqrtHalf=1.5, polyDeg=0 → effective=1.5; denDeg=3 > 1.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const logs57k392 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs57kp1392 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK392a = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs57k392] };
+    const numKp1392a = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, ...logs57kp1392] };
+    const gK392a = { kind: "apply" as const, head: DIV, args: [numK392a, k3] };
+    const gKp1392a = { kind: "apply" as const, head: DIV, args: [numKp1392a, kp1_3] };
+    const f392a = { kind: "apply" as const, head: SUB, args: [gK392a, gKp1392a] };
+    const result = evaluateSum(f392a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("(√k)³·log(k)⁵⁷/k³ refused (58 logs — not Phase 392)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs58k392 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs58kp1392 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK392r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs58k392] };
+    const numKp1392r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, ...logs58kp1392] };
+    const gK392r = { kind: "apply" as const, head: DIV, args: [numK392r, k3r] };
+    const gKp1392r = { kind: "apply" as const, head: DIV, args: [numKp1392r, kp1_3r] };
+    const f392r = { kind: "apply" as const, head: SUB, args: [gK392r, gKp1392r] };
+    const result = evaluateSum(f392r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 393 — Four-Sqrt × Fifty-Seven-Log × polynomial numerator", () => {
+  it("(√k)⁴·log(k)⁵⁷/k³ closes (sqrtHalf=2.0, polyDeg=0 → effective=2; denDeg=3 > 2)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const logs57k393 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs57kp1393 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK393a = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs57k393] };
+    const numKp1393a = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, ...logs57kp1393] };
+    const gK393a = { kind: "apply" as const, head: DIV, args: [numK393a, k3] };
+    const gKp1393a = { kind: "apply" as const, head: DIV, args: [numKp1393a, kp1_3] };
+    const f393a = { kind: "apply" as const, head: SUB, args: [gK393a, gKp1393a] };
+    const result = evaluateSum(f393a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("(√k)⁴·log(k)⁵⁷/k³ refused (58 logs — not Phase 393)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs58k393 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs58kp1393 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK393r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs58k393] };
+    const numKp1393r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, ...logs58kp1393] };
+    const gK393r = { kind: "apply" as const, head: DIV, args: [numK393r, k3r] };
+    const gKp1393r = { kind: "apply" as const, head: DIV, args: [numKp1393r, kp1_3r] };
+    const f393r = { kind: "apply" as const, head: SUB, args: [gK393r, gKp1393r] };
+    const result = evaluateSum(f393r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 394 — Five-Sqrt × Fifty-Seven-Log × polynomial numerator", () => {
+  it("(√k)^5·log(k)⁵⁷/k³ closes (sqrtHalf=2.5, polyDeg=0 → effective=2.5; denDeg=3 > 2.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const logs57k394 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs57kp1394 = Array.from({ length: 57 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK394a = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs57k394] };
+    const numKp1394a = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, ...logs57kp1394] };
+    const gK394a = { kind: "apply" as const, head: DIV, args: [numK394a, k3] };
+    const gKp1394a = { kind: "apply" as const, head: DIV, args: [numKp1394a, kp1_3] };
+    const f394a = { kind: "apply" as const, head: SUB, args: [gK394a, gKp1394a] };
+    const result = evaluateSum(f394a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("(√k)^5·log(k)⁵⁷/k³ refused (58 logs — not Phase 394)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs58k394 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs58kp1394 = Array.from({ length: 58 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK394r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs58k394] };
+    const numKp1394r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, ...logs58kp1394] };
+    const gK394r = { kind: "apply" as const, head: DIV, args: [numK394r, k3r] };
+    const gKp1394r = { kind: "apply" as const, head: DIV, args: [numKp1394r, kp1_3r] };
+    const f394r = { kind: "apply" as const, head: SUB, args: [gK394r, gKp1394r] };
+    const result = evaluateSum(f394r, k, int(1), sym("%inf"), evalNode);
     expect(result).toMatchObject({ kind: "apply", head: SUM });
   });
 });


### PR DESCRIPTION
## Summary

Adds Phase 389–394: the Fifty-Seven-Log convergence recognizer family across Python, Rust, and TypeScript.

Each phase handles summands whose numerator contains exactly **57 logarithmic factors** and **0–5 square-root factors**.

### Phases
| Phase | Description |
|-------|-------------|
| 389 | Zero-Sqrt × Fifty-Seven-Log × polynomial numerator |
| 390 | One-Sqrt × Fifty-Seven-Log × polynomial numerator |
| 391 | Two-Sqrt × Fifty-Seven-Log × polynomial numerator |
| 392 | Three-Sqrt × Fifty-Seven-Log × polynomial numerator |
| 393 | Four-Sqrt × Fifty-Seven-Log × polynomial numerator |
| 394 | Five-Sqrt × Fifty-Seven-Log × polynomial numerator |

### Changes
- **Python**: +6 helpers + dispatch + 12 tests; cascade fix (57→58 logs); 1079 tests pass; 91% coverage
- **Rust**: +6 helpers + dispatch + cascade fix; 972 tests pass
- **TypeScript**: +6 helpers + dispatch + cascade fix; 990 tests pass
- Version bumped 2.325.0 → 2.331.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)