### PR TITLE
feat(cas-summation): add Phase 401-406 (Fifty-Nine-Log family, v2.337.0→v2.343.0)

### DIFF
--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.343.0 — 2026-05-28
+
+### Added
+- Phase 401 (`_fifty_nine_log_poly_effective_x2`): Zero-Sqrt × Fifty-Nine-Log × polynomial numerator recognizer.
+- Phase 402 (`_one_sqrt_fifty_nine_log_poly_effective_x2`): One-Sqrt × Fifty-Nine-Log × polynomial numerator recognizer.
+- Phase 403 (`_two_sqrt_fifty_nine_log_poly_effective_x2`): Two-Sqrt × Fifty-Nine-Log × polynomial numerator recognizer.
+- Phase 404 (`_three_sqrt_fifty_nine_log_poly_effective_x2`): Three-Sqrt × Fifty-Nine-Log × polynomial numerator recognizer.
+- Phase 405 (`_four_sqrt_fifty_nine_log_poly_effective_x2`): Four-Sqrt × Fifty-Nine-Log × polynomial numerator recognizer.
+- Phase 406 (`_five_sqrt_fifty_nine_log_poly_effective_x2`): Five-Sqrt × Fifty-Nine-Log × polynomial numerator recognizer. Completes the Fifty-Nine-Log family.
+- 12 new test cases covering Phase 401–406 (closes + refused for each).
+- Cascade fix: Phase 395–400 refused tests updated from 59→60 log factors.
+
 ## 2.337.0 — 2026-05-28
 
 ### Added

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "2.337.0"
+version = "2.343.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -1477,6 +1477,60 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
                 return True
         elif _h_diverges_at_infinity(den, k):
             return True
+    # Phase 406: ``Mul(Sqrt(P1)×5, Log(h1)×59, polynomial..., bounded...)`` numerator.
+    s5l59p_x2 = _five_sqrt_fifty_nine_log_poly_effective_x2(num, k)
+    if s5l59p_x2 is not None:
+        den_deg_s5l59 = _polynomial_degree_in_k(den, k)
+        if den_deg_s5l59 is not None:
+            if 2 * den_deg_s5l59 > s5l59p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 405: ``Mul(Sqrt(P1)×4, Log(h1)×59, polynomial..., bounded...)`` numerator.
+    s4l59p_x2 = _four_sqrt_fifty_nine_log_poly_effective_x2(num, k)
+    if s4l59p_x2 is not None:
+        den_deg_s4l59 = _polynomial_degree_in_k(den, k)
+        if den_deg_s4l59 is not None:
+            if 2 * den_deg_s4l59 > s4l59p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 404: ``Mul(Sqrt(P1)×3, Log(h1)×59, polynomial..., bounded...)`` numerator.
+    s3l59p_x2 = _three_sqrt_fifty_nine_log_poly_effective_x2(num, k)
+    if s3l59p_x2 is not None:
+        den_deg_s3l59 = _polynomial_degree_in_k(den, k)
+        if den_deg_s3l59 is not None:
+            if 2 * den_deg_s3l59 > s3l59p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 403: ``Mul(Sqrt(P), Sqrt(P2), Log(h1)×59, polynomial..., bounded...)`` numerator.
+    s2l59p_x2 = _two_sqrt_fifty_nine_log_poly_effective_x2(num, k)
+    if s2l59p_x2 is not None:
+        den_deg_s2l59 = _polynomial_degree_in_k(den, k)
+        if den_deg_s2l59 is not None:
+            if 2 * den_deg_s2l59 > s2l59p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 402: ``Mul(Sqrt(P), Log(h1)×59, polynomial..., bounded...)`` numerator.
+    s1l59p_x2 = _one_sqrt_fifty_nine_log_poly_effective_x2(num, k)
+    if s1l59p_x2 is not None:
+        den_deg_s1l59 = _polynomial_degree_in_k(den, k)
+        if den_deg_s1l59 is not None:
+            if 2 * den_deg_s1l59 > s1l59p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 401: ``Mul(Log(h1)×59, polynomial..., bounded...)`` numerator.
+    sl59p_x2 = _fifty_nine_log_poly_effective_x2(num, k)
+    if sl59p_x2 is not None:
+        den_deg_sl59 = _polynomial_degree_in_k(den, k)
+        if den_deg_sl59 is not None:
+            if 2 * den_deg_sl59 > sl59p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
     # Phase 400: ``Mul(Sqrt(P1)×5, Log(h1)×58, polynomial..., bounded...)`` numerator.
     s5l58p_x2 = _five_sqrt_fifty_eight_log_poly_effective_x2(num, k)
     if s5l58p_x2 is not None:
@@ -13729,6 +13783,189 @@ def _five_sqrt_fifty_seven_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> i
             continue
         return None
     if len(sqrt_degs_x2) != 5 or log_count != 57:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _fifty_nine_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 401 — Zero-Sqrt × Fifty-Nine-Log × polynomial numerator."""
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        if _sqrt_effective_half_degree_x2(arg, k) is not None:
+            return None
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 59:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if log_count != 59:
+        return None
+    return 2 * poly_deg_sum
+
+
+def _one_sqrt_fifty_nine_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 402 — One-Sqrt × Fifty-Nine-Log × polynomial numerator."""
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_deg_x2: int | None = None
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if sqrt_deg_x2 is not None:
+                return None
+            sqrt_deg_x2 = deg_x2
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 59:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if sqrt_deg_x2 is None or log_count != 59:
+        return None
+    return sqrt_deg_x2 + 2 * poly_deg_sum
+
+
+def _two_sqrt_fifty_nine_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 403 — Two-Sqrt × Fifty-Nine-Log × polynomial numerator."""
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 2:
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 59:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 2 or log_count != 59:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _three_sqrt_fifty_nine_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 404 — Three-Sqrt × Fifty-Nine-Log × polynomial numerator."""
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 3:
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 59:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 3 or log_count != 59:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _four_sqrt_fifty_nine_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 405 — Four-Sqrt × Fifty-Nine-Log × polynomial numerator."""
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 4:
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 59:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 4 or log_count != 59:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _five_sqrt_fifty_nine_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 406 — Five-Sqrt × Fifty-Nine-Log × polynomial numerator.
+    Completes the Fifty-Nine-Log family (Phases 401-406).
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 5:
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 59:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 5 or log_count != 59:
         return None
     return sum(sqrt_degs_x2) + 2 * poly_deg_sum
 

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -17892,6 +17892,7 @@ class TestPhase205TwoSqrtTwentySixLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -18076,6 +18077,7 @@ class TestPhase206ThreeSqrtTwentySixLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -18266,6 +18268,7 @@ class TestPhase207FourSqrtTwentySixLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -18456,6 +18459,7 @@ class TestPhase208FiveSqrtTwentySixLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -19014,6 +19018,7 @@ class TestPhase211TwoSqrtTwentySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -19202,6 +19207,7 @@ class TestPhase212ThreeSqrtTwentySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -19396,6 +19402,7 @@ class TestPhase213FourSqrtTwentySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -19590,6 +19597,7 @@ class TestPhase214FiveSqrtTwentySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -20160,6 +20168,7 @@ class TestPhase217TwoSqrtTwentyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -20352,6 +20361,7 @@ class TestPhase218ThreeSqrtTwentyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -20550,6 +20560,7 @@ class TestPhase219FourSqrtTwentyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -20748,6 +20759,7 @@ class TestPhase220FiveSqrtTwentyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -21331,6 +21343,7 @@ class TestPhase223TwoSqrtTwentyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -21527,6 +21540,7 @@ class TestPhase224ThreeSqrtTwentyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -21729,6 +21743,7 @@ class TestPhase225FourSqrtTwentyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -21931,6 +21946,7 @@ class TestPhase226FiveSqrtTwentyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -22525,6 +22541,7 @@ class TestPhase229TwoSqrtThirtyLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -22725,6 +22742,7 @@ class TestPhase230ThreeSqrtThirtyLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -22925,6 +22943,7 @@ class TestPhase231FourSqrtThirtyLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -23131,6 +23150,7 @@ class TestPhase232FiveSqrtThirtyLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -23737,6 +23757,7 @@ class TestPhase235TwoSqrtThirtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -23941,6 +23962,7 @@ class TestPhase236ThreeSqrtThirtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -24151,6 +24173,7 @@ class TestPhase237FourSqrtThirtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -24361,6 +24384,7 @@ class TestPhase238FiveSqrtThirtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -24979,6 +25003,7 @@ class TestPhase241TwoSqrtThirtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -25187,6 +25212,7 @@ class TestPhase242ThreeSqrtThirtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -25401,6 +25427,7 @@ class TestPhase243FourSqrtThirtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -25615,6 +25642,7 @@ class TestPhase244FiveSqrtThirtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -26245,6 +26273,7 @@ class TestPhase247TwoSqrtThirtyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -26457,6 +26486,7 @@ class TestPhase248ThreeSqrtThirtyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -26675,6 +26705,7 @@ class TestPhase249FourSqrtThirtyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -26893,6 +26924,7 @@ class TestPhase250FiveSqrtThirtyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -27535,6 +27567,7 @@ class TestPhase253TwoSqrtThirtyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -27751,6 +27784,7 @@ class TestPhase254ThreeSqrtThirtyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -27973,6 +28007,7 @@ class TestPhase255FourSqrtThirtyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -28195,6 +28230,7 @@ class TestPhase256FiveSqrtThirtyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -28849,6 +28885,7 @@ class TestPhase259TwoSqrtThirtyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -29069,6 +29106,7 @@ class TestPhase260ThreeSqrtThirtyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -29295,6 +29333,7 @@ class TestPhase261FourSqrtThirtyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -29521,6 +29560,7 @@ class TestPhase262FiveSqrtThirtyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -30187,6 +30227,7 @@ class TestPhase265TwoSqrtThirtySixLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -30411,6 +30452,7 @@ class TestPhase266ThreeSqrtThirtySixLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -30641,6 +30683,7 @@ class TestPhase267FourSqrtThirtySixLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -30871,6 +30914,7 @@ class TestPhase268FiveSqrtThirtySixLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -31095,6 +31139,7 @@ class TestPhase269ThirtySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -31322,6 +31367,7 @@ class TestPhase270OneSqrtThirtySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -31549,6 +31595,7 @@ class TestPhase271TwoSqrtThirtySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -31776,6 +31823,7 @@ class TestPhase272ThreeSqrtThirtySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -32003,6 +32051,7 @@ class TestPhase273FourSqrtThirtySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -32236,6 +32285,7 @@ class TestPhase274FiveSqrtThirtySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -32463,6 +32513,7 @@ class TestPhase275ThirtyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -32694,6 +32745,7 @@ class TestPhase276OneSqrtThirtyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -32925,6 +32977,7 @@ class TestPhase277TwoSqrtThirtyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -33156,6 +33209,7 @@ class TestPhase278ThreeSqrtThirtyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -33393,6 +33447,7 @@ class TestPhase279FourSqrtThirtyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -33630,6 +33685,7 @@ class TestPhase280FiveSqrtThirtyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -33862,6 +33918,7 @@ class TestPhase281ThirtyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -34097,6 +34154,7 @@ class TestPhase282OneSqrtThirtyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -34334,6 +34392,7 @@ class TestPhase283TwoSqrtThirtyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -34571,6 +34630,7 @@ class TestPhase284ThreeSqrtThirtyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -34808,6 +34868,7 @@ class TestPhase285FourSqrtThirtyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -35045,6 +35106,7 @@ class TestPhase286FiveSqrtThirtyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -35281,6 +35343,7 @@ class TestPhase287FortyLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -35520,6 +35583,7 @@ class TestPhase288OneSqrtFortyLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -35761,6 +35825,7 @@ class TestPhase289TwoSqrtFortyLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -36002,6 +36067,7 @@ class TestPhase290ThreeSqrtFortyLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -36243,6 +36309,7 @@ class TestPhase291FourSqrtFortyLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -36484,6 +36551,7 @@ class TestPhase292FiveSqrtFortyLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -36724,6 +36792,7 @@ class TestPhase293FortyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -36896,6 +36965,7 @@ class TestPhase294OneSqrtFortyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -37068,6 +37138,7 @@ class TestPhase295TwoSqrtFortyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -37240,6 +37311,7 @@ class TestPhase296ThreeSqrtFortyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -37412,6 +37484,7 @@ class TestPhase297FourSqrtFortyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -37584,6 +37657,7 @@ class TestPhase298FiveSqrtFortyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -37755,6 +37829,7 @@ class TestPhase299FortyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -37929,6 +38004,7 @@ class TestPhase300OneSqrtFortyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -38103,6 +38179,7 @@ class TestPhase301TwoSqrtFortyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -38277,6 +38354,7 @@ class TestPhase302ThreeSqrtFortyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -38451,6 +38529,7 @@ class TestPhase303FourSqrtFortyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -38625,6 +38704,7 @@ class TestPhase304FiveSqrtFortyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -38798,6 +38878,7 @@ class TestPhase305FortyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -38975,6 +39056,7 @@ class TestPhase306OneSqrtFortyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -39152,6 +39234,7 @@ class TestPhase307TwoSqrtFortyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -39329,6 +39412,7 @@ class TestPhase308ThreeSqrtFortyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -39506,6 +39590,7 @@ class TestPhase309FourSqrtFortyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -39683,6 +39768,7 @@ class TestPhase310FiveSqrtFortyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -39858,6 +39944,7 @@ class TestPhase311FortyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -40037,6 +40124,7 @@ class TestPhase312OneSqrtFortyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -40216,6 +40304,7 @@ class TestPhase313TwoSqrtFortyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -40395,6 +40484,7 @@ class TestPhase314ThreeSqrtFortyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -40574,6 +40664,7 @@ class TestPhase315FourSqrtFortyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -40753,6 +40844,7 @@ class TestPhase316FiveSqrtFortyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -40930,6 +41022,7 @@ class TestPhase317FortyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -41110,6 +41203,7 @@ class TestPhase318OneSqrtFortyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -41290,6 +41384,7 @@ class TestPhase319TwoSqrtFortyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -41470,6 +41565,7 @@ class TestPhase320ThreeSqrtFortyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -41650,6 +41746,7 @@ class TestPhase321FourSqrtFortyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -41830,6 +41927,7 @@ class TestPhase322FiveSqrtFortyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -42009,6 +42107,7 @@ class TestPhase323FortysSixLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -42191,6 +42290,7 @@ class TestPhase324OneSqrtFortySixLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -42373,6 +42473,7 @@ class TestPhase325TwoSqrtFortySixLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -42555,6 +42656,7 @@ class TestPhase326ThreeSqrtFortySixLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -42737,6 +42839,7 @@ class TestPhase327FourSqrtFortySixLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -42919,6 +43022,7 @@ class TestPhase328FiveSqrtFortySixLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -43100,6 +43204,7 @@ class TestPhase329FortySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -43284,6 +43389,7 @@ class TestPhase330OneSqrtFortySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -43468,6 +43574,7 @@ class TestPhase331TwoSqrtFortySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -43652,6 +43759,7 @@ class TestPhase332ThreeSqrtFortySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -43836,6 +43944,7 @@ class TestPhase333FourSqrtFortySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -44020,6 +44129,7 @@ class TestPhase334FiveSqrtFortySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -44203,6 +44313,7 @@ class TestPhase335FortyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -44390,6 +44501,7 @@ class TestPhase336OneSqrtFortyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -44577,6 +44689,7 @@ class TestPhase337TwoSqrtFortyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -44764,6 +44877,7 @@ class TestPhase338ThreeSqrtFortyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -44951,6 +45065,7 @@ class TestPhase339FourSqrtFortyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -45138,6 +45253,7 @@ class TestPhase340FiveSqrtFortyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -45323,6 +45439,7 @@ class TestPhase341FortyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -45512,6 +45629,7 @@ class TestPhase342OneSqrtFortyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -45701,6 +45819,7 @@ class TestPhase343TwoSqrtFortyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -45890,6 +46009,7 @@ class TestPhase344ThreeSqrtFortyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -46079,6 +46199,7 @@ class TestPhase345FourSqrtFortyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -46268,6 +46389,7 @@ class TestPhase346FiveSqrtFortyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -46455,6 +46577,7 @@ class TestPhase347FiftyLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -46646,6 +46769,7 @@ class TestPhase348OneSqrtFiftyLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -46837,6 +46961,7 @@ class TestPhase349TwoSqrtFiftyLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -47028,6 +47153,7 @@ class TestPhase350ThreeSqrtFiftyLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -47219,6 +47345,7 @@ class TestPhase351FourSqrtFiftyLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -47410,6 +47537,7 @@ class TestPhase352FiveSqrtFiftyLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -47599,6 +47727,7 @@ class TestPhase353FiftyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -47792,6 +47921,7 @@ class TestPhase354OneSqrtFiftyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -47985,6 +48115,7 @@ class TestPhase355TwoSqrtFiftyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -48178,6 +48309,7 @@ class TestPhase356ThreeSqrtFiftyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -48371,6 +48503,7 @@ class TestPhase357FourSqrtFiftyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -48564,6 +48697,7 @@ class TestPhase358FiveSqrtFiftyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -48715,6 +48849,7 @@ class TestPhase359FiftyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 57th log (over 56; refused)
             IRApply(LOG, (_k,)),  # 59th log (over 58; refused)
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (_k,)),  # 62nd log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -48760,6 +48895,7 @@ class TestPhase359FiftyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -48914,6 +49050,7 @@ class TestPhase360OneSqrtFiftyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 57th log (over 56; refused)
             IRApply(LOG, (_k,)),  # 59th log (over 58; refused)
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (_k,)),  # 62nd log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -48960,6 +49097,7 @@ class TestPhase360OneSqrtFiftyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -49114,6 +49252,7 @@ class TestPhase361TwoSqrtFiftyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 57th log (over 56; refused)
             IRApply(LOG, (_k,)),  # 59th log (over 58; refused)
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (_k,)),  # 62nd log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -49160,6 +49299,7 @@ class TestPhase361TwoSqrtFiftyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -49314,6 +49454,7 @@ class TestPhase362ThreeSqrtFiftyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 57th log (over 56; refused)
             IRApply(LOG, (_k,)),  # 59th log (over 58; refused)
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (_k,)),  # 62nd log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -49360,6 +49501,7 @@ class TestPhase362ThreeSqrtFiftyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -49514,6 +49656,7 @@ class TestPhase363FourSqrtFiftyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 57th log (over 56; refused)
             IRApply(LOG, (_k,)),  # 59th log (over 58; refused)
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (_k,)),  # 62nd log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -49560,6 +49703,7 @@ class TestPhase363FourSqrtFiftyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -49714,6 +49858,7 @@ class TestPhase364FiveSqrtFiftyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 57th log (over 56; refused)
             IRApply(LOG, (_k,)),  # 59th log (over 58; refused)
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (_k,)),  # 62nd log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -49760,6 +49905,7 @@ class TestPhase364FiveSqrtFiftyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -49952,6 +50098,7 @@ class TestPhase365FiftyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -50148,6 +50295,7 @@ class TestPhase366OneSqrtFiftyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -50344,6 +50492,7 @@ class TestPhase367TwoSqrtFiftyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -50540,6 +50689,7 @@ class TestPhase368ThreeSqrtFiftyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -50736,6 +50886,7 @@ class TestPhase369FourSqrtFiftyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -50932,6 +51083,7 @@ class TestPhase370FiveSqrtFiftyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -51126,6 +51278,7 @@ class TestPhase371FiftyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -51324,6 +51477,7 @@ class TestPhase372OneSqrtFiftyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -51522,6 +51676,7 @@ class TestPhase373TwoSqrtFiftyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -51720,6 +51875,7 @@ class TestPhase374ThreeSqrtFiftyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -51918,6 +52074,7 @@ class TestPhase375FourSqrtFiftyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -52116,6 +52273,7 @@ class TestPhase376FiveSqrtFiftyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -52273,6 +52431,7 @@ class TestPhase377FiftyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 57th log (over 56; refused)
             IRApply(LOG, (_k,)),  # 59th log (over 58; refused)
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (_k,)),  # 62nd log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -52318,6 +52477,7 @@ class TestPhase377FiftyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -52478,6 +52638,7 @@ class TestPhase378OneSqrtFiftyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 57th log (over 56; refused)
             IRApply(LOG, (_k,)),  # 59th log (over 58; refused)
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (_k,)),  # 62nd log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -52524,6 +52685,7 @@ class TestPhase378OneSqrtFiftyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -52684,6 +52846,7 @@ class TestPhase379TwoSqrtFiftyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 57th log (over 56; refused)
             IRApply(LOG, (_k,)),  # 59th log (over 58; refused)
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (_k,)),  # 62nd log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -52730,6 +52893,7 @@ class TestPhase379TwoSqrtFiftyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -52890,6 +53054,7 @@ class TestPhase380ThreeSqrtFiftyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 57th log (over 56; refused)
             IRApply(LOG, (_k,)),  # 59th log (over 58; refused)
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (_k,)),  # 62nd log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -52936,6 +53101,7 @@ class TestPhase380ThreeSqrtFiftyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -53096,6 +53262,7 @@ class TestPhase381FourSqrtFiftyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 57th log (over 56; refused)
             IRApply(LOG, (_k,)),  # 59th log (over 58; refused)
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (_k,)),  # 62nd log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -53142,6 +53309,7 @@ class TestPhase381FourSqrtFiftyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -53302,6 +53470,7 @@ class TestPhase382FiveSqrtFiftyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 57th log (over 56; refused)
             IRApply(LOG, (_k,)),  # 59th log (over 58; refused)
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (_k,)),  # 62nd log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -53348,6 +53517,7 @@ class TestPhase382FiveSqrtFiftyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -53507,6 +53677,7 @@ class TestPhase383ZeroSqrtFiftySixLogPoly:
             IRApply(LOG, (_k,)),  # 57th log (over 56; refused)
             IRApply(LOG, (_k,)),  # 59th log (over 58; refused)
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (_k,)),  # 62nd log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -53552,6 +53723,7 @@ class TestPhase383ZeroSqrtFiftySixLogPoly:
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -53718,6 +53890,7 @@ class TestPhase384OneSqrtFiftySixLogPoly:
             IRApply(LOG, (_k,)),  # 57th log (over 56; refused)
             IRApply(LOG, (_k,)),  # 59th log (over 58; refused)
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (_k,)),  # 62nd log
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1,
@@ -53764,6 +53937,7 @@ class TestPhase384OneSqrtFiftySixLogPoly:
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -53930,6 +54104,7 @@ class TestPhase385TwoSqrtFiftySixLogPoly:
             IRApply(LOG, (_k,)),  # 57th log (over 56; refused)
             IRApply(LOG, (_k,)),  # 59th log (over 58; refused)
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (_k,)),  # 62nd log
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1,
@@ -53976,6 +54151,7 @@ class TestPhase385TwoSqrtFiftySixLogPoly:
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -54142,6 +54318,7 @@ class TestPhase386ThreeSqrtFiftySixLogPoly:
             IRApply(LOG, (_k,)),  # 57th log (over 56; refused)
             IRApply(LOG, (_k,)),  # 59th log (over 58; refused)
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (_k,)),  # 62nd log
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -54188,6 +54365,7 @@ class TestPhase386ThreeSqrtFiftySixLogPoly:
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -54354,6 +54532,7 @@ class TestPhase387FourSqrtFiftySixLogPoly:
             IRApply(LOG, (_k,)),  # 57th log (over 56; refused)
             IRApply(LOG, (_k,)),  # 59th log (over 58; refused)
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (_k,)),  # 62nd log
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -54400,6 +54579,7 @@ class TestPhase387FourSqrtFiftySixLogPoly:
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -54566,6 +54746,7 @@ class TestPhase388FiveSqrtFiftySixLogPoly:
             IRApply(LOG, (_k,)),  # 57th log (over 56; refused)
             IRApply(LOG, (_k,)),  # 59th log (over 58; refused)
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (_k,)),  # 62nd log
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -54612,6 +54793,7 @@ class TestPhase388FiveSqrtFiftySixLogPoly:
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -54773,6 +54955,7 @@ class TestPhase389ZeroSqrtFiftySevenLogPoly:
             IRApply(LOG, (_k,)),  # 57th log
             IRApply(LOG, (_k,)),  # 59th log (over 58; refused)
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (_k,)),  # 62nd log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -54818,6 +55001,7 @@ class TestPhase389ZeroSqrtFiftySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 57th log
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -54986,6 +55170,7 @@ class TestPhase390OneSqrtFiftySevenLogPoly:
             IRApply(LOG, (_k,)),  # 57th log
             IRApply(LOG, (_k,)),  # 59th log (over 58; refused)
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (_k,)),  # 62nd log
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1,
@@ -55032,6 +55217,7 @@ class TestPhase390OneSqrtFiftySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 57th log
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -55200,6 +55386,7 @@ class TestPhase391TwoSqrtFiftySevenLogPoly:
             IRApply(LOG, (_k,)),  # 57th log
             IRApply(LOG, (_k,)),  # 59th log (over 58; refused)
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (_k,)),  # 62nd log
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1,
@@ -55246,6 +55433,7 @@ class TestPhase391TwoSqrtFiftySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 57th log
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -55414,6 +55602,7 @@ class TestPhase392ThreeSqrtFiftySevenLogPoly:
             IRApply(LOG, (_k,)),  # 57th log
             IRApply(LOG, (_k,)),  # 59th log (over 58; refused)
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (_k,)),  # 62nd log
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -55460,6 +55649,7 @@ class TestPhase392ThreeSqrtFiftySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 57th log
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -55628,6 +55818,7 @@ class TestPhase393FourSqrtFiftySevenLogPoly:
             IRApply(LOG, (_k,)),  # 57th log
             IRApply(LOG, (_k,)),  # 59th log (over 58; refused)
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (_k,)),  # 62nd log
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -55674,6 +55865,7 @@ class TestPhase393FourSqrtFiftySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 57th log
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -55842,6 +56034,7 @@ class TestPhase394FiveSqrtFiftySevenLogPoly:
             IRApply(LOG, (_k,)),  # 57th log
             IRApply(LOG, (_k,)),  # 59th log (over 58; refused)
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (_k,)),  # 62nd log (over 59; refused by Phase 406)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -55888,6 +56081,7 @@ class TestPhase394FiveSqrtFiftySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 57th log
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log (over 59; refused by Phase 406)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -56051,6 +56245,7 @@ class TestPhase395ZeroSqrtFiftyEightLogPoly:
             IRApply(LOG, (_k,)),  # 57th log
             IRApply(LOG, (_k,)),  # 58th log
             IRApply(LOG, (_k,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (_k,)),  # 60th log
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -56096,6 +56291,7 @@ class TestPhase395ZeroSqrtFiftyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 57th log
             IRApply(LOG, (kp1,)),  # 58th log
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -56266,6 +56462,7 @@ class TestPhase396OneSqrtFiftyEightLogPoly:
             IRApply(LOG, (_k,)),  # 57th log
             IRApply(LOG, (_k,)),  # 58th log
             IRApply(LOG, (_k,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (_k,)),  # 60th log
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1,
@@ -56312,6 +56509,7 @@ class TestPhase396OneSqrtFiftyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 57th log
             IRApply(LOG, (kp1,)),  # 58th log
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -56482,6 +56680,7 @@ class TestPhase397TwoSqrtFiftyEightLogPoly:
             IRApply(LOG, (_k,)),  # 57th log
             IRApply(LOG, (_k,)),  # 58th log
             IRApply(LOG, (_k,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (_k,)),  # 60th log
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1,
@@ -56528,6 +56727,7 @@ class TestPhase397TwoSqrtFiftyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 57th log
             IRApply(LOG, (kp1,)),  # 58th log
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -56698,6 +56898,7 @@ class TestPhase398ThreeSqrtFiftyEightLogPoly:
             IRApply(LOG, (_k,)),  # 57th log
             IRApply(LOG, (_k,)),  # 58th log
             IRApply(LOG, (_k,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (_k,)),  # 60th log
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -56744,6 +56945,7 @@ class TestPhase398ThreeSqrtFiftyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 57th log
             IRApply(LOG, (kp1,)),  # 58th log
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -56914,6 +57116,7 @@ class TestPhase399FourSqrtFiftyEightLogPoly:
             IRApply(LOG, (_k,)),  # 57th log
             IRApply(LOG, (_k,)),  # 58th log
             IRApply(LOG, (_k,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (_k,)),  # 60th log
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -56960,6 +57163,7 @@ class TestPhase399FourSqrtFiftyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 57th log
             IRApply(LOG, (kp1,)),  # 58th log
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -57130,6 +57334,7 @@ class TestPhase400FiveSqrtFiftyEightLogPoly:
             IRApply(LOG, (_k,)),  # 57th log
             IRApply(LOG, (_k,)),  # 58th log
             IRApply(LOG, (_k,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (_k,)),  # 60th log
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -57176,6 +57381,1331 @@ class TestPhase400FiveSqrtFiftyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 57th log
             IRApply(LOG, (kp1,)),  # 58th log
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
+            IRApply(LOG, (kp1,)),  # 60th log
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase401ZeroSqrtFiftyNineLogPoly:
+    """Phase 401 -- Zero-Sqrt x Fifty-Nine-Log x polynomial numerator."""
+
+    def test_log59_k_over_k2_closes(self):
+        """log(k)^59/k^2: eff_x2=0; 2*2=4 > 0 -> closes"""
+        from symbolic_ir import SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+            IRApply(LOG, (_k,)),  # 58th log
+            IRApply(LOG, (_k,)),  # 59th log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+            IRApply(LOG, (kp1,)),  # 58th log
+            IRApply(LOG, (kp1,)),  # 59th log
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_log59_k_over_k2_refused(self):
+        """log(k)^60/k2: 60 logs -> not Phase 401 -> refused"""
+        from symbolic_ir import SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+            IRApply(LOG, (_k,)),  # 58th log
+            IRApply(LOG, (_k,)),  # 59th log
+            IRApply(LOG, (_k,)),  # 60th log
+            IRApply(LOG, (_k,)),  # 61st log (over 59; refused)
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+            IRApply(LOG, (kp1,)),  # 58th log
+            IRApply(LOG, (kp1,)),  # 59th log
+            IRApply(LOG, (kp1,)),  # 60th log
+            IRApply(LOG, (kp1,)),  # 61st log (over 59; refused)
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase402OneSqrtFiftyNineLogPoly:
+    """Phase 402 -- One-Sqrt x Fifty-Nine-Log x polynomial numerator."""
+
+    def test_sqrt_k_log59_k_over_k2_closes(self):
+        """sqrt(k)*log(k)^59/k^2: eff_x2=1; 2*2=4 > 1 -> closes"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        sqrt_k = IRApply(SQRT, (_k,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_k = IRApply(MUL, (
+            sqrt_k,
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+            IRApply(LOG, (_k,)),  # 58th log
+            IRApply(LOG, (_k,)),  # 59th log
+        ))
+        num_kp1 = IRApply(MUL, (
+            sqrt_kp1,
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+            IRApply(LOG, (kp1,)),  # 58th log
+            IRApply(LOG, (kp1,)),  # 59th log
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_log59_k_over_k2_refused(self):
+        """sqrt(k)*log(k)^60/k2: 60 logs -> not Phase 402 -> refused"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        sqrt_k = IRApply(SQRT, (_k,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_k = IRApply(MUL, (
+            sqrt_k,
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+            IRApply(LOG, (_k,)),  # 58th log
+            IRApply(LOG, (_k,)),  # 59th log
+            IRApply(LOG, (_k,)),  # 60th log
+            IRApply(LOG, (_k,)),  # 61st log (over 59; refused)
+        ))
+        num_kp1 = IRApply(MUL, (
+            sqrt_kp1,
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+            IRApply(LOG, (kp1,)),  # 58th log
+            IRApply(LOG, (kp1,)),  # 59th log
+            IRApply(LOG, (kp1,)),  # 60th log
+            IRApply(LOG, (kp1,)),  # 61st log (over 59; refused)
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase403TwoSqrtFiftyNineLogPoly:
+    """Phase 403 -- Two-Sqrt x Fifty-Nine-Log x polynomial numerator."""
+
+    def test_2sqrt_k_log59_k_over_k2_closes(self):
+        """sqrt(k)^2*log(k)^59/k^2: eff_x2=2; 2*2=4 > 2 -> closes"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        sqrt_k = IRApply(SQRT, (_k,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_k = IRApply(MUL, (
+            sqrt_k, sqrt_k,
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+            IRApply(LOG, (_k,)),  # 58th log
+            IRApply(LOG, (_k,)),  # 59th log
+        ))
+        num_kp1 = IRApply(MUL, (
+            sqrt_kp1, sqrt_kp1,
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+            IRApply(LOG, (kp1,)),  # 58th log
+            IRApply(LOG, (kp1,)),  # 59th log
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_2sqrt_k_log59_k_over_k2_refused(self):
+        """sqrt(k)^2*log(k)^60/k2: 60 logs -> not Phase 403 -> refused"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        sqrt_k = IRApply(SQRT, (_k,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_k = IRApply(MUL, (
+            sqrt_k, sqrt_k,
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+            IRApply(LOG, (_k,)),  # 58th log
+            IRApply(LOG, (_k,)),  # 59th log
+            IRApply(LOG, (_k,)),  # 60th log
+            IRApply(LOG, (_k,)),  # 61st log (over 59; refused)
+        ))
+        num_kp1 = IRApply(MUL, (
+            sqrt_kp1, sqrt_kp1,
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+            IRApply(LOG, (kp1,)),  # 58th log
+            IRApply(LOG, (kp1,)),  # 59th log
+            IRApply(LOG, (kp1,)),  # 60th log
+            IRApply(LOG, (kp1,)),  # 61st log (over 59; refused)
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase404ThreeSqrtFiftyNineLogPoly:
+    """Phase 404 -- Three-Sqrt x Fifty-Nine-Log x polynomial numerator."""
+
+    def test_3sqrt_k_log59_k_over_k3_closes(self):
+        """sqrt(k)^3*log(k)^59/k^3: eff_x2=3; 2*3=6 > 3 -> closes"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        sqrt_k = IRApply(SQRT, (_k,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_k = IRApply(MUL, (
+            sqrt_k, sqrt_k, sqrt_k,
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+            IRApply(LOG, (_k,)),  # 58th log
+            IRApply(LOG, (_k,)),  # 59th log
+        ))
+        num_kp1 = IRApply(MUL, (
+            sqrt_kp1, sqrt_kp1, sqrt_kp1,
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+            IRApply(LOG, (kp1,)),  # 58th log
+            IRApply(LOG, (kp1,)),  # 59th log
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_3sqrt_k_log59_k_over_k3_refused(self):
+        """sqrt(k)^3*log(k)^60/k3: 60 logs -> not Phase 404 -> refused"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        sqrt_k = IRApply(SQRT, (_k,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_k = IRApply(MUL, (
+            sqrt_k, sqrt_k, sqrt_k,
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+            IRApply(LOG, (_k,)),  # 58th log
+            IRApply(LOG, (_k,)),  # 59th log
+            IRApply(LOG, (_k,)),  # 60th log
+            IRApply(LOG, (_k,)),  # 61st log (over 59; refused)
+        ))
+        num_kp1 = IRApply(MUL, (
+            sqrt_kp1, sqrt_kp1, sqrt_kp1,
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+            IRApply(LOG, (kp1,)),  # 58th log
+            IRApply(LOG, (kp1,)),  # 59th log
+            IRApply(LOG, (kp1,)),  # 60th log
+            IRApply(LOG, (kp1,)),  # 61st log (over 59; refused)
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase405FourSqrtFiftyNineLogPoly:
+    """Phase 405 -- Four-Sqrt x Fifty-Nine-Log x polynomial numerator."""
+
+    def test_4sqrt_k_log59_k_over_k3_closes(self):
+        """sqrt(k)^4*log(k)^59/k^3: eff_x2=4; 2*3=6 > 4 -> closes"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        sqrt_k = IRApply(SQRT, (_k,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_k = IRApply(MUL, (
+            sqrt_k, sqrt_k, sqrt_k, sqrt_k,
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+            IRApply(LOG, (_k,)),  # 58th log
+            IRApply(LOG, (_k,)),  # 59th log
+        ))
+        num_kp1 = IRApply(MUL, (
+            sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+            IRApply(LOG, (kp1,)),  # 58th log
+            IRApply(LOG, (kp1,)),  # 59th log
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_4sqrt_k_log59_k_over_k3_refused(self):
+        """sqrt(k)^4*log(k)^60/k3: 60 logs -> not Phase 405 -> refused"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        sqrt_k = IRApply(SQRT, (_k,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_k = IRApply(MUL, (
+            sqrt_k, sqrt_k, sqrt_k, sqrt_k,
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+            IRApply(LOG, (_k,)),  # 58th log
+            IRApply(LOG, (_k,)),  # 59th log
+            IRApply(LOG, (_k,)),  # 60th log
+            IRApply(LOG, (_k,)),  # 61st log (over 59; refused)
+        ))
+        num_kp1 = IRApply(MUL, (
+            sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+            IRApply(LOG, (kp1,)),  # 58th log
+            IRApply(LOG, (kp1,)),  # 59th log
+            IRApply(LOG, (kp1,)),  # 60th log
+            IRApply(LOG, (kp1,)),  # 61st log (over 59; refused)
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase406FiveSqrtFiftyNineLogPoly:
+    """Phase 406 -- Five-Sqrt x Fifty-Nine-Log x polynomial numerator."""
+
+    def test_5sqrt_k_log59_k_over_k3_closes(self):
+        """sqrt(k)^5*log(k)^59/k^3: eff_x2=5; 2*3=6 > 5 -> closes"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        sqrt_k = IRApply(SQRT, (_k,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_k = IRApply(MUL, (
+            sqrt_k, sqrt_k, sqrt_k, sqrt_k, sqrt_k,
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+            IRApply(LOG, (_k,)),  # 58th log
+            IRApply(LOG, (_k,)),  # 59th log
+        ))
+        num_kp1 = IRApply(MUL, (
+            sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+            IRApply(LOG, (kp1,)),  # 58th log
+            IRApply(LOG, (kp1,)),  # 59th log
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_5sqrt_k_log59_k_over_k3_refused(self):
+        """sqrt(k)^5*log(k)^60/k3: 60 logs -> not Phase 406 -> refused"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        sqrt_k = IRApply(SQRT, (_k,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_k = IRApply(MUL, (
+            sqrt_k, sqrt_k, sqrt_k, sqrt_k, sqrt_k,
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+            IRApply(LOG, (_k,)),  # 58th log
+            IRApply(LOG, (_k,)),  # 59th log
+            IRApply(LOG, (_k,)),  # 60th log
+            IRApply(LOG, (_k,)),  # 61st log (over 59; refused)
+        ))
+        num_kp1 = IRApply(MUL, (
+            sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+            IRApply(LOG, (kp1,)),  # 58th log
+            IRApply(LOG, (kp1,)),  # 59th log
+            IRApply(LOG, (kp1,)),  # 60th log
+            IRApply(LOG, (kp1,)),  # 61st log (over 59; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))

--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.343.0 — 2026-05-28
+
+### Added
+- Phase 401 (`fifty_nine_log_poly_effective_x2`): Zero-Sqrt × Fifty-Nine-Log × polynomial numerator recognizer.
+- Phase 402 (`one_sqrt_fifty_nine_log_poly_effective_x2`): One-Sqrt × Fifty-Nine-Log.
+- Phase 403 (`two_sqrt_fifty_nine_log_poly_effective_x2`): Two-Sqrt × Fifty-Nine-Log.
+- Phase 404 (`three_sqrt_fifty_nine_log_poly_effective_x2`): Three-Sqrt × Fifty-Nine-Log.
+- Phase 405 (`four_sqrt_fifty_nine_log_poly_effective_x2`): Four-Sqrt × Fifty-Nine-Log.
+- Phase 406 (`five_sqrt_fifty_nine_log_poly_effective_x2`): Five-Sqrt × Fifty-Nine-Log. Completes the Fifty-Nine-Log family.
+- 12 new test functions covering Phase 401–406 (converges + refused for each).
+- Cascade fix: Phase 395–400 refused tests updated from 59→60 log factors.
+
 ## 2.337.0 — 2026-05-28
 
 ### Added

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "2.337.0"
+version = "2.343.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -7983,6 +7983,169 @@ fn five_sqrt_fifty_seven_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Opt
     Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg_sum)
 }
 
+/// Phase 401 — Zero-Sqrt × Fifty-Nine-Log × polynomial numerator.
+///
+/// The Fifty-Nine-Log family (Phases 401–406) extends the recogniser to
+/// summands whose numerator contains exactly fifty-nine logarithmic factors
+/// and zero to five square-root factors.  This is Phase 401: zero sqrts.
+fn fifty_nine_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if sqrt_effective_half_degree_x2(arg, k).is_some() { return None; }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 59 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg; continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if log_count != 59 { return None; }
+    Some(2 * poly_deg_sum)
+}
+
+/// Phase 402 — One-Sqrt × Fifty-Nine-Log × polynomial numerator.
+fn one_sqrt_fifty_nine_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut sqrt_deg: Option<i64> = None;
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if let Some(hd) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_deg.is_some() { return None; }
+            sqrt_deg = Some(hd); continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 59 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg; continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_deg.is_none() || log_count != 59 { return None; }
+    Some(sqrt_deg.unwrap() + 2 * poly_deg_sum)
+}
+
+/// Phase 403 — Two-Sqrt × Fifty-Nine-Log × polynomial numerator.
+fn two_sqrt_fifty_nine_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut sqrt_degs: Vec<i64> = Vec::new();
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if let Some(hd) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs.len() >= 2 { return None; }
+            sqrt_degs.push(hd); continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 59 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg; continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs.len() != 2 || log_count != 59 { return None; }
+    Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg_sum)
+}
+
+/// Phase 404 — Three-Sqrt × Fifty-Nine-Log × polynomial numerator.
+fn three_sqrt_fifty_nine_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut sqrt_degs: Vec<i64> = Vec::new();
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if let Some(hd) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs.len() >= 3 { return None; }
+            sqrt_degs.push(hd); continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 59 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg; continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs.len() != 3 || log_count != 59 { return None; }
+    Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg_sum)
+}
+
+/// Phase 405 — Four-Sqrt × Fifty-Nine-Log × polynomial numerator.
+fn four_sqrt_fifty_nine_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut sqrt_degs: Vec<i64> = Vec::new();
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if let Some(hd) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs.len() >= 4 { return None; }
+            sqrt_degs.push(hd); continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 59 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg; continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs.len() != 4 || log_count != 59 { return None; }
+    Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg_sum)
+}
+
+/// Phase 406 — Five-Sqrt × Fifty-Nine-Log × polynomial numerator.
+/// Completes the Fifty-Nine-Log family (Phases 401–406).
+fn five_sqrt_fifty_nine_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut sqrt_degs: Vec<i64> = Vec::new();
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if let Some(hd) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs.len() >= 5 { return None; }
+            sqrt_degs.push(hd); continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 59 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg; continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs.len() != 5 || log_count != 59 { return None; }
+    Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg_sum)
+}
+
 /// Phase 395 — Zero-Sqrt × Fifty-Eight-Log × polynomial numerator.
 ///
 /// The Fifty-Eight-Log family (Phases 395–400) extends the recogniser to
@@ -11514,6 +11677,42 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
         } else if h_diverges_at_infinity(den, k) {
             return true;
         }
+    }
+    // Phase 406: Mul(Sqrt(P1)×5, Log(h1)×59, ...) numerator.
+    if let Some(s5l59_x2) = five_sqrt_fifty_nine_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s5l59) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s5l59 > s5l59_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 405: Mul(Sqrt(P1)×4, Log(h1)×59, ...) numerator.
+    if let Some(s4l59_x2) = four_sqrt_fifty_nine_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s4l59) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s4l59 > s4l59_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 404: Mul(Sqrt(P1)×3, Log(h1)×59, ...) numerator.
+    if let Some(s3l59_x2) = three_sqrt_fifty_nine_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s3l59) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s3l59 > s3l59_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 403: Mul(Sqrt(P), Sqrt(P2), Log(h1)×59, ...) numerator.
+    if let Some(s2l59_x2) = two_sqrt_fifty_nine_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s2l59) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s2l59 > s2l59_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 402: Mul(Sqrt(P), Log(h1)×59, ...) numerator.
+    if let Some(s1l59_x2) = one_sqrt_fifty_nine_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s1l59) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s1l59 > s1l59_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 401: Mul(Log(h1)×59, ...) numerator.
+    if let Some(sl59_x2) = fifty_nine_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_sl59) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_sl59 > sl59_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
     }
     // Phase 400: Mul(Sqrt(P1)×5, Log(h1)×58, ...) numerator.
     if let Some(s5l58_x2) = five_sqrt_fifty_eight_log_poly_effective_x2(num, k) {

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -13278,7 +13278,8 @@ fn phase191_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log (over 59; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -13314,7 +13315,8 @@ fn phase191_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log (over 59; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -13441,7 +13443,8 @@ fn phase192_sqrt_k_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log (over 59; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -13478,7 +13481,8 @@ fn phase192_sqrt_k_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log (over 59; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -14018,7 +14022,8 @@ fn phase197_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log (over 59; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -14054,7 +14059,8 @@ fn phase197_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log (over 59; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -14800,7 +14806,8 @@ fn phase203_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log (over 59; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -14836,7 +14843,8 @@ fn phase203_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log (over 59; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -15587,7 +15595,8 @@ fn phase209_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log (over 59; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -15624,7 +15633,8 @@ fn phase209_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log (over 59; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -16405,7 +16415,8 @@ fn phase215_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log (over 59; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -16442,7 +16453,8 @@ fn phase215_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log (over 59; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -17223,7 +17235,8 @@ fn phase221_log30_k_times_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log (over 59; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -17260,7 +17273,8 @@ fn phase221_log30_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log (over 59; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -18041,7 +18055,8 @@ fn phase227_log31_k_times_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log (over 59; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -18078,7 +18093,8 @@ fn phase227_log31_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log (over 59; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -18859,7 +18875,8 @@ fn phase233_log32_k_times_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log (over 59; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -18896,7 +18913,8 @@ fn phase233_log32_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log (over 59; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -19678,7 +19696,8 @@ fn phase239_log33_k_times_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log (over 59; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -19714,7 +19733,8 @@ fn phase239_log33_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log (over 59; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -20497,7 +20517,8 @@ fn phase245_log34_k_times_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log (over 59; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -20532,7 +20553,8 @@ fn phase245_log34_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log (over 59; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -21314,7 +21336,8 @@ fn phase251_log36_k_times_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log (over 59; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -21348,7 +21371,8 @@ fn phase251_log36_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log (over 59; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -22120,7 +22144,8 @@ fn phase257_log36_k_times_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log (over 59; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -22154,7 +22179,8 @@ fn phase257_log36_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log (over 59; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -23711,7 +23737,8 @@ fn phase269_log38_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log (over 59; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -23745,7 +23772,8 @@ fn phase269_log38_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log (over 59; refused)
         kp1.clone(),
     ]);
     let g_k269c = apply(sym(DIV), vec![num_k, k2]);
@@ -23886,7 +23914,8 @@ fn phase270_sqrt_k_log38_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log (over 59; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -23921,7 +23950,8 @@ fn phase270_sqrt_k_log38_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log (over 59; refused)
         kp1.clone(),
     ]);
     let g_k270c = apply(sym(DIV), vec![num_k, k2]);
@@ -24615,7 +24645,8 @@ fn phase275_log39_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log (over 59; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -24649,7 +24680,8 @@ fn phase275_log39_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log (over 59; refused)
         kp1.clone(),
     ]);
     let g_k275c = apply(sym(DIV), vec![num_k, k2]);
@@ -24794,7 +24826,8 @@ fn phase276_sqrt_k_log39_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log (over 59; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -24829,7 +24862,8 @@ fn phase276_sqrt_k_log39_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log (over 59; refused)
         kp1.clone(),
     ]);
     let g_k276c = apply(sym(DIV), vec![num_k, k2]);
@@ -25530,7 +25564,8 @@ fn phase281_log40_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log (over 59; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -25560,7 +25595,8 @@ fn phase281_log40_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log (over 59; refused)
         kp1.clone(),
     ]);
     let g_kphase281r = apply(sym(DIV), vec![num_k, k2]);
@@ -25693,7 +25729,8 @@ fn phase282_sqrt1_k_log40_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log (over 59; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -25724,7 +25761,8 @@ fn phase282_sqrt1_k_log40_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log (over 59; refused)
         kp1.clone(),
     ]);
     let g_kphase282r = apply(sym(DIV), vec![num_k, k2]);
@@ -26359,7 +26397,8 @@ fn phase287_log42_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -26387,7 +26426,8 @@ fn phase287_log42_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase287r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase287r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -26518,7 +26558,8 @@ fn phase288_sqrt1_k_log42_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -26547,7 +26588,8 @@ fn phase288_sqrt1_k_log42_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase288r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase288r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -26678,7 +26720,8 @@ fn phase289_sqrt2_k_log42_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -26707,7 +26750,8 @@ fn phase289_sqrt2_k_log42_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase289r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase289r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -26838,7 +26882,8 @@ fn phase290_sqrt3_k_log42_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -26867,7 +26912,8 @@ fn phase290_sqrt3_k_log42_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase290r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase290r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -26998,7 +27044,8 @@ fn phase291_sqrt4_k_log42_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -27027,7 +27074,8 @@ fn phase291_sqrt4_k_log42_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase291r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase291r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -27158,7 +27206,8 @@ fn phase292_sqrt5_k_log42_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -27187,7 +27236,8 @@ fn phase292_sqrt5_k_log42_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase292r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase292r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -27271,7 +27321,8 @@ fn phase293_log42_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -27299,7 +27350,8 @@ fn phase293_log42_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase293r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase293r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -27390,7 +27442,8 @@ fn phase294_sqrt1_k_log42_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -27419,7 +27472,8 @@ fn phase294_sqrt1_k_log42_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase294r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase294r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -27510,7 +27564,8 @@ fn phase295_sqrt2_k_log42_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -27539,7 +27594,8 @@ fn phase295_sqrt2_k_log42_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase295r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase295r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -27630,7 +27686,8 @@ fn phase296_sqrt3_k_log42_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -27659,7 +27716,8 @@ fn phase296_sqrt3_k_log42_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase296r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase296r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -27750,7 +27808,8 @@ fn phase297_sqrt4_k_log42_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -27779,7 +27838,8 @@ fn phase297_sqrt4_k_log42_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase297r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase297r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -27870,7 +27930,8 @@ fn phase298_sqrt5_k_log42_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -27899,7 +27960,8 @@ fn phase298_sqrt5_k_log42_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase298r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase298r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -27983,7 +28045,8 @@ fn phase299_log45_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -28011,7 +28074,8 @@ fn phase299_log45_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase299r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase299r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -28102,7 +28166,8 @@ fn phase300_sqrt1_k_log45_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -28131,7 +28196,8 @@ fn phase300_sqrt1_k_log45_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase300r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase300r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -28222,7 +28288,8 @@ fn phase301_sqrt2_k_log45_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -28251,7 +28318,8 @@ fn phase301_sqrt2_k_log45_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase301r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase301r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -28342,7 +28410,8 @@ fn phase302_sqrt3_k_log45_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -28371,7 +28440,8 @@ fn phase302_sqrt3_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase302r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase302r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -28462,7 +28532,8 @@ fn phase303_sqrt4_k_log45_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -28491,7 +28562,8 @@ fn phase303_sqrt4_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase303r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase303r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -28582,7 +28654,8 @@ fn phase304_sqrt5_k_log45_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -28611,7 +28684,8 @@ fn phase304_sqrt5_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase304r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase304r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -28695,7 +28769,8 @@ fn phase305_log45_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -28722,7 +28797,8 @@ fn phase305_log45_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase305r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase305r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -28812,7 +28888,8 @@ fn phase306_sqrt1_k_log45_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -28840,7 +28917,8 @@ fn phase306_sqrt1_k_log45_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase306r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase306r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -28930,7 +29008,8 @@ fn phase307_sqrt2_k_log45_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -28958,7 +29037,8 @@ fn phase307_sqrt2_k_log45_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase307r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase307r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -29048,7 +29128,8 @@ fn phase308_sqrt3_k_log45_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -29076,7 +29157,8 @@ fn phase308_sqrt3_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase308r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase308r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -29166,7 +29248,8 @@ fn phase309_sqrt4_k_log45_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -29194,7 +29277,8 @@ fn phase309_sqrt4_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase309r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase309r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -29284,7 +29368,8 @@ fn phase310_sqrt5_k_log45_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -29312,7 +29397,8 @@ fn phase310_sqrt5_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase310r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase310r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -29394,7 +29480,8 @@ fn phase311_log45_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -29420,7 +29507,8 @@ fn phase311_log45_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase311r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase311r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -29509,7 +29597,8 @@ fn phase312_sqrt1_k_log45_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -29536,7 +29625,8 @@ fn phase312_sqrt1_k_log45_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase312r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase312r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -29625,7 +29715,8 @@ fn phase313_sqrt2_k_log45_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -29652,7 +29743,8 @@ fn phase313_sqrt2_k_log45_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase313r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase313r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -29741,7 +29833,8 @@ fn phase314_sqrt3_k_log45_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -29768,7 +29861,8 @@ fn phase314_sqrt3_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase314r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase314r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -29857,7 +29951,8 @@ fn phase315_sqrt4_k_log45_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -29884,7 +29979,8 @@ fn phase315_sqrt4_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase315r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase315r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -29973,7 +30069,8 @@ fn phase316_sqrt5_k_log45_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -30000,7 +30097,8 @@ fn phase316_sqrt5_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase316r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase316r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -30081,7 +30179,8 @@ fn phase317_log46_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -30106,7 +30205,8 @@ fn phase317_log46_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase317r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase317r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -30194,7 +30294,8 @@ fn phase318_sqrt1_k_log46_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -30220,7 +30321,8 @@ fn phase318_sqrt1_k_log46_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase318r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase318r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -30308,7 +30410,8 @@ fn phase319_sqrt2_k_log46_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -30334,7 +30437,8 @@ fn phase319_sqrt2_k_log46_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase319r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase319r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -30422,7 +30526,8 @@ fn phase320_sqrt3_k_log46_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -30448,7 +30553,8 @@ fn phase320_sqrt3_k_log46_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase320r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase320r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -30536,7 +30642,8 @@ fn phase321_sqrt4_k_log46_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -30562,7 +30669,8 @@ fn phase321_sqrt4_k_log46_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase321r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase321r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -30650,7 +30758,8 @@ fn phase322_sqrt5_k_log46_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -30676,7 +30785,8 @@ fn phase322_sqrt5_k_log46_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase322r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase322r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -30759,7 +30869,8 @@ fn phase323_log47_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -30784,7 +30895,8 @@ fn phase323_log47_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase323r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase323r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -30874,7 +30986,8 @@ fn phase324_sqrt1_k_log47_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -30900,7 +31013,8 @@ fn phase324_sqrt1_k_log47_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase324r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase324r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -30990,7 +31104,8 @@ fn phase325_sqrt2_k_log47_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -31016,7 +31131,8 @@ fn phase325_sqrt2_k_log47_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase325r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase325r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -31106,7 +31222,8 @@ fn phase326_sqrt3_k_log47_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -31132,7 +31249,8 @@ fn phase326_sqrt3_k_log47_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase326r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase326r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -31222,7 +31340,8 @@ fn phase327_sqrt4_k_log47_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -31248,7 +31367,8 @@ fn phase327_sqrt4_k_log47_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase327r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase327r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -31338,7 +31458,8 @@ fn phase328_sqrt5_k_log47_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -31364,7 +31485,8 @@ fn phase328_sqrt5_k_log47_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase328r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase328r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -31419,7 +31541,7 @@ fn phase329_log47_k_over_k2_converges() {
 
 #[test]
 fn phase329_log48_k_over_k2_refused() {
-    // phase329 log48 k over k2 refused: 59 logs → refused (Phase 395 handles exactly 58).
+    // phase329 log48 k over k2 refused: 60 logs → refused (Phase 401 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -31449,7 +31571,8 @@ fn phase329_log48_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -31474,7 +31597,8 @@ fn phase329_log48_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase329r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase329r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -31533,7 +31657,7 @@ fn phase330_sqrt1_k_log47_k_over_k2_converges() {
 
 #[test]
 fn phase330_sqrt1_k_log48_k_over_k2_refused() {
-    // phase330 sqrt1 k log48 k over k2 refused: 59 logs → refused (Phase 396 handles exactly 58).
+    // phase330 sqrt1 k log48 k over k2 refused: 60 logs → refused (Phase 402 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -31566,7 +31690,8 @@ fn phase330_sqrt1_k_log48_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -31592,7 +31717,8 @@ fn phase330_sqrt1_k_log48_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase330r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase330r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -31651,7 +31777,7 @@ fn phase331_sqrt2_k_log47_k_over_k2_converges() {
 
 #[test]
 fn phase331_sqrt2_k_log48_k_over_k2_refused() {
-    // phase331 sqrt2 k log48 k over k2 refused: 59 logs → refused (Phase 397 handles exactly 58).
+    // phase331 sqrt2 k log48 k over k2 refused: 60 logs → refused (Phase 403 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -31684,7 +31810,8 @@ fn phase331_sqrt2_k_log48_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -31710,7 +31837,8 @@ fn phase331_sqrt2_k_log48_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase331r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase331r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -31769,7 +31897,7 @@ fn phase332_sqrt3_k_log47_k_over_k3_converges() {
 
 #[test]
 fn phase332_sqrt3_k_log48_k_over_k3_refused() {
-    // phase332 sqrt3 k log48 k over k3 refused: 59 logs → refused (Phase 398 handles exactly 58).
+    // phase332 sqrt3 k log48 k over k3 refused: 60 logs → refused (Phase 404 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -31802,7 +31930,8 @@ fn phase332_sqrt3_k_log48_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -31828,7 +31957,8 @@ fn phase332_sqrt3_k_log48_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase332r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase332r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -31887,7 +32017,7 @@ fn phase333_sqrt4_k_log47_k_over_k3_converges() {
 
 #[test]
 fn phase333_sqrt4_k_log48_k_over_k3_refused() {
-    // phase333 sqrt4 k log48 k over k3 refused: 59 logs → refused (Phase 399 handles exactly 58).
+    // phase333 sqrt4 k log48 k over k3 refused: 60 logs → refused (Phase 405 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -31920,7 +32050,8 @@ fn phase333_sqrt4_k_log48_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -31946,7 +32077,8 @@ fn phase333_sqrt4_k_log48_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase333r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase333r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -32005,7 +32137,7 @@ fn phase334_sqrt5_k_log47_k_over_k3_converges() {
 
 #[test]
 fn phase334_sqrt5_k_log48_k_over_k3_refused() {
-    // phase334 sqrt5 k log48 k over k3 refused: 59 logs → refused (Phase 400 handles exactly 58).
+    // phase334 sqrt5 k log48 k over k3 refused: 60 logs → refused (Phase 406 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -32038,7 +32170,8 @@ fn phase334_sqrt5_k_log48_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -32064,7 +32197,8 @@ fn phase334_sqrt5_k_log48_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase334r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase334r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -32119,7 +32253,7 @@ fn phase335_log48_k_over_k2_converges() {
 
 #[test]
 fn phase335_log50_k_over_k2_refused() {
-    // log(k)^50 / k2: 59 logs → refused (Phase 395 handles exactly 58).
+    // log(k)^50 / k2: 60 logs → refused (Phase 401 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -32149,7 +32283,8 @@ fn phase335_log50_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -32174,7 +32309,8 @@ fn phase335_log50_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase335r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase335r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -32233,7 +32369,7 @@ fn phase336_sqrt1_k_log48_k_over_k2_converges() {
 
 #[test]
 fn phase336_sqrt1_k_log50_k_over_k2_refused() {
-    // sqrt(k)*log(k)^50 / k2: 59 logs → refused (Phase 396 handles exactly 58).
+    // sqrt(k)*log(k)^50 / k2: 60 logs → refused (Phase 402 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -32266,7 +32402,8 @@ fn phase336_sqrt1_k_log50_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -32292,7 +32429,8 @@ fn phase336_sqrt1_k_log50_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase336r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase336r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -32351,7 +32489,7 @@ fn phase337_sqrt2_k_log48_k_over_k2_converges() {
 
 #[test]
 fn phase337_sqrt2_k_log50_k_over_k2_refused() {
-    // sqrt(k)^2*log(k)^50 / k2: 59 logs → refused (Phase 397 handles exactly 58).
+    // sqrt(k)^2*log(k)^50 / k2: 60 logs → refused (Phase 403 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -32384,7 +32522,8 @@ fn phase337_sqrt2_k_log50_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -32410,7 +32549,8 @@ fn phase337_sqrt2_k_log50_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase337r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase337r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -32469,7 +32609,7 @@ fn phase338_sqrt3_k_log48_k_over_k3_converges() {
 
 #[test]
 fn phase338_sqrt3_k_log50_k_over_k3_refused() {
-    // sqrt(k)^3*log(k)^50 / k3: 59 logs → refused (Phase 398 handles exactly 58).
+    // sqrt(k)^3*log(k)^50 / k3: 60 logs → refused (Phase 404 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -32502,7 +32642,8 @@ fn phase338_sqrt3_k_log50_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -32528,7 +32669,8 @@ fn phase338_sqrt3_k_log50_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase338r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase338r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -32587,7 +32729,7 @@ fn phase339_sqrt4_k_log48_k_over_k3_converges() {
 
 #[test]
 fn phase339_sqrt4_k_log50_k_over_k3_refused() {
-    // sqrt(k)^4*log(k)^50 / k3: 59 logs → refused (Phase 399 handles exactly 58).
+    // sqrt(k)^4*log(k)^50 / k3: 60 logs → refused (Phase 405 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -32620,7 +32762,8 @@ fn phase339_sqrt4_k_log50_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -32646,7 +32789,8 @@ fn phase339_sqrt4_k_log50_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase339r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase339r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -32705,7 +32849,7 @@ fn phase340_sqrt5_k_log48_k_over_k3_converges() {
 
 #[test]
 fn phase340_sqrt5_k_log50_k_over_k3_refused() {
-    // sqrt(k)^5*log(k)^50 / k3: 59 logs → refused (Phase 400 handles exactly 58).
+    // sqrt(k)^5*log(k)^50 / k3: 60 logs → refused (Phase 406 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -32738,7 +32882,8 @@ fn phase340_sqrt5_k_log50_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -32764,7 +32909,8 @@ fn phase340_sqrt5_k_log50_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase340r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase340r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -32821,7 +32967,7 @@ fn phase341_log49_k_over_k2_converges() {
 
 #[test]
 fn phase341_log50_k_over_k2_refused() {
-    // log(k)^50 / k2: 59 logs → refused (Phase 395 handles exactly 58).
+    // log(k)^50 / k2: 60 logs → refused (Phase 401 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -32851,7 +32997,8 @@ fn phase341_log50_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -32876,7 +33023,8 @@ fn phase341_log50_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase341r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase341r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -32937,7 +33085,7 @@ fn phase342_sqrt1_k_log49_k_over_k2_converges() {
 
 #[test]
 fn phase342_sqrt1_k_log50_k_over_k2_refused() {
-    // sqrt(k)*log(k)^50 / k2: 59 logs → refused (Phase 396 handles exactly 58).
+    // sqrt(k)*log(k)^50 / k2: 60 logs → refused (Phase 402 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -32970,7 +33118,8 @@ fn phase342_sqrt1_k_log50_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -32996,7 +33145,8 @@ fn phase342_sqrt1_k_log50_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase342r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase342r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -33057,7 +33207,7 @@ fn phase343_sqrt2_k_log49_k_over_k3_converges() {
 
 #[test]
 fn phase343_sqrt2_k_log50_k_over_k2_refused() {
-    // sqrt(k)^2*log(k)^50 / k2: 59 logs → refused (Phase 397 handles exactly 58).
+    // sqrt(k)^2*log(k)^50 / k2: 60 logs → refused (Phase 403 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -33090,7 +33240,8 @@ fn phase343_sqrt2_k_log50_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -33116,7 +33267,8 @@ fn phase343_sqrt2_k_log50_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase343r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase343r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -33177,7 +33329,7 @@ fn phase344_sqrt3_k_log49_k_over_k3_converges() {
 
 #[test]
 fn phase344_sqrt3_k_log50_k_over_k3_refused() {
-    // sqrt(k)^3*log(k)^50 / k3: 59 logs → refused (Phase 398 handles exactly 58).
+    // sqrt(k)^3*log(k)^50 / k3: 60 logs → refused (Phase 404 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -33210,7 +33362,8 @@ fn phase344_sqrt3_k_log50_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -33236,7 +33389,8 @@ fn phase344_sqrt3_k_log50_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase344r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase344r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -33297,7 +33451,7 @@ fn phase345_sqrt4_k_log49_k_over_k3_converges() {
 
 #[test]
 fn phase345_sqrt4_k_log50_k_over_k3_refused() {
-    // sqrt(k)^4*log(k)^50 / k3: 59 logs → refused (Phase 399 handles exactly 58).
+    // sqrt(k)^4*log(k)^50 / k3: 60 logs → refused (Phase 405 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -33330,7 +33484,8 @@ fn phase345_sqrt4_k_log50_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -33356,7 +33511,8 @@ fn phase345_sqrt4_k_log50_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase345r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase345r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -33417,7 +33573,7 @@ fn phase346_sqrt5_k_log49_k_over_k3_converges() {
 
 #[test]
 fn phase346_sqrt5_k_log50_k_over_k3_refused() {
-    // sqrt(k)^5*log(k)^50 / k3: 59 logs → refused (Phase 400 handles exactly 58).
+    // sqrt(k)^5*log(k)^50 / k3: 60 logs → refused (Phase 406 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -33450,7 +33606,8 @@ fn phase346_sqrt5_k_log50_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -33476,7 +33633,8 @@ fn phase346_sqrt5_k_log50_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase346r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase346r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -33535,7 +33693,7 @@ fn phase347_log50_k_over_k2_converges() {
 
 #[test]
 fn phase347_log51_k_over_k2_refused() {
-    // log(k)^51 / k2: 59 logs → refused (Phase 395 handles exactly 58).
+    // log(k)^51 / k2: 60 logs → refused (Phase 401 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -33565,7 +33723,8 @@ fn phase347_log51_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -33590,7 +33749,8 @@ fn phase347_log51_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase347r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase347r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -33653,7 +33813,7 @@ fn phase348_sqrt1_k_log50_k_over_k2_converges() {
 
 #[test]
 fn phase348_sqrt1_k_log51_k_over_k2_refused() {
-    // sqrt(k)*log(k)^51 / k2: 59 logs → refused (Phase 396 handles exactly 58).
+    // sqrt(k)*log(k)^51 / k2: 60 logs → refused (Phase 402 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -33686,7 +33846,8 @@ fn phase348_sqrt1_k_log51_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -33712,7 +33873,8 @@ fn phase348_sqrt1_k_log51_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase348r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase348r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -33775,7 +33937,7 @@ fn phase349_sqrt2_k_log50_k_over_k3_converges() {
 
 #[test]
 fn phase349_sqrt2_k_log51_k_over_k2_refused() {
-    // sqrt(k)^2*log(k)^51 / k2: 59 logs → refused (Phase 397 handles exactly 58).
+    // sqrt(k)^2*log(k)^51 / k2: 60 logs → refused (Phase 403 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -33808,7 +33970,8 @@ fn phase349_sqrt2_k_log51_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -33834,7 +33997,8 @@ fn phase349_sqrt2_k_log51_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase349r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase349r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -33897,7 +34061,7 @@ fn phase350_sqrt3_k_log50_k_over_k3_converges() {
 
 #[test]
 fn phase350_sqrt3_k_log51_k_over_k3_refused() {
-    // sqrt(k)^3*log(k)^51 / k3: 59 logs → refused (Phase 398 handles exactly 58).
+    // sqrt(k)^3*log(k)^51 / k3: 60 logs → refused (Phase 404 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -33930,7 +34094,8 @@ fn phase350_sqrt3_k_log51_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -33956,7 +34121,8 @@ fn phase350_sqrt3_k_log51_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase350r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase350r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -34019,7 +34185,7 @@ fn phase351_sqrt4_k_log50_k_over_k3_converges() {
 
 #[test]
 fn phase351_sqrt4_k_log51_k_over_k3_refused() {
-    // sqrt(k)^4*log(k)^51 / k3: 59 logs → refused (Phase 399 handles exactly 58).
+    // sqrt(k)^4*log(k)^51 / k3: 60 logs → refused (Phase 405 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -34052,7 +34218,8 @@ fn phase351_sqrt4_k_log51_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -34078,7 +34245,8 @@ fn phase351_sqrt4_k_log51_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase351r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase351r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -34141,7 +34309,7 @@ fn phase352_sqrt5_k_log50_k_over_k3_converges() {
 
 #[test]
 fn phase352_sqrt5_k_log51_k_over_k3_refused() {
-    // sqrt(k)^5*log(k)^51 / k3: 59 logs → refused (Phase 400 handles exactly 58).
+    // sqrt(k)^5*log(k)^51 / k3: 60 logs → refused (Phase 406 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -34174,7 +34342,8 @@ fn phase352_sqrt5_k_log51_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -34200,7 +34369,8 @@ fn phase352_sqrt5_k_log51_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase352r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase352r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -34261,7 +34431,7 @@ fn phase353_log51_k_over_k2_converges() {
 
 #[test]
 fn phase353_log52_k_over_k2_refused() {
-    // log(k)^52 / k2: 59 logs → refused (Phase 395 handles exactly 58).
+    // log(k)^52 / k2: 60 logs → refused (Phase 401 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -34291,7 +34461,8 @@ fn phase353_log52_k_over_k2_refused() {
         log_k.clone(), // 54th log
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -34316,7 +34487,8 @@ fn phase353_log52_k_over_k2_refused() {
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase353r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase353r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -34381,7 +34553,7 @@ fn phase354_sqrt1_k_log51_k_over_k2_converges() {
 
 #[test]
 fn phase354_sqrt1_k_log52_k_over_k2_refused() {
-    // sqrt(k)^1*log(k)^52 / k2: 59 logs → refused (Phase 396 handles exactly 58).
+    // sqrt(k)^1*log(k)^52 / k2: 60 logs → refused (Phase 402 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -34414,7 +34586,8 @@ fn phase354_sqrt1_k_log52_k_over_k2_refused() {
         log_k.clone(), // 54th log
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -34440,7 +34613,8 @@ fn phase354_sqrt1_k_log52_k_over_k2_refused() {
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase354r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase354r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -34505,7 +34679,7 @@ fn phase355_sqrt2_k_log51_k_over_k3_converges() {
 
 #[test]
 fn phase355_sqrt2_k_log52_k_over_k3_refused() {
-    // sqrt(k)^2*log(k)^52 / k3: 59 logs → refused (Phase 397 handles exactly 58).
+    // sqrt(k)^2*log(k)^52 / k3: 60 logs → refused (Phase 403 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -34538,7 +34712,8 @@ fn phase355_sqrt2_k_log52_k_over_k3_refused() {
         log_k.clone(), // 54th log
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -34564,7 +34739,8 @@ fn phase355_sqrt2_k_log52_k_over_k3_refused() {
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase355r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase355r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -34629,7 +34805,7 @@ fn phase356_sqrt3_k_log51_k_over_k3_converges() {
 
 #[test]
 fn phase356_sqrt3_k_log52_k_over_k3_refused() {
-    // sqrt(k)^3*log(k)^52 / k3: 59 logs → refused (Phase 398 handles exactly 58).
+    // sqrt(k)^3*log(k)^52 / k3: 60 logs → refused (Phase 404 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -34662,7 +34838,8 @@ fn phase356_sqrt3_k_log52_k_over_k3_refused() {
         log_k.clone(), // 54th log
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -34688,7 +34865,8 @@ fn phase356_sqrt3_k_log52_k_over_k3_refused() {
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase356r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase356r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -34753,7 +34931,7 @@ fn phase357_sqrt4_k_log51_k_over_k3_converges() {
 
 #[test]
 fn phase357_sqrt4_k_log52_k_over_k3_refused() {
-    // sqrt(k)^4*log(k)^52 / k3: 59 logs → refused (Phase 399 handles exactly 58).
+    // sqrt(k)^4*log(k)^52 / k3: 60 logs → refused (Phase 405 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -34786,7 +34964,8 @@ fn phase357_sqrt4_k_log52_k_over_k3_refused() {
         log_k.clone(), // 54th log
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -34812,7 +34991,8 @@ fn phase357_sqrt4_k_log52_k_over_k3_refused() {
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase357r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase357r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -34877,7 +35057,7 @@ fn phase358_sqrt5_k_log51_k_over_k3_converges() {
 
 #[test]
 fn phase358_sqrt5_k_log52_k_over_k3_refused() {
-    // sqrt(k)^5*log(k)^52 / k3: 59 logs → refused (Phase 400 handles exactly 58).
+    // sqrt(k)^5*log(k)^52 / k3: 60 logs → refused (Phase 406 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -34910,7 +35090,8 @@ fn phase358_sqrt5_k_log52_k_over_k3_refused() {
         log_k.clone(), // 54th log
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -34936,7 +35117,8 @@ fn phase358_sqrt5_k_log52_k_over_k3_refused() {
         log_kp1.clone(), // 54th log
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase358r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase358r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -35029,7 +35211,8 @@ fn phase359_log53_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -35054,7 +35237,8 @@ fn phase359_log53_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase359r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase359r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -35154,7 +35338,8 @@ fn phase360_sqrt1_k_log53_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -35180,7 +35365,8 @@ fn phase360_sqrt1_k_log53_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase360r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase360r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -35280,7 +35466,8 @@ fn phase361_sqrt2_k_log53_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -35306,7 +35493,8 @@ fn phase361_sqrt2_k_log53_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase361r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase361r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -35406,7 +35594,8 @@ fn phase362_sqrt3_k_log53_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -35432,7 +35621,8 @@ fn phase362_sqrt3_k_log53_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase362r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase362r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -35532,7 +35722,8 @@ fn phase363_sqrt4_k_log53_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -35558,7 +35749,8 @@ fn phase363_sqrt4_k_log53_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase363r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase363r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -35658,7 +35850,8 @@ fn phase364_sqrt5_k_log53_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -35684,7 +35877,8 @@ fn phase364_sqrt5_k_log53_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_kphase364r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase364r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -35748,7 +35942,7 @@ fn phase365_log53_k_over_k2_converges() {
 
 #[test]
 fn phase365_log53_k_over_k2_refused() {
-    // log53 k over k2: 59 logs → refused (Phase 395 handles exactly 58).
+    // log53 k over k2: 60 logs → refused (Phase 401 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -35778,7 +35972,8 @@ fn phase365_log53_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -35803,7 +35998,8 @@ fn phase365_log53_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_k365r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_365r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -35872,7 +36068,7 @@ fn phase366_sqrt1_k_log53_k_over_k2_converges() {
 
 #[test]
 fn phase366_sqrt1_k_log53_k_over_k2_refused() {
-    // sqrt1 k log53 k over k2: 59 logs → refused (Phase 396 handles exactly 58).
+    // sqrt1 k log53 k over k2: 60 logs → refused (Phase 402 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -35905,7 +36101,8 @@ fn phase366_sqrt1_k_log53_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -35931,7 +36128,8 @@ fn phase366_sqrt1_k_log53_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_k366r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_366r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -36000,7 +36198,7 @@ fn phase367_sqrt2_k_log53_k_over_k2_converges() {
 
 #[test]
 fn phase367_sqrt2_k_log53_k_over_k2_refused() {
-    // sqrt2 k log53 k over k2: 59 logs → refused (Phase 397 handles exactly 58).
+    // sqrt2 k log53 k over k2: 60 logs → refused (Phase 403 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -36033,7 +36231,8 @@ fn phase367_sqrt2_k_log53_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -36059,7 +36258,8 @@ fn phase367_sqrt2_k_log53_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_k367r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_367r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -36128,7 +36328,7 @@ fn phase368_sqrt3_k_log53_k_over_k3_converges() {
 
 #[test]
 fn phase368_sqrt3_k_log53_k_over_k3_refused() {
-    // sqrt3 k log53 k over k3: 59 logs → refused (Phase 398 handles exactly 58).
+    // sqrt3 k log53 k over k3: 60 logs → refused (Phase 404 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -36161,7 +36361,8 @@ fn phase368_sqrt3_k_log53_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -36187,7 +36388,8 @@ fn phase368_sqrt3_k_log53_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_k368r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_368r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -36256,7 +36458,7 @@ fn phase369_sqrt4_k_log53_k_over_k3_converges() {
 
 #[test]
 fn phase369_sqrt4_k_log53_k_over_k3_refused() {
-    // sqrt4 k log53 k over k3: 59 logs → refused (Phase 399 handles exactly 58).
+    // sqrt4 k log53 k over k3: 60 logs → refused (Phase 405 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -36289,7 +36491,8 @@ fn phase369_sqrt4_k_log53_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -36315,7 +36518,8 @@ fn phase369_sqrt4_k_log53_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_k369r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_369r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -36384,7 +36588,7 @@ fn phase370_sqrt5_k_log53_k_over_k3_converges() {
 
 #[test]
 fn phase370_sqrt5_k_log53_k_over_k3_refused() {
-    // sqrt5 k log53 k over k3: 59 logs → refused (Phase 400 handles exactly 58).
+    // sqrt5 k log53 k over k3: 60 logs → refused (Phase 406 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -36417,7 +36621,8 @@ fn phase370_sqrt5_k_log53_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -36443,7 +36648,8 @@ fn phase370_sqrt5_k_log53_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_k370r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_370r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -36510,7 +36716,7 @@ fn phase371_log54_k_over_k2_converges() {
 
 #[test]
 fn phase371_log54_k_over_k2_refused() {
-    // log54 k over k2: 59 logs → refused (Phase 395 handles exactly 58).
+    // log54 k over k2: 60 logs → refused (Phase 401 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -36540,7 +36746,8 @@ fn phase371_log54_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -36565,7 +36772,8 @@ fn phase371_log54_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_k371r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_371r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -36636,7 +36844,7 @@ fn phase372_sqrt1_k_log54_k_over_k2_converges() {
 
 #[test]
 fn phase372_sqrt1_k_log54_k_over_k2_refused() {
-    // sqrt1 k log54 k over k2: 59 logs → refused (Phase 396 handles exactly 58).
+    // sqrt1 k log54 k over k2: 60 logs → refused (Phase 402 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -36669,7 +36877,8 @@ fn phase372_sqrt1_k_log54_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -36695,7 +36904,8 @@ fn phase372_sqrt1_k_log54_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_k372r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_372r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -36766,7 +36976,7 @@ fn phase373_sqrt2_k_log54_k_over_k2_converges() {
 
 #[test]
 fn phase373_sqrt2_k_log54_k_over_k2_refused() {
-    // sqrt2 k log54 k over k2: 59 logs → refused (Phase 397 handles exactly 58).
+    // sqrt2 k log54 k over k2: 60 logs → refused (Phase 403 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -36799,7 +37009,8 @@ fn phase373_sqrt2_k_log54_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -36825,7 +37036,8 @@ fn phase373_sqrt2_k_log54_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_k373r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_373r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -36896,7 +37108,7 @@ fn phase374_sqrt3_k_log54_k_over_k3_converges() {
 
 #[test]
 fn phase374_sqrt3_k_log54_k_over_k3_refused() {
-    // sqrt3 k log54 k over k3: 59 logs → refused (Phase 398 handles exactly 58).
+    // sqrt3 k log54 k over k3: 60 logs → refused (Phase 404 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -36929,7 +37141,8 @@ fn phase374_sqrt3_k_log54_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -36955,7 +37168,8 @@ fn phase374_sqrt3_k_log54_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_k374r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_374r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -37026,7 +37240,7 @@ fn phase375_sqrt4_k_log54_k_over_k3_converges() {
 
 #[test]
 fn phase375_sqrt4_k_log54_k_over_k3_refused() {
-    // sqrt4 k log54 k over k3: 59 logs → refused (Phase 399 handles exactly 58).
+    // sqrt4 k log54 k over k3: 60 logs → refused (Phase 405 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -37059,7 +37273,8 @@ fn phase375_sqrt4_k_log54_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -37085,7 +37300,8 @@ fn phase375_sqrt4_k_log54_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_k375r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_375r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -37156,7 +37372,7 @@ fn phase376_sqrt5_k_log54_k_over_k3_converges() {
 
 #[test]
 fn phase376_sqrt5_k_log54_k_over_k3_refused() {
-    // sqrt5 k log54 k over k3: 59 logs → refused (Phase 400 handles exactly 58).
+    // sqrt5 k log54 k over k3: 60 logs → refused (Phase 406 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -37189,7 +37405,8 @@ fn phase376_sqrt5_k_log54_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -37215,7 +37432,8 @@ fn phase376_sqrt5_k_log54_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_k376r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_376r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -37284,7 +37502,7 @@ fn phase377_log55_k_over_k2_converges() {
 
 #[test]
 fn phase377_log55_k_over_k2_refused() {
-    // log55 k over k2: 59 logs → refused (Phase 395 handles exactly 58).
+    // log55 k over k2: 60 logs → refused (Phase 401 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -37314,7 +37532,8 @@ fn phase377_log55_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -37339,7 +37558,8 @@ fn phase377_log55_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_k377r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_377r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -37412,7 +37632,7 @@ fn phase378_sqrt1_k_log55_k_over_k2_converges() {
 
 #[test]
 fn phase378_sqrt1_k_log55_k_over_k2_refused() {
-    // sqrt1 k log55 k over k2: 59 logs → refused (Phase 396 handles exactly 58).
+    // sqrt1 k log55 k over k2: 60 logs → refused (Phase 402 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -37445,7 +37665,8 @@ fn phase378_sqrt1_k_log55_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -37471,7 +37692,8 @@ fn phase378_sqrt1_k_log55_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_k378r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_378r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -37544,7 +37766,7 @@ fn phase379_sqrt2_k_log55_k_over_k2_converges() {
 
 #[test]
 fn phase379_sqrt2_k_log55_k_over_k2_refused() {
-    // sqrt2 k log55 k over k2: 59 logs → refused (Phase 397 handles exactly 58).
+    // sqrt2 k log55 k over k2: 60 logs → refused (Phase 403 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -37577,7 +37799,8 @@ fn phase379_sqrt2_k_log55_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -37603,7 +37826,8 @@ fn phase379_sqrt2_k_log55_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_k379r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_379r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -37676,7 +37900,7 @@ fn phase380_sqrt3_k_log55_k_over_k3_converges() {
 
 #[test]
 fn phase380_sqrt3_k_log55_k_over_k3_refused() {
-    // sqrt3 k log55 k over k3: 59 logs → refused (Phase 398 handles exactly 58).
+    // sqrt3 k log55 k over k3: 60 logs → refused (Phase 404 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -37709,7 +37933,8 @@ fn phase380_sqrt3_k_log55_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -37735,7 +37960,8 @@ fn phase380_sqrt3_k_log55_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_k380r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_380r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -37808,7 +38034,7 @@ fn phase381_sqrt4_k_log55_k_over_k3_converges() {
 
 #[test]
 fn phase381_sqrt4_k_log55_k_over_k3_refused() {
-    // sqrt4 k log55 k over k3: 59 logs → refused (Phase 399 handles exactly 58).
+    // sqrt4 k log55 k over k3: 60 logs → refused (Phase 405 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -37841,7 +38067,8 @@ fn phase381_sqrt4_k_log55_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -37867,7 +38094,8 @@ fn phase381_sqrt4_k_log55_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_k381r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_381r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -37940,7 +38168,7 @@ fn phase382_sqrt5_k_log55_k_over_k3_converges() {
 
 #[test]
 fn phase382_sqrt5_k_log55_k_over_k3_refused() {
-    // sqrt5 k log55 k over k3: 59 logs → refused (Phase 400 handles exactly 58).
+    // sqrt5 k log55 k over k3: 60 logs → refused (Phase 406 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -37973,7 +38201,8 @@ fn phase382_sqrt5_k_log55_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -37999,7 +38228,8 @@ fn phase382_sqrt5_k_log55_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_k382r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_382r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -38072,7 +38302,7 @@ fn phase383_log56_k_over_k2_converges() {
 
 #[test]
 fn phase383_log56_k_over_k2_refused() {
-    // log56 k over k2: 59 logs → refused (Phase 395 handles exactly 58).
+    // log56 k over k2: 60 logs → refused (Phase 401 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -38102,7 +38332,8 @@ fn phase383_log56_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -38127,7 +38358,8 @@ fn phase383_log56_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_k383r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_383r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -38202,7 +38434,7 @@ fn phase384_sqrt1_k_log56_k_over_k2_converges() {
 
 #[test]
 fn phase384_sqrt1_k_log56_k_over_k2_refused() {
-    // sqrt1 k log56 k over k2: 59 logs → refused (Phase 396 handles exactly 58).
+    // sqrt1 k log56 k over k2: 60 logs → refused (Phase 402 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -38235,7 +38467,8 @@ fn phase384_sqrt1_k_log56_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -38261,7 +38494,8 @@ fn phase384_sqrt1_k_log56_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_k384r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_384r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -38336,7 +38570,7 @@ fn phase385_sqrt2_k_log56_k_over_k2_converges() {
 
 #[test]
 fn phase385_sqrt2_k_log56_k_over_k2_refused() {
-    // sqrt2 k log56 k over k2: 59 logs → refused (Phase 397 handles exactly 58).
+    // sqrt2 k log56 k over k2: 60 logs → refused (Phase 403 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -38369,7 +38603,8 @@ fn phase385_sqrt2_k_log56_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -38395,7 +38630,8 @@ fn phase385_sqrt2_k_log56_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_k385r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_385r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -38470,7 +38706,7 @@ fn phase386_sqrt3_k_log56_k_over_k3_converges() {
 
 #[test]
 fn phase386_sqrt3_k_log56_k_over_k3_refused() {
-    // sqrt3 k log56 k over k3: 59 logs → refused (Phase 398 handles exactly 58).
+    // sqrt3 k log56 k over k3: 60 logs → refused (Phase 404 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -38503,7 +38739,8 @@ fn phase386_sqrt3_k_log56_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -38529,7 +38766,8 @@ fn phase386_sqrt3_k_log56_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_k386r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_386r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -38604,7 +38842,7 @@ fn phase387_sqrt4_k_log56_k_over_k3_converges() {
 
 #[test]
 fn phase387_sqrt4_k_log56_k_over_k3_refused() {
-    // sqrt4 k log56 k over k3: 59 logs → refused (Phase 399 handles exactly 58).
+    // sqrt4 k log56 k over k3: 60 logs → refused (Phase 405 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -38637,7 +38875,8 @@ fn phase387_sqrt4_k_log56_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -38663,7 +38902,8 @@ fn phase387_sqrt4_k_log56_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_k387r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_387r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -38738,7 +38978,7 @@ fn phase388_sqrt5_k_log56_k_over_k3_converges() {
 
 #[test]
 fn phase388_sqrt5_k_log56_k_over_k3_refused() {
-    // sqrt5 k log56 k over k3: 59 logs → refused (Phase 400 handles exactly 58).
+    // sqrt5 k log56 k over k3: 60 logs → refused (Phase 406 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -38771,7 +39011,8 @@ fn phase388_sqrt5_k_log56_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -38797,7 +39038,8 @@ fn phase388_sqrt5_k_log56_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_k388r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_388r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -38870,7 +39112,7 @@ fn phase389_log57_k_over_k2_converges() {
 
 #[test]
 fn phase389_log57_k_over_k2_refused() {
-    // log57 k over k2: 59 logs → refused (Phase 395 handles exactly 58).
+    // log57 k over k2: 60 logs → refused (Phase 401 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -38900,7 +39142,8 @@ fn phase389_log57_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -38925,7 +39168,8 @@ fn phase389_log57_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_k389r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_389r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -39002,7 +39246,7 @@ fn phase390_sqrt1_k_log57_k_over_k2_converges() {
 
 #[test]
 fn phase390_sqrt1_k_log57_k_over_k2_refused() {
-    // sqrt1 k log57 k over k2: 59 logs → refused (Phase 396 handles exactly 58).
+    // sqrt1 k log57 k over k2: 60 logs → refused (Phase 402 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -39035,7 +39279,8 @@ fn phase390_sqrt1_k_log57_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -39061,7 +39306,8 @@ fn phase390_sqrt1_k_log57_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_k390r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_390r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -39138,7 +39384,7 @@ fn phase391_sqrt2_k_log57_k_over_k2_converges() {
 
 #[test]
 fn phase391_sqrt2_k_log57_k_over_k2_refused() {
-    // sqrt2 k log57 k over k2: 59 logs → refused (Phase 397 handles exactly 58).
+    // sqrt2 k log57 k over k2: 60 logs → refused (Phase 403 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -39171,7 +39417,8 @@ fn phase391_sqrt2_k_log57_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -39197,7 +39444,8 @@ fn phase391_sqrt2_k_log57_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_k391r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_391r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -39274,7 +39522,7 @@ fn phase392_sqrt3_k_log57_k_over_k3_converges() {
 
 #[test]
 fn phase392_sqrt3_k_log57_k_over_k3_refused() {
-    // sqrt3 k log57 k over k3: 59 logs → refused (Phase 398 handles exactly 58).
+    // sqrt3 k log57 k over k3: 60 logs → refused (Phase 404 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -39307,7 +39555,8 @@ fn phase392_sqrt3_k_log57_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -39333,7 +39582,8 @@ fn phase392_sqrt3_k_log57_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_k392r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_392r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -39410,7 +39660,7 @@ fn phase393_sqrt4_k_log57_k_over_k3_converges() {
 
 #[test]
 fn phase393_sqrt4_k_log57_k_over_k3_refused() {
-    // sqrt4 k log57 k over k3: 59 logs → refused (Phase 399 handles exactly 58).
+    // sqrt4 k log57 k over k3: 60 logs → refused (Phase 405 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -39443,7 +39693,8 @@ fn phase393_sqrt4_k_log57_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -39469,7 +39720,8 @@ fn phase393_sqrt4_k_log57_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_k393r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_393r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -39546,7 +39798,7 @@ fn phase394_sqrt5_k_log57_k_over_k3_converges() {
 
 #[test]
 fn phase394_sqrt5_k_log57_k_over_k3_refused() {
-    // sqrt5 k log57 k over k3: 59 logs → refused (Phase 400 handles exactly 58).
+    // sqrt5 k log57 k over k3: 60 logs → refused (Phase 406 handles exactly 59).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -39579,7 +39831,8 @@ fn phase394_sqrt5_k_log57_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log
         log_k.clone(), // 58th log (over 57; refused)
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -39605,7 +39858,8 @@ fn phase394_sqrt5_k_log57_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log
         log_kp1.clone(), // 58th log (over 57; refused)
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_k394r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_394r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -39712,7 +39966,8 @@ fn phase395_log58_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log
         log_k.clone(), // 58th log
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -39737,7 +39992,8 @@ fn phase395_log58_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log
         log_kp1.clone(), // 58th log
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_k395r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_395r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -39851,7 +40107,8 @@ fn phase396_sqrt1_k_log58_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log
         log_k.clone(), // 58th log
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -39877,7 +40134,8 @@ fn phase396_sqrt1_k_log58_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log
         log_kp1.clone(), // 58th log
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_k396r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_396r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -39991,7 +40249,8 @@ fn phase397_sqrt2_k_log58_k_over_k2_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log
         log_k.clone(), // 58th log
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -40017,7 +40276,8 @@ fn phase397_sqrt2_k_log58_k_over_k2_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log
         log_kp1.clone(), // 58th log
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_k397r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_397r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -40131,7 +40391,8 @@ fn phase398_sqrt3_k_log58_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log
         log_k.clone(), // 58th log
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -40157,7 +40418,8 @@ fn phase398_sqrt3_k_log58_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log
         log_kp1.clone(), // 58th log
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_k398r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_398r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -40271,7 +40533,8 @@ fn phase399_sqrt4_k_log58_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log
         log_k.clone(), // 58th log
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -40297,7 +40560,8 @@ fn phase399_sqrt4_k_log58_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log
         log_kp1.clone(), // 58th log
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_k399r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_399r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -40411,7 +40675,8 @@ fn phase400_sqrt5_k_log58_k_over_k3_refused() {
         log_k.clone(), // 56th log
         log_k.clone(), // 57th log
         log_k.clone(), // 58th log
-        log_k, // 59th log (over 58; refused)
+        log_k.clone(), // 59th log (over 58; refused)
+        log_k, // 60th log
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -40437,11 +40702,580 @@ fn phase400_sqrt5_k_log58_k_over_k3_refused() {
         log_kp1.clone(), // 56th log
         log_kp1.clone(), // 57th log
         log_kp1.clone(), // 58th log
-        log_kp1, // 59th log (over 58; refused)
+        log_kp1.clone(), // 59th log (over 58; refused)
+        log_kp1, // 60th log
     ]);
     let g_k400r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_400r = apply(sym(DIV), vec![num_kp1, kp1_3]);
     let f400r = apply(sym(SUB), vec![g_k400r, g_kp1_400r]);
     let out = evaluate_sum(f400r, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase401_log59_k_over_k2_converges() {
+    // log(k)^59/k^2: 59 logs, eff_x2=0; 2*2=4>0 -> closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 45
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 50
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 55
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k, // 59 logs
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase401_log59_k_over_k2_refused() {
+    // 60 logs → refused (Phase 401 handles exactly 59).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k, // 60th log
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1, // 60th log
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase402_sqrt1_log59_k_over_k2_converges() {
+    // sqrt(k)*log(k)^59/k^2: eff_x2=1; 2*2=4>1 -> closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k, // 59 logs
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase402_sqrt1_log59_k_over_k2_refused() {
+    // 60 logs → refused (Phase 402 handles exactly 59).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k, // 60th log
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1, // 60th
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase403_sqrt2_log59_k_over_k2_converges() {
+    // sqrt(k)^2*log(k)^59/k^2: eff_x2=2; 2*2=4>2 -> closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k, // 59 logs
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase403_sqrt2_log59_k_over_k2_refused() {
+    // 60 logs → refused (Phase 403 handles exactly 59).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k, // 60th
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1, // 60th
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase404_sqrt3_log59_k_over_k3_converges() {
+    // sqrt(k)^3*log(k)^59/k^3: eff_x2=3; 2*3=6>3 -> closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k, // 59 logs
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase404_sqrt3_log59_k_over_k3_refused() {
+    // 60 logs → refused (Phase 404 handles exactly 59).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k, // 60th
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1, // 60th
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase405_sqrt4_log59_k_over_k3_converges() {
+    // sqrt(k)^4*log(k)^59/k^3: eff_x2=4; 2*3=6>4 -> closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k, // 59 logs
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase405_sqrt4_log59_k_over_k3_refused() {
+    // 60 logs → refused (Phase 405 handles exactly 59).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k, // 60th
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1, // 60th
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase406_sqrt5_log59_k_over_k3_converges() {
+    // sqrt(k)^5*log(k)^59/k^3: eff_x2=5; 2*3=6>5 -> closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k, // 59 logs
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1, // 59 logs
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase406_sqrt5_log59_k_over_k3_refused() {
+    // 60 logs → refused (Phase 406 handles exactly 59).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 55th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k, // 60th log (over 59; refused)
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 55th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1, // 60th log (over 59; refused)
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
     assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.343.0 — 2026-05-28
+
+### Added
+- Phase 401 (`fiftyNineLogPolyEffectiveDeg`): Zero-Sqrt × Fifty-Nine-Log × polynomial numerator recognizer.
+- Phase 402 (`oneSqrtFiftyNineLogPolyEffectiveDeg`): One-Sqrt × Fifty-Nine-Log.
+- Phase 403 (`twoSqrtFiftyNineLogPolyEffectiveDeg`): Two-Sqrt × Fifty-Nine-Log.
+- Phase 404 (`threeSqrtFiftyNineLogPolyEffectiveDeg`): Three-Sqrt × Fifty-Nine-Log.
+- Phase 405 (`fourSqrtFiftyNineLogPolyEffectiveDeg`): Four-Sqrt × Fifty-Nine-Log.
+- Phase 406 (`fiveSqrtFiftyNineLogPolyEffectiveDeg`): Five-Sqrt × Fifty-Nine-Log. Completes the Fifty-Nine-Log family.
+- 6 new describe blocks covering Phase 401–406 (closes + refused for each).
+- Cascade fix: Phase 394–400 refused tests updated from 59→60 log factors.
+
 ## 2.337.0 — 2026-05-28
 
 ### Added

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "2.337.0",
+  "version": "2.343.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -7098,6 +7098,162 @@ function fiveSqrtFiftySevenLogPolyEffectiveDeg(node: IRNode, k: IRNode): number 
   return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + sqrtHalfDegs[3] + sqrtHalfDegs[4] + polyDeg;
 }
 
+/** Phase 401 — Zero-Sqrt × Fifty-Nine-Log × polynomial numerator.
+ * effectiveDeg = polyDeg (no sqrt factors).
+ * Caller checks `denDeg > fiftyNineLogPolyEffectiveDeg(num, k)`.
+ */
+function fiftyNineLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    if (sqrtEffectiveHalfDegree(arg, k) !== undefined) return undefined;
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 59) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (logCount !== 59) return undefined;
+  return polyDeg;
+}
+
+/** Phase 402 — One-Sqrt × Fifty-Nine-Log × polynomial numerator. */
+function oneSqrtFiftyNineLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  let sqrtHalfDeg: number | undefined;
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDeg !== undefined) return undefined;
+      sqrtHalfDeg = hd; continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 59) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDeg === undefined || logCount !== 59) return undefined;
+  return sqrtHalfDeg + polyDeg;
+}
+
+/** Phase 403 — Two-Sqrt × Fifty-Nine-Log × polynomial numerator. */
+function twoSqrtFiftyNineLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDegs.length >= 2) return undefined;
+      sqrtHalfDegs.push(hd); continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 59) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 2 || logCount !== 59) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + polyDeg;
+}
+
+/** Phase 404 — Three-Sqrt × Fifty-Nine-Log × polynomial numerator. */
+function threeSqrtFiftyNineLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDegs.length >= 3) return undefined;
+      sqrtHalfDegs.push(hd); continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 59) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 3 || logCount !== 59) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + polyDeg;
+}
+
+/** Phase 405 — Four-Sqrt × Fifty-Nine-Log × polynomial numerator. */
+function fourSqrtFiftyNineLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDegs.length >= 4) return undefined;
+      sqrtHalfDegs.push(hd); continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 59) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 4 || logCount !== 59) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + sqrtHalfDegs[3] + polyDeg;
+}
+
+/** Phase 406 — Five-Sqrt × Fifty-Nine-Log × polynomial numerator.
+ * Completes the Fifty-Nine-Log family (Phases 401–406).
+ */
+function fiveSqrtFiftyNineLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDegs.length >= 5) return undefined;
+      sqrtHalfDegs.push(hd); continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 59) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 5 || logCount !== 59) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + sqrtHalfDegs[3] + sqrtHalfDegs[4] + polyDeg;
+}
+
 /** Phase 395 — Zero-Sqrt × Fifty-Eight-Log × polynomial numerator.
  * effectiveDeg = polyDeg (no sqrt factors).
  * Caller checks `denDeg > fiftyEightLogPolyEffectiveDeg(num, k)`.
@@ -10734,6 +10890,66 @@ function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
     const denDegS2l8 = polynomialDegreeInK(den, k);
     if (denDegS2l8 !== undefined) {
       if (denDegS2l8 > s2l8Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 406: five sqrt + 59 logs
+  const s5l59Deg = fiveSqrtFiftyNineLogPolyEffectiveDeg(num, k);
+  if (s5l59Deg !== undefined) {
+    const denDegS5l59 = polynomialDegreeInK(den, k);
+    if (denDegS5l59 !== undefined) {
+      if (denDegS5l59 > s5l59Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 405: four sqrt + 59 logs
+  const s4l59Deg = fourSqrtFiftyNineLogPolyEffectiveDeg(num, k);
+  if (s4l59Deg !== undefined) {
+    const denDegS4l59 = polynomialDegreeInK(den, k);
+    if (denDegS4l59 !== undefined) {
+      if (denDegS4l59 > s4l59Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 404: three sqrt + 59 logs
+  const s3l59Deg = threeSqrtFiftyNineLogPolyEffectiveDeg(num, k);
+  if (s3l59Deg !== undefined) {
+    const denDegS3l59 = polynomialDegreeInK(den, k);
+    if (denDegS3l59 !== undefined) {
+      if (denDegS3l59 > s3l59Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 403: two sqrt + 59 logs
+  const s2l59Deg = twoSqrtFiftyNineLogPolyEffectiveDeg(num, k);
+  if (s2l59Deg !== undefined) {
+    const denDegS2l59 = polynomialDegreeInK(den, k);
+    if (denDegS2l59 !== undefined) {
+      if (denDegS2l59 > s2l59Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 402: one sqrt + 59 logs
+  const s1l59Deg = oneSqrtFiftyNineLogPolyEffectiveDeg(num, k);
+  if (s1l59Deg !== undefined) {
+    const denDegS1l59 = polynomialDegreeInK(den, k);
+    if (denDegS1l59 !== undefined) {
+      if (denDegS1l59 > s1l59Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 401: zero sqrt + 59 logs
+  const sl59Deg = fiftyNineLogPolyEffectiveDeg(num, k);
+  if (sl59Deg !== undefined) {
+    const denDegSl59 = polynomialDegreeInK(den, k);
+    if (denDegSl59 !== undefined) {
+      if (denDegSl59 > sl59Deg) return true;
     } else if (hDivergesAtInfinity(den, k)) {
       return true;
     }

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -15271,8 +15271,8 @@ describe("Phase 167 — Twenty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK167r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1167r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK167r = { kind: "apply" as const, head: DIV, args: [numK167r, k2] };
@@ -15321,8 +15321,8 @@ describe("Phase 168 — One-Sqrt × Twenty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK168r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [k] }, ...logs29k, k] };
     const numKp1168r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [kp1] }, ...logs29kp1, kp1] };
     const gK168r = { kind: "apply" as const, head: DIV, args: [numK168r, k2] };
@@ -15375,8 +15375,8 @@ describe("Phase 169 — Two-Sqrt × Twenty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK169r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -15431,8 +15431,8 @@ describe("Phase 170 — Three-Sqrt × Twenty-Log × polynomial numerator", () =>
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK170r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15487,8 +15487,8 @@ describe("Phase 171 — Four-Sqrt × Twenty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK171r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15543,8 +15543,8 @@ describe("Phase 172 — Five-Sqrt × Twenty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK172r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15595,8 +15595,8 @@ describe("Phase 173 — Twenty-One-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK173r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1173r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK173r = { kind: "apply" as const, head: DIV, args: [numK173r, k2] };
@@ -15645,8 +15645,8 @@ describe("Phase 174 — One-Sqrt × Twenty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK174r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [k] }, ...logs29k, k] };
     const numKp1174r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [kp1] }, ...logs29kp1, kp1] };
     const gK174r = { kind: "apply" as const, head: DIV, args: [numK174r, k2] };
@@ -15699,8 +15699,8 @@ describe("Phase 175 — Two-Sqrt × Twenty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK175r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -15755,8 +15755,8 @@ describe("Phase 176 — Three-Sqrt × Twenty-One-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK176r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15811,8 +15811,8 @@ describe("Phase 177 — Four-Sqrt × Twenty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK177r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15867,8 +15867,8 @@ describe("Phase 178 — Five-Sqrt × Twenty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK178r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15919,8 +15919,8 @@ describe("Phase 179 — Twenty-Two-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK179r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1179r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK179r = { kind: "apply" as const, head: DIV, args: [numK179r, k2] };
@@ -15969,8 +15969,8 @@ describe("Phase 180 — One-Sqrt × Twenty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK180r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [k] }, ...logs29k, k] };
     const numKp1180r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [kp1] }, ...logs29kp1, kp1] };
     const gK180r = { kind: "apply" as const, head: DIV, args: [numK180r, k2] };
@@ -16023,8 +16023,8 @@ describe("Phase 181 — Two-Sqrt × Twenty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK181r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -16079,8 +16079,8 @@ describe("Phase 182 — Three-Sqrt × Twenty-Two-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK182r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16135,8 +16135,8 @@ describe("Phase 183 — Four-Sqrt × Twenty-Two-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK183r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16191,8 +16191,8 @@ describe("Phase 184 — Five-Sqrt × Twenty-Two-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK184r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16243,8 +16243,8 @@ describe("Phase 185 — Twenty-Three-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK185r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1185r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK185r = { kind: "apply" as const, head: DIV, args: [numK185r, k2] };
@@ -16293,8 +16293,8 @@ describe("Phase 186 — One-Sqrt × Twenty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK186r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [k] }, ...logs29k, k] };
     const numKp1186r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [kp1] }, ...logs29kp1, kp1] };
     const gK186r = { kind: "apply" as const, head: DIV, args: [numK186r, k2] };
@@ -16347,8 +16347,8 @@ describe("Phase 187 — Two-Sqrt × Twenty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK187r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -16403,8 +16403,8 @@ describe("Phase 188 — Three-Sqrt × Twenty-Three-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK188r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16459,8 +16459,8 @@ describe("Phase 189 — Four-Sqrt × Twenty-Three-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK189r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16515,8 +16515,8 @@ describe("Phase 190 — Five-Sqrt × Twenty-Three-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK190r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16567,8 +16567,8 @@ describe("Phase 191 — Twenty-Four-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK191r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1191r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK191r = { kind: "apply" as const, head: DIV, args: [numK191r, k2] };
@@ -16621,8 +16621,8 @@ describe("Phase 192 — One-Sqrt × Twenty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK192r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs29k, k] };
@@ -16677,8 +16677,8 @@ describe("Phase 193 — Two-Sqrt × Twenty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK193r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -16733,8 +16733,8 @@ describe("Phase 194 — Three-Sqrt × Twenty-Four-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK194r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16789,8 +16789,8 @@ describe("Phase 195 — Four-Sqrt × Twenty-Four-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK195r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16845,8 +16845,8 @@ describe("Phase 196 — Five-Sqrt × Twenty-Four-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK196r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16897,8 +16897,8 @@ describe("Phase 197 — Twenty-Five-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK197r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1197r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK197r = { kind: "apply" as const, head: DIV, args: [numK197r, k2] };
@@ -16951,8 +16951,8 @@ describe("Phase 198 — One-Sqrt × Twenty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK198r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs29k, k] };
@@ -17007,8 +17007,8 @@ describe("Phase 199 — Two-Sqrt × Twenty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK199r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -17063,8 +17063,8 @@ describe("Phase 200 — Three-Sqrt × Twenty-Five-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK200r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17119,8 +17119,8 @@ describe("Phase 201 — Four-Sqrt × Twenty-Five-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK201r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17175,8 +17175,8 @@ describe("Phase 202 — Five-Sqrt × Twenty-Five-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK202r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17227,8 +17227,8 @@ describe("Phase 203 — Twenty-Six-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK203r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1203r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK203r = { kind: "apply" as const, head: DIV, args: [numK203r, k2] };
@@ -17279,8 +17279,8 @@ describe("Phase 204 — One-Sqrt × Twenty-Six-Log × polynomial numerator", () 
   it("√k·log(k)²⁹·k/k² refused (30 logs — not Phase 204)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK204r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs29k, k] };
@@ -17333,8 +17333,8 @@ describe("Phase 205 — Two-Sqrt × Twenty-Six-Log × polynomial numerator", () 
   it("√k·√k·log(k)²⁹/k² refused (30 logs — not Phase 205)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK205r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k, k] };
@@ -17387,8 +17387,8 @@ describe("Phase 206 — Three-Sqrt × Twenty-Six-Log × polynomial numerator", (
   it("(√k)³·log(k)²⁹/k² refused (30 logs — not Phase 206)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK206r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k, k] };
@@ -17443,8 +17443,8 @@ describe("Phase 207 — Four-Sqrt × Twenty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK207r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k, k] };
@@ -17499,8 +17499,8 @@ describe("Phase 208 — Five-Sqrt × Twenty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK208r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17551,8 +17551,8 @@ describe("Phase 209 — Zero-Sqrt × Twenty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK209r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1209r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK209r = { kind: "apply" as const, head: DIV, args: [numK209r, k2] };
@@ -17603,8 +17603,8 @@ describe("Phase 210 — One-Sqrt × Twenty-Seven-Log × polynomial numerator", (
   it("√k·log(k)²⁹·k/k² refused (30 logs — not Phase 210)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK210r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs29k, k] };
@@ -17659,8 +17659,8 @@ describe("Phase 211 — Two-Sqrt × Twenty-Seven-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK211r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -17715,8 +17715,8 @@ describe("Phase 212 — Three-Sqrt × Twenty-Seven-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK212r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17771,8 +17771,8 @@ describe("Phase 213 — Four-Sqrt × Twenty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK213r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17827,8 +17827,8 @@ describe("Phase 214 — Five-Sqrt × Twenty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK214r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17879,8 +17879,8 @@ describe("Phase 215 — Zero-Sqrt × Twenty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK215r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1215r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK215r = { kind: "apply" as const, head: DIV, args: [numK215r, k2] };
@@ -17933,8 +17933,8 @@ describe("Phase 216 — One-Sqrt × Twenty-Eight-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK216r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs29k, k] };
@@ -17989,8 +17989,8 @@ describe("Phase 217 — Two-Sqrt × Twenty-Eight-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK217r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -18045,8 +18045,8 @@ describe("Phase 218 — Three-Sqrt × Twenty-Eight-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK218r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -18101,8 +18101,8 @@ describe("Phase 219 — Four-Sqrt × Twenty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK219r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -18157,8 +18157,8 @@ describe("Phase 220 — Five-Sqrt × Twenty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK220r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -18209,8 +18209,8 @@ describe("Phase 221 — Zero-Sqrt × Twenty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK221r = { kind: "apply" as const, head: MUL, args: [...logs30k, k] };
     const numKp1221r = { kind: "apply" as const, head: MUL, args: [...logs30kp1, kp1] };
     const gK221r = { kind: "apply" as const, head: DIV, args: [numK221r, k2] };
@@ -18263,8 +18263,8 @@ describe("Phase 222 — One-Sqrt × Twenty-Nine-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK222r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs30k, k] };
@@ -18319,8 +18319,8 @@ describe("Phase 223 — Two-Sqrt × Twenty-Nine-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK223r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs30k, k] };
@@ -18375,8 +18375,8 @@ describe("Phase 224 — Three-Sqrt × Twenty-Nine-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK224r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs30k, k] };
@@ -18431,8 +18431,8 @@ describe("Phase 225 — Four-Sqrt × Twenty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK225r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs30k, k] };
@@ -18487,8 +18487,8 @@ describe("Phase 226 — Five-Sqrt × Twenty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK226r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs30k, k] };
@@ -18539,8 +18539,8 @@ describe("Phase 227 — Zero-Sqrt × Thirty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK227r = { kind: "apply" as const, head: MUL, args: [...logs31k, k] };
     const numKp1227r = { kind: "apply" as const, head: MUL, args: [...logs31kp1, kp1] };
     const gK227r = { kind: "apply" as const, head: DIV, args: [numK227r, k2] };
@@ -18593,8 +18593,8 @@ describe("Phase 228 — One-Sqrt × Thirty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK228r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs31k, k] };
@@ -18649,8 +18649,8 @@ describe("Phase 229 — Two-Sqrt × Thirty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK229r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs31k, k] };
@@ -18705,8 +18705,8 @@ describe("Phase 230 — Three-Sqrt × Thirty-Log × polynomial numerator", () =>
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK230r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs31k, k] };
@@ -18761,8 +18761,8 @@ describe("Phase 231 — Four-Sqrt × Thirty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK231r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs31k, k] };
@@ -18817,8 +18817,8 @@ describe("Phase 232 — Five-Sqrt × Thirty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK232r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs31k, k] };
@@ -18869,8 +18869,8 @@ describe("Phase 233 — Zero-Sqrt × Thirty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK233r = { kind: "apply" as const, head: MUL, args: [...logs32k, k] };
     const numKp1233r = { kind: "apply" as const, head: MUL, args: [...logs32kp1, kp1] };
     const gK233r = { kind: "apply" as const, head: DIV, args: [numK233r, k2] };
@@ -18923,8 +18923,8 @@ describe("Phase 234 — One-Sqrt × Thirty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK234r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs32k, k] };
@@ -18979,8 +18979,8 @@ describe("Phase 235 — Two-Sqrt × Thirty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK235r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs32k, k] };
@@ -19035,8 +19035,8 @@ describe("Phase 236 — Three-Sqrt × Thirty-One-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK236r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs32k, k] };
@@ -19091,8 +19091,8 @@ describe("Phase 237 — Four-Sqrt × Thirty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK237r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs32k, k] };
@@ -19147,8 +19147,8 @@ describe("Phase 238 — Five-Sqrt × Thirty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK238r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs32k, k] };
@@ -19199,8 +19199,8 @@ describe("Phase 239 — Thirty-Two-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs33k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK239r = { kind: "apply" as const, head: MUL, args: [...logs33k, k] };
     const numKp1239r = { kind: "apply" as const, head: MUL, args: [...logs33kp1, kp1] };
     const gK239r = { kind: "apply" as const, head: DIV, args: [numK239r, k2] };
@@ -19249,8 +19249,8 @@ describe("Phase 240 — One-Sqrt × Thirty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs33k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK240r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [k] }, ...logs33k, k] };
     const numKp1240r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [kp1] }, ...logs33kp1, kp1] };
     const gK240r = { kind: "apply" as const, head: DIV, args: [numK240r, k2] };
@@ -19303,8 +19303,8 @@ describe("Phase 241 — Two-Sqrt × Thirty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs33k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK241r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs33k] };
@@ -19359,8 +19359,8 @@ describe("Phase 242 — Three-Sqrt × Thirty-Two-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs33k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK242r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs33k] };
@@ -19415,8 +19415,8 @@ describe("Phase 243 — Four-Sqrt × Thirty-Two-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs33k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK243r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs33k, k] };
@@ -19471,8 +19471,8 @@ describe("Phase 244 — Five-Sqrt × Thirty-Two-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs33k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK244r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs33k, k] };
@@ -19523,8 +19523,8 @@ describe("Phase 245 — Thirty-Three-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs34k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK245r = { kind: "apply" as const, head: MUL, args: [...logs34k, k] };
     const numKp1245r = { kind: "apply" as const, head: MUL, args: [...logs34kp1, kp1] };
     const gK245r = { kind: "apply" as const, head: DIV, args: [numK245r, k2] };
@@ -19577,8 +19577,8 @@ describe("Phase 246 — One-Sqrt × Thirty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs34k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK246r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs34k, k] };
@@ -19633,8 +19633,8 @@ describe("Phase 247 — Two-Sqrt × Thirty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs34k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK247r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs34k] };
@@ -19689,8 +19689,8 @@ describe("Phase 248 — Three-Sqrt × Thirty-Three-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs34k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK248r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs34k] };
@@ -19745,8 +19745,8 @@ describe("Phase 249 — Four-Sqrt × Thirty-Three-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs34k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK249r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs34k] };
@@ -19801,8 +19801,8 @@ describe("Phase 250 — Five-Sqrt × Thirty-Three-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs34k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK250r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs34k, k] };
@@ -19853,8 +19853,8 @@ describe("Phase 251 — Thirty-Four-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs36k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK251r = { kind: "apply" as const, head: MUL, args: [...logs36k, k] };
     const numKp1251r = { kind: "apply" as const, head: MUL, args: [...logs36kp1, kp1] };
     const gK251r = { kind: "apply" as const, head: DIV, args: [numK251r, k2] };
@@ -19907,8 +19907,8 @@ describe("Phase 252 — One-Sqrt × Thirty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs36k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK252r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs36k, k] };
@@ -19963,8 +19963,8 @@ describe("Phase 253 — Two-Sqrt × Thirty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs36k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK253r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs36k] };
@@ -20019,8 +20019,8 @@ describe("Phase 254 — Three-Sqrt × Thirty-Four-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs36k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK254r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs36k] };
@@ -20075,8 +20075,8 @@ describe("Phase 255 — Four-Sqrt × Thirty-Four-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs36k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK255r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs36k] };
@@ -20131,8 +20131,8 @@ describe("Phase 256 — Five-Sqrt × Thirty-Four-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK256r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs36k, k] };
@@ -20183,8 +20183,8 @@ describe("Phase 257 — Thirty-Five-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK257r = { kind: "apply" as const, head: MUL, args: [...logs36k, k] };
     const numKp1257r = { kind: "apply" as const, head: MUL, args: [...logs36kp1, kp1] };
     const gK257r = { kind: "apply" as const, head: DIV, args: [numK257r, k2] };
@@ -20237,8 +20237,8 @@ describe("Phase 258 — One-Sqrt × Thirty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK258r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs36k, k] };
@@ -20293,8 +20293,8 @@ describe("Phase 259 — Two-Sqrt × Thirty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK259r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs36k, k] };
@@ -20349,8 +20349,8 @@ describe("Phase 260 — Three-Sqrt × Thirty-Five-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK260r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs36k, k] };
@@ -20405,8 +20405,8 @@ describe("Phase 261 — Four-Sqrt × Thirty-Five-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK261r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs36k, k] };
@@ -20461,8 +20461,8 @@ describe("Phase 262 — Five-Sqrt × Thirty-Five-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK262r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs36k, k] };
@@ -20513,8 +20513,8 @@ describe("Phase 263 — Zero-Sqrt × Thirty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK263r = { kind: "apply" as const, head: MUL, args: [...logs37k, k] };
     const numKp1263r = { kind: "apply" as const, head: MUL, args: [...logs37kp1, kp1] };
     const gK263r = { kind: "apply" as const, head: DIV, args: [numK263r, k2] };
@@ -20567,8 +20567,8 @@ describe("Phase 264 — One-Sqrt × Thirty-Six-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK264r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs37k, k] };
@@ -20623,8 +20623,8 @@ describe("Phase 265 — Two-Sqrt × Thirty-Six-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK265r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs37k] };
@@ -20679,8 +20679,8 @@ describe("Phase 266 — Three-Sqrt × Thirty-Six-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK266r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs37k] };
@@ -20735,8 +20735,8 @@ describe("Phase 267 — Four-Sqrt × Thirty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK267r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs37k, k] };
@@ -20791,8 +20791,8 @@ describe("Phase 268 — Five-Sqrt × Thirty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK268r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs37k, k] };
@@ -20843,8 +20843,8 @@ describe("Phase 269 — Zero-Sqrt × Thirty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs38k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs38kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs38k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK269r = { kind: "apply" as const, head: MUL, args: [...logs38k, k] };
     const numKp1269r = { kind: "apply" as const, head: MUL, args: [...logs38kp1, kp1] };
     const gK269r = { kind: "apply" as const, head: DIV, args: [numK269r, k2] };
@@ -20897,8 +20897,8 @@ describe("Phase 270 — One-Sqrt × Thirty-Seven-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs38k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs38kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs38k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK270r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs38k, k] };
@@ -20953,8 +20953,8 @@ describe("Phase 271 — Two-Sqrt × Thirty-Seven-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs38k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs38kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs38k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK271r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs38k, k] };
@@ -21009,8 +21009,8 @@ describe("Phase 272 — Three-Sqrt × Thirty-Seven-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs38k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs38kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs38k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK272r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs38k, k] };
@@ -21065,8 +21065,8 @@ describe("Phase 273 — Four-Sqrt × Thirty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs38k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs38kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs38k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK273r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs38k, k] };
@@ -21121,8 +21121,8 @@ describe("Phase 274 — Five-Sqrt × Thirty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs38k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs38kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs38k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK274r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs38k, k] };
@@ -21173,8 +21173,8 @@ describe("Phase 275 — Zero-Sqrt × Thirty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs39k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs39kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs39k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs39kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK275r = { kind: "apply" as const, head: MUL, args: [...logs39k, k] };
     const numKp1275r = { kind: "apply" as const, head: MUL, args: [...logs39kp1, kp1] };
     const gK275r = { kind: "apply" as const, head: DIV, args: [numK275r, k2] };
@@ -21227,8 +21227,8 @@ describe("Phase 276 — One-Sqrt × Thirty-Eight-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs39k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs39kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs39k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs39kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK276r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs39k, k] };
@@ -21283,8 +21283,8 @@ describe("Phase 277 — Two-Sqrt × Thirty-Eight-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs39k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs39kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs39k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs39kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK277r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs39k, k] };
@@ -21339,8 +21339,8 @@ describe("Phase 278 — Three-Sqrt × Thirty-Eight-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs39k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs39kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs39k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs39kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK278r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs39k, k] };
@@ -21395,8 +21395,8 @@ describe("Phase 279 — Four-Sqrt × Thirty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs39k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs39kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs39k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs39kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK279r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs39k, k] };
@@ -21451,8 +21451,8 @@ describe("Phase 280 — Five-Sqrt × Thirty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs39k = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs39kp1 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs39k = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs39kp1 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK280r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs39k, k] };
@@ -21504,8 +21504,8 @@ describe("Phase 281 — Zero-Sqrt × Thirty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs40k281 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs40kp1281 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs40k281 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1281 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK281r = { kind: "apply" as const, head: MUL, args: [...logs40k281, k] };
     const numKp1281r = { kind: "apply" as const, head: MUL, args: [...logs40kp1281, kp1] };
     const gK281r = { kind: "apply" as const, head: DIV, args: [numK281r, k2r] };
@@ -21558,8 +21558,8 @@ describe("Phase 282 — One-Sqrt × Thirty-Nine-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs40k282 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs40kp1282 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs40k282 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1282 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK282r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs40k282, k] };
@@ -21614,8 +21614,8 @@ describe("Phase 283 — Two-Sqrt × Thirty-Nine-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs40k283 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs40kp1283 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs40k283 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1283 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK283r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs40k283, k] };
@@ -21670,8 +21670,8 @@ describe("Phase 284 — Three-Sqrt × Thirty-Nine-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs40k284 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs40kp1284 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs40k284 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1284 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK284r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs40k284, k] };
@@ -21726,8 +21726,8 @@ describe("Phase 285 — Four-Sqrt × Thirty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs40k285 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs40kp1285 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs40k285 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1285 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK285r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs40k285, k] };
@@ -21782,8 +21782,8 @@ describe("Phase 286 — Five-Sqrt × Thirty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs40k286 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs40kp1286 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs40k286 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1286 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK286r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs40k286, k] };
@@ -21834,8 +21834,8 @@ describe("Phase 287 — Zero-Sqrt × Forty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k287 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1287 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k287 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1287 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK287r = { kind: "apply" as const, head: MUL, args: [...logs42k287, k] };
     const numKp1287r = { kind: "apply" as const, head: MUL, args: [...logs42kp1287, kp1] };
     const gK287r = { kind: "apply" as const, head: DIV, args: [numK287r, k2r] };
@@ -21888,8 +21888,8 @@ describe("Phase 288 — One-Sqrt × Forty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k288 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1288 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k288 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1288 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK288r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs42k288, k] };
@@ -21944,8 +21944,8 @@ describe("Phase 289 — Two-Sqrt × Forty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k289 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1289 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k289 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1289 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK289r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs42k289, k] };
@@ -22000,8 +22000,8 @@ describe("Phase 290 — Three-Sqrt × Forty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k290 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1290 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k290 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1290 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK290r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs42k290, k] };
@@ -22056,8 +22056,8 @@ describe("Phase 291 — Four-Sqrt × Forty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k291 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1291 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k291 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1291 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK291r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs42k291, k] };
@@ -22112,8 +22112,8 @@ describe("Phase 292 — Five-Sqrt × Forty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k292 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1292 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k292 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1292 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK292r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs42k292, k] };
@@ -22164,8 +22164,8 @@ describe("Phase 293 — Zero-Sqrt × Forty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k293 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1293 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k293 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1293 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK293r = { kind: "apply" as const, head: MUL, args: [...logs42k293, k] };
     const numKp1293r = { kind: "apply" as const, head: MUL, args: [...logs42kp1293, kp1] };
     const gK293r = { kind: "apply" as const, head: DIV, args: [numK293r, k2r] };
@@ -22200,8 +22200,8 @@ describe("Phase 294 — One-Sqrt × Forty-One-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k294 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1294 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k294 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1294 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK294r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs42k294, k] };
@@ -22238,8 +22238,8 @@ describe("Phase 295 — Two-Sqrt × Forty-One-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k295 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1295 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k295 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1295 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK295r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs42k295, k] };
@@ -22276,8 +22276,8 @@ describe("Phase 296 — Three-Sqrt × Forty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k296 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1296 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k296 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1296 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK296r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs42k296, k] };
@@ -22314,8 +22314,8 @@ describe("Phase 297 — Four-Sqrt × Forty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k297 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1297 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k297 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1297 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK297r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs42k297, k] };
@@ -22352,8 +22352,8 @@ describe("Phase 298 — Five-Sqrt × Forty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k298 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1298 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k298 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1298 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK298r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs42k298, k] };
@@ -22388,8 +22388,8 @@ describe("Phase 299 — Zero-Sqrt × Forty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k299 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1299 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k299 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1299 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK299r = { kind: "apply" as const, head: MUL, args: [...logs44k299, k] };
     const numKp1299r = { kind: "apply" as const, head: MUL, args: [...logs44kp1299, kp1] };
     const gK299r = { kind: "apply" as const, head: DIV, args: [numK299r, k2r] };
@@ -22424,8 +22424,8 @@ describe("Phase 300 — One-Sqrt × Forty-Two-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k300 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1300 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k300 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1300 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK300r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs44k300, k] };
@@ -22462,8 +22462,8 @@ describe("Phase 301 — Two-Sqrt × Forty-Two-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k301 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1301 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k301 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1301 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK301r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs44k301, k] };
@@ -22500,8 +22500,8 @@ describe("Phase 302 — Three-Sqrt × Forty-Two-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k302 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1302 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k302 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1302 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK302r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs44k302, k] };
@@ -22538,8 +22538,8 @@ describe("Phase 303 — Four-Sqrt × Forty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k303 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1303 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k303 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1303 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK303r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs44k303, k] };
@@ -22576,8 +22576,8 @@ describe("Phase 304 — Five-Sqrt × Forty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k304 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1304 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k304 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1304 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK304r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs44k304, k] };
@@ -22612,8 +22612,8 @@ describe("Phase 305 — Zero-Sqrt × Forty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k305 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1305 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k305 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1305 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK305r = { kind: "apply" as const, head: MUL, args: [...logs44k305, k] };
     const numKp1305r = { kind: "apply" as const, head: MUL, args: [...logs44kp1305, kp1] };
     const gK305r = { kind: "apply" as const, head: DIV, args: [numK305r, k2r] };
@@ -22648,8 +22648,8 @@ describe("Phase 306 — One-Sqrt × Forty-Three-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k306 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1306 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k306 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1306 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK306r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs44k306, k] };
@@ -22686,8 +22686,8 @@ describe("Phase 307 — Two-Sqrt × Forty-Three-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k307 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1307 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k307 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1307 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK307r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs44k307, k] };
@@ -22724,8 +22724,8 @@ describe("Phase 308 — Three-Sqrt × Forty-Three-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1, kp1] };
-    const logs44k308 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1308 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k308 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1308 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK308r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs44k308, k] };
@@ -22762,8 +22762,8 @@ describe("Phase 309 — Four-Sqrt × Forty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1, kp1] };
-    const logs44k309 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1309 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k309 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1309 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK309r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs44k309, k] };
@@ -22800,8 +22800,8 @@ describe("Phase 310 — Five-Sqrt × Forty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k310 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1310 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k310 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1310 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK310r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs44k310, k] };
@@ -22836,8 +22836,8 @@ describe("Phase 311 — Forty-Four-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs45k311 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs45kp1311 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs45k311 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs45kp1311 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK311r = { kind: "apply" as const, head: MUL, args: [...logs45k311, k] };
     const numKp1311r = { kind: "apply" as const, head: MUL, args: [...logs45kp1311, kp1] };
     const gK311r = { kind: "apply" as const, head: DIV, args: [numK311r, k2r] };
@@ -22872,8 +22872,8 @@ describe("Phase 312 — One-Sqrt × Forty-Four-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs45k312 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs45kp1312 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs45k312 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs45kp1312 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK312r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs45k312, k] };
@@ -22910,8 +22910,8 @@ describe("Phase 313 — Two-Sqrt × Forty-Four-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs45k313 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs45kp1313 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs45k313 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs45kp1313 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK313r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs45k313, k] };
@@ -22948,8 +22948,8 @@ describe("Phase 314 — Three-Sqrt × Forty-Four-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs45k314 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs45kp1314 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs45k314 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs45kp1314 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK314r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs45k314, k] };
@@ -22986,8 +22986,8 @@ describe("Phase 315 — Four-Sqrt × Forty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs45k315 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs45kp1315 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs45k315 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs45kp1315 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK315r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs45k315, k] };
@@ -23024,8 +23024,8 @@ describe("Phase 316 — Five-Sqrt × Forty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs45k316 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs45kp1316 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs45k316 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs45kp1316 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK316r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs45k316, k] };
@@ -23060,8 +23060,8 @@ describe("Phase 317 — Forty-Five-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs46k317 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs46kp1317 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs46k317 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs46kp1317 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK317r = { kind: "apply" as const, head: MUL, args: [...logs46k317, k] };
     const numKp1317r = { kind: "apply" as const, head: MUL, args: [...logs46kp1317, kp1] };
     const gK317r = { kind: "apply" as const, head: DIV, args: [numK317r, k2r] };
@@ -23096,8 +23096,8 @@ describe("Phase 318 — One-Sqrt × Forty-Five-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs46k318 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs46kp1318 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs46k318 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs46kp1318 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK318r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs46k318, k] };
@@ -23134,8 +23134,8 @@ describe("Phase 319 — Two-Sqrt × Forty-Five-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs46k319 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs46kp1319 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs46k319 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs46kp1319 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK319r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs46k319, k] };
@@ -23172,8 +23172,8 @@ describe("Phase 320 — Three-Sqrt × Forty-Five-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs46k320 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs46kp1320 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs46k320 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs46kp1320 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK320r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs46k320, k] };
@@ -23210,8 +23210,8 @@ describe("Phase 321 — Four-Sqrt × Forty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs46k321 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs46kp1321 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs46k321 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs46kp1321 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK321r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs46k321, k] };
@@ -23248,8 +23248,8 @@ describe("Phase 322 — Five-Sqrt × Forty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs46k322 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs46kp1322 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs46k322 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs46kp1322 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK322r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs46k322, k] };
@@ -23284,8 +23284,8 @@ describe("Phase 323 — Forty-Six-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs47k323 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs47kp1323 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs47k323 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs47kp1323 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK323r = { kind: "apply" as const, head: MUL, args: [...logs47k323, k] };
     const numKp1323r = { kind: "apply" as const, head: MUL, args: [...logs47kp1323, kp1] };
     const gK323r = { kind: "apply" as const, head: DIV, args: [numK323r, k2r] };
@@ -23320,8 +23320,8 @@ describe("Phase 324 — One-Sqrt × Forty-Six-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs47k324 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs47kp1324 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs47k324 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs47kp1324 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK324r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs47k324, k] };
@@ -23358,8 +23358,8 @@ describe("Phase 325 — Two-Sqrt × Forty-Six-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs47k325 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs47kp1325 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs47k325 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs47kp1325 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK325r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs47k325, k] };
@@ -23396,8 +23396,8 @@ describe("Phase 326 — Three-Sqrt × Forty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs47k326 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs47kp1326 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs47k326 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs47kp1326 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK326r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs47k326, k] };
@@ -23434,8 +23434,8 @@ describe("Phase 327 — Four-Sqrt × Forty-Six-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs47k327 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs47kp1327 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs47k327 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs47kp1327 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK327r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs47k327, k] };
@@ -23472,8 +23472,8 @@ describe("Phase 328 — Five-Sqrt × Forty-Six-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs47k328 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs47kp1328 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs47k328 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs47kp1328 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK328r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs47k328, k] };
@@ -23508,8 +23508,8 @@ describe("Phase 329 — Forty-Seven-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k329 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1329 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k329 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1329 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK329r = { kind: "apply" as const, head: MUL, args: [...logs49k329, k] };
     const numKp1329r = { kind: "apply" as const, head: MUL, args: [...logs49kp1329, kp1] };
     const gK329r = { kind: "apply" as const, head: DIV, args: [numK329r, k2r] };
@@ -23544,8 +23544,8 @@ describe("Phase 330 — One-Sqrt × Forty-Seven-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k330 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1330 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k330 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1330 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK330r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs49k330, k] };
@@ -23582,8 +23582,8 @@ describe("Phase 331 — Two-Sqrt × Forty-Seven-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k331 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1331 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k331 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1331 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK331r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs49k331, k] };
@@ -23620,8 +23620,8 @@ describe("Phase 332 — Three-Sqrt × Forty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k332 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1332 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k332 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1332 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK332r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs49k332, k] };
@@ -23658,8 +23658,8 @@ describe("Phase 333 — Four-Sqrt × Forty-Seven-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k333 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1333 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k333 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1333 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK333r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs49k333, k] };
@@ -23696,8 +23696,8 @@ describe("Phase 334 — Five-Sqrt × Forty-Seven-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k334 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1334 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k334 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1334 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK334r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs49k334, k] };
@@ -23732,8 +23732,8 @@ describe("Phase 335 — Zero-Sqrt × Forty-Eight-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k335 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1335 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k335 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1335 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK335r = { kind: "apply" as const, head: MUL, args: [...logs49k335, k] };
     const numKp1335r = { kind: "apply" as const, head: MUL, args: [...logs49kp1335, kp1] };
     const gK335r = { kind: "apply" as const, head: DIV, args: [numK335r, k2r] };
@@ -23768,8 +23768,8 @@ describe("Phase 336 — One-Sqrt × Forty-Eight-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k336 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1336 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k336 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1336 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK336r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs49k336, k] };
@@ -23806,8 +23806,8 @@ describe("Phase 337 — Two-Sqrt × Forty-Eight-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k337 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1337 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k337 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1337 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK337r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs49k337, k] };
@@ -23844,8 +23844,8 @@ describe("Phase 338 — Three-Sqrt × Forty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k338 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1338 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k338 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1338 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK338r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs49k338, k] };
@@ -23882,8 +23882,8 @@ describe("Phase 339 — Four-Sqrt × Forty-Eight-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k339 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1339 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k339 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1339 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK339r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs49k339, k] };
@@ -23920,8 +23920,8 @@ describe("Phase 340 — Five-Sqrt × Forty-Eight-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k340 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1340 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k340 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1340 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK340r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs49k340, k] };
@@ -23956,8 +23956,8 @@ describe("Phase 341 — Zero-Sqrt × Forty-Nine-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k341 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1341 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k341 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1341 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK341r = { kind: "apply" as const, head: MUL, args: [...logs51k341, k] };
     const numKp1341r = { kind: "apply" as const, head: MUL, args: [...logs51kp1341, kp1] };
     const gK341r = { kind: "apply" as const, head: DIV, args: [numK341r, k2r] };
@@ -23992,8 +23992,8 @@ describe("Phase 342 — One-Sqrt × Forty-Nine-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k342 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1342 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k342 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1342 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK342r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs51k342, k] };
@@ -24030,8 +24030,8 @@ describe("Phase 343 — Two-Sqrt × Forty-Nine-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k343 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1343 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k343 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1343 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK343r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs51k343, k] };
@@ -24068,8 +24068,8 @@ describe("Phase 344 — Three-Sqrt × Forty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k344 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1344 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k344 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1344 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK344r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs51k344, k] };
@@ -24106,8 +24106,8 @@ describe("Phase 345 — Four-Sqrt × Forty-Nine-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k345 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1345 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k345 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1345 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK345r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs51k345, k] };
@@ -24144,8 +24144,8 @@ describe("Phase 346 — Five-Sqrt × Forty-Nine-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k346 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1346 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k346 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1346 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK346r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs51k346, k] };
@@ -24180,8 +24180,8 @@ describe("Phase 347 — Zero-Sqrt × Fifty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k347 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1347 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k347 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1347 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK347r = { kind: "apply" as const, head: MUL, args: [...logs51k347, k] };
     const numKp1347r = { kind: "apply" as const, head: MUL, args: [...logs51kp1347, kp1] };
     const gK347r = { kind: "apply" as const, head: DIV, args: [numK347r, k2r] };
@@ -24216,8 +24216,8 @@ describe("Phase 348 — One-Sqrt × Fifty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k348 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1348 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k348 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1348 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK348r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs51k348, k] };
@@ -24254,8 +24254,8 @@ describe("Phase 349 — Two-Sqrt × Fifty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k349 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1349 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k349 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1349 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK349r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs51k349, k] };
@@ -24292,8 +24292,8 @@ describe("Phase 350 — Three-Sqrt × Fifty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k350 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1350 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k350 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1350 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK350r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs51k350, k] };
@@ -24330,8 +24330,8 @@ describe("Phase 351 — Four-Sqrt × Fifty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k351 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1351 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k351 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1351 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK351r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs51k351, k] };
@@ -24368,8 +24368,8 @@ describe("Phase 352 — Five-Sqrt × Fifty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k352 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1352 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k352 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1352 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK352r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs51k352, k] };
@@ -24405,8 +24405,8 @@ describe("Phase 353 — Zero-Sqrt × Fifty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs52k353 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs52kp1353 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs52k353 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs52kp1353 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK353r = { kind: "apply" as const, head: MUL, args: [...logs52k353, k] };
     const numKp1353r = { kind: "apply" as const, head: MUL, args: [...logs52kp1353, kp1] };
     const gK353r = { kind: "apply" as const, head: DIV, args: [numK353r, k2r] };
@@ -24441,8 +24441,8 @@ describe("Phase 354 — One-Sqrt × Fifty-One-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs52k354 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs52kp1354 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs52k354 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs52kp1354 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK354r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs52k354, k] };
@@ -24479,8 +24479,8 @@ describe("Phase 355 — Two-Sqrt × Fifty-One-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs52k355 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs52kp1355 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs52k355 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs52kp1355 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK355r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs52k355, k] };
@@ -24517,8 +24517,8 @@ describe("Phase 356 — Three-Sqrt × Fifty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs52k356 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs52kp1356 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs52k356 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs52kp1356 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK356r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs52k356, k] };
@@ -24555,8 +24555,8 @@ describe("Phase 357 — Four-Sqrt × Fifty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs52k357 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs52kp1357 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs52k357 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs52kp1357 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK357r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs52k357, k] };
@@ -24593,8 +24593,8 @@ describe("Phase 358 — Five-Sqrt × Fifty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs52k358 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs52kp1358 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs52k358 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs52kp1358 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK358r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs52k358, k] };
@@ -24629,8 +24629,8 @@ describe("Phase 359 — Zero-Sqrt × Fifty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs53k359 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs53kp1359 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs53k359 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs53kp1359 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK359r = { kind: "apply" as const, head: MUL, args: [...logs53k359, k] };
     const numKp1359r = { kind: "apply" as const, head: MUL, args: [...logs53kp1359, kp1] };
     const gK359r = { kind: "apply" as const, head: DIV, args: [numK359r, k2r] };
@@ -24665,8 +24665,8 @@ describe("Phase 360 — One-Sqrt × Fifty-Two-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs53k360 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs53kp1360 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs53k360 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs53kp1360 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK360r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs53k360, k] };
@@ -24703,8 +24703,8 @@ describe("Phase 361 — Two-Sqrt × Fifty-Two-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs53k361 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs53kp1361 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs53k361 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs53kp1361 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK361r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs53k361, k] };
@@ -24741,8 +24741,8 @@ describe("Phase 362 — Three-Sqrt × Fifty-Two-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs53k362 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs53kp1362 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs53k362 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs53kp1362 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK362r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs53k362, k] };
@@ -24779,8 +24779,8 @@ describe("Phase 363 — Four-Sqrt × Fifty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs53k363 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs53kp1363 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs53k363 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs53kp1363 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK363r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs53k363, k] };
@@ -24817,8 +24817,8 @@ describe("Phase 364 — Five-Sqrt × Fifty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs53k364 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs53kp1364 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs53k364 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs53kp1364 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK364r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs53k364, k] };
@@ -24853,8 +24853,8 @@ describe("Phase 365 — Zero-Sqrt × Fifty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs54k365 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs54kp1365 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs54k365 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs54kp1365 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK365r = { kind: "apply" as const, head: MUL, args: [...logs54k365, k] };
     const numKp1365r = { kind: "apply" as const, head: MUL, args: [...logs54kp1365, kp1] };
     const gK365r = { kind: "apply" as const, head: DIV, args: [numK365r, k2r] };
@@ -24889,8 +24889,8 @@ describe("Phase 366 — One-Sqrt × Fifty-Three-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs54k366 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs54kp1366 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs54k366 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs54kp1366 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK366r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs54k366, k] };
@@ -24927,8 +24927,8 @@ describe("Phase 367 — Two-Sqrt × Fifty-Three-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs54k367 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs54kp1367 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs54k367 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs54kp1367 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK367r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs54k367, k] };
@@ -24965,8 +24965,8 @@ describe("Phase 368 — Three-Sqrt × Fifty-Three-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs54k368 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs54kp1368 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs54k368 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs54kp1368 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK368r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs54k368, k] };
@@ -25003,8 +25003,8 @@ describe("Phase 369 — Four-Sqrt × Fifty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs54k369 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs54kp1369 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs54k369 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs54kp1369 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK369r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs54k369, k] };
@@ -25041,8 +25041,8 @@ describe("Phase 370 — Five-Sqrt × Fifty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs54k370 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs54kp1370 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs54k370 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs54kp1370 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK370r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs54k370] };
@@ -25077,8 +25077,8 @@ describe("Phase 371 — Zero-Sqrt × Fifty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs56k371 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs56kp1371 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs56k371 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs56kp1371 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK371r = { kind: "apply" as const, head: MUL, args: [...logs56k371, k] };
     const numKp1371r = { kind: "apply" as const, head: MUL, args: [...logs56kp1371, kp1] };
     const gK371r = { kind: "apply" as const, head: DIV, args: [numK371r, k2r] };
@@ -25113,8 +25113,8 @@ describe("Phase 372 — One-Sqrt × Fifty-Four-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs56k372 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs56kp1372 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs56k372 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs56kp1372 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK372r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs56k372, k] };
@@ -25151,8 +25151,8 @@ describe("Phase 373 — Two-Sqrt × Fifty-Four-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs56k373 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs56kp1373 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs56k373 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs56kp1373 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK373r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs56k373, k] };
@@ -25189,8 +25189,8 @@ describe("Phase 374 — Three-Sqrt × Fifty-Four-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs56k374 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs56kp1374 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs56k374 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs56kp1374 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK374r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs56k374, k] };
@@ -25227,8 +25227,8 @@ describe("Phase 375 — Four-Sqrt × Fifty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs56k375 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs56kp1375 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs56k375 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs56kp1375 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK375r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs56k375, k] };
@@ -25265,8 +25265,8 @@ describe("Phase 376 — Five-Sqrt × Fifty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs56k376 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs56kp1376 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs56k376 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs56kp1376 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK376r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs56k376] };
@@ -25301,8 +25301,8 @@ describe("Phase 377 — Zero-Sqrt × Fifty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs56k377 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs56kp1377 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs56k377 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs56kp1377 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK377r = { kind: "apply" as const, head: MUL, args: [...logs56k377] };
     const numKp1377r = { kind: "apply" as const, head: MUL, args: [...logs56kp1377] };
     const gK377r = { kind: "apply" as const, head: DIV, args: [numK377r, k2r] };
@@ -25337,8 +25337,8 @@ describe("Phase 378 — One-Sqrt × Fifty-Five-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs56k378 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs56kp1378 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs56k378 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs56kp1378 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK378r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs56k378] };
@@ -25375,8 +25375,8 @@ describe("Phase 379 — Two-Sqrt × Fifty-Five-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs56k379 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs56kp1379 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs56k379 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs56kp1379 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK379r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs56k379] };
@@ -25413,8 +25413,8 @@ describe("Phase 380 — Three-Sqrt × Fifty-Five-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs56k380 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs56kp1380 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs56k380 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs56kp1380 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK380r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs56k380] };
@@ -25451,8 +25451,8 @@ describe("Phase 381 — Four-Sqrt × Fifty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs56k381 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs56kp1381 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs56k381 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs56kp1381 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK381r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs56k381] };
@@ -25489,8 +25489,8 @@ describe("Phase 382 — Five-Sqrt × Fifty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs56k382 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs56kp1382 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs56k382 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs56kp1382 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK382r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs56k382] };
@@ -25525,8 +25525,8 @@ describe("Phase 383 — Zero-Sqrt × Fifty-Six-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs57k383 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs57kp1383 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs57k383 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs57kp1383 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK383r = { kind: "apply" as const, head: MUL, args: [...logs57k383] };
     const numKp1383r = { kind: "apply" as const, head: MUL, args: [...logs57kp1383] };
     const gK383r = { kind: "apply" as const, head: DIV, args: [numK383r, k2r] };
@@ -25561,8 +25561,8 @@ describe("Phase 384 — One-Sqrt × Fifty-Six-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs57k384 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs57kp1384 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs57k384 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs57kp1384 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK384r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs57k384] };
@@ -25599,8 +25599,8 @@ describe("Phase 385 — Two-Sqrt × Fifty-Six-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs57k385 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs57kp1385 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs57k385 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs57kp1385 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK385r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs57k385] };
@@ -25637,8 +25637,8 @@ describe("Phase 386 — Three-Sqrt × Fifty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs57k386 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs57kp1386 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs57k386 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs57kp1386 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK386r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs57k386] };
@@ -25675,8 +25675,8 @@ describe("Phase 387 — Four-Sqrt × Fifty-Six-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs57k387 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs57kp1387 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs57k387 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs57kp1387 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK387r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs57k387] };
@@ -25713,8 +25713,8 @@ describe("Phase 388 — Five-Sqrt × Fifty-Six-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs57k388 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs57kp1388 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs57k388 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs57kp1388 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK388r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs57k388] };
@@ -25749,8 +25749,8 @@ describe("Phase 389 — Zero-Sqrt × Fifty-Seven-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs59k389 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs59kp1389 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs59k389 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs59kp1389 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK389r = { kind: "apply" as const, head: MUL, args: [...logs59k389] };
     const numKp1389r = { kind: "apply" as const, head: MUL, args: [...logs59kp1389] };
     const gK389r = { kind: "apply" as const, head: DIV, args: [numK389r, k2r] };
@@ -25785,8 +25785,8 @@ describe("Phase 390 — One-Sqrt × Fifty-Seven-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs59k390 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs59kp1390 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs59k390 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs59kp1390 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK390r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs59k390] };
@@ -25823,8 +25823,8 @@ describe("Phase 391 — Two-Sqrt × Fifty-Seven-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs59k391 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs59kp1391 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs59k391 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs59kp1391 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK391r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs59k391] };
@@ -25861,8 +25861,8 @@ describe("Phase 392 — Three-Sqrt × Fifty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs59k392 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs59kp1392 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs59k392 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs59kp1392 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK392r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs59k392] };
@@ -25899,8 +25899,8 @@ describe("Phase 393 — Four-Sqrt × Fifty-Seven-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs59k393 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs59kp1393 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs59k393 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs59kp1393 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK393r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs59k393] };
@@ -25932,13 +25932,13 @@ describe("Phase 394 — Five-Sqrt × Fifty-Seven-Log × polynomial numerator", (
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)^5·log(k)⁵⁷/k³ refused (59 logs — not Phase 400)", () => {
+  it("(√k)^5·log(k)⁵⁷/k³ refused (60 logs — not Phase 400)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs59k394 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs59kp1394 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs59k394 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs59kp1394 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK394r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs59k394] };
@@ -25968,13 +25968,13 @@ describe("Phase 395 — Zero-Sqrt × Fifty-Eight-Log × polynomial numerator", (
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("log(k)⁵⁸/k² refused (59 logs — not Phase 401)", () => {
+  it("log(k)⁵⁸/k² refused (60 logs — not Phase 401)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs59k395 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs59kp1395 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs59k395 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs59kp1395 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK395r = { kind: "apply" as const, head: MUL, args: [...logs59k395] };
     const numKp1395r = { kind: "apply" as const, head: MUL, args: [...logs59kp1395] };
     const gK395r = { kind: "apply" as const, head: DIV, args: [numK395r, k2r] };
@@ -26004,13 +26004,13 @@ describe("Phase 396 — One-Sqrt × Fifty-Eight-Log × polynomial numerator", ()
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("√k·log(k)⁵⁸/k² refused (59 logs — not Phase 402)", () => {
+  it("√k·log(k)⁵⁸/k² refused (60 logs — not Phase 402)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs59k396 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs59kp1396 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs59k396 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs59kp1396 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK396r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs59k396] };
@@ -26042,13 +26042,13 @@ describe("Phase 397 — Two-Sqrt × Fifty-Eight-Log × polynomial numerator", ()
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)²·log(k)⁵⁸/k² refused (59 logs — not Phase 403)", () => {
+  it("(√k)²·log(k)⁵⁸/k² refused (60 logs — not Phase 403)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs59k397 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs59kp1397 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs59k397 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs59kp1397 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK397r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs59k397] };
@@ -26080,13 +26080,13 @@ describe("Phase 398 — Three-Sqrt × Fifty-Eight-Log × polynomial numerator", 
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)³·log(k)⁵⁸/k³ refused (59 logs — not Phase 404)", () => {
+  it("(√k)³·log(k)⁵⁸/k³ refused (60 logs — not Phase 404)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs59k398 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs59kp1398 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs59k398 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs59kp1398 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK398r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs59k398] };
@@ -26118,13 +26118,13 @@ describe("Phase 399 — Four-Sqrt × Fifty-Eight-Log × polynomial numerator", (
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)⁴·log(k)⁵⁸/k³ refused (59 logs — not Phase 405)", () => {
+  it("(√k)⁴·log(k)⁵⁸/k³ refused (60 logs — not Phase 405)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs59k399 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs59kp1399 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs59k399 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs59kp1399 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK399r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs59k399] };
@@ -26156,13 +26156,13 @@ describe("Phase 400 — Five-Sqrt × Fifty-Eight-Log × polynomial numerator", (
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)^5·log(k)⁵⁸/k³ refused (59 logs — not Phase 406)", () => {
+  it("(√k)^5·log(k)⁵⁸/k³ refused (60 logs — not Phase 406)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs59k400 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs59kp1400 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs59k400 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs59kp1400 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK400r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs59k400] };
@@ -26171,6 +26171,230 @@ describe("Phase 400 — Five-Sqrt × Fifty-Eight-Log × polynomial numerator", (
     const gKp1400r = { kind: "apply" as const, head: DIV, args: [numKp1400r, kp1_3r] };
     const f400r = { kind: "apply" as const, head: SUB, args: [gK400r, gKp1400r] };
     const result = evaluateSum(f400r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 401 — Zero-Sqrt × Fifty-Nine-Log × polynomial numerator", () => {
+  it("log(k)⁵⁹/k² closes (polyDeg=0, denDeg=2 > 0)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const logs59k401 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs59kp1401 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const numK401a = { kind: "apply" as const, head: MUL, args: [...logs59k401] };
+    const numKp1401a = { kind: "apply" as const, head: MUL, args: [...logs59kp1401] };
+    const gK401a = { kind: "apply" as const, head: DIV, args: [numK401a, k2] };
+    const gKp1401a = { kind: "apply" as const, head: DIV, args: [numKp1401a, kp1_2] };
+    const f401a = { kind: "apply" as const, head: SUB, args: [gK401a, gKp1401a] };
+    const result = evaluateSum(f401a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("log(k)⁵⁹/k² refused (60 logs — not Phase 401)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs60k401 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs60kp1401 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const numK401r = { kind: "apply" as const, head: MUL, args: [...logs60k401] };
+    const numKp1401r = { kind: "apply" as const, head: MUL, args: [...logs60kp1401] };
+    const gK401r = { kind: "apply" as const, head: DIV, args: [numK401r, k2r] };
+    const gKp1401r = { kind: "apply" as const, head: DIV, args: [numKp1401r, kp1_2r] };
+    const f401r = { kind: "apply" as const, head: SUB, args: [gK401r, gKp1401r] };
+    const result = evaluateSum(f401r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 402 — One-Sqrt × Fifty-Nine-Log × polynomial numerator", () => {
+  it("√k·log(k)⁵⁹/k² closes (sqrtHalf=0.5, denDeg=2 > 0.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const logs59k402 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs59kp1402 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK402a = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs59k402] };
+    const numKp1402a = { kind: "apply" as const, head: MUL, args: [sqrtKp1, ...logs59kp1402] };
+    const gK402a = { kind: "apply" as const, head: DIV, args: [numK402a, k2] };
+    const gKp1402a = { kind: "apply" as const, head: DIV, args: [numKp1402a, kp1_2] };
+    const f402a = { kind: "apply" as const, head: SUB, args: [gK402a, gKp1402a] };
+    const result = evaluateSum(f402a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("√k·log(k)⁵⁹/k² refused (60 logs — not Phase 402)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs60k402 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs60kp1402 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK402r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs60k402] };
+    const numKp1402r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, ...logs60kp1402] };
+    const gK402r = { kind: "apply" as const, head: DIV, args: [numK402r, k2r] };
+    const gKp1402r = { kind: "apply" as const, head: DIV, args: [numKp1402r, kp1_2r] };
+    const f402r = { kind: "apply" as const, head: SUB, args: [gK402r, gKp1402r] };
+    const result = evaluateSum(f402r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 403 — Two-Sqrt × Fifty-Nine-Log × polynomial numerator", () => {
+  it("(√k)²·log(k)⁵⁹/k² closes (sqrtHalf=1, denDeg=2 > 1)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const logs59k403 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs59kp1403 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK403a = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs59k403] };
+    const numKp1403a = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, ...logs59kp1403] };
+    const gK403a = { kind: "apply" as const, head: DIV, args: [numK403a, k2] };
+    const gKp1403a = { kind: "apply" as const, head: DIV, args: [numKp1403a, kp1_2] };
+    const f403a = { kind: "apply" as const, head: SUB, args: [gK403a, gKp1403a] };
+    const result = evaluateSum(f403a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("(√k)²·log(k)⁵⁹/k² refused (60 logs — not Phase 403)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs60k403 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs60kp1403 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK403r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs60k403] };
+    const numKp1403r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, ...logs60kp1403] };
+    const gK403r = { kind: "apply" as const, head: DIV, args: [numK403r, k2r] };
+    const gKp1403r = { kind: "apply" as const, head: DIV, args: [numKp1403r, kp1_2r] };
+    const f403r = { kind: "apply" as const, head: SUB, args: [gK403r, gKp1403r] };
+    const result = evaluateSum(f403r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 404 — Three-Sqrt × Fifty-Nine-Log × polynomial numerator", () => {
+  it("(√k)³·log(k)⁵⁹/k³ closes (sqrtHalf=1.5, denDeg=3 > 1.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const logs59k404 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs59kp1404 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK404a = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs59k404] };
+    const numKp1404a = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, ...logs59kp1404] };
+    const gK404a = { kind: "apply" as const, head: DIV, args: [numK404a, k3] };
+    const gKp1404a = { kind: "apply" as const, head: DIV, args: [numKp1404a, kp1_3] };
+    const f404a = { kind: "apply" as const, head: SUB, args: [gK404a, gKp1404a] };
+    const result = evaluateSum(f404a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("(√k)³·log(k)⁵⁹/k³ refused (60 logs — not Phase 404)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs60k404 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs60kp1404 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK404r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs60k404] };
+    const numKp1404r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, ...logs60kp1404] };
+    const gK404r = { kind: "apply" as const, head: DIV, args: [numK404r, k3r] };
+    const gKp1404r = { kind: "apply" as const, head: DIV, args: [numKp1404r, kp1_3r] };
+    const f404r = { kind: "apply" as const, head: SUB, args: [gK404r, gKp1404r] };
+    const result = evaluateSum(f404r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 405 — Four-Sqrt × Fifty-Nine-Log × polynomial numerator", () => {
+  it("(√k)⁴·log(k)⁵⁹/k³ closes (sqrtHalf=2, denDeg=3 > 2)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const logs59k405 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs59kp1405 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK405a = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs59k405] };
+    const numKp1405a = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, ...logs59kp1405] };
+    const gK405a = { kind: "apply" as const, head: DIV, args: [numK405a, k3] };
+    const gKp1405a = { kind: "apply" as const, head: DIV, args: [numKp1405a, kp1_3] };
+    const f405a = { kind: "apply" as const, head: SUB, args: [gK405a, gKp1405a] };
+    const result = evaluateSum(f405a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("(√k)⁴·log(k)⁵⁹/k³ refused (60 logs — not Phase 405)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs60k405 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs60kp1405 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK405r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs60k405] };
+    const numKp1405r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, ...logs60kp1405] };
+    const gK405r = { kind: "apply" as const, head: DIV, args: [numK405r, k3r] };
+    const gKp1405r = { kind: "apply" as const, head: DIV, args: [numKp1405r, kp1_3r] };
+    const f405r = { kind: "apply" as const, head: SUB, args: [gK405r, gKp1405r] };
+    const result = evaluateSum(f405r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 406 — Five-Sqrt × Fifty-Nine-Log × polynomial numerator", () => {
+  it("(√k)^5·log(k)⁵⁹/k³ closes (sqrtHalf=2.5, denDeg=3 > 2.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const logs59k406 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs59kp1406 = Array.from({ length: 59 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK406a = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs59k406] };
+    const numKp1406a = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, ...logs59kp1406] };
+    const gK406a = { kind: "apply" as const, head: DIV, args: [numK406a, k3] };
+    const gKp1406a = { kind: "apply" as const, head: DIV, args: [numKp1406a, kp1_3] };
+    const f406a = { kind: "apply" as const, head: SUB, args: [gK406a, gKp1406a] };
+    const result = evaluateSum(f406a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("(√k)^5·log(k)⁵⁹/k³ refused (60 logs — not Phase 406)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs60k406 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs60kp1406 = Array.from({ length: 60 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK406r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs60k406] };
+    const numKp1406r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, ...logs60kp1406] };
+    const gK406r = { kind: "apply" as const, head: DIV, args: [numK406r, k3r] };
+    const gKp1406r = { kind: "apply" as const, head: DIV, args: [numKp1406r, kp1_3r] };
+    const f406r = { kind: "apply" as const, head: SUB, args: [gK406r, gKp1406r] };
+    const result = evaluateSum(f406r, k, int(1), sym("%inf"), evalNode);
     expect(result).toMatchObject({ kind: "apply", head: SUM });
   });
 });


### PR DESCRIPTION
## Summary

Adds Phase 401–406: the Fifty-Nine-Log convergence recognizer family across Python, Rust, and TypeScript.

Each phase handles summands whose numerator contains exactly **59 logarithmic factors** and **0–5 square-root factors**.

### Phases
| Phase | Description |
|-------|-------------|
| 401 | Zero-Sqrt × Fifty-Nine-Log × polynomial numerator |
| 402 | One-Sqrt × Fifty-Nine-Log × polynomial numerator |
| 403 | Two-Sqrt × Fifty-Nine-Log × polynomial numerator |
| 404 | Three-Sqrt × Fifty-Nine-Log × polynomial numerator |
| 405 | Four-Sqrt × Fifty-Nine-Log × polynomial numerator |
| 406 | Five-Sqrt × Fifty-Nine-Log × polynomial numerator |

### Changes
- **Python**: +6 helpers + dispatch + 12 tests; cascade fix (59→60 logs); 1103 tests pass; 91% coverage
- **Rust**: +6 helpers + dispatch + cascade fix; 996 tests pass
- **TypeScript**: +6 helpers + dispatch + cascade fix; 1014 tests pass
- Version bumped 2.337.0 → 2.343.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)