### PR TITLE
feat(cas-summation): Phase 413-418 — Sixty-One-Log family (v2.355.0)

### DIFF
--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.355.0 — 2026-05-28
+
+### Added
+- Phase 413 (`_sixty_one_log_poly_effective_x2`): Zero-Sqrt × Sixty-One-Log × polynomial numerator recognizer.
+- Phase 414 (`_one_sqrt_sixty_one_log_poly_effective_x2`): One-Sqrt × Sixty-One-Log × polynomial numerator recognizer.
+- Phase 415 (`_two_sqrt_sixty_one_log_poly_effective_x2`): Two-Sqrt × Sixty-One-Log × polynomial numerator recognizer.
+- Phase 416 (`_three_sqrt_sixty_one_log_poly_effective_x2`): Three-Sqrt × Sixty-One-Log × polynomial numerator recognizer.
+- Phase 417 (`_four_sqrt_sixty_one_log_poly_effective_x2`): Four-Sqrt × Sixty-One-Log × polynomial numerator recognizer.
+- Phase 418 (`_five_sqrt_sixty_one_log_poly_effective_x2`): Five-Sqrt × Sixty-One-Log × polynomial numerator recognizer. Completes the Sixty-One-Log family.
+- 12 new test cases covering Phase 413–418 (closes + refused for each).
+- Cascade fix: refused tests for Phases 359–412 (all those previously using exactly 61 logs as the "over-boundary" value) updated to use 62 log factors, since Phase 413 now accepts exactly 61.
+
 ## 2.349.0 — 2026-05-28
 
 ### Added

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "2.349.0"
+version = "2.355.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -1477,6 +1477,60 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
                 return True
         elif _h_diverges_at_infinity(den, k):
             return True
+    # Phase 418: ``Mul(Sqrt(P1)×5, Log(h1)×61, polynomial..., bounded...)`` numerator.
+    s5l61p_x2 = _five_sqrt_sixty_one_log_poly_effective_x2(num, k)
+    if s5l61p_x2 is not None:
+        den_deg_s5l61 = _polynomial_degree_in_k(den, k)
+        if den_deg_s5l61 is not None:
+            if 2 * den_deg_s5l61 > s5l61p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 417: ``Mul(Sqrt(P1)×4, Log(h1)×61, polynomial..., bounded...)`` numerator.
+    s4l61p_x2 = _four_sqrt_sixty_one_log_poly_effective_x2(num, k)
+    if s4l61p_x2 is not None:
+        den_deg_s4l61 = _polynomial_degree_in_k(den, k)
+        if den_deg_s4l61 is not None:
+            if 2 * den_deg_s4l61 > s4l61p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 416: ``Mul(Sqrt(P1)×3, Log(h1)×61, polynomial..., bounded...)`` numerator.
+    s3l61p_x2 = _three_sqrt_sixty_one_log_poly_effective_x2(num, k)
+    if s3l61p_x2 is not None:
+        den_deg_s3l61 = _polynomial_degree_in_k(den, k)
+        if den_deg_s3l61 is not None:
+            if 2 * den_deg_s3l61 > s3l61p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 415: ``Mul(Sqrt(P), Sqrt(P2), Log(h1)×61, polynomial..., bounded...)`` numerator.
+    s2l61p_x2 = _two_sqrt_sixty_one_log_poly_effective_x2(num, k)
+    if s2l61p_x2 is not None:
+        den_deg_s2l61 = _polynomial_degree_in_k(den, k)
+        if den_deg_s2l61 is not None:
+            if 2 * den_deg_s2l61 > s2l61p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 414: ``Mul(Sqrt(P), Log(h1)×61, polynomial..., bounded...)`` numerator.
+    s1l61p_x2 = _one_sqrt_sixty_one_log_poly_effective_x2(num, k)
+    if s1l61p_x2 is not None:
+        den_deg_s1l61 = _polynomial_degree_in_k(den, k)
+        if den_deg_s1l61 is not None:
+            if 2 * den_deg_s1l61 > s1l61p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 413: ``Mul(Log(h1)×61, polynomial..., bounded...)`` numerator.
+    sl61p_x2 = _sixty_one_log_poly_effective_x2(num, k)
+    if sl61p_x2 is not None:
+        den_deg_sl61 = _polynomial_degree_in_k(den, k)
+        if den_deg_sl61 is not None:
+            if 2 * den_deg_sl61 > sl61p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
     # Phase 412: ``Mul(Sqrt(P1)×5, Log(h1)×60, polynomial..., bounded...)`` numerator.
     s5l60p_x2 = _five_sqrt_sixty_log_poly_effective_x2(num, k)
     if s5l60p_x2 is not None:
@@ -13837,6 +13891,189 @@ def _five_sqrt_fifty_seven_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> i
             continue
         return None
     if len(sqrt_degs_x2) != 5 or log_count != 57:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _sixty_one_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 413 — Zero-Sqrt × Sixty-One-Log × polynomial numerator."""
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        if _sqrt_effective_half_degree_x2(arg, k) is not None:
+            return None
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 61:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if log_count != 61:
+        return None
+    return 2 * poly_deg_sum
+
+
+def _one_sqrt_sixty_one_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 414 — One-Sqrt × Sixty-One-Log × polynomial numerator."""
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_deg_x2: int | None = None
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if sqrt_deg_x2 is not None:
+                return None
+            sqrt_deg_x2 = deg_x2
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 61:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if sqrt_deg_x2 is None or log_count != 61:
+        return None
+    return sqrt_deg_x2 + 2 * poly_deg_sum
+
+
+def _two_sqrt_sixty_one_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 415 — Two-Sqrt × Sixty-One-Log × polynomial numerator."""
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 2:
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 61:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 2 or log_count != 61:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _three_sqrt_sixty_one_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 416 — Three-Sqrt × Sixty-One-Log × polynomial numerator."""
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 3:
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 61:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 3 or log_count != 61:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _four_sqrt_sixty_one_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 417 — Four-Sqrt × Sixty-One-Log × polynomial numerator."""
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 4:
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 61:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 4 or log_count != 61:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _five_sqrt_sixty_one_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 418 — Five-Sqrt × Sixty-One-Log × polynomial numerator.
+    Completes the Sixty-One-Log family (Phases 413-418).
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 5:
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 61:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 5 or log_count != 61:
         return None
     return sum(sqrt_degs_x2) + 2 * poly_deg_sum
 

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -17892,7 +17892,7 @@ class TestPhase205TwoSqrtTwentySixLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -18077,7 +18077,7 @@ class TestPhase206ThreeSqrtTwentySixLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -18268,7 +18268,7 @@ class TestPhase207FourSqrtTwentySixLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -18459,7 +18459,7 @@ class TestPhase208FiveSqrtTwentySixLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -19018,7 +19018,7 @@ class TestPhase211TwoSqrtTwentySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -19207,7 +19207,7 @@ class TestPhase212ThreeSqrtTwentySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -19402,7 +19402,7 @@ class TestPhase213FourSqrtTwentySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -19597,7 +19597,7 @@ class TestPhase214FiveSqrtTwentySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -20168,7 +20168,7 @@ class TestPhase217TwoSqrtTwentyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -20361,7 +20361,7 @@ class TestPhase218ThreeSqrtTwentyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -20560,7 +20560,7 @@ class TestPhase219FourSqrtTwentyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -20759,7 +20759,7 @@ class TestPhase220FiveSqrtTwentyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -21343,7 +21343,7 @@ class TestPhase223TwoSqrtTwentyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -21540,7 +21540,7 @@ class TestPhase224ThreeSqrtTwentyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -21743,7 +21743,7 @@ class TestPhase225FourSqrtTwentyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -21946,7 +21946,7 @@ class TestPhase226FiveSqrtTwentyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -22541,7 +22541,7 @@ class TestPhase229TwoSqrtThirtyLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -22742,7 +22742,7 @@ class TestPhase230ThreeSqrtThirtyLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -22943,7 +22943,7 @@ class TestPhase231FourSqrtThirtyLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -23150,7 +23150,7 @@ class TestPhase232FiveSqrtThirtyLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -23757,7 +23757,7 @@ class TestPhase235TwoSqrtThirtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -23962,7 +23962,7 @@ class TestPhase236ThreeSqrtThirtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -24173,7 +24173,7 @@ class TestPhase237FourSqrtThirtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -24384,7 +24384,7 @@ class TestPhase238FiveSqrtThirtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -25003,7 +25003,7 @@ class TestPhase241TwoSqrtThirtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -25212,7 +25212,7 @@ class TestPhase242ThreeSqrtThirtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -25427,7 +25427,7 @@ class TestPhase243FourSqrtThirtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -25642,7 +25642,7 @@ class TestPhase244FiveSqrtThirtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -26273,7 +26273,7 @@ class TestPhase247TwoSqrtThirtyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -26486,7 +26486,7 @@ class TestPhase248ThreeSqrtThirtyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -26705,7 +26705,7 @@ class TestPhase249FourSqrtThirtyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -26924,7 +26924,7 @@ class TestPhase250FiveSqrtThirtyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -27567,7 +27567,7 @@ class TestPhase253TwoSqrtThirtyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -27784,7 +27784,7 @@ class TestPhase254ThreeSqrtThirtyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -28007,7 +28007,7 @@ class TestPhase255FourSqrtThirtyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -28230,7 +28230,7 @@ class TestPhase256FiveSqrtThirtyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -28885,7 +28885,7 @@ class TestPhase259TwoSqrtThirtyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -29106,7 +29106,7 @@ class TestPhase260ThreeSqrtThirtyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -29333,7 +29333,7 @@ class TestPhase261FourSqrtThirtyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -29560,7 +29560,7 @@ class TestPhase262FiveSqrtThirtyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -30227,7 +30227,7 @@ class TestPhase265TwoSqrtThirtySixLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -30452,7 +30452,7 @@ class TestPhase266ThreeSqrtThirtySixLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -30683,7 +30683,7 @@ class TestPhase267FourSqrtThirtySixLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -30914,7 +30914,7 @@ class TestPhase268FiveSqrtThirtySixLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -31139,7 +31139,7 @@ class TestPhase269ThirtySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -31367,7 +31367,7 @@ class TestPhase270OneSqrtThirtySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -31595,7 +31595,7 @@ class TestPhase271TwoSqrtThirtySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -31823,7 +31823,7 @@ class TestPhase272ThreeSqrtThirtySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -32051,7 +32051,7 @@ class TestPhase273FourSqrtThirtySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -32285,7 +32285,7 @@ class TestPhase274FiveSqrtThirtySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -32513,7 +32513,7 @@ class TestPhase275ThirtyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -32745,7 +32745,7 @@ class TestPhase276OneSqrtThirtyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -32977,7 +32977,7 @@ class TestPhase277TwoSqrtThirtyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -33209,7 +33209,7 @@ class TestPhase278ThreeSqrtThirtyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -33447,7 +33447,7 @@ class TestPhase279FourSqrtThirtyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -33685,7 +33685,7 @@ class TestPhase280FiveSqrtThirtyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -33918,7 +33918,7 @@ class TestPhase281ThirtyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -34154,7 +34154,7 @@ class TestPhase282OneSqrtThirtyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -34392,7 +34392,7 @@ class TestPhase283TwoSqrtThirtyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -34630,7 +34630,7 @@ class TestPhase284ThreeSqrtThirtyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -34868,7 +34868,7 @@ class TestPhase285FourSqrtThirtyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -35106,7 +35106,7 @@ class TestPhase286FiveSqrtThirtyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -35343,7 +35343,7 @@ class TestPhase287FortyLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -35583,7 +35583,7 @@ class TestPhase288OneSqrtFortyLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -35825,7 +35825,7 @@ class TestPhase289TwoSqrtFortyLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -36067,7 +36067,7 @@ class TestPhase290ThreeSqrtFortyLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -36309,7 +36309,7 @@ class TestPhase291FourSqrtFortyLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -36551,7 +36551,7 @@ class TestPhase292FiveSqrtFortyLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -36792,7 +36792,7 @@ class TestPhase293FortyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -36965,7 +36965,7 @@ class TestPhase294OneSqrtFortyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -37138,7 +37138,7 @@ class TestPhase295TwoSqrtFortyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -37311,7 +37311,7 @@ class TestPhase296ThreeSqrtFortyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -37484,7 +37484,7 @@ class TestPhase297FourSqrtFortyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -37657,7 +37657,7 @@ class TestPhase298FiveSqrtFortyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -37829,7 +37829,7 @@ class TestPhase299FortyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -38004,7 +38004,7 @@ class TestPhase300OneSqrtFortyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -38179,7 +38179,7 @@ class TestPhase301TwoSqrtFortyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -38354,7 +38354,7 @@ class TestPhase302ThreeSqrtFortyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -38529,7 +38529,7 @@ class TestPhase303FourSqrtFortyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -38704,7 +38704,7 @@ class TestPhase304FiveSqrtFortyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -38878,7 +38878,7 @@ class TestPhase305FortyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -39056,7 +39056,7 @@ class TestPhase306OneSqrtFortyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -39234,7 +39234,7 @@ class TestPhase307TwoSqrtFortyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -39412,7 +39412,7 @@ class TestPhase308ThreeSqrtFortyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -39590,7 +39590,7 @@ class TestPhase309FourSqrtFortyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -39768,7 +39768,7 @@ class TestPhase310FiveSqrtFortyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -39944,7 +39944,7 @@ class TestPhase311FortyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -40124,7 +40124,7 @@ class TestPhase312OneSqrtFortyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -40304,7 +40304,7 @@ class TestPhase313TwoSqrtFortyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -40484,7 +40484,7 @@ class TestPhase314ThreeSqrtFortyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -40664,7 +40664,7 @@ class TestPhase315FourSqrtFortyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -40844,7 +40844,7 @@ class TestPhase316FiveSqrtFortyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -41022,7 +41022,7 @@ class TestPhase317FortyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -41203,7 +41203,7 @@ class TestPhase318OneSqrtFortyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -41384,7 +41384,7 @@ class TestPhase319TwoSqrtFortyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -41565,7 +41565,7 @@ class TestPhase320ThreeSqrtFortyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -41746,7 +41746,7 @@ class TestPhase321FourSqrtFortyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -41927,7 +41927,7 @@ class TestPhase322FiveSqrtFortyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -42107,7 +42107,7 @@ class TestPhase323FortysSixLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -42290,7 +42290,7 @@ class TestPhase324OneSqrtFortySixLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -42473,7 +42473,7 @@ class TestPhase325TwoSqrtFortySixLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -42656,7 +42656,7 @@ class TestPhase326ThreeSqrtFortySixLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -42839,7 +42839,7 @@ class TestPhase327FourSqrtFortySixLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -43022,7 +43022,7 @@ class TestPhase328FiveSqrtFortySixLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -43204,7 +43204,7 @@ class TestPhase329FortySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -43389,7 +43389,7 @@ class TestPhase330OneSqrtFortySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -43574,7 +43574,7 @@ class TestPhase331TwoSqrtFortySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -43759,7 +43759,7 @@ class TestPhase332ThreeSqrtFortySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -43944,7 +43944,7 @@ class TestPhase333FourSqrtFortySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -44129,7 +44129,7 @@ class TestPhase334FiveSqrtFortySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -44313,7 +44313,7 @@ class TestPhase335FortyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -44501,7 +44501,7 @@ class TestPhase336OneSqrtFortyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -44689,7 +44689,7 @@ class TestPhase337TwoSqrtFortyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -44877,7 +44877,7 @@ class TestPhase338ThreeSqrtFortyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -45065,7 +45065,7 @@ class TestPhase339FourSqrtFortyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -45253,7 +45253,7 @@ class TestPhase340FiveSqrtFortyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -45439,7 +45439,7 @@ class TestPhase341FortyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -45629,7 +45629,7 @@ class TestPhase342OneSqrtFortyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -45819,7 +45819,7 @@ class TestPhase343TwoSqrtFortyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -46009,7 +46009,7 @@ class TestPhase344ThreeSqrtFortyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -46199,7 +46199,7 @@ class TestPhase345FourSqrtFortyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -46389,7 +46389,7 @@ class TestPhase346FiveSqrtFortyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -46577,7 +46577,7 @@ class TestPhase347FiftyLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -46769,7 +46769,7 @@ class TestPhase348OneSqrtFiftyLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -46961,7 +46961,7 @@ class TestPhase349TwoSqrtFiftyLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -47153,7 +47153,7 @@ class TestPhase350ThreeSqrtFiftyLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -47345,7 +47345,7 @@ class TestPhase351FourSqrtFiftyLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -47537,7 +47537,7 @@ class TestPhase352FiveSqrtFiftyLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -47727,7 +47727,7 @@ class TestPhase353FiftyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -47921,7 +47921,7 @@ class TestPhase354OneSqrtFiftyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -48115,7 +48115,7 @@ class TestPhase355TwoSqrtFiftyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -48309,7 +48309,7 @@ class TestPhase356ThreeSqrtFiftyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -48503,7 +48503,7 @@ class TestPhase357FourSqrtFiftyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -48697,7 +48697,7 @@ class TestPhase358FiveSqrtFiftyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -48851,6 +48851,7 @@ class TestPhase359FiftyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -48898,6 +48899,7 @@ class TestPhase359FiftyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -49054,6 +49056,7 @@ class TestPhase360OneSqrtFiftyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -49102,6 +49105,7 @@ class TestPhase360OneSqrtFiftyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -49258,6 +49262,7 @@ class TestPhase361TwoSqrtFiftyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -49306,6 +49311,7 @@ class TestPhase361TwoSqrtFiftyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -49462,6 +49468,7 @@ class TestPhase362ThreeSqrtFiftyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -49510,6 +49517,7 @@ class TestPhase362ThreeSqrtFiftyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -49666,6 +49674,7 @@ class TestPhase363FourSqrtFiftyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -49714,6 +49723,7 @@ class TestPhase363FourSqrtFiftyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -49870,6 +49880,7 @@ class TestPhase364FiveSqrtFiftyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -49918,6 +49929,7 @@ class TestPhase364FiveSqrtFiftyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -50110,7 +50122,7 @@ class TestPhase365FiftyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -50307,7 +50319,7 @@ class TestPhase366OneSqrtFiftyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -50504,7 +50516,7 @@ class TestPhase367TwoSqrtFiftyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -50701,7 +50713,7 @@ class TestPhase368ThreeSqrtFiftyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -50898,7 +50910,7 @@ class TestPhase369FourSqrtFiftyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -51095,7 +51107,7 @@ class TestPhase370FiveSqrtFiftyThreeLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -51290,7 +51302,7 @@ class TestPhase371FiftyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -51489,7 +51501,7 @@ class TestPhase372OneSqrtFiftyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -51688,7 +51700,7 @@ class TestPhase373TwoSqrtFiftyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -51887,7 +51899,7 @@ class TestPhase374ThreeSqrtFiftyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -52086,7 +52098,7 @@ class TestPhase375FourSqrtFiftyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -52285,7 +52297,7 @@ class TestPhase376FiveSqrtFiftyFourLogPoly:
             IRApply(LOG, (kp1,)),  # 56th log (over 55; refused)
             IRApply(LOG, (kp1,)),  # 57th log (over 56; refused)
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -52445,6 +52457,7 @@ class TestPhase377FiftyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -52492,6 +52505,7 @@ class TestPhase377FiftyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -52654,6 +52668,7 @@ class TestPhase378OneSqrtFiftyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -52702,6 +52717,7 @@ class TestPhase378OneSqrtFiftyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -52864,6 +52880,7 @@ class TestPhase379TwoSqrtFiftyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -52912,6 +52929,7 @@ class TestPhase379TwoSqrtFiftyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -53074,6 +53092,7 @@ class TestPhase380ThreeSqrtFiftyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -53122,6 +53141,7 @@ class TestPhase380ThreeSqrtFiftyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -53284,6 +53304,7 @@ class TestPhase381FourSqrtFiftyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -53332,6 +53353,7 @@ class TestPhase381FourSqrtFiftyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -53494,6 +53516,7 @@ class TestPhase382FiveSqrtFiftyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -53542,6 +53565,7 @@ class TestPhase382FiveSqrtFiftyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -53703,6 +53727,7 @@ class TestPhase383ZeroSqrtFiftySixLogPoly:
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -53750,6 +53775,7 @@ class TestPhase383ZeroSqrtFiftySixLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -53918,6 +53944,7 @@ class TestPhase384OneSqrtFiftySixLogPoly:
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1,
@@ -53966,6 +53993,7 @@ class TestPhase384OneSqrtFiftySixLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -54134,6 +54162,7 @@ class TestPhase385TwoSqrtFiftySixLogPoly:
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1,
@@ -54182,6 +54211,7 @@ class TestPhase385TwoSqrtFiftySixLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -54350,6 +54380,7 @@ class TestPhase386ThreeSqrtFiftySixLogPoly:
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -54398,6 +54429,7 @@ class TestPhase386ThreeSqrtFiftySixLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -54566,6 +54598,7 @@ class TestPhase387FourSqrtFiftySixLogPoly:
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -54614,6 +54647,7 @@ class TestPhase387FourSqrtFiftySixLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -54782,6 +54816,7 @@ class TestPhase388FiveSqrtFiftySixLogPoly:
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -54830,6 +54865,7 @@ class TestPhase388FiveSqrtFiftySixLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -54993,6 +55029,7 @@ class TestPhase389ZeroSqrtFiftySevenLogPoly:
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -55040,6 +55077,7 @@ class TestPhase389ZeroSqrtFiftySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -55210,6 +55248,7 @@ class TestPhase390OneSqrtFiftySevenLogPoly:
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1,
@@ -55258,6 +55297,7 @@ class TestPhase390OneSqrtFiftySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -55428,6 +55468,7 @@ class TestPhase391TwoSqrtFiftySevenLogPoly:
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1,
@@ -55476,6 +55517,7 @@ class TestPhase391TwoSqrtFiftySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -55646,6 +55688,7 @@ class TestPhase392ThreeSqrtFiftySevenLogPoly:
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -55694,6 +55737,7 @@ class TestPhase392ThreeSqrtFiftySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -55864,6 +55908,7 @@ class TestPhase393FourSqrtFiftySevenLogPoly:
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -55912,6 +55957,7 @@ class TestPhase393FourSqrtFiftySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -56082,6 +56128,7 @@ class TestPhase394FiveSqrtFiftySevenLogPoly:
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
             IRApply(LOG, (_k,)),  # 62nd log (over 59; refused by Phase 406)
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -56130,6 +56177,7 @@ class TestPhase394FiveSqrtFiftySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
             IRApply(LOG, (kp1,)),  # 62nd log (over 59; refused by Phase 406)
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -56293,8 +56341,9 @@ class TestPhase395ZeroSqrtFiftyEightLogPoly:
             IRApply(LOG, (_k,)),  # 57th log
             IRApply(LOG, (_k,)),  # 58th log
             IRApply(LOG, (_k,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (_k,)),  # 61st log
+            IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -56340,8 +56389,9 @@ class TestPhase395ZeroSqrtFiftyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 57th log
             IRApply(LOG, (kp1,)),  # 58th log
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -56512,8 +56562,9 @@ class TestPhase396OneSqrtFiftyEightLogPoly:
             IRApply(LOG, (_k,)),  # 57th log
             IRApply(LOG, (_k,)),  # 58th log
             IRApply(LOG, (_k,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (_k,)),  # 61st log
+            IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1,
@@ -56560,8 +56611,9 @@ class TestPhase396OneSqrtFiftyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 57th log
             IRApply(LOG, (kp1,)),  # 58th log
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -56732,8 +56784,9 @@ class TestPhase397TwoSqrtFiftyEightLogPoly:
             IRApply(LOG, (_k,)),  # 57th log
             IRApply(LOG, (_k,)),  # 58th log
             IRApply(LOG, (_k,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (_k,)),  # 61st log
+            IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1,
@@ -56780,8 +56833,9 @@ class TestPhase397TwoSqrtFiftyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 57th log
             IRApply(LOG, (kp1,)),  # 58th log
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -56952,8 +57006,9 @@ class TestPhase398ThreeSqrtFiftyEightLogPoly:
             IRApply(LOG, (_k,)),  # 57th log
             IRApply(LOG, (_k,)),  # 58th log
             IRApply(LOG, (_k,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (_k,)),  # 61st log
+            IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -57000,8 +57055,9 @@ class TestPhase398ThreeSqrtFiftyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 57th log
             IRApply(LOG, (kp1,)),  # 58th log
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -57172,8 +57228,9 @@ class TestPhase399FourSqrtFiftyEightLogPoly:
             IRApply(LOG, (_k,)),  # 57th log
             IRApply(LOG, (_k,)),  # 58th log
             IRApply(LOG, (_k,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (_k,)),  # 61st log
+            IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -57220,8 +57277,9 @@ class TestPhase399FourSqrtFiftyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 57th log
             IRApply(LOG, (kp1,)),  # 58th log
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -57392,8 +57450,9 @@ class TestPhase400FiveSqrtFiftyEightLogPoly:
             IRApply(LOG, (_k,)),  # 57th log
             IRApply(LOG, (_k,)),  # 58th log
             IRApply(LOG, (_k,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (_k,)),  # 61st log
+            IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -57440,8 +57499,9 @@ class TestPhase400FiveSqrtFiftyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 57th log
             IRApply(LOG, (kp1,)),  # 58th log
             IRApply(LOG, (kp1,)),  # 59th log (over 58; refused)
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -57607,8 +57667,9 @@ class TestPhase401ZeroSqrtFiftyNineLogPoly:
             IRApply(LOG, (_k,)),  # 57th log
             IRApply(LOG, (_k,)),  # 58th log
             IRApply(LOG, (_k,)),  # 59th log
-            IRApply(LOG, (_k,)),  # 61st log
+            IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 61st log (over 59; refused)
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -57654,8 +57715,9 @@ class TestPhase401ZeroSqrtFiftyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 57th log
             IRApply(LOG, (kp1,)),  # 58th log
             IRApply(LOG, (kp1,)),  # 59th log
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 61st log (over 59; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -57828,8 +57890,9 @@ class TestPhase402OneSqrtFiftyNineLogPoly:
             IRApply(LOG, (_k,)),  # 57th log
             IRApply(LOG, (_k,)),  # 58th log
             IRApply(LOG, (_k,)),  # 59th log
-            IRApply(LOG, (_k,)),  # 61st log
+            IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 61st log (over 59; refused)
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1,
@@ -57876,8 +57939,9 @@ class TestPhase402OneSqrtFiftyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 57th log
             IRApply(LOG, (kp1,)),  # 58th log
             IRApply(LOG, (kp1,)),  # 59th log
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 61st log (over 59; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -58050,8 +58114,9 @@ class TestPhase403TwoSqrtFiftyNineLogPoly:
             IRApply(LOG, (_k,)),  # 57th log
             IRApply(LOG, (_k,)),  # 58th log
             IRApply(LOG, (_k,)),  # 59th log
-            IRApply(LOG, (_k,)),  # 61st log
+            IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 61st log (over 59; refused)
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1,
@@ -58098,8 +58163,9 @@ class TestPhase403TwoSqrtFiftyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 57th log
             IRApply(LOG, (kp1,)),  # 58th log
             IRApply(LOG, (kp1,)),  # 59th log
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 61st log (over 59; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -58272,8 +58338,9 @@ class TestPhase404ThreeSqrtFiftyNineLogPoly:
             IRApply(LOG, (_k,)),  # 57th log
             IRApply(LOG, (_k,)),  # 58th log
             IRApply(LOG, (_k,)),  # 59th log
-            IRApply(LOG, (_k,)),  # 61st log
+            IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 61st log (over 59; refused)
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -58320,8 +58387,9 @@ class TestPhase404ThreeSqrtFiftyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 57th log
             IRApply(LOG, (kp1,)),  # 58th log
             IRApply(LOG, (kp1,)),  # 59th log
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 61st log (over 59; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -58494,8 +58562,9 @@ class TestPhase405FourSqrtFiftyNineLogPoly:
             IRApply(LOG, (_k,)),  # 57th log
             IRApply(LOG, (_k,)),  # 58th log
             IRApply(LOG, (_k,)),  # 59th log
-            IRApply(LOG, (_k,)),  # 61st log
+            IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 61st log (over 59; refused)
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -58542,8 +58611,9 @@ class TestPhase405FourSqrtFiftyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 57th log
             IRApply(LOG, (kp1,)),  # 58th log
             IRApply(LOG, (kp1,)),  # 59th log
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 61st log (over 59; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -58716,8 +58786,9 @@ class TestPhase406FiveSqrtFiftyNineLogPoly:
             IRApply(LOG, (_k,)),  # 57th log
             IRApply(LOG, (_k,)),  # 58th log
             IRApply(LOG, (_k,)),  # 59th log
-            IRApply(LOG, (_k,)),  # 61st log
+            IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 61st log (over 59; refused)
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -58764,8 +58835,9 @@ class TestPhase406FiveSqrtFiftyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 57th log
             IRApply(LOG, (kp1,)),  # 58th log
             IRApply(LOG, (kp1,)),  # 59th log
-            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 61st log (over 59; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -58935,6 +59007,7 @@ class TestPhase407ZeroSqrtSixtyLogPoly:
             IRApply(LOG, (_k,)),  # 59th log
             IRApply(LOG, (_k,)),  # 60th log
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -58982,6 +59055,7 @@ class TestPhase407ZeroSqrtSixtyLogPoly:
             IRApply(LOG, (kp1,)),  # 59th log
             IRApply(LOG, (kp1,)),  # 60th log
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -59158,6 +59232,7 @@ class TestPhase408OneSqrtSixtyLogPoly:
             IRApply(LOG, (_k,)),  # 59th log
             IRApply(LOG, (_k,)),  # 60th log
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1,
@@ -59206,6 +59281,7 @@ class TestPhase408OneSqrtSixtyLogPoly:
             IRApply(LOG, (kp1,)),  # 59th log
             IRApply(LOG, (kp1,)),  # 60th log
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -59382,6 +59458,7 @@ class TestPhase409TwoSqrtSixtyLogPoly:
             IRApply(LOG, (_k,)),  # 59th log
             IRApply(LOG, (_k,)),  # 60th log
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1,
@@ -59430,6 +59507,7 @@ class TestPhase409TwoSqrtSixtyLogPoly:
             IRApply(LOG, (kp1,)),  # 59th log
             IRApply(LOG, (kp1,)),  # 60th log
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -59606,6 +59684,7 @@ class TestPhase410ThreeSqrtSixtyLogPoly:
             IRApply(LOG, (_k,)),  # 59th log
             IRApply(LOG, (_k,)),  # 60th log
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -59654,6 +59733,7 @@ class TestPhase410ThreeSqrtSixtyLogPoly:
             IRApply(LOG, (kp1,)),  # 59th log
             IRApply(LOG, (kp1,)),  # 60th log
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -59830,6 +59910,7 @@ class TestPhase411FourSqrtSixtyLogPoly:
             IRApply(LOG, (_k,)),  # 59th log
             IRApply(LOG, (_k,)),  # 60th log
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -59878,6 +59959,7 @@ class TestPhase411FourSqrtSixtyLogPoly:
             IRApply(LOG, (kp1,)),  # 59th log
             IRApply(LOG, (kp1,)),  # 60th log
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -60054,6 +60136,7 @@ class TestPhase412FiveSqrtSixtyLogPoly:
             IRApply(LOG, (_k,)),  # 59th log
             IRApply(LOG, (_k,)),  # 60th log
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -60102,6 +60185,1367 @@ class TestPhase412FiveSqrtSixtyLogPoly:
             IRApply(LOG, (kp1,)),  # 59th log
             IRApply(LOG, (kp1,)),  # 60th log
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase413ZeroSqrtSixtyOneLogPoly:
+    """Phase 413 -- Zero-Sqrt x Sixty-One-Log x polynomial numerator."""
+
+    def test_log61_k_over_k2_closes(self):
+        """log(k)^61/k^2: eff_x2=0; 2*2=4 > 0 -> closes"""
+        from symbolic_ir import SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+            IRApply(LOG, (_k,)),  # 58th log
+            IRApply(LOG, (_k,)),  # 59th log
+            IRApply(LOG, (_k,)),  # 60th log
+            IRApply(LOG, (_k,)),  # 61st log
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+            IRApply(LOG, (kp1,)),  # 58th log
+            IRApply(LOG, (kp1,)),  # 59th log
+            IRApply(LOG, (kp1,)),  # 60th log
+            IRApply(LOG, (kp1,)),  # 61st log
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_log61_k_over_k2_refused(self):
+        """log(k)^62/k2: 62 logs -> not Phase 413 -> refused"""
+        from symbolic_ir import SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+            IRApply(LOG, (_k,)),  # 58th log
+            IRApply(LOG, (_k,)),  # 59th log
+            IRApply(LOG, (_k,)),  # 60th log
+            IRApply(LOG, (_k,)),  # 61st log
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+            IRApply(LOG, (kp1,)),  # 58th log
+            IRApply(LOG, (kp1,)),  # 59th log
+            IRApply(LOG, (kp1,)),  # 60th log
+            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase414OneSqrtSixtyOneLogPoly:
+    """Phase 414 -- One-Sqrt x Sixty-One-Log x polynomial numerator."""
+
+    def test_sqrt_k_log61_k_over_k2_closes(self):
+        """sqrt(k)*log(k)^61/k^2: eff_x2=1; 2*2=4 > 1 -> closes"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        sqrt_k = IRApply(SQRT, (_k,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_k = IRApply(MUL, (
+            sqrt_k,
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+            IRApply(LOG, (_k,)),  # 58th log
+            IRApply(LOG, (_k,)),  # 59th log
+            IRApply(LOG, (_k,)),  # 60th log
+            IRApply(LOG, (_k,)),  # 61st log
+        ))
+        num_kp1 = IRApply(MUL, (
+            sqrt_kp1,
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+            IRApply(LOG, (kp1,)),  # 58th log
+            IRApply(LOG, (kp1,)),  # 59th log
+            IRApply(LOG, (kp1,)),  # 60th log
+            IRApply(LOG, (kp1,)),  # 61st log
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_log61_k_over_k2_refused(self):
+        """sqrt(k)*log(k)^62/k2: 62 logs -> not Phase 414 -> refused"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        sqrt_k = IRApply(SQRT, (_k,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_k = IRApply(MUL, (
+            sqrt_k,
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+            IRApply(LOG, (_k,)),  # 58th log
+            IRApply(LOG, (_k,)),  # 59th log
+            IRApply(LOG, (_k,)),  # 60th log
+            IRApply(LOG, (_k,)),  # 61st log
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
+        ))
+        num_kp1 = IRApply(MUL, (
+            sqrt_kp1,
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+            IRApply(LOG, (kp1,)),  # 58th log
+            IRApply(LOG, (kp1,)),  # 59th log
+            IRApply(LOG, (kp1,)),  # 60th log
+            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase415TwoSqrtSixtyOneLogPoly:
+    """Phase 415 -- Two-Sqrt x Sixty-One-Log x polynomial numerator."""
+
+    def test_2sqrt_k_log61_k_over_k2_closes(self):
+        """sqrt(k)^2*log(k)^61/k^2: eff_x2=2; 2*2=4 > 2 -> closes"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        sqrt_k = IRApply(SQRT, (_k,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_k = IRApply(MUL, (
+            sqrt_k, sqrt_k,
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+            IRApply(LOG, (_k,)),  # 58th log
+            IRApply(LOG, (_k,)),  # 59th log
+            IRApply(LOG, (_k,)),  # 60th log
+            IRApply(LOG, (_k,)),  # 61st log
+        ))
+        num_kp1 = IRApply(MUL, (
+            sqrt_kp1, sqrt_kp1,
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+            IRApply(LOG, (kp1,)),  # 58th log
+            IRApply(LOG, (kp1,)),  # 59th log
+            IRApply(LOG, (kp1,)),  # 60th log
+            IRApply(LOG, (kp1,)),  # 61st log
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_2sqrt_k_log61_k_over_k2_refused(self):
+        """sqrt(k)^2*log(k)^62/k2: 62 logs -> not Phase 415 -> refused"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        sqrt_k = IRApply(SQRT, (_k,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_k = IRApply(MUL, (
+            sqrt_k, sqrt_k,
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+            IRApply(LOG, (_k,)),  # 58th log
+            IRApply(LOG, (_k,)),  # 59th log
+            IRApply(LOG, (_k,)),  # 60th log
+            IRApply(LOG, (_k,)),  # 61st log
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
+        ))
+        num_kp1 = IRApply(MUL, (
+            sqrt_kp1, sqrt_kp1,
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+            IRApply(LOG, (kp1,)),  # 58th log
+            IRApply(LOG, (kp1,)),  # 59th log
+            IRApply(LOG, (kp1,)),  # 60th log
+            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase416ThreeSqrtSixtyOneLogPoly:
+    """Phase 416 -- Three-Sqrt x Sixty-One-Log x polynomial numerator."""
+
+    def test_3sqrt_k_log61_k_over_k3_closes(self):
+        """sqrt(k)^3*log(k)^61/k^3: eff_x2=3; 2*3=6 > 3 -> closes"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        sqrt_k = IRApply(SQRT, (_k,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_k = IRApply(MUL, (
+            sqrt_k, sqrt_k, sqrt_k,
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+            IRApply(LOG, (_k,)),  # 58th log
+            IRApply(LOG, (_k,)),  # 59th log
+            IRApply(LOG, (_k,)),  # 60th log
+            IRApply(LOG, (_k,)),  # 61st log
+        ))
+        num_kp1 = IRApply(MUL, (
+            sqrt_kp1, sqrt_kp1, sqrt_kp1,
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+            IRApply(LOG, (kp1,)),  # 58th log
+            IRApply(LOG, (kp1,)),  # 59th log
+            IRApply(LOG, (kp1,)),  # 60th log
+            IRApply(LOG, (kp1,)),  # 61st log
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_3sqrt_k_log61_k_over_k3_refused(self):
+        """sqrt(k)^3*log(k)^62/k3: 62 logs -> not Phase 416 -> refused"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        sqrt_k = IRApply(SQRT, (_k,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_k = IRApply(MUL, (
+            sqrt_k, sqrt_k, sqrt_k,
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+            IRApply(LOG, (_k,)),  # 58th log
+            IRApply(LOG, (_k,)),  # 59th log
+            IRApply(LOG, (_k,)),  # 60th log
+            IRApply(LOG, (_k,)),  # 61st log
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
+        ))
+        num_kp1 = IRApply(MUL, (
+            sqrt_kp1, sqrt_kp1, sqrt_kp1,
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+            IRApply(LOG, (kp1,)),  # 58th log
+            IRApply(LOG, (kp1,)),  # 59th log
+            IRApply(LOG, (kp1,)),  # 60th log
+            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase417FourSqrtSixtyOneLogPoly:
+    """Phase 417 -- Four-Sqrt x Sixty-One-Log x polynomial numerator."""
+
+    def test_4sqrt_k_log61_k_over_k3_closes(self):
+        """sqrt(k)^4*log(k)^61/k^3: eff_x2=4; 2*3=6 > 4 -> closes"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        sqrt_k = IRApply(SQRT, (_k,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_k = IRApply(MUL, (
+            sqrt_k, sqrt_k, sqrt_k, sqrt_k,
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+            IRApply(LOG, (_k,)),  # 58th log
+            IRApply(LOG, (_k,)),  # 59th log
+            IRApply(LOG, (_k,)),  # 60th log
+            IRApply(LOG, (_k,)),  # 61st log
+        ))
+        num_kp1 = IRApply(MUL, (
+            sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+            IRApply(LOG, (kp1,)),  # 58th log
+            IRApply(LOG, (kp1,)),  # 59th log
+            IRApply(LOG, (kp1,)),  # 60th log
+            IRApply(LOG, (kp1,)),  # 61st log
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_4sqrt_k_log61_k_over_k3_refused(self):
+        """sqrt(k)^4*log(k)^62/k3: 62 logs -> not Phase 417 -> refused"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        sqrt_k = IRApply(SQRT, (_k,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_k = IRApply(MUL, (
+            sqrt_k, sqrt_k, sqrt_k, sqrt_k,
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+            IRApply(LOG, (_k,)),  # 58th log
+            IRApply(LOG, (_k,)),  # 59th log
+            IRApply(LOG, (_k,)),  # 60th log
+            IRApply(LOG, (_k,)),  # 61st log
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
+        ))
+        num_kp1 = IRApply(MUL, (
+            sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+            IRApply(LOG, (kp1,)),  # 58th log
+            IRApply(LOG, (kp1,)),  # 59th log
+            IRApply(LOG, (kp1,)),  # 60th log
+            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase418FiveSqrtSixtyOneLogPoly:
+    """Phase 418 -- Five-Sqrt x Sixty-One-Log x polynomial numerator."""
+
+    def test_5sqrt_k_log61_k_over_k3_closes(self):
+        """sqrt(k)^5*log(k)^61/k^3: eff_x2=5; 2*3=6 > 5 -> closes"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        sqrt_k = IRApply(SQRT, (_k,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_k = IRApply(MUL, (
+            sqrt_k, sqrt_k, sqrt_k, sqrt_k, sqrt_k,
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+            IRApply(LOG, (_k,)),  # 58th log
+            IRApply(LOG, (_k,)),  # 59th log
+            IRApply(LOG, (_k,)),  # 60th log
+            IRApply(LOG, (_k,)),  # 61st log
+        ))
+        num_kp1 = IRApply(MUL, (
+            sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+            IRApply(LOG, (kp1,)),  # 58th log
+            IRApply(LOG, (kp1,)),  # 59th log
+            IRApply(LOG, (kp1,)),  # 60th log
+            IRApply(LOG, (kp1,)),  # 61st log
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_5sqrt_k_log61_k_over_k3_refused(self):
+        """sqrt(k)^5*log(k)^62/k3: 62 logs -> not Phase 418 -> refused"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        sqrt_k = IRApply(SQRT, (_k,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_k = IRApply(MUL, (
+            sqrt_k, sqrt_k, sqrt_k, sqrt_k, sqrt_k,
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+            IRApply(LOG, (_k,)),  # 58th log
+            IRApply(LOG, (_k,)),  # 59th log
+            IRApply(LOG, (_k,)),  # 60th log
+            IRApply(LOG, (_k,)),  # 61st log
+            IRApply(LOG, (_k,)),  # 62nd log (over 61; refused)
+        ))
+        num_kp1 = IRApply(MUL, (
+            sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+            IRApply(LOG, (kp1,)),  # 58th log
+            IRApply(LOG, (kp1,)),  # 59th log
+            IRApply(LOG, (kp1,)),  # 60th log
+            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log (over 61; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))

--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.355.0 — 2026-05-28
+
+### Added
+- Phase 413 (`sixty_one_log_poly_effective_x2`): Zero-Sqrt × Sixty-One-Log × polynomial numerator recognizer.
+- Phase 414 (`one_sqrt_sixty_one_log_poly_effective_x2`): One-Sqrt × Sixty-One-Log.
+- Phase 415 (`two_sqrt_sixty_one_log_poly_effective_x2`): Two-Sqrt × Sixty-One-Log.
+- Phase 416 (`three_sqrt_sixty_one_log_poly_effective_x2`): Three-Sqrt × Sixty-One-Log.
+- Phase 417 (`four_sqrt_sixty_one_log_poly_effective_x2`): Four-Sqrt × Sixty-One-Log.
+- Phase 418 (`five_sqrt_sixty_one_log_poly_effective_x2`): Five-Sqrt × Sixty-One-Log. Completes the Sixty-One-Log family.
+- 12 new test functions covering Phase 413–418 (converges + refused for each).
+- Cascade fix: refused tests for Phases across the full chain (all those previously using exactly 61 logs as the "over-boundary" value) updated to use 62 log factors, since Phase 413 now accepts exactly 61. Also fixed Phase 417–418 refused test log counts (had 57 logs instead of 62).
+
 ## 2.349.0 — 2026-05-28
 
 ### Added

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "2.349.0"
+version = "2.355.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -7983,6 +7983,181 @@ fn five_sqrt_fifty_seven_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Opt
     Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg_sum)
 }
 
+/// Phase 413 — Zero-Sqrt × Sixty-One-Log × polynomial numerator.
+///
+/// The Sixty-One-Log family (Phases 413–418) extends the recogniser to
+/// summands whose numerator contains exactly sixty-one logarithmic factors
+/// and zero to five square-root factors.  This is Phase 413: zero sqrts.
+fn sixty_one_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if sqrt_effective_half_degree_x2(arg, k).is_some() { return None; }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 61 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg;
+            continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if log_count != 61 { return None; }
+    Some(2 * poly_deg_sum)
+}
+
+/// Phase 414 — One-Sqrt × Sixty-One-Log × polynomial numerator.
+fn one_sqrt_sixty_one_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut sqrt_deg: Option<i64> = None;
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_deg.is_some() { return None; }
+            sqrt_deg = Some(d);
+            continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 61 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg;
+            continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_deg.is_none() || log_count != 61 { return None; }
+    Some(sqrt_deg.unwrap() + 2 * poly_deg_sum)
+}
+
+/// Phase 415 — Two-Sqrt × Sixty-One-Log × polynomial numerator.
+fn two_sqrt_sixty_one_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut sqrt_degs: Vec<i64> = Vec::new();
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs.len() >= 2 { return None; }
+            sqrt_degs.push(d);
+            continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 61 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg;
+            continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs.len() != 2 || log_count != 61 { return None; }
+    Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg_sum)
+}
+
+/// Phase 416 — Three-Sqrt × Sixty-One-Log × polynomial numerator.
+fn three_sqrt_sixty_one_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut sqrt_degs: Vec<i64> = Vec::new();
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs.len() >= 3 { return None; }
+            sqrt_degs.push(d);
+            continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 61 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg;
+            continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs.len() != 3 || log_count != 61 { return None; }
+    Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg_sum)
+}
+
+/// Phase 417 — Four-Sqrt × Sixty-One-Log × polynomial numerator.
+fn four_sqrt_sixty_one_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut sqrt_degs: Vec<i64> = Vec::new();
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs.len() >= 4 { return None; }
+            sqrt_degs.push(d);
+            continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 61 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg;
+            continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs.len() != 4 || log_count != 61 { return None; }
+    Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg_sum)
+}
+
+/// Phase 418 — Five-Sqrt × Sixty-One-Log × polynomial numerator.
+///
+/// Completes the Sixty-One-Log family (Phases 413–418).
+fn five_sqrt_sixty_one_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut sqrt_degs: Vec<i64> = Vec::new();
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs.len() >= 5 { return None; }
+            sqrt_degs.push(d);
+            continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 61 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg;
+            continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs.len() != 5 || log_count != 61 { return None; }
+    Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg_sum)
+}
+
 /// Phase 407 — Zero-Sqrt × Sixty-Log × polynomial numerator.
 ///
 /// The Sixty-Log family (Phases 407–412) extends the recogniser to
@@ -11852,6 +12027,42 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
         } else if h_diverges_at_infinity(den, k) {
             return true;
         }
+    }
+    // Phase 418: Mul(Sqrt(P1)×5, Log(h1)×61, ...) numerator.
+    if let Some(s5l61_x2) = five_sqrt_sixty_one_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s5l61) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s5l61 > s5l61_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 417: Mul(Sqrt(P1)×4, Log(h1)×61, ...) numerator.
+    if let Some(s4l61_x2) = four_sqrt_sixty_one_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s4l61) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s4l61 > s4l61_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 416: Mul(Sqrt(P1)×3, Log(h1)×61, ...) numerator.
+    if let Some(s3l61_x2) = three_sqrt_sixty_one_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s3l61) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s3l61 > s3l61_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 415: Mul(Sqrt(P), Sqrt(P2), Log(h1)×61, ...) numerator.
+    if let Some(s2l61_x2) = two_sqrt_sixty_one_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s2l61) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s2l61 > s2l61_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 414: Mul(Sqrt(P), Log(h1)×61, ...) numerator.
+    if let Some(s1l61_x2) = one_sqrt_sixty_one_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s1l61) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s1l61 > s1l61_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 413: Mul(Log(h1)×61, ...) numerator.
+    if let Some(sl61_x2) = sixty_one_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_sl61) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_sl61 > sl61_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
     }
     // Phase 412: Mul(Sqrt(P1)×5, Log(h1)×60, ...) numerator.
     if let Some(s5l60_x2) = five_sqrt_sixty_log_poly_effective_x2(num, k) {

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -13280,7 +13280,8 @@ fn phase191_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
         log_k.clone(), // 60th log (over 59; refused)
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -13318,7 +13319,8 @@ fn phase191_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
         log_kp1.clone(), // 60th log (over 59; refused)
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -13447,7 +13449,8 @@ fn phase192_sqrt_k_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
         log_k.clone(), // 60th log (over 59; refused)
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -13486,7 +13489,8 @@ fn phase192_sqrt_k_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
         log_kp1.clone(), // 60th log (over 59; refused)
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -14028,7 +14032,8 @@ fn phase197_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
         log_k.clone(), // 60th log (over 59; refused)
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -14066,7 +14071,8 @@ fn phase197_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
         log_kp1.clone(), // 60th log (over 59; refused)
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -14814,7 +14820,8 @@ fn phase203_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
         log_k.clone(), // 60th log (over 59; refused)
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -14852,7 +14859,8 @@ fn phase203_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
         log_kp1.clone(), // 60th log (over 59; refused)
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -15605,7 +15613,8 @@ fn phase209_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
         log_k.clone(), // 60th log (over 59; refused)
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -15644,7 +15653,8 @@ fn phase209_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
         log_kp1.clone(), // 60th log (over 59; refused)
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -16427,7 +16437,8 @@ fn phase215_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
         log_k.clone(), // 60th log (over 59; refused)
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -16466,7 +16477,8 @@ fn phase215_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
         log_kp1.clone(), // 60th log (over 59; refused)
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -17249,7 +17261,8 @@ fn phase221_log30_k_times_k_over_k2_refused() {
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
         log_k.clone(), // 60th log (over 59; refused)
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -17288,7 +17301,8 @@ fn phase221_log30_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
         log_kp1.clone(), // 60th log (over 59; refused)
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -18071,7 +18085,8 @@ fn phase227_log31_k_times_k_over_k2_refused() {
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
         log_k.clone(), // 60th log (over 59; refused)
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -18110,7 +18125,8 @@ fn phase227_log31_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
         log_kp1.clone(), // 60th log (over 59; refused)
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -18893,7 +18909,8 @@ fn phase233_log32_k_times_k_over_k2_refused() {
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
         log_k.clone(), // 60th log (over 59; refused)
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -18932,7 +18949,8 @@ fn phase233_log32_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
         log_kp1.clone(), // 60th log (over 59; refused)
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -19716,7 +19734,8 @@ fn phase239_log33_k_times_k_over_k2_refused() {
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
         log_k.clone(), // 60th log (over 59; refused)
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -19754,7 +19773,8 @@ fn phase239_log33_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
         log_kp1.clone(), // 60th log (over 59; refused)
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -20539,7 +20559,8 @@ fn phase245_log34_k_times_k_over_k2_refused() {
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
         log_k.clone(), // 60th log (over 59; refused)
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -20576,7 +20597,8 @@ fn phase245_log34_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
         log_kp1.clone(), // 60th log (over 59; refused)
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -21360,7 +21382,8 @@ fn phase251_log36_k_times_k_over_k2_refused() {
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
         log_k.clone(), // 60th log (over 59; refused)
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -21396,7 +21419,8 @@ fn phase251_log36_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
         log_kp1.clone(), // 60th log (over 59; refused)
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -22170,7 +22194,8 @@ fn phase257_log36_k_times_k_over_k2_refused() {
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
         log_k.clone(), // 60th log (over 59; refused)
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -22206,7 +22231,8 @@ fn phase257_log36_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
         log_kp1.clone(), // 60th log (over 59; refused)
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -23765,7 +23791,8 @@ fn phase269_log38_k_over_k2_refused() {
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
         log_k.clone(), // 60th log (over 59; refused)
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -23801,7 +23828,8 @@ fn phase269_log38_k_over_k2_refused() {
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
         log_kp1.clone(), // 60th log (over 59; refused)
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
         kp1.clone(),
     ]);
     let g_k269c = apply(sym(DIV), vec![num_k, k2]);
@@ -23944,7 +23972,8 @@ fn phase270_sqrt_k_log38_k_over_k2_refused() {
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
         log_k.clone(), // 60th log (over 59; refused)
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -23981,7 +24010,8 @@ fn phase270_sqrt_k_log38_k_over_k2_refused() {
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
         log_kp1.clone(), // 60th log (over 59; refused)
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
         kp1.clone(),
     ]);
     let g_k270c = apply(sym(DIV), vec![num_k, k2]);
@@ -24677,7 +24707,8 @@ fn phase275_log39_k_over_k2_refused() {
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
         log_k.clone(), // 60th log (over 59; refused)
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -24713,7 +24744,8 @@ fn phase275_log39_k_over_k2_refused() {
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
         log_kp1.clone(), // 60th log (over 59; refused)
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
         kp1.clone(),
     ]);
     let g_k275c = apply(sym(DIV), vec![num_k, k2]);
@@ -24860,7 +24892,8 @@ fn phase276_sqrt_k_log39_k_over_k2_refused() {
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
         log_k.clone(), // 60th log (over 59; refused)
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -24897,7 +24930,8 @@ fn phase276_sqrt_k_log39_k_over_k2_refused() {
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
         log_kp1.clone(), // 60th log (over 59; refused)
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
         kp1.clone(),
     ]);
     let g_k276c = apply(sym(DIV), vec![num_k, k2]);
@@ -25600,7 +25634,8 @@ fn phase281_log40_k_over_k2_refused() {
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
         log_k.clone(), // 60th log (over 59; refused)
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -25632,7 +25667,8 @@ fn phase281_log40_k_over_k2_refused() {
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
         log_kp1.clone(), // 60th log (over 59; refused)
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
         kp1.clone(),
     ]);
     let g_kphase281r = apply(sym(DIV), vec![num_k, k2]);
@@ -25767,7 +25803,8 @@ fn phase282_sqrt1_k_log40_k_over_k2_refused() {
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
         log_k.clone(), // 60th log (over 59; refused)
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -25800,7 +25837,8 @@ fn phase282_sqrt1_k_log40_k_over_k2_refused() {
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
         log_kp1.clone(), // 60th log (over 59; refused)
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
         kp1.clone(),
     ]);
     let g_kphase282r = apply(sym(DIV), vec![num_k, k2]);
@@ -26436,8 +26474,9 @@ fn phase287_log42_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -26466,8 +26505,9 @@ fn phase287_log42_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase287r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase287r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -26599,8 +26639,9 @@ fn phase288_sqrt1_k_log42_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -26630,8 +26671,9 @@ fn phase288_sqrt1_k_log42_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase288r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase288r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -26763,8 +26805,9 @@ fn phase289_sqrt2_k_log42_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -26794,8 +26837,9 @@ fn phase289_sqrt2_k_log42_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase289r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase289r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -26927,8 +26971,9 @@ fn phase290_sqrt3_k_log42_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -26958,8 +27003,9 @@ fn phase290_sqrt3_k_log42_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase290r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase290r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -27091,8 +27137,9 @@ fn phase291_sqrt4_k_log42_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -27122,8 +27169,9 @@ fn phase291_sqrt4_k_log42_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase291r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase291r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -27255,8 +27303,9 @@ fn phase292_sqrt5_k_log42_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -27286,8 +27335,9 @@ fn phase292_sqrt5_k_log42_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase292r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase292r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -27372,8 +27422,9 @@ fn phase293_log42_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -27402,8 +27453,9 @@ fn phase293_log42_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase293r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase293r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -27495,8 +27547,9 @@ fn phase294_sqrt1_k_log42_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -27526,8 +27579,9 @@ fn phase294_sqrt1_k_log42_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase294r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase294r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -27619,8 +27673,9 @@ fn phase295_sqrt2_k_log42_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -27650,8 +27705,9 @@ fn phase295_sqrt2_k_log42_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase295r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase295r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -27743,8 +27799,9 @@ fn phase296_sqrt3_k_log42_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -27774,8 +27831,9 @@ fn phase296_sqrt3_k_log42_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase296r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase296r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -27867,8 +27925,9 @@ fn phase297_sqrt4_k_log42_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -27898,8 +27957,9 @@ fn phase297_sqrt4_k_log42_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase297r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase297r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -27991,8 +28051,9 @@ fn phase298_sqrt5_k_log42_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -28022,8 +28083,9 @@ fn phase298_sqrt5_k_log42_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase298r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase298r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -28108,8 +28170,9 @@ fn phase299_log45_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -28138,8 +28201,9 @@ fn phase299_log45_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase299r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase299r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -28231,8 +28295,9 @@ fn phase300_sqrt1_k_log45_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -28262,8 +28327,9 @@ fn phase300_sqrt1_k_log45_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase300r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase300r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -28355,8 +28421,9 @@ fn phase301_sqrt2_k_log45_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -28386,8 +28453,9 @@ fn phase301_sqrt2_k_log45_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase301r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase301r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -28479,8 +28547,9 @@ fn phase302_sqrt3_k_log45_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -28510,8 +28579,9 @@ fn phase302_sqrt3_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase302r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase302r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -28603,8 +28673,9 @@ fn phase303_sqrt4_k_log45_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -28634,8 +28705,9 @@ fn phase303_sqrt4_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase303r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase303r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -28727,8 +28799,9 @@ fn phase304_sqrt5_k_log45_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -28758,8 +28831,9 @@ fn phase304_sqrt5_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase304r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase304r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -28844,8 +28918,9 @@ fn phase305_log45_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -28873,8 +28948,9 @@ fn phase305_log45_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase305r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase305r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -28965,8 +29041,9 @@ fn phase306_sqrt1_k_log45_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -28995,8 +29072,9 @@ fn phase306_sqrt1_k_log45_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase306r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase306r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -29087,8 +29165,9 @@ fn phase307_sqrt2_k_log45_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -29117,8 +29196,9 @@ fn phase307_sqrt2_k_log45_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase307r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase307r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -29209,8 +29289,9 @@ fn phase308_sqrt3_k_log45_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -29239,8 +29320,9 @@ fn phase308_sqrt3_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase308r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase308r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -29331,8 +29413,9 @@ fn phase309_sqrt4_k_log45_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -29361,8 +29444,9 @@ fn phase309_sqrt4_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase309r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase309r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -29453,8 +29537,9 @@ fn phase310_sqrt5_k_log45_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -29483,8 +29568,9 @@ fn phase310_sqrt5_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase310r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase310r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -29567,8 +29653,9 @@ fn phase311_log45_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -29595,8 +29682,9 @@ fn phase311_log45_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase311r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase311r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -29686,8 +29774,9 @@ fn phase312_sqrt1_k_log45_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -29715,8 +29804,9 @@ fn phase312_sqrt1_k_log45_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase312r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase312r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -29806,8 +29896,9 @@ fn phase313_sqrt2_k_log45_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -29835,8 +29926,9 @@ fn phase313_sqrt2_k_log45_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase313r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase313r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -29926,8 +30018,9 @@ fn phase314_sqrt3_k_log45_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -29955,8 +30048,9 @@ fn phase314_sqrt3_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase314r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase314r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -30046,8 +30140,9 @@ fn phase315_sqrt4_k_log45_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -30075,8 +30170,9 @@ fn phase315_sqrt4_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase315r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase315r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -30166,8 +30262,9 @@ fn phase316_sqrt5_k_log45_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -30195,8 +30292,9 @@ fn phase316_sqrt5_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase316r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase316r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -30278,8 +30376,9 @@ fn phase317_log46_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -30305,8 +30404,9 @@ fn phase317_log46_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase317r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase317r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -30395,8 +30495,9 @@ fn phase318_sqrt1_k_log46_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -30423,8 +30524,9 @@ fn phase318_sqrt1_k_log46_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase318r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase318r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -30513,8 +30615,9 @@ fn phase319_sqrt2_k_log46_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -30541,8 +30644,9 @@ fn phase319_sqrt2_k_log46_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase319r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase319r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -30631,8 +30735,9 @@ fn phase320_sqrt3_k_log46_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -30659,8 +30764,9 @@ fn phase320_sqrt3_k_log46_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase320r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase320r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -30749,8 +30855,9 @@ fn phase321_sqrt4_k_log46_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -30777,8 +30884,9 @@ fn phase321_sqrt4_k_log46_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase321r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase321r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -30867,8 +30975,9 @@ fn phase322_sqrt5_k_log46_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -30895,8 +31004,9 @@ fn phase322_sqrt5_k_log46_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase322r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase322r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -30980,8 +31090,9 @@ fn phase323_log47_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -31007,8 +31118,9 @@ fn phase323_log47_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase323r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase323r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -31099,8 +31211,9 @@ fn phase324_sqrt1_k_log47_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -31127,8 +31240,9 @@ fn phase324_sqrt1_k_log47_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase324r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase324r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -31219,8 +31333,9 @@ fn phase325_sqrt2_k_log47_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -31247,8 +31362,9 @@ fn phase325_sqrt2_k_log47_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase325r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase325r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -31339,8 +31455,9 @@ fn phase326_sqrt3_k_log47_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -31367,8 +31484,9 @@ fn phase326_sqrt3_k_log47_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase326r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase326r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -31459,8 +31577,9 @@ fn phase327_sqrt4_k_log47_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -31487,8 +31606,9 @@ fn phase327_sqrt4_k_log47_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase327r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase327r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -31579,8 +31699,9 @@ fn phase328_sqrt5_k_log47_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -31607,8 +31728,9 @@ fn phase328_sqrt5_k_log47_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase328r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase328r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -31663,7 +31785,7 @@ fn phase329_log47_k_over_k2_converges() {
 
 #[test]
 fn phase329_log48_k_over_k2_refused() {
-    // phase329 log48 k over k2 refused: 61 logs → refused (Phase 407 handles exactly 60).
+    // phase329 log48 k over k2 refused: 62 logs → refused (Phase 413 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -31694,8 +31816,9 @@ fn phase329_log48_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -31721,8 +31844,9 @@ fn phase329_log48_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase329r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase329r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -31781,7 +31905,7 @@ fn phase330_sqrt1_k_log47_k_over_k2_converges() {
 
 #[test]
 fn phase330_sqrt1_k_log48_k_over_k2_refused() {
-    // phase330 sqrt1 k log48 k over k2 refused: 61 logs → refused (Phase 408 handles exactly 60).
+    // phase330 sqrt1 k log48 k over k2 refused: 62 logs → refused (Phase 414 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -31815,8 +31939,9 @@ fn phase330_sqrt1_k_log48_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -31843,8 +31968,9 @@ fn phase330_sqrt1_k_log48_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase330r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase330r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -31903,7 +32029,7 @@ fn phase331_sqrt2_k_log47_k_over_k2_converges() {
 
 #[test]
 fn phase331_sqrt2_k_log48_k_over_k2_refused() {
-    // phase331 sqrt2 k log48 k over k2 refused: 61 logs → refused (Phase 409 handles exactly 60).
+    // phase331 sqrt2 k log48 k over k2 refused: 62 logs → refused (Phase 415 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -31937,8 +32063,9 @@ fn phase331_sqrt2_k_log48_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -31965,8 +32092,9 @@ fn phase331_sqrt2_k_log48_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase331r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase331r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -32025,7 +32153,7 @@ fn phase332_sqrt3_k_log47_k_over_k3_converges() {
 
 #[test]
 fn phase332_sqrt3_k_log48_k_over_k3_refused() {
-    // phase332 sqrt3 k log48 k over k3 refused: 61 logs → refused (Phase 410 handles exactly 60).
+    // phase332 sqrt3 k log48 k over k3 refused: 62 logs → refused (Phase 416 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -32059,8 +32187,9 @@ fn phase332_sqrt3_k_log48_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -32087,8 +32216,9 @@ fn phase332_sqrt3_k_log48_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase332r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase332r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -32147,7 +32277,7 @@ fn phase333_sqrt4_k_log47_k_over_k3_converges() {
 
 #[test]
 fn phase333_sqrt4_k_log48_k_over_k3_refused() {
-    // phase333 sqrt4 k log48 k over k3 refused: 61 logs → refused (Phase 411 handles exactly 60).
+    // phase333 sqrt4 k log48 k over k3 refused: 62 logs → refused (Phase 417 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -32181,8 +32311,9 @@ fn phase333_sqrt4_k_log48_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -32209,8 +32340,9 @@ fn phase333_sqrt4_k_log48_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase333r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase333r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -32269,7 +32401,7 @@ fn phase334_sqrt5_k_log47_k_over_k3_converges() {
 
 #[test]
 fn phase334_sqrt5_k_log48_k_over_k3_refused() {
-    // phase334 sqrt5 k log48 k over k3 refused: 61 logs → refused (Phase 412 handles exactly 60).
+    // phase334 sqrt5 k log48 k over k3 refused: 62 logs → refused (Phase 418 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -32303,8 +32435,9 @@ fn phase334_sqrt5_k_log48_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -32331,8 +32464,9 @@ fn phase334_sqrt5_k_log48_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase334r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase334r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -32387,7 +32521,7 @@ fn phase335_log48_k_over_k2_converges() {
 
 #[test]
 fn phase335_log50_k_over_k2_refused() {
-    // log(k)^50 / k2: 61 logs → refused (Phase 407 handles exactly 60).
+    // log(k)^50 / k2: 62 logs → refused (Phase 413 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -32418,8 +32552,9 @@ fn phase335_log50_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -32445,8 +32580,9 @@ fn phase335_log50_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase335r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase335r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -32505,7 +32641,7 @@ fn phase336_sqrt1_k_log48_k_over_k2_converges() {
 
 #[test]
 fn phase336_sqrt1_k_log50_k_over_k2_refused() {
-    // sqrt(k)*log(k)^50 / k2: 61 logs → refused (Phase 408 handles exactly 60).
+    // sqrt(k)*log(k)^50 / k2: 62 logs → refused (Phase 414 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -32539,8 +32675,9 @@ fn phase336_sqrt1_k_log50_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -32567,8 +32704,9 @@ fn phase336_sqrt1_k_log50_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase336r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase336r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -32627,7 +32765,7 @@ fn phase337_sqrt2_k_log48_k_over_k2_converges() {
 
 #[test]
 fn phase337_sqrt2_k_log50_k_over_k2_refused() {
-    // sqrt(k)^2*log(k)^50 / k2: 61 logs → refused (Phase 409 handles exactly 60).
+    // sqrt(k)^2*log(k)^50 / k2: 62 logs → refused (Phase 415 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -32661,8 +32799,9 @@ fn phase337_sqrt2_k_log50_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -32689,8 +32828,9 @@ fn phase337_sqrt2_k_log50_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase337r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase337r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -32749,7 +32889,7 @@ fn phase338_sqrt3_k_log48_k_over_k3_converges() {
 
 #[test]
 fn phase338_sqrt3_k_log50_k_over_k3_refused() {
-    // sqrt(k)^3*log(k)^50 / k3: 61 logs → refused (Phase 410 handles exactly 60).
+    // sqrt(k)^3*log(k)^50 / k3: 62 logs → refused (Phase 416 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -32783,8 +32923,9 @@ fn phase338_sqrt3_k_log50_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -32811,8 +32952,9 @@ fn phase338_sqrt3_k_log50_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase338r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase338r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -32871,7 +33013,7 @@ fn phase339_sqrt4_k_log48_k_over_k3_converges() {
 
 #[test]
 fn phase339_sqrt4_k_log50_k_over_k3_refused() {
-    // sqrt(k)^4*log(k)^50 / k3: 61 logs → refused (Phase 411 handles exactly 60).
+    // sqrt(k)^4*log(k)^50 / k3: 62 logs → refused (Phase 417 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -32905,8 +33047,9 @@ fn phase339_sqrt4_k_log50_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -32933,8 +33076,9 @@ fn phase339_sqrt4_k_log50_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase339r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase339r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -32993,7 +33137,7 @@ fn phase340_sqrt5_k_log48_k_over_k3_converges() {
 
 #[test]
 fn phase340_sqrt5_k_log50_k_over_k3_refused() {
-    // sqrt(k)^5*log(k)^50 / k3: 61 logs → refused (Phase 412 handles exactly 60).
+    // sqrt(k)^5*log(k)^50 / k3: 62 logs → refused (Phase 418 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -33027,8 +33171,9 @@ fn phase340_sqrt5_k_log50_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -33055,8 +33200,9 @@ fn phase340_sqrt5_k_log50_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase340r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase340r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -33113,7 +33259,7 @@ fn phase341_log49_k_over_k2_converges() {
 
 #[test]
 fn phase341_log50_k_over_k2_refused() {
-    // log(k)^50 / k2: 61 logs → refused (Phase 407 handles exactly 60).
+    // log(k)^50 / k2: 62 logs → refused (Phase 413 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -33144,8 +33290,9 @@ fn phase341_log50_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -33171,8 +33318,9 @@ fn phase341_log50_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase341r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase341r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -33233,7 +33381,7 @@ fn phase342_sqrt1_k_log49_k_over_k2_converges() {
 
 #[test]
 fn phase342_sqrt1_k_log50_k_over_k2_refused() {
-    // sqrt(k)*log(k)^50 / k2: 61 logs → refused (Phase 408 handles exactly 60).
+    // sqrt(k)*log(k)^50 / k2: 62 logs → refused (Phase 414 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -33267,8 +33415,9 @@ fn phase342_sqrt1_k_log50_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -33295,8 +33444,9 @@ fn phase342_sqrt1_k_log50_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase342r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase342r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -33357,7 +33507,7 @@ fn phase343_sqrt2_k_log49_k_over_k3_converges() {
 
 #[test]
 fn phase343_sqrt2_k_log50_k_over_k2_refused() {
-    // sqrt(k)^2*log(k)^50 / k2: 61 logs → refused (Phase 409 handles exactly 60).
+    // sqrt(k)^2*log(k)^50 / k2: 62 logs → refused (Phase 415 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -33391,8 +33541,9 @@ fn phase343_sqrt2_k_log50_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -33419,8 +33570,9 @@ fn phase343_sqrt2_k_log50_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase343r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase343r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -33481,7 +33633,7 @@ fn phase344_sqrt3_k_log49_k_over_k3_converges() {
 
 #[test]
 fn phase344_sqrt3_k_log50_k_over_k3_refused() {
-    // sqrt(k)^3*log(k)^50 / k3: 61 logs → refused (Phase 410 handles exactly 60).
+    // sqrt(k)^3*log(k)^50 / k3: 62 logs → refused (Phase 416 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -33515,8 +33667,9 @@ fn phase344_sqrt3_k_log50_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -33543,8 +33696,9 @@ fn phase344_sqrt3_k_log50_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase344r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase344r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -33605,7 +33759,7 @@ fn phase345_sqrt4_k_log49_k_over_k3_converges() {
 
 #[test]
 fn phase345_sqrt4_k_log50_k_over_k3_refused() {
-    // sqrt(k)^4*log(k)^50 / k3: 61 logs → refused (Phase 411 handles exactly 60).
+    // sqrt(k)^4*log(k)^50 / k3: 62 logs → refused (Phase 417 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -33639,8 +33793,9 @@ fn phase345_sqrt4_k_log50_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -33667,8 +33822,9 @@ fn phase345_sqrt4_k_log50_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase345r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase345r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -33729,7 +33885,7 @@ fn phase346_sqrt5_k_log49_k_over_k3_converges() {
 
 #[test]
 fn phase346_sqrt5_k_log50_k_over_k3_refused() {
-    // sqrt(k)^5*log(k)^50 / k3: 61 logs → refused (Phase 412 handles exactly 60).
+    // sqrt(k)^5*log(k)^50 / k3: 62 logs → refused (Phase 418 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -33763,8 +33919,9 @@ fn phase346_sqrt5_k_log50_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -33791,8 +33948,9 @@ fn phase346_sqrt5_k_log50_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase346r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase346r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -33851,7 +34009,7 @@ fn phase347_log50_k_over_k2_converges() {
 
 #[test]
 fn phase347_log51_k_over_k2_refused() {
-    // log(k)^51 / k2: 61 logs → refused (Phase 407 handles exactly 60).
+    // log(k)^51 / k2: 62 logs → refused (Phase 413 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -33882,8 +34040,9 @@ fn phase347_log51_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -33909,8 +34068,9 @@ fn phase347_log51_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase347r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase347r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -33973,7 +34133,7 @@ fn phase348_sqrt1_k_log50_k_over_k2_converges() {
 
 #[test]
 fn phase348_sqrt1_k_log51_k_over_k2_refused() {
-    // sqrt(k)*log(k)^51 / k2: 61 logs → refused (Phase 408 handles exactly 60).
+    // sqrt(k)*log(k)^51 / k2: 62 logs → refused (Phase 414 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -34007,8 +34167,9 @@ fn phase348_sqrt1_k_log51_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -34035,8 +34196,9 @@ fn phase348_sqrt1_k_log51_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase348r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase348r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -34099,7 +34261,7 @@ fn phase349_sqrt2_k_log50_k_over_k3_converges() {
 
 #[test]
 fn phase349_sqrt2_k_log51_k_over_k2_refused() {
-    // sqrt(k)^2*log(k)^51 / k2: 61 logs → refused (Phase 409 handles exactly 60).
+    // sqrt(k)^2*log(k)^51 / k2: 62 logs → refused (Phase 415 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -34133,8 +34295,9 @@ fn phase349_sqrt2_k_log51_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -34161,8 +34324,9 @@ fn phase349_sqrt2_k_log51_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase349r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase349r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -34225,7 +34389,7 @@ fn phase350_sqrt3_k_log50_k_over_k3_converges() {
 
 #[test]
 fn phase350_sqrt3_k_log51_k_over_k3_refused() {
-    // sqrt(k)^3*log(k)^51 / k3: 61 logs → refused (Phase 410 handles exactly 60).
+    // sqrt(k)^3*log(k)^51 / k3: 62 logs → refused (Phase 416 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -34259,8 +34423,9 @@ fn phase350_sqrt3_k_log51_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -34287,8 +34452,9 @@ fn phase350_sqrt3_k_log51_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase350r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase350r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -34351,7 +34517,7 @@ fn phase351_sqrt4_k_log50_k_over_k3_converges() {
 
 #[test]
 fn phase351_sqrt4_k_log51_k_over_k3_refused() {
-    // sqrt(k)^4*log(k)^51 / k3: 61 logs → refused (Phase 411 handles exactly 60).
+    // sqrt(k)^4*log(k)^51 / k3: 62 logs → refused (Phase 417 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -34385,8 +34551,9 @@ fn phase351_sqrt4_k_log51_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -34413,8 +34580,9 @@ fn phase351_sqrt4_k_log51_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase351r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase351r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -34477,7 +34645,7 @@ fn phase352_sqrt5_k_log50_k_over_k3_converges() {
 
 #[test]
 fn phase352_sqrt5_k_log51_k_over_k3_refused() {
-    // sqrt(k)^5*log(k)^51 / k3: 61 logs → refused (Phase 412 handles exactly 60).
+    // sqrt(k)^5*log(k)^51 / k3: 62 logs → refused (Phase 418 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -34511,8 +34679,9 @@ fn phase352_sqrt5_k_log51_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -34539,8 +34708,9 @@ fn phase352_sqrt5_k_log51_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase352r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase352r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -34601,7 +34771,7 @@ fn phase353_log51_k_over_k2_converges() {
 
 #[test]
 fn phase353_log52_k_over_k2_refused() {
-    // log(k)^52 / k2: 61 logs → refused (Phase 407 handles exactly 60).
+    // log(k)^52 / k2: 62 logs → refused (Phase 413 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -34632,8 +34802,9 @@ fn phase353_log52_k_over_k2_refused() {
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -34659,8 +34830,9 @@ fn phase353_log52_k_over_k2_refused() {
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase353r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase353r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -34725,7 +34897,7 @@ fn phase354_sqrt1_k_log51_k_over_k2_converges() {
 
 #[test]
 fn phase354_sqrt1_k_log52_k_over_k2_refused() {
-    // sqrt(k)^1*log(k)^52 / k2: 61 logs → refused (Phase 408 handles exactly 60).
+    // sqrt(k)^1*log(k)^52 / k2: 62 logs → refused (Phase 414 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -34759,8 +34931,9 @@ fn phase354_sqrt1_k_log52_k_over_k2_refused() {
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -34787,8 +34960,9 @@ fn phase354_sqrt1_k_log52_k_over_k2_refused() {
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase354r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase354r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -34853,7 +35027,7 @@ fn phase355_sqrt2_k_log51_k_over_k3_converges() {
 
 #[test]
 fn phase355_sqrt2_k_log52_k_over_k3_refused() {
-    // sqrt(k)^2*log(k)^52 / k3: 61 logs → refused (Phase 409 handles exactly 60).
+    // sqrt(k)^2*log(k)^52 / k3: 62 logs → refused (Phase 415 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -34887,8 +35061,9 @@ fn phase355_sqrt2_k_log52_k_over_k3_refused() {
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -34915,8 +35090,9 @@ fn phase355_sqrt2_k_log52_k_over_k3_refused() {
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase355r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase355r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -34981,7 +35157,7 @@ fn phase356_sqrt3_k_log51_k_over_k3_converges() {
 
 #[test]
 fn phase356_sqrt3_k_log52_k_over_k3_refused() {
-    // sqrt(k)^3*log(k)^52 / k3: 61 logs → refused (Phase 410 handles exactly 60).
+    // sqrt(k)^3*log(k)^52 / k3: 62 logs → refused (Phase 416 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -35015,8 +35191,9 @@ fn phase356_sqrt3_k_log52_k_over_k3_refused() {
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -35043,8 +35220,9 @@ fn phase356_sqrt3_k_log52_k_over_k3_refused() {
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase356r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase356r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -35109,7 +35287,7 @@ fn phase357_sqrt4_k_log51_k_over_k3_converges() {
 
 #[test]
 fn phase357_sqrt4_k_log52_k_over_k3_refused() {
-    // sqrt(k)^4*log(k)^52 / k3: 61 logs → refused (Phase 411 handles exactly 60).
+    // sqrt(k)^4*log(k)^52 / k3: 62 logs → refused (Phase 417 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -35143,8 +35321,9 @@ fn phase357_sqrt4_k_log52_k_over_k3_refused() {
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -35171,8 +35350,9 @@ fn phase357_sqrt4_k_log52_k_over_k3_refused() {
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase357r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase357r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -35237,7 +35417,7 @@ fn phase358_sqrt5_k_log51_k_over_k3_converges() {
 
 #[test]
 fn phase358_sqrt5_k_log52_k_over_k3_refused() {
-    // sqrt(k)^5*log(k)^52 / k3: 61 logs → refused (Phase 412 handles exactly 60).
+    // sqrt(k)^5*log(k)^52 / k3: 62 logs → refused (Phase 418 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -35271,8 +35451,9 @@ fn phase358_sqrt5_k_log52_k_over_k3_refused() {
         log_k.clone(), // 55th log (over 54; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -35299,8 +35480,9 @@ fn phase358_sqrt5_k_log52_k_over_k3_refused() {
         log_kp1.clone(), // 55th log (over 54; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase358r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase358r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -35394,8 +35576,9 @@ fn phase359_log53_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -35421,8 +35604,9 @@ fn phase359_log53_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase359r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase359r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -35523,8 +35707,9 @@ fn phase360_sqrt1_k_log53_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -35551,8 +35736,9 @@ fn phase360_sqrt1_k_log53_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase360r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase360r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -35653,8 +35839,9 @@ fn phase361_sqrt2_k_log53_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -35681,8 +35868,9 @@ fn phase361_sqrt2_k_log53_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase361r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase361r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -35783,8 +35971,9 @@ fn phase362_sqrt3_k_log53_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -35811,8 +36000,9 @@ fn phase362_sqrt3_k_log53_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase362r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase362r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -35913,8 +36103,9 @@ fn phase363_sqrt4_k_log53_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -35941,8 +36132,9 @@ fn phase363_sqrt4_k_log53_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase363r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase363r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -36043,8 +36235,9 @@ fn phase364_sqrt5_k_log53_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -36071,8 +36264,9 @@ fn phase364_sqrt5_k_log53_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_kphase364r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase364r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -36136,7 +36330,7 @@ fn phase365_log53_k_over_k2_converges() {
 
 #[test]
 fn phase365_log53_k_over_k2_refused() {
-    // log53 k over k2: 61 logs → refused (Phase 407 handles exactly 60).
+    // log53 k over k2: 62 logs → refused (Phase 413 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -36167,8 +36361,9 @@ fn phase365_log53_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -36194,8 +36389,9 @@ fn phase365_log53_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k365r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_365r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -36264,7 +36460,7 @@ fn phase366_sqrt1_k_log53_k_over_k2_converges() {
 
 #[test]
 fn phase366_sqrt1_k_log53_k_over_k2_refused() {
-    // sqrt1 k log53 k over k2: 61 logs → refused (Phase 408 handles exactly 60).
+    // sqrt1 k log53 k over k2: 62 logs → refused (Phase 414 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -36298,8 +36494,9 @@ fn phase366_sqrt1_k_log53_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -36326,8 +36523,9 @@ fn phase366_sqrt1_k_log53_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k366r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_366r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -36396,7 +36594,7 @@ fn phase367_sqrt2_k_log53_k_over_k2_converges() {
 
 #[test]
 fn phase367_sqrt2_k_log53_k_over_k2_refused() {
-    // sqrt2 k log53 k over k2: 61 logs → refused (Phase 409 handles exactly 60).
+    // sqrt2 k log53 k over k2: 62 logs → refused (Phase 415 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -36430,8 +36628,9 @@ fn phase367_sqrt2_k_log53_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -36458,8 +36657,9 @@ fn phase367_sqrt2_k_log53_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k367r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_367r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -36528,7 +36728,7 @@ fn phase368_sqrt3_k_log53_k_over_k3_converges() {
 
 #[test]
 fn phase368_sqrt3_k_log53_k_over_k3_refused() {
-    // sqrt3 k log53 k over k3: 61 logs → refused (Phase 410 handles exactly 60).
+    // sqrt3 k log53 k over k3: 62 logs → refused (Phase 416 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -36562,8 +36762,9 @@ fn phase368_sqrt3_k_log53_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -36590,8 +36791,9 @@ fn phase368_sqrt3_k_log53_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k368r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_368r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -36660,7 +36862,7 @@ fn phase369_sqrt4_k_log53_k_over_k3_converges() {
 
 #[test]
 fn phase369_sqrt4_k_log53_k_over_k3_refused() {
-    // sqrt4 k log53 k over k3: 61 logs → refused (Phase 411 handles exactly 60).
+    // sqrt4 k log53 k over k3: 62 logs → refused (Phase 417 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -36694,8 +36896,9 @@ fn phase369_sqrt4_k_log53_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -36722,8 +36925,9 @@ fn phase369_sqrt4_k_log53_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k369r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_369r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -36792,7 +36996,7 @@ fn phase370_sqrt5_k_log53_k_over_k3_converges() {
 
 #[test]
 fn phase370_sqrt5_k_log53_k_over_k3_refused() {
-    // sqrt5 k log53 k over k3: 61 logs → refused (Phase 412 handles exactly 60).
+    // sqrt5 k log53 k over k3: 62 logs → refused (Phase 418 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -36826,8 +37030,9 @@ fn phase370_sqrt5_k_log53_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -36854,8 +37059,9 @@ fn phase370_sqrt5_k_log53_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k370r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_370r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -36922,7 +37128,7 @@ fn phase371_log54_k_over_k2_converges() {
 
 #[test]
 fn phase371_log54_k_over_k2_refused() {
-    // log54 k over k2: 61 logs → refused (Phase 407 handles exactly 60).
+    // log54 k over k2: 62 logs → refused (Phase 413 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -36953,8 +37159,9 @@ fn phase371_log54_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -36980,8 +37187,9 @@ fn phase371_log54_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k371r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_371r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -37052,7 +37260,7 @@ fn phase372_sqrt1_k_log54_k_over_k2_converges() {
 
 #[test]
 fn phase372_sqrt1_k_log54_k_over_k2_refused() {
-    // sqrt1 k log54 k over k2: 61 logs → refused (Phase 408 handles exactly 60).
+    // sqrt1 k log54 k over k2: 62 logs → refused (Phase 414 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -37086,8 +37294,9 @@ fn phase372_sqrt1_k_log54_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -37114,8 +37323,9 @@ fn phase372_sqrt1_k_log54_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k372r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_372r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -37186,7 +37396,7 @@ fn phase373_sqrt2_k_log54_k_over_k2_converges() {
 
 #[test]
 fn phase373_sqrt2_k_log54_k_over_k2_refused() {
-    // sqrt2 k log54 k over k2: 61 logs → refused (Phase 409 handles exactly 60).
+    // sqrt2 k log54 k over k2: 62 logs → refused (Phase 415 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -37220,8 +37430,9 @@ fn phase373_sqrt2_k_log54_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -37248,8 +37459,9 @@ fn phase373_sqrt2_k_log54_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k373r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_373r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -37320,7 +37532,7 @@ fn phase374_sqrt3_k_log54_k_over_k3_converges() {
 
 #[test]
 fn phase374_sqrt3_k_log54_k_over_k3_refused() {
-    // sqrt3 k log54 k over k3: 61 logs → refused (Phase 410 handles exactly 60).
+    // sqrt3 k log54 k over k3: 62 logs → refused (Phase 416 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -37354,8 +37566,9 @@ fn phase374_sqrt3_k_log54_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -37382,8 +37595,9 @@ fn phase374_sqrt3_k_log54_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k374r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_374r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -37454,7 +37668,7 @@ fn phase375_sqrt4_k_log54_k_over_k3_converges() {
 
 #[test]
 fn phase375_sqrt4_k_log54_k_over_k3_refused() {
-    // sqrt4 k log54 k over k3: 61 logs → refused (Phase 411 handles exactly 60).
+    // sqrt4 k log54 k over k3: 62 logs → refused (Phase 417 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -37488,8 +37702,9 @@ fn phase375_sqrt4_k_log54_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -37516,8 +37731,9 @@ fn phase375_sqrt4_k_log54_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k375r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_375r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -37588,7 +37804,7 @@ fn phase376_sqrt5_k_log54_k_over_k3_converges() {
 
 #[test]
 fn phase376_sqrt5_k_log54_k_over_k3_refused() {
-    // sqrt5 k log54 k over k3: 61 logs → refused (Phase 412 handles exactly 60).
+    // sqrt5 k log54 k over k3: 62 logs → refused (Phase 418 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -37622,8 +37838,9 @@ fn phase376_sqrt5_k_log54_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -37650,8 +37867,9 @@ fn phase376_sqrt5_k_log54_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k376r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_376r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -37720,7 +37938,7 @@ fn phase377_log55_k_over_k2_converges() {
 
 #[test]
 fn phase377_log55_k_over_k2_refused() {
-    // log55 k over k2: 61 logs → refused (Phase 407 handles exactly 60).
+    // log55 k over k2: 62 logs → refused (Phase 413 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -37751,8 +37969,9 @@ fn phase377_log55_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -37778,8 +37997,9 @@ fn phase377_log55_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k377r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_377r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -37852,7 +38072,7 @@ fn phase378_sqrt1_k_log55_k_over_k2_converges() {
 
 #[test]
 fn phase378_sqrt1_k_log55_k_over_k2_refused() {
-    // sqrt1 k log55 k over k2: 61 logs → refused (Phase 408 handles exactly 60).
+    // sqrt1 k log55 k over k2: 62 logs → refused (Phase 414 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -37886,8 +38106,9 @@ fn phase378_sqrt1_k_log55_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -37914,8 +38135,9 @@ fn phase378_sqrt1_k_log55_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k378r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_378r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -37988,7 +38210,7 @@ fn phase379_sqrt2_k_log55_k_over_k2_converges() {
 
 #[test]
 fn phase379_sqrt2_k_log55_k_over_k2_refused() {
-    // sqrt2 k log55 k over k2: 61 logs → refused (Phase 409 handles exactly 60).
+    // sqrt2 k log55 k over k2: 62 logs → refused (Phase 415 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -38022,8 +38244,9 @@ fn phase379_sqrt2_k_log55_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -38050,8 +38273,9 @@ fn phase379_sqrt2_k_log55_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k379r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_379r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -38124,7 +38348,7 @@ fn phase380_sqrt3_k_log55_k_over_k3_converges() {
 
 #[test]
 fn phase380_sqrt3_k_log55_k_over_k3_refused() {
-    // sqrt3 k log55 k over k3: 61 logs → refused (Phase 410 handles exactly 60).
+    // sqrt3 k log55 k over k3: 62 logs → refused (Phase 416 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -38158,8 +38382,9 @@ fn phase380_sqrt3_k_log55_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -38186,8 +38411,9 @@ fn phase380_sqrt3_k_log55_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k380r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_380r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -38260,7 +38486,7 @@ fn phase381_sqrt4_k_log55_k_over_k3_converges() {
 
 #[test]
 fn phase381_sqrt4_k_log55_k_over_k3_refused() {
-    // sqrt4 k log55 k over k3: 61 logs → refused (Phase 411 handles exactly 60).
+    // sqrt4 k log55 k over k3: 62 logs → refused (Phase 417 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -38294,8 +38520,9 @@ fn phase381_sqrt4_k_log55_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -38322,8 +38549,9 @@ fn phase381_sqrt4_k_log55_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k381r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_381r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -38396,7 +38624,7 @@ fn phase382_sqrt5_k_log55_k_over_k3_converges() {
 
 #[test]
 fn phase382_sqrt5_k_log55_k_over_k3_refused() {
-    // sqrt5 k log55 k over k3: 61 logs → refused (Phase 412 handles exactly 60).
+    // sqrt5 k log55 k over k3: 62 logs → refused (Phase 418 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -38430,8 +38658,9 @@ fn phase382_sqrt5_k_log55_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -38458,8 +38687,9 @@ fn phase382_sqrt5_k_log55_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k382r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_382r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -38532,7 +38762,7 @@ fn phase383_log56_k_over_k2_converges() {
 
 #[test]
 fn phase383_log56_k_over_k2_refused() {
-    // log56 k over k2: 61 logs → refused (Phase 407 handles exactly 60).
+    // log56 k over k2: 62 logs → refused (Phase 413 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -38563,8 +38793,9 @@ fn phase383_log56_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -38590,8 +38821,9 @@ fn phase383_log56_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k383r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_383r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -38666,7 +38898,7 @@ fn phase384_sqrt1_k_log56_k_over_k2_converges() {
 
 #[test]
 fn phase384_sqrt1_k_log56_k_over_k2_refused() {
-    // sqrt1 k log56 k over k2: 61 logs → refused (Phase 408 handles exactly 60).
+    // sqrt1 k log56 k over k2: 62 logs → refused (Phase 414 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -38700,8 +38932,9 @@ fn phase384_sqrt1_k_log56_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -38728,8 +38961,9 @@ fn phase384_sqrt1_k_log56_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k384r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_384r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -38804,7 +39038,7 @@ fn phase385_sqrt2_k_log56_k_over_k2_converges() {
 
 #[test]
 fn phase385_sqrt2_k_log56_k_over_k2_refused() {
-    // sqrt2 k log56 k over k2: 61 logs → refused (Phase 409 handles exactly 60).
+    // sqrt2 k log56 k over k2: 62 logs → refused (Phase 415 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -38838,8 +39072,9 @@ fn phase385_sqrt2_k_log56_k_over_k2_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -38866,8 +39101,9 @@ fn phase385_sqrt2_k_log56_k_over_k2_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k385r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_385r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -38942,7 +39178,7 @@ fn phase386_sqrt3_k_log56_k_over_k3_converges() {
 
 #[test]
 fn phase386_sqrt3_k_log56_k_over_k3_refused() {
-    // sqrt3 k log56 k over k3: 61 logs → refused (Phase 410 handles exactly 60).
+    // sqrt3 k log56 k over k3: 62 logs → refused (Phase 416 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -38976,8 +39212,9 @@ fn phase386_sqrt3_k_log56_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -39004,8 +39241,9 @@ fn phase386_sqrt3_k_log56_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k386r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_386r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -39080,7 +39318,7 @@ fn phase387_sqrt4_k_log56_k_over_k3_converges() {
 
 #[test]
 fn phase387_sqrt4_k_log56_k_over_k3_refused() {
-    // sqrt4 k log56 k over k3: 61 logs → refused (Phase 411 handles exactly 60).
+    // sqrt4 k log56 k over k3: 62 logs → refused (Phase 417 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -39114,8 +39352,9 @@ fn phase387_sqrt4_k_log56_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -39142,8 +39381,9 @@ fn phase387_sqrt4_k_log56_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k387r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_387r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -39218,7 +39458,7 @@ fn phase388_sqrt5_k_log56_k_over_k3_converges() {
 
 #[test]
 fn phase388_sqrt5_k_log56_k_over_k3_refused() {
-    // sqrt5 k log56 k over k3: 61 logs → refused (Phase 412 handles exactly 60).
+    // sqrt5 k log56 k over k3: 62 logs → refused (Phase 418 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -39252,8 +39492,9 @@ fn phase388_sqrt5_k_log56_k_over_k3_refused() {
         log_k.clone(), // 57th log (over 56; refused)
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -39280,8 +39521,9 @@ fn phase388_sqrt5_k_log56_k_over_k3_refused() {
         log_kp1.clone(), // 57th log (over 56; refused)
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k388r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_388r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -39354,7 +39596,7 @@ fn phase389_log57_k_over_k2_converges() {
 
 #[test]
 fn phase389_log57_k_over_k2_refused() {
-    // log57 k over k2: 61 logs → refused (Phase 407 handles exactly 60).
+    // log57 k over k2: 62 logs → refused (Phase 413 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -39385,8 +39627,9 @@ fn phase389_log57_k_over_k2_refused() {
         log_k.clone(), // 57th log
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -39412,8 +39655,9 @@ fn phase389_log57_k_over_k2_refused() {
         log_kp1.clone(), // 57th log
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k389r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_389r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -39490,7 +39734,7 @@ fn phase390_sqrt1_k_log57_k_over_k2_converges() {
 
 #[test]
 fn phase390_sqrt1_k_log57_k_over_k2_refused() {
-    // sqrt1 k log57 k over k2: 61 logs → refused (Phase 408 handles exactly 60).
+    // sqrt1 k log57 k over k2: 62 logs → refused (Phase 414 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -39524,8 +39768,9 @@ fn phase390_sqrt1_k_log57_k_over_k2_refused() {
         log_k.clone(), // 57th log
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -39552,8 +39797,9 @@ fn phase390_sqrt1_k_log57_k_over_k2_refused() {
         log_kp1.clone(), // 57th log
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k390r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_390r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -39630,7 +39876,7 @@ fn phase391_sqrt2_k_log57_k_over_k2_converges() {
 
 #[test]
 fn phase391_sqrt2_k_log57_k_over_k2_refused() {
-    // sqrt2 k log57 k over k2: 61 logs → refused (Phase 409 handles exactly 60).
+    // sqrt2 k log57 k over k2: 62 logs → refused (Phase 415 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -39664,8 +39910,9 @@ fn phase391_sqrt2_k_log57_k_over_k2_refused() {
         log_k.clone(), // 57th log
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -39692,8 +39939,9 @@ fn phase391_sqrt2_k_log57_k_over_k2_refused() {
         log_kp1.clone(), // 57th log
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k391r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_391r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -39770,7 +40018,7 @@ fn phase392_sqrt3_k_log57_k_over_k3_converges() {
 
 #[test]
 fn phase392_sqrt3_k_log57_k_over_k3_refused() {
-    // sqrt3 k log57 k over k3: 61 logs → refused (Phase 410 handles exactly 60).
+    // sqrt3 k log57 k over k3: 62 logs → refused (Phase 416 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -39804,8 +40052,9 @@ fn phase392_sqrt3_k_log57_k_over_k3_refused() {
         log_k.clone(), // 57th log
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -39832,8 +40081,9 @@ fn phase392_sqrt3_k_log57_k_over_k3_refused() {
         log_kp1.clone(), // 57th log
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k392r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_392r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -39910,7 +40160,7 @@ fn phase393_sqrt4_k_log57_k_over_k3_converges() {
 
 #[test]
 fn phase393_sqrt4_k_log57_k_over_k3_refused() {
-    // sqrt4 k log57 k over k3: 61 logs → refused (Phase 411 handles exactly 60).
+    // sqrt4 k log57 k over k3: 62 logs → refused (Phase 417 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -39944,8 +40194,9 @@ fn phase393_sqrt4_k_log57_k_over_k3_refused() {
         log_k.clone(), // 57th log
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -39972,8 +40223,9 @@ fn phase393_sqrt4_k_log57_k_over_k3_refused() {
         log_kp1.clone(), // 57th log
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k393r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_393r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -40050,7 +40302,7 @@ fn phase394_sqrt5_k_log57_k_over_k3_converges() {
 
 #[test]
 fn phase394_sqrt5_k_log57_k_over_k3_refused() {
-    // sqrt5 k log57 k over k3: 61 logs → refused (Phase 412 handles exactly 60).
+    // sqrt5 k log57 k over k3: 62 logs → refused (Phase 418 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
@@ -40084,8 +40336,9 @@ fn phase394_sqrt5_k_log57_k_over_k3_refused() {
         log_k.clone(), // 57th log
         log_k.clone(), // 58th log (over 57; refused)
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -40112,8 +40365,9 @@ fn phase394_sqrt5_k_log57_k_over_k3_refused() {
         log_kp1.clone(), // 57th log
         log_kp1.clone(), // 58th log (over 57; refused)
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k394r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_394r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -40221,8 +40475,9 @@ fn phase395_log58_k_over_k2_refused() {
         log_k.clone(), // 57th log
         log_k.clone(), // 58th log
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -40248,8 +40503,9 @@ fn phase395_log58_k_over_k2_refused() {
         log_kp1.clone(), // 57th log
         log_kp1.clone(), // 58th log
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k395r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_395r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -40364,8 +40620,9 @@ fn phase396_sqrt1_k_log58_k_over_k2_refused() {
         log_k.clone(), // 57th log
         log_k.clone(), // 58th log
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -40392,8 +40649,9 @@ fn phase396_sqrt1_k_log58_k_over_k2_refused() {
         log_kp1.clone(), // 57th log
         log_kp1.clone(), // 58th log
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k396r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_396r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -40508,8 +40766,9 @@ fn phase397_sqrt2_k_log58_k_over_k2_refused() {
         log_k.clone(), // 57th log
         log_k.clone(), // 58th log
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -40536,8 +40795,9 @@ fn phase397_sqrt2_k_log58_k_over_k2_refused() {
         log_kp1.clone(), // 57th log
         log_kp1.clone(), // 58th log
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k397r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_397r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -40652,8 +40912,9 @@ fn phase398_sqrt3_k_log58_k_over_k3_refused() {
         log_k.clone(), // 57th log
         log_k.clone(), // 58th log
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -40680,8 +40941,9 @@ fn phase398_sqrt3_k_log58_k_over_k3_refused() {
         log_kp1.clone(), // 57th log
         log_kp1.clone(), // 58th log
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k398r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_398r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -40796,8 +41058,9 @@ fn phase399_sqrt4_k_log58_k_over_k3_refused() {
         log_k.clone(), // 57th log
         log_k.clone(), // 58th log
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -40824,8 +41087,9 @@ fn phase399_sqrt4_k_log58_k_over_k3_refused() {
         log_kp1.clone(), // 57th log
         log_kp1.clone(), // 58th log
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k399r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_399r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -40940,8 +41204,9 @@ fn phase400_sqrt5_k_log58_k_over_k3_refused() {
         log_k.clone(), // 57th log
         log_k.clone(), // 58th log
         log_k.clone(), // 59th log (over 58; refused)
-        log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -40968,8 +41233,9 @@ fn phase400_sqrt5_k_log58_k_over_k3_refused() {
         log_kp1.clone(), // 57th log
         log_kp1.clone(), // 58th log
         log_kp1.clone(), // 59th log (over 58; refused)
-        log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k400r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_400r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -41024,7 +41290,7 @@ fn phase401_log59_k_over_k2_converges() {
 
 #[test]
 fn phase401_log59_k_over_k2_refused() {
-    // 61 logs → refused (Phase 407 handles exactly 60).
+    // 62 logs → refused (Phase 413 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -41043,8 +41309,9 @@ fn phase401_log59_k_over_k2_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
-        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
@@ -41058,8 +41325,9 @@ fn phase401_log59_k_over_k2_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
-        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 61st log
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -41118,7 +41386,7 @@ fn phase402_sqrt1_log59_k_over_k2_converges() {
 
 #[test]
 fn phase402_sqrt1_log59_k_over_k2_refused() {
-    // 61 logs → refused (Phase 408 handles exactly 60).
+    // 62 logs → refused (Phase 414 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -41140,8 +41408,9 @@ fn phase402_sqrt1_log59_k_over_k2_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
-        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 61st log
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 62nd log
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -41157,7 +41426,8 @@ fn phase402_sqrt1_log59_k_over_k2_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -41216,7 +41486,7 @@ fn phase403_sqrt2_log59_k_over_k2_converges() {
 
 #[test]
 fn phase403_sqrt2_log59_k_over_k2_refused() {
-    // 61 logs → refused (Phase 409 handles exactly 60).
+    // 62 logs → refused (Phase 415 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -41239,7 +41509,8 @@ fn phase403_sqrt2_log59_k_over_k2_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -41255,7 +41526,8 @@ fn phase403_sqrt2_log59_k_over_k2_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -41314,7 +41586,7 @@ fn phase404_sqrt3_log59_k_over_k3_converges() {
 
 #[test]
 fn phase404_sqrt3_log59_k_over_k3_refused() {
-    // 61 logs → refused (Phase 410 handles exactly 60).
+    // 62 logs → refused (Phase 416 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
@@ -41337,7 +41609,8 @@ fn phase404_sqrt3_log59_k_over_k3_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -41353,7 +41626,8 @@ fn phase404_sqrt3_log59_k_over_k3_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -41412,7 +41686,7 @@ fn phase405_sqrt4_log59_k_over_k3_converges() {
 
 #[test]
 fn phase405_sqrt4_log59_k_over_k3_refused() {
-    // 61 logs → refused (Phase 411 handles exactly 60).
+    // 62 logs → refused (Phase 417 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
@@ -41435,7 +41709,8 @@ fn phase405_sqrt4_log59_k_over_k3_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -41451,7 +41726,8 @@ fn phase405_sqrt4_log59_k_over_k3_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -41510,7 +41786,7 @@ fn phase406_sqrt5_log59_k_over_k3_converges() {
 
 #[test]
 fn phase406_sqrt5_log59_k_over_k3_refused() {
-    // 61 logs → refused (Phase 412 handles exactly 60).
+    // 62 logs → refused (Phase 418 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
@@ -41533,7 +41809,8 @@ fn phase406_sqrt5_log59_k_over_k3_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 55th
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th log (over 59; refused)
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 61st log (over 60; refused)
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -41549,7 +41826,8 @@ fn phase406_sqrt5_log59_k_over_k3_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 55th
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th log (over 59; refused)
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 61st log (over 60; refused)
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -41604,7 +41882,7 @@ fn phase407_log60_k_over_k2_converges() {
 
 #[test]
 fn phase407_log60_k_over_k2_refused() {
-    // 61 logs → refused (Phase 407 handles exactly 60).
+    // 62 logs → refused (Phase 413 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -41624,7 +41902,8 @@ fn phase407_log60_k_over_k2_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 61st log
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
@@ -41639,7 +41918,8 @@ fn phase407_log60_k_over_k2_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 61st log
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -41698,7 +41978,7 @@ fn phase408_sqrt1_log60_k_over_k2_converges() {
 
 #[test]
 fn phase408_sqrt1_log60_k_over_k2_refused() {
-    // 61 logs → refused (Phase 408 handles exactly 60).
+    // 62 logs → refused (Phase 414 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -41721,7 +42001,8 @@ fn phase408_sqrt1_log60_k_over_k2_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 61st log
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -41737,7 +42018,8 @@ fn phase408_sqrt1_log60_k_over_k2_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 61st log
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -41796,7 +42078,7 @@ fn phase409_sqrt2_log60_k_over_k2_converges() {
 
 #[test]
 fn phase409_sqrt2_log60_k_over_k2_refused() {
-    // 61 logs → refused (Phase 409 handles exactly 60).
+    // 62 logs → refused (Phase 415 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -41819,7 +42101,8 @@ fn phase409_sqrt2_log60_k_over_k2_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 61st log
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -41835,7 +42118,8 @@ fn phase409_sqrt2_log60_k_over_k2_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 61st log
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -41894,7 +42178,7 @@ fn phase410_sqrt3_log60_k_over_k3_converges() {
 
 #[test]
 fn phase410_sqrt3_log60_k_over_k3_refused() {
-    // 61 logs → refused (Phase 410 handles exactly 60).
+    // 62 logs → refused (Phase 416 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
@@ -41917,7 +42201,8 @@ fn phase410_sqrt3_log60_k_over_k3_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 61st log
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -41933,7 +42218,8 @@ fn phase410_sqrt3_log60_k_over_k3_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 61st log
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -41992,7 +42278,7 @@ fn phase411_sqrt4_log60_k_over_k3_converges() {
 
 #[test]
 fn phase411_sqrt4_log60_k_over_k3_refused() {
-    // 61 logs → refused (Phase 411 handles exactly 60).
+    // 62 logs → refused (Phase 417 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
@@ -42015,7 +42301,8 @@ fn phase411_sqrt4_log60_k_over_k3_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 55th
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 61st log
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -42031,7 +42318,8 @@ fn phase411_sqrt4_log60_k_over_k3_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 61st log
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -42088,7 +42376,7 @@ fn phase412_sqrt5_log60_k_over_k3_converges() {
 
 #[test]
 fn phase412_sqrt5_log60_k_over_k3_refused() {
-    // 61 logs → refused (Phase 412 handles exactly 60).
+    // 62 logs → refused (Phase 418 handles exactly 61).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
@@ -42111,7 +42399,8 @@ fn phase412_sqrt5_log60_k_over_k3_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
-        log_k, // 61st log (over 60; refused)
+        log_k.clone(), // 61st log
+        log_k, // 62nd log (over 61; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -42127,7 +42416,610 @@ fn phase412_sqrt5_log60_k_over_k3_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
-        log_kp1, // 61st log (over 60; refused)
+        log_kp1.clone(), // 61st log
+        log_kp1, // 62nd log (over 61; refused)
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase413_log61_k_over_k2_converges() {
+    // log(k)^61/k^2: eff_x2=0; 2*2=4>0 -> closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
+        log_k, // 61 logs
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
+        log_kp1, // 61 logs
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase413_log61_k_over_k2_refused() {
+    // 62 logs -> refused (Phase 413 handles exactly 61).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
+        log_k.clone(), // 61st log
+        log_k, // 62nd log (over 61; refused)
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
+        log_kp1.clone(), // 61st log
+        log_kp1, // 62nd log (over 61; refused)
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase414_sqrt1_log61_k_over_k2_converges() {
+    // sqrt(k)*log(k)^61/k^2: eff_x2=1; 2*2=4>1 -> closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
+        log_k, // 61 logs
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
+        log_kp1, // 61 logs
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase414_sqrt1_log61_k_over_k2_refused() {
+    // 62 logs -> refused (Phase 414 handles exactly 61).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
+        log_k.clone(), // 61st log
+        log_k, // 62nd log (over 61; refused)
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
+        log_kp1.clone(), // 61st log
+        log_kp1, // 62nd log (over 61; refused)
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase415_sqrt2_log61_k_over_k2_converges() {
+    // sqrt(k)^2*log(k)^61/k^2: eff_x2=2; 2*2=4>2 -> closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
+        log_k, // 61 logs
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
+        log_kp1, // 61 logs
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase415_sqrt2_log61_k_over_k2_refused() {
+    // 62 logs -> refused (Phase 415 handles exactly 61).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
+        log_k.clone(), // 61st log
+        log_k, // 62nd log (over 61; refused)
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
+        log_kp1.clone(), // 61st log
+        log_kp1, // 62nd log (over 61; refused)
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase416_sqrt3_log61_k_over_k3_converges() {
+    // sqrt(k)^3*log(k)^61/k^3: eff_x2=3; 2*3=6>3 -> closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
+        log_k, // 61 logs
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
+        log_kp1, // 61 logs
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase416_sqrt3_log61_k_over_k3_refused() {
+    // 62 logs -> refused (Phase 416 handles exactly 61).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
+        log_k.clone(), // 61st log
+        log_k, // 62nd log (over 61; refused)
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
+        log_kp1.clone(), // 61st log
+        log_kp1, // 62nd log (over 61; refused)
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase417_sqrt4_log61_k_over_k3_converges() {
+    // sqrt(k)^4*log(k)^61/k^3: eff_x2=4; 2*3=6>4 -> closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 55th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
+        log_k, // 61 logs
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 55th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
+        log_kp1, // 61 logs
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase417_sqrt4_log61_k_over_k3_refused() {
+    // 62 logs -> refused (Phase 417 handles exactly 61).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 50th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 55th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
+        log_k.clone(), // 61st log
+        log_k, // 62nd log (over 61; refused)
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 50th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 55th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
+        log_kp1.clone(), // 61st log
+        log_kp1, // 62nd log (over 61; refused)
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase418_sqrt5_log61_k_over_k3_converges() {
+    // sqrt(k)^5*log(k)^61/k^3: eff_x2=5; 2*3=6>5 -> closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
+        log_k, // 61 logs
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
+        log_kp1, // 61 logs
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase418_sqrt5_log61_k_over_k3_refused() {
+    // 62 logs -> refused (Phase 418 handles exactly 61).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 50th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 55th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
+        log_k.clone(), // 61st log
+        log_k, // 62nd log (over 61; refused)
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 50th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 55th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
+        log_kp1.clone(), // 61st log
+        log_kp1, // 62nd log (over 61; refused)
     ]);
     let g_k = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_3]);

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.355.0 — 2026-05-28
+
+### Added
+- Phase 413 (`sixtyOneLogPolyEffectiveDeg`): Zero-Sqrt × Sixty-One-Log × polynomial numerator recognizer.
+- Phase 414 (`oneSqrtSixtyOneLogPolyEffectiveDeg`): One-Sqrt × Sixty-One-Log.
+- Phase 415 (`twoSqrtSixtyOneLogPolyEffectiveDeg`): Two-Sqrt × Sixty-One-Log.
+- Phase 416 (`threeSqrtSixtyOneLogPolyEffectiveDeg`): Three-Sqrt × Sixty-One-Log.
+- Phase 417 (`fourSqrtSixtyOneLogPolyEffectiveDeg`): Four-Sqrt × Sixty-One-Log.
+- Phase 418 (`fiveSqrtSixtyOneLogPolyEffectiveDeg`): Five-Sqrt × Sixty-One-Log. Completes the Sixty-One-Log family.
+- 6 new describe blocks covering Phase 413–418 (closes + refused for each).
+- Cascade fix: refused tests for Phases 407–412 (all those previously using exactly 61 logs as the "over-boundary" value) updated to use 62 log factors, since Phase 413 now accepts exactly 61.
+
 ## 2.349.0 — 2026-05-28
 
 ### Added

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "2.349.0",
+  "version": "2.355.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -7098,6 +7098,167 @@ function fiveSqrtFiftySevenLogPolyEffectiveDeg(node: IRNode, k: IRNode): number 
   return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + sqrtHalfDegs[3] + sqrtHalfDegs[4] + polyDeg;
 }
 
+/** Phase 413 — Zero-Sqrt × Sixty-One-Log × polynomial numerator.
+ * effectiveDeg = polyDeg (no sqrt factors).
+ * Caller checks `denDeg > sixtyOneLogPolyEffectiveDeg(num, k)`.
+ */
+function sixtyOneLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    if (sqrtEffectiveHalfDegree(arg, k) !== undefined) return undefined;
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 61) return undefined;
+      continue;
+    }
+    const deg = polynomialDegreeInK(arg, k);
+    if (deg !== undefined) { polyDeg += deg; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (logCount !== 61) return undefined;
+  return polyDeg;
+}
+
+/** Phase 414 — One-Sqrt × Sixty-One-Log × polynomial numerator. */
+function oneSqrtSixtyOneLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  let sqrtHalfDeg: number | undefined;
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const sd = sqrtEffectiveHalfDegree(arg, k);
+    if (sd !== undefined) {
+      if (sqrtHalfDeg !== undefined) return undefined;
+      sqrtHalfDeg = sd;
+      continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 61) return undefined;
+      continue;
+    }
+    const deg = polynomialDegreeInK(arg, k);
+    if (deg !== undefined) { polyDeg += deg; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDeg === undefined || logCount !== 61) return undefined;
+  return sqrtHalfDeg + polyDeg;
+}
+
+/** Phase 415 — Two-Sqrt × Sixty-One-Log × polynomial numerator. */
+function twoSqrtSixtyOneLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const sd = sqrtEffectiveHalfDegree(arg, k);
+    if (sd !== undefined) {
+      if (sqrtHalfDegs.length >= 2) return undefined;
+      sqrtHalfDegs.push(sd);
+      continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 61) return undefined;
+      continue;
+    }
+    const deg = polynomialDegreeInK(arg, k);
+    if (deg !== undefined) { polyDeg += deg; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 2 || logCount !== 61) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + polyDeg;
+}
+
+/** Phase 416 — Three-Sqrt × Sixty-One-Log × polynomial numerator. */
+function threeSqrtSixtyOneLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const sd = sqrtEffectiveHalfDegree(arg, k);
+    if (sd !== undefined) {
+      if (sqrtHalfDegs.length >= 3) return undefined;
+      sqrtHalfDegs.push(sd);
+      continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 61) return undefined;
+      continue;
+    }
+    const deg = polynomialDegreeInK(arg, k);
+    if (deg !== undefined) { polyDeg += deg; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 3 || logCount !== 61) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + polyDeg;
+}
+
+/** Phase 417 — Four-Sqrt × Sixty-One-Log × polynomial numerator. */
+function fourSqrtSixtyOneLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const sd = sqrtEffectiveHalfDegree(arg, k);
+    if (sd !== undefined) {
+      if (sqrtHalfDegs.length >= 4) return undefined;
+      sqrtHalfDegs.push(sd);
+      continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 61) return undefined;
+      continue;
+    }
+    const deg = polynomialDegreeInK(arg, k);
+    if (deg !== undefined) { polyDeg += deg; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 4 || logCount !== 61) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + sqrtHalfDegs[3] + polyDeg;
+}
+
+/** Phase 418 — Five-Sqrt × Sixty-One-Log × polynomial numerator.
+ * Completes the Sixty-One-Log family (Phases 413–418).
+ */
+function fiveSqrtSixtyOneLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const sd = sqrtEffectiveHalfDegree(arg, k);
+    if (sd !== undefined) {
+      if (sqrtHalfDegs.length >= 5) return undefined;
+      sqrtHalfDegs.push(sd);
+      continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 61) return undefined;
+      continue;
+    }
+    const deg = polynomialDegreeInK(arg, k);
+    if (deg !== undefined) { polyDeg += deg; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 5 || logCount !== 61) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + sqrtHalfDegs[3] + sqrtHalfDegs[4] + polyDeg;
+}
+
 /** Phase 407 — Zero-Sqrt × Sixty-Log × polynomial numerator.
  * effectiveDeg = polyDeg (no sqrt factors).
  * Caller checks `denDeg > sixtyLogPolyEffectiveDeg(num, k)`.
@@ -11051,6 +11212,66 @@ function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
     const denDegS2l8 = polynomialDegreeInK(den, k);
     if (denDegS2l8 !== undefined) {
       if (denDegS2l8 > s2l8Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 418: five sqrt + 61 logs
+  const s5l61Deg = fiveSqrtSixtyOneLogPolyEffectiveDeg(num, k);
+  if (s5l61Deg !== undefined) {
+    const denDegS5l61 = polynomialDegreeInK(den, k);
+    if (denDegS5l61 !== undefined) {
+      if (denDegS5l61 > s5l61Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 417: four sqrt + 61 logs
+  const s4l61Deg = fourSqrtSixtyOneLogPolyEffectiveDeg(num, k);
+  if (s4l61Deg !== undefined) {
+    const denDegS4l61 = polynomialDegreeInK(den, k);
+    if (denDegS4l61 !== undefined) {
+      if (denDegS4l61 > s4l61Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 416: three sqrt + 61 logs
+  const s3l61Deg = threeSqrtSixtyOneLogPolyEffectiveDeg(num, k);
+  if (s3l61Deg !== undefined) {
+    const denDegS3l61 = polynomialDegreeInK(den, k);
+    if (denDegS3l61 !== undefined) {
+      if (denDegS3l61 > s3l61Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 415: two sqrt + 61 logs
+  const s2l61Deg = twoSqrtSixtyOneLogPolyEffectiveDeg(num, k);
+  if (s2l61Deg !== undefined) {
+    const denDegS2l61 = polynomialDegreeInK(den, k);
+    if (denDegS2l61 !== undefined) {
+      if (denDegS2l61 > s2l61Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 414: one sqrt + 61 logs
+  const s1l61Deg = oneSqrtSixtyOneLogPolyEffectiveDeg(num, k);
+  if (s1l61Deg !== undefined) {
+    const denDegS1l61 = polynomialDegreeInK(den, k);
+    if (denDegS1l61 !== undefined) {
+      if (denDegS1l61 > s1l61Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 413: zero sqrt + 61 logs
+  const sl61Deg = sixtyOneLogPolyEffectiveDeg(num, k);
+  if (sl61Deg !== undefined) {
+    const denDegSl61 = polynomialDegreeInK(den, k);
+    if (denDegSl61 !== undefined) {
+      if (denDegSl61 > sl61Deg) return true;
     } else if (hDivergesAtInfinity(den, k)) {
       return true;
     }

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -26192,7 +26192,7 @@ describe("Phase 401 — Zero-Sqrt × Fifty-Nine-Log × polynomial numerator", ()
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("log(k)⁵⁹/k² refused (61 logs — not Phase 407)", () => {
+  it("log(k)⁵⁹/k² refused (62 logs — not Phase 413)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
@@ -26228,7 +26228,7 @@ describe("Phase 402 — One-Sqrt × Fifty-Nine-Log × polynomial numerator", () 
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("√k·log(k)⁵⁹/k² refused (61 logs — not Phase 408)", () => {
+  it("√k·log(k)⁵⁹/k² refused (62 logs — not Phase 414)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
@@ -26266,7 +26266,7 @@ describe("Phase 403 — Two-Sqrt × Fifty-Nine-Log × polynomial numerator", () 
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)²·log(k)⁵⁹/k² refused (61 logs — not Phase 409)", () => {
+  it("(√k)²·log(k)⁵⁹/k² refused (62 logs — not Phase 415)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
@@ -26304,7 +26304,7 @@ describe("Phase 404 — Three-Sqrt × Fifty-Nine-Log × polynomial numerator", (
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)³·log(k)⁵⁹/k³ refused (61 logs — not Phase 410)", () => {
+  it("(√k)³·log(k)⁵⁹/k³ refused (62 logs — not Phase 416)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
@@ -26342,7 +26342,7 @@ describe("Phase 405 — Four-Sqrt × Fifty-Nine-Log × polynomial numerator", ()
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)⁴·log(k)⁵⁹/k³ refused (61 logs — not Phase 411)", () => {
+  it("(√k)⁴·log(k)⁵⁹/k³ refused (62 logs — not Phase 417)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
@@ -26380,7 +26380,7 @@ describe("Phase 406 — Five-Sqrt × Fifty-Nine-Log × polynomial numerator", ()
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)^5·log(k)⁵⁹/k³ refused (61 logs — not Phase 412)", () => {
+  it("(√k)^5·log(k)⁵⁹/k³ refused (62 logs — not Phase 418)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
@@ -26416,15 +26416,15 @@ describe("Phase 407 — Zero-Sqrt × Sixty-Log × polynomial numerator", () => {
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("log(k)⁶⁰/k² refused (61 logs — not Phase 407)", () => {
+  it("log(k)⁶⁰/k² refused (62 logs — not Phase 413)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs61k407 = Array.from({ length: 61 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs61kp1407 = Array.from({ length: 61 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
-    const numK407r = { kind: "apply" as const, head: MUL, args: [...logs61k407] };
-    const numKp1407r = { kind: "apply" as const, head: MUL, args: [...logs61kp1407] };
+    const logs62k413 = Array.from({ length: 62 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs62kp1413 = Array.from({ length: 62 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const numK407r = { kind: "apply" as const, head: MUL, args: [...logs62k413] };
+    const numKp1407r = { kind: "apply" as const, head: MUL, args: [...logs62kp1413] };
     const gK407r = { kind: "apply" as const, head: DIV, args: [numK407r, k2r] };
     const gKp1407r = { kind: "apply" as const, head: DIV, args: [numKp1407r, kp1_2r] };
     const f407r = { kind: "apply" as const, head: SUB, args: [gK407r, gKp1407r] };
@@ -26452,17 +26452,17 @@ describe("Phase 408 — One-Sqrt × Sixty-Log × polynomial numerator", () => {
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("√k·log(k)⁶⁰/k² refused (61 logs — not Phase 408)", () => {
+  it("√k·log(k)⁶⁰/k² refused (62 logs — not Phase 414)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs61k408 = Array.from({ length: 61 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs61kp1408 = Array.from({ length: 61 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs62k414 = Array.from({ length: 62 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs62kp1414 = Array.from({ length: 62 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
-    const numK408r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs61k408] };
-    const numKp1408r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, ...logs61kp1408] };
+    const numK408r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs62k414] };
+    const numKp1408r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, ...logs62kp1414] };
     const gK408r = { kind: "apply" as const, head: DIV, args: [numK408r, k2r] };
     const gKp1408r = { kind: "apply" as const, head: DIV, args: [numKp1408r, kp1_2r] };
     const f408r = { kind: "apply" as const, head: SUB, args: [gK408r, gKp1408r] };
@@ -26490,17 +26490,17 @@ describe("Phase 409 — Two-Sqrt × Sixty-Log × polynomial numerator", () => {
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)²·log(k)⁶⁰/k² refused (61 logs — not Phase 409)", () => {
+  it("(√k)²·log(k)⁶⁰/k² refused (62 logs — not Phase 415)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs61k409 = Array.from({ length: 61 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs61kp1409 = Array.from({ length: 61 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs62k415 = Array.from({ length: 62 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs62kp1415 = Array.from({ length: 62 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
-    const numK409r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs61k409] };
-    const numKp1409r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, ...logs61kp1409] };
+    const numK409r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs62k415] };
+    const numKp1409r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, ...logs62kp1415] };
     const gK409r = { kind: "apply" as const, head: DIV, args: [numK409r, k2r] };
     const gKp1409r = { kind: "apply" as const, head: DIV, args: [numKp1409r, kp1_2r] };
     const f409r = { kind: "apply" as const, head: SUB, args: [gK409r, gKp1409r] };
@@ -26528,17 +26528,17 @@ describe("Phase 410 — Three-Sqrt × Sixty-Log × polynomial numerator", () => 
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)³·log(k)⁶⁰/k³ refused (61 logs — not Phase 410)", () => {
+  it("(√k)³·log(k)⁶⁰/k³ refused (62 logs — not Phase 416)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs61k410 = Array.from({ length: 61 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs61kp1410 = Array.from({ length: 61 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs62k416 = Array.from({ length: 62 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs62kp1416 = Array.from({ length: 62 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
-    const numK410r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs61k410] };
-    const numKp1410r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, ...logs61kp1410] };
+    const numK410r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs62k416] };
+    const numKp1410r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, ...logs62kp1416] };
     const gK410r = { kind: "apply" as const, head: DIV, args: [numK410r, k3r] };
     const gKp1410r = { kind: "apply" as const, head: DIV, args: [numKp1410r, kp1_3r] };
     const f410r = { kind: "apply" as const, head: SUB, args: [gK410r, gKp1410r] };
@@ -26566,17 +26566,17 @@ describe("Phase 411 — Four-Sqrt × Sixty-Log × polynomial numerator", () => {
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)⁴·log(k)⁶⁰/k³ refused (61 logs — not Phase 411)", () => {
+  it("(√k)⁴·log(k)⁶⁰/k³ refused (62 logs — not Phase 417)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs61k411 = Array.from({ length: 61 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs61kp1411 = Array.from({ length: 61 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs62k417 = Array.from({ length: 62 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs62kp1417 = Array.from({ length: 62 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
-    const numK411r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs61k411] };
-    const numKp1411r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, ...logs61kp1411] };
+    const numK411r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs62k417] };
+    const numKp1411r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, ...logs62kp1417] };
     const gK411r = { kind: "apply" as const, head: DIV, args: [numK411r, k3r] };
     const gKp1411r = { kind: "apply" as const, head: DIV, args: [numKp1411r, kp1_3r] };
     const f411r = { kind: "apply" as const, head: SUB, args: [gK411r, gKp1411r] };
@@ -26604,21 +26604,245 @@ describe("Phase 412 — Five-Sqrt × Sixty-Log × polynomial numerator", () => {
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)^5·log(k)⁶⁰/k³ refused (61 logs — not Phase 412)", () => {
+  it("(√k)^5·log(k)⁶⁰/k³ refused (62 logs — not Phase 418)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs61k412 = Array.from({ length: 61 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs61kp1412 = Array.from({ length: 61 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs62k418 = Array.from({ length: 62 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs62kp1418 = Array.from({ length: 62 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
-    const numK412r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs61k412] };
-    const numKp1412r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, ...logs61kp1412] };
+    const numK412r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs62k418] };
+    const numKp1412r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, ...logs62kp1418] };
     const gK412r = { kind: "apply" as const, head: DIV, args: [numK412r, k3r] };
     const gKp1412r = { kind: "apply" as const, head: DIV, args: [numKp1412r, kp1_3r] };
     const f412r = { kind: "apply" as const, head: SUB, args: [gK412r, gKp1412r] };
     const result = evaluateSum(f412r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 413 — Sixty-One-Log × polynomial numerator", () => {
+  it("log(k)⁶¹/k² closes (logCount=61, denDeg=2 > 1)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const logs61k413 = Array.from({ length: 61 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs61kp1413 = Array.from({ length: 61 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const numK413a = { kind: "apply" as const, head: MUL, args: [...logs61k413] };
+    const numKp1413a = { kind: "apply" as const, head: MUL, args: [...logs61kp1413] };
+    const gK413a = { kind: "apply" as const, head: DIV, args: [numK413a, k2] };
+    const gKp1413a = { kind: "apply" as const, head: DIV, args: [numKp1413a, kp1_2] };
+    const f413a = { kind: "apply" as const, head: SUB, args: [gK413a, gKp1413a] };
+    const result = evaluateSum(f413a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("log(k)⁶¹/k² refused (62 logs — not Phase 413)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs62k413r = Array.from({ length: 62 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs62kp1413r = Array.from({ length: 62 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const numK413r = { kind: "apply" as const, head: MUL, args: [...logs62k413r] };
+    const numKp1413r = { kind: "apply" as const, head: MUL, args: [...logs62kp1413r] };
+    const gK413r = { kind: "apply" as const, head: DIV, args: [numK413r, k2r] };
+    const gKp1413r = { kind: "apply" as const, head: DIV, args: [numKp1413r, kp1_2r] };
+    const f413r = { kind: "apply" as const, head: SUB, args: [gK413r, gKp1413r] };
+    const result = evaluateSum(f413r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 414 — One-Sqrt × Sixty-One-Log × polynomial numerator", () => {
+  it("√k·log(k)⁶¹/k² closes (sqrtHalf=0.5, denDeg=2 > 1.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const logs61k414 = Array.from({ length: 61 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs61kp1414 = Array.from({ length: 61 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK414a = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs61k414] };
+    const numKp1414a = { kind: "apply" as const, head: MUL, args: [sqrtKp1, ...logs61kp1414] };
+    const gK414a = { kind: "apply" as const, head: DIV, args: [numK414a, k2] };
+    const gKp1414a = { kind: "apply" as const, head: DIV, args: [numKp1414a, kp1_2] };
+    const f414a = { kind: "apply" as const, head: SUB, args: [gK414a, gKp1414a] };
+    const result = evaluateSum(f414a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("√k·log(k)⁶¹/k² refused (62 logs — not Phase 414)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs62k414r = Array.from({ length: 62 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs62kp1414r = Array.from({ length: 62 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK414r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs62k414r] };
+    const numKp1414r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, ...logs62kp1414r] };
+    const gK414r = { kind: "apply" as const, head: DIV, args: [numK414r, k2r] };
+    const gKp1414r = { kind: "apply" as const, head: DIV, args: [numKp1414r, kp1_2r] };
+    const f414r = { kind: "apply" as const, head: SUB, args: [gK414r, gKp1414r] };
+    const result = evaluateSum(f414r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 415 — Two-Sqrt × Sixty-One-Log × polynomial numerator", () => {
+  it("(√k)²·log(k)⁶¹/k² closes (sqrtHalf=1, denDeg=2 > 2)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const logs61k415 = Array.from({ length: 61 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs61kp1415 = Array.from({ length: 61 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK415a = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs61k415] };
+    const numKp1415a = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, ...logs61kp1415] };
+    const gK415a = { kind: "apply" as const, head: DIV, args: [numK415a, k2] };
+    const gKp1415a = { kind: "apply" as const, head: DIV, args: [numKp1415a, kp1_2] };
+    const f415a = { kind: "apply" as const, head: SUB, args: [gK415a, gKp1415a] };
+    const result = evaluateSum(f415a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("(√k)²·log(k)⁶¹/k² refused (62 logs — not Phase 415)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs62k415r = Array.from({ length: 62 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs62kp1415r = Array.from({ length: 62 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK415r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs62k415r] };
+    const numKp1415r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, ...logs62kp1415r] };
+    const gK415r = { kind: "apply" as const, head: DIV, args: [numK415r, k2r] };
+    const gKp1415r = { kind: "apply" as const, head: DIV, args: [numKp1415r, kp1_2r] };
+    const f415r = { kind: "apply" as const, head: SUB, args: [gK415r, gKp1415r] };
+    const result = evaluateSum(f415r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 416 — Three-Sqrt × Sixty-One-Log × polynomial numerator", () => {
+  it("(√k)³·log(k)⁶¹/k³ closes (sqrtHalf=1.5, denDeg=3 > 2.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const logs61k416 = Array.from({ length: 61 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs61kp1416 = Array.from({ length: 61 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK416a = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs61k416] };
+    const numKp1416a = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, ...logs61kp1416] };
+    const gK416a = { kind: "apply" as const, head: DIV, args: [numK416a, k3] };
+    const gKp1416a = { kind: "apply" as const, head: DIV, args: [numKp1416a, kp1_3] };
+    const f416a = { kind: "apply" as const, head: SUB, args: [gK416a, gKp1416a] };
+    const result = evaluateSum(f416a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("(√k)³·log(k)⁶¹/k³ refused (62 logs — not Phase 416)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs62k416r = Array.from({ length: 62 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs62kp1416r = Array.from({ length: 62 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK416r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs62k416r] };
+    const numKp1416r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, ...logs62kp1416r] };
+    const gK416r = { kind: "apply" as const, head: DIV, args: [numK416r, k3r] };
+    const gKp1416r = { kind: "apply" as const, head: DIV, args: [numKp1416r, kp1_3r] };
+    const f416r = { kind: "apply" as const, head: SUB, args: [gK416r, gKp1416r] };
+    const result = evaluateSum(f416r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 417 — Four-Sqrt × Sixty-One-Log × polynomial numerator", () => {
+  it("(√k)⁴·log(k)⁶¹/k³ closes (sqrtHalf=2, denDeg=3 > 3)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const logs61k417 = Array.from({ length: 61 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs61kp1417 = Array.from({ length: 61 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK417a = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs61k417] };
+    const numKp1417a = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, ...logs61kp1417] };
+    const gK417a = { kind: "apply" as const, head: DIV, args: [numK417a, k3] };
+    const gKp1417a = { kind: "apply" as const, head: DIV, args: [numKp1417a, kp1_3] };
+    const f417a = { kind: "apply" as const, head: SUB, args: [gK417a, gKp1417a] };
+    const result = evaluateSum(f417a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("(√k)⁴·log(k)⁶¹/k³ refused (62 logs — not Phase 417)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs62k417r = Array.from({ length: 62 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs62kp1417r = Array.from({ length: 62 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK417r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs62k417r] };
+    const numKp1417r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, ...logs62kp1417r] };
+    const gK417r = { kind: "apply" as const, head: DIV, args: [numK417r, k3r] };
+    const gKp1417r = { kind: "apply" as const, head: DIV, args: [numKp1417r, kp1_3r] };
+    const f417r = { kind: "apply" as const, head: SUB, args: [gK417r, gKp1417r] };
+    const result = evaluateSum(f417r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 418 — Five-Sqrt × Sixty-One-Log × polynomial numerator", () => {
+  it("(√k)^5·log(k)⁶¹/k³ closes (sqrtHalf=2.5, denDeg=3 > 3.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const logs61k418 = Array.from({ length: 61 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs61kp1418 = Array.from({ length: 61 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK418a = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs61k418] };
+    const numKp1418a = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, ...logs61kp1418] };
+    const gK418a = { kind: "apply" as const, head: DIV, args: [numK418a, k3] };
+    const gKp1418a = { kind: "apply" as const, head: DIV, args: [numKp1418a, kp1_3] };
+    const f418a = { kind: "apply" as const, head: SUB, args: [gK418a, gKp1418a] };
+    const result = evaluateSum(f418a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("(√k)^5·log(k)⁶¹/k³ refused (62 logs — not Phase 418)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs62k418r = Array.from({ length: 62 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs62kp1418r = Array.from({ length: 62 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK418r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs62k418r] };
+    const numKp1418r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, ...logs62kp1418r] };
+    const gK418r = { kind: "apply" as const, head: DIV, args: [numK418r, k3r] };
+    const gKp1418r = { kind: "apply" as const, head: DIV, args: [numKp1418r, kp1_3r] };
+    const f418r = { kind: "apply" as const, head: SUB, args: [gK418r, gKp1418r] };
+    const result = evaluateSum(f418r, k, int(1), sym("%inf"), evalNode);
     expect(result).toMatchObject({ kind: "apply", head: SUM });
   });
 });


### PR DESCRIPTION
## Summary

Implements Phases 413–418 (Sixty-One-Log family) across Python, Rust, and TypeScript.

Each phase recognises summands whose numerator contains **exactly 61 logarithmic factors** and 0–5 square-root factors:

| Phase | Name | Recogniser |
|-------|------|-----------|
| 413 | Zero-Sqrt × Sixty-One-Log | `_sixty_one_log_poly_effective_x2` |
| 414 | One-Sqrt × Sixty-One-Log | `_one_sqrt_sixty_one_log_poly_effective_x2` |
| 415 | Two-Sqrt × Sixty-One-Log | `_two_sqrt_sixty_one_log_poly_effective_x2` |
| 416 | Three-Sqrt × Sixty-One-Log | `_three_sqrt_sixty_one_log_poly_effective_x2` |
| 417 | Four-Sqrt × Sixty-One-Log | `_four_sqrt_sixty_one_log_poly_effective_x2` |
| 418 | Five-Sqrt × Sixty-One-Log | `_five_sqrt_sixty_one_log_poly_effective_x2` |

## Changes

- **Python** (v2.349.0 → v2.355.0): +6 helpers, +6 dispatch blocks, +12 tests (1127 total)
- **Rust** (v2.349.0 → v2.355.0): +6 helpers, +6 dispatch blocks, +12 tests (1020 total)
- **TypeScript** (v2.349.0 → v2.355.0): +6 helpers, +6 dispatch blocks, +6 describe blocks

## Cascade Fix

Since Phase 413 now accepts exactly 61-log inputs, all existing refused tests that previously used 61 logs as their "over-boundary" sample (Phases 359–412) were updated to use 62 logs. Phase 417 and 418 refused test log counts were also corrected (had 57 entries, needed 62).

🤖 Generated with [Claude Code](https://claude.com/claude-code)