### PR TITLE
feat(cas-summation): Phase 425-430 — Sixty-Three-Log family (v2.367.0)

### DIFF
--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.367.0 — 2026-05-28
+
+### Added
+- Phase 425 (`_sixty_three_log_poly_effective_x2`): Zero-Sqrt × Sixty-Three-Log × polynomial numerator recognizer.
+- Phase 426 (`_one_sqrt_sixty_three_log_poly_effective_x2`): One-Sqrt × Sixty-Three-Log × polynomial numerator recognizer.
+- Phase 427 (`_two_sqrt_sixty_three_log_poly_effective_x2`): Two-Sqrt × Sixty-Three-Log × polynomial numerator recognizer.
+- Phase 428 (`_three_sqrt_sixty_three_log_poly_effective_x2`): Three-Sqrt × Sixty-Three-Log × polynomial numerator recognizer.
+- Phase 429 (`_four_sqrt_sixty_three_log_poly_effective_x2`): Four-Sqrt × Sixty-Three-Log × polynomial numerator recognizer.
+- Phase 430 (`_five_sqrt_sixty_three_log_poly_effective_x2`): Five-Sqrt × Sixty-Three-Log × polynomial numerator recognizer. Completes the Sixty-Three-Log family.
+- 12 new test cases covering Phase 425–430 (closes + refused for each).
+- Cascade fix: refused tests across all earlier phases that previously used exactly 63 logs as the "over-boundary" value updated to use 64 log factors, since Phase 425 now accepts exactly 63.
+
 ## 2.361.0 — 2026-05-28
 
 ### Added

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "2.361.0"
+version = "2.367.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -1477,6 +1477,60 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
                 return True
         elif _h_diverges_at_infinity(den, k):
             return True
+    # Phase 430: ``Mul(Sqrt(P1)×5, Log(h1)×63, polynomial..., bounded...)`` numerator.
+    s5l63p_x2 = _five_sqrt_sixty_three_log_poly_effective_x2(num, k)
+    if s5l63p_x2 is not None:
+        den_deg_s5l63 = _polynomial_degree_in_k(den, k)
+        if den_deg_s5l63 is not None:
+            if 2 * den_deg_s5l63 > s5l63p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 429: ``Mul(Sqrt(P1)×4, Log(h1)×63, polynomial..., bounded...)`` numerator.
+    s4l63p_x2 = _four_sqrt_sixty_three_log_poly_effective_x2(num, k)
+    if s4l63p_x2 is not None:
+        den_deg_s4l63 = _polynomial_degree_in_k(den, k)
+        if den_deg_s4l63 is not None:
+            if 2 * den_deg_s4l63 > s4l63p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 428: ``Mul(Sqrt(P1)×3, Log(h1)×63, polynomial..., bounded...)`` numerator.
+    s3l63p_x2 = _three_sqrt_sixty_three_log_poly_effective_x2(num, k)
+    if s3l63p_x2 is not None:
+        den_deg_s3l63 = _polynomial_degree_in_k(den, k)
+        if den_deg_s3l63 is not None:
+            if 2 * den_deg_s3l63 > s3l63p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 427: ``Mul(Sqrt(P), Sqrt(P2), Log(h1)×63, polynomial..., bounded...)`` numerator.
+    s2l63p_x2 = _two_sqrt_sixty_three_log_poly_effective_x2(num, k)
+    if s2l63p_x2 is not None:
+        den_deg_s2l63 = _polynomial_degree_in_k(den, k)
+        if den_deg_s2l63 is not None:
+            if 2 * den_deg_s2l63 > s2l63p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 426: ``Mul(Sqrt(P), Log(h1)×63, polynomial..., bounded...)`` numerator.
+    s1l63p_x2 = _one_sqrt_sixty_three_log_poly_effective_x2(num, k)
+    if s1l63p_x2 is not None:
+        den_deg_s1l63 = _polynomial_degree_in_k(den, k)
+        if den_deg_s1l63 is not None:
+            if 2 * den_deg_s1l63 > s1l63p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 425: ``Mul(Log(h1)×63, polynomial..., bounded...)`` numerator.
+    sl63p_x2 = _sixty_three_log_poly_effective_x2(num, k)
+    if sl63p_x2 is not None:
+        den_deg_sl63 = _polynomial_degree_in_k(den, k)
+        if den_deg_sl63 is not None:
+            if 2 * den_deg_sl63 > sl63p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
     # Phase 424: ``Mul(Sqrt(P1)×5, Log(h1)×62, polynomial..., bounded...)`` numerator.
     s5l62p_x2 = _five_sqrt_sixty_two_log_poly_effective_x2(num, k)
     if s5l62p_x2 is not None:
@@ -13945,6 +13999,189 @@ def _five_sqrt_fifty_seven_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> i
             continue
         return None
     if len(sqrt_degs_x2) != 5 or log_count != 57:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _sixty_three_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 425 — Zero-Sqrt × Sixty-Three-Log × polynomial numerator."""
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        if _sqrt_effective_half_degree_x2(arg, k) is not None:
+            return None
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 63:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if log_count != 63:
+        return None
+    return 2 * poly_deg_sum
+
+
+def _one_sqrt_sixty_three_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 426 — One-Sqrt × Sixty-Three-Log × polynomial numerator."""
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_deg_x2: int | None = None
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if sqrt_deg_x2 is not None:
+                return None
+            sqrt_deg_x2 = deg_x2
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 63:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if sqrt_deg_x2 is None or log_count != 63:
+        return None
+    return sqrt_deg_x2 + 2 * poly_deg_sum
+
+
+def _two_sqrt_sixty_three_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 427 — Two-Sqrt × Sixty-Three-Log × polynomial numerator."""
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 2:
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 63:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 2 or log_count != 63:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _three_sqrt_sixty_three_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 428 — Three-Sqrt × Sixty-Three-Log × polynomial numerator."""
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 3:
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 63:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 3 or log_count != 63:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _four_sqrt_sixty_three_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 429 — Four-Sqrt × Sixty-Three-Log × polynomial numerator."""
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 4:
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 63:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 4 or log_count != 63:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _five_sqrt_sixty_three_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 430 — Five-Sqrt × Sixty-Three-Log × polynomial numerator.
+    Completes the Sixty-Three-Log family (Phases 425-430).
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 5:
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 63:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 5 or log_count != 63:
         return None
     return sum(sqrt_degs_x2) + 2 * poly_deg_sum
 

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -48853,6 +48853,7 @@ class TestPhase359FiftyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -48902,6 +48903,7 @@ class TestPhase359FiftyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -49060,6 +49062,7 @@ class TestPhase360OneSqrtFiftyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -49110,6 +49113,7 @@ class TestPhase360OneSqrtFiftyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -49268,6 +49272,7 @@ class TestPhase361TwoSqrtFiftyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -49318,6 +49323,7 @@ class TestPhase361TwoSqrtFiftyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -49476,6 +49482,7 @@ class TestPhase362ThreeSqrtFiftyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -49526,6 +49533,7 @@ class TestPhase362ThreeSqrtFiftyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -49684,6 +49692,7 @@ class TestPhase363FourSqrtFiftyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -49734,6 +49743,7 @@ class TestPhase363FourSqrtFiftyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -49892,6 +49902,7 @@ class TestPhase364FiveSqrtFiftyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -49942,6 +49953,7 @@ class TestPhase364FiveSqrtFiftyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -52471,6 +52483,7 @@ class TestPhase377FiftyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -52520,6 +52533,7 @@ class TestPhase377FiftyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -52684,6 +52698,7 @@ class TestPhase378OneSqrtFiftyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)),
@@ -52734,6 +52749,7 @@ class TestPhase378OneSqrtFiftyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -52898,6 +52914,7 @@ class TestPhase379TwoSqrtFiftyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -52948,6 +52965,7 @@ class TestPhase379TwoSqrtFiftyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -53112,6 +53130,7 @@ class TestPhase380ThreeSqrtFiftyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -53162,6 +53181,7 @@ class TestPhase380ThreeSqrtFiftyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -53326,6 +53346,7 @@ class TestPhase381FourSqrtFiftyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -53376,6 +53397,7 @@ class TestPhase381FourSqrtFiftyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -53540,6 +53562,7 @@ class TestPhase382FiveSqrtFiftyFiveLogPoly:
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
@@ -53590,6 +53613,7 @@ class TestPhase382FiveSqrtFiftyFiveLogPoly:
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -53753,6 +53777,7 @@ class TestPhase383ZeroSqrtFiftySixLogPoly:
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -53802,6 +53827,7 @@ class TestPhase383ZeroSqrtFiftySixLogPoly:
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -53972,6 +53998,7 @@ class TestPhase384OneSqrtFiftySixLogPoly:
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1,
@@ -54022,6 +54049,7 @@ class TestPhase384OneSqrtFiftySixLogPoly:
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -54192,6 +54220,7 @@ class TestPhase385TwoSqrtFiftySixLogPoly:
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1,
@@ -54242,6 +54271,7 @@ class TestPhase385TwoSqrtFiftySixLogPoly:
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -54412,6 +54442,7 @@ class TestPhase386ThreeSqrtFiftySixLogPoly:
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -54462,6 +54493,7 @@ class TestPhase386ThreeSqrtFiftySixLogPoly:
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -54632,6 +54664,7 @@ class TestPhase387FourSqrtFiftySixLogPoly:
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -54682,6 +54715,7 @@ class TestPhase387FourSqrtFiftySixLogPoly:
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -54852,6 +54886,7 @@ class TestPhase388FiveSqrtFiftySixLogPoly:
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -54902,6 +54937,7 @@ class TestPhase388FiveSqrtFiftySixLogPoly:
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -55067,6 +55103,7 @@ class TestPhase389ZeroSqrtFiftySevenLogPoly:
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -55116,6 +55153,7 @@ class TestPhase389ZeroSqrtFiftySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -55288,6 +55326,7 @@ class TestPhase390OneSqrtFiftySevenLogPoly:
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1,
@@ -55338,6 +55377,7 @@ class TestPhase390OneSqrtFiftySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -55510,6 +55550,7 @@ class TestPhase391TwoSqrtFiftySevenLogPoly:
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1,
@@ -55560,6 +55601,7 @@ class TestPhase391TwoSqrtFiftySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -55732,6 +55774,7 @@ class TestPhase392ThreeSqrtFiftySevenLogPoly:
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -55782,6 +55825,7 @@ class TestPhase392ThreeSqrtFiftySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -55954,6 +55998,7 @@ class TestPhase393FourSqrtFiftySevenLogPoly:
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -56004,6 +56049,7 @@ class TestPhase393FourSqrtFiftySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -56176,6 +56222,7 @@ class TestPhase394FiveSqrtFiftySevenLogPoly:
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -56226,6 +56273,7 @@ class TestPhase394FiveSqrtFiftySevenLogPoly:
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -56393,6 +56441,7 @@ class TestPhase395ZeroSqrtFiftyEightLogPoly:
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -56442,6 +56491,7 @@ class TestPhase395ZeroSqrtFiftyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -56616,6 +56666,7 @@ class TestPhase396OneSqrtFiftyEightLogPoly:
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1,
@@ -56666,6 +56717,7 @@ class TestPhase396OneSqrtFiftyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -56840,6 +56892,7 @@ class TestPhase397TwoSqrtFiftyEightLogPoly:
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1,
@@ -56890,6 +56943,7 @@ class TestPhase397TwoSqrtFiftyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -57064,6 +57118,7 @@ class TestPhase398ThreeSqrtFiftyEightLogPoly:
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -57114,6 +57169,7 @@ class TestPhase398ThreeSqrtFiftyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -57288,6 +57344,7 @@ class TestPhase399FourSqrtFiftyEightLogPoly:
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -57338,6 +57395,7 @@ class TestPhase399FourSqrtFiftyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -57512,6 +57570,7 @@ class TestPhase400FiveSqrtFiftyEightLogPoly:
             IRApply(LOG, (_k,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -57562,6 +57621,7 @@ class TestPhase400FiveSqrtFiftyEightLogPoly:
             IRApply(LOG, (kp1,)),  # 63rd log (over 61; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -57731,6 +57791,7 @@ class TestPhase401ZeroSqrtFiftyNineLogPoly:
             IRApply(LOG, (_k,)),  # 61st log (over 59; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -57780,6 +57841,7 @@ class TestPhase401ZeroSqrtFiftyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log (over 59; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -57956,6 +58018,7 @@ class TestPhase402OneSqrtFiftyNineLogPoly:
             IRApply(LOG, (_k,)),  # 61st log (over 59; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1,
@@ -58006,6 +58069,7 @@ class TestPhase402OneSqrtFiftyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log (over 59; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -58182,6 +58246,7 @@ class TestPhase403TwoSqrtFiftyNineLogPoly:
             IRApply(LOG, (_k,)),  # 61st log (over 59; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1,
@@ -58232,6 +58297,7 @@ class TestPhase403TwoSqrtFiftyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log (over 59; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -58408,6 +58474,7 @@ class TestPhase404ThreeSqrtFiftyNineLogPoly:
             IRApply(LOG, (_k,)),  # 61st log (over 59; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -58458,6 +58525,7 @@ class TestPhase404ThreeSqrtFiftyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log (over 59; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -58634,6 +58702,7 @@ class TestPhase405FourSqrtFiftyNineLogPoly:
             IRApply(LOG, (_k,)),  # 61st log (over 59; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -58684,6 +58753,7 @@ class TestPhase405FourSqrtFiftyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log (over 59; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -58860,6 +58930,7 @@ class TestPhase406FiveSqrtFiftyNineLogPoly:
             IRApply(LOG, (_k,)),  # 61st log (over 59; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -58910,6 +58981,7 @@ class TestPhase406FiveSqrtFiftyNineLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log (over 59; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -59081,6 +59153,7 @@ class TestPhase407ZeroSqrtSixtyLogPoly:
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -59130,6 +59203,7 @@ class TestPhase407ZeroSqrtSixtyLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -59308,6 +59382,7 @@ class TestPhase408OneSqrtSixtyLogPoly:
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1,
@@ -59358,6 +59433,7 @@ class TestPhase408OneSqrtSixtyLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -59536,6 +59612,7 @@ class TestPhase409TwoSqrtSixtyLogPoly:
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1,
@@ -59586,6 +59663,7 @@ class TestPhase409TwoSqrtSixtyLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -59764,6 +59842,7 @@ class TestPhase410ThreeSqrtSixtyLogPoly:
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -59814,6 +59893,7 @@ class TestPhase410ThreeSqrtSixtyLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -59992,6 +60072,7 @@ class TestPhase411FourSqrtSixtyLogPoly:
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -60042,6 +60123,7 @@ class TestPhase411FourSqrtSixtyLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -60220,6 +60302,7 @@ class TestPhase412FiveSqrtSixtyLogPoly:
             IRApply(LOG, (_k,)),  # 61st log (over 60; refused)
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -60270,6 +60353,7 @@ class TestPhase412FiveSqrtSixtyLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log (over 60; refused)
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -60443,6 +60527,7 @@ class TestPhase413ZeroSqrtSixtyOneLogPoly:
             IRApply(LOG, (_k,)),  # 61st log
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -60492,6 +60577,7 @@ class TestPhase413ZeroSqrtSixtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -60672,6 +60758,7 @@ class TestPhase414OneSqrtSixtyOneLogPoly:
             IRApply(LOG, (_k,)),  # 61st log
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1,
@@ -60722,6 +60809,7 @@ class TestPhase414OneSqrtSixtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -60902,6 +60990,7 @@ class TestPhase415TwoSqrtSixtyOneLogPoly:
             IRApply(LOG, (_k,)),  # 61st log
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1,
@@ -60952,6 +61041,7 @@ class TestPhase415TwoSqrtSixtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -61132,6 +61222,7 @@ class TestPhase416ThreeSqrtSixtyOneLogPoly:
             IRApply(LOG, (_k,)),  # 61st log
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -61182,6 +61273,7 @@ class TestPhase416ThreeSqrtSixtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -61362,6 +61454,7 @@ class TestPhase417FourSqrtSixtyOneLogPoly:
             IRApply(LOG, (_k,)),  # 61st log
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -61412,6 +61505,7 @@ class TestPhase417FourSqrtSixtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -61592,6 +61686,7 @@ class TestPhase418FiveSqrtSixtyOneLogPoly:
             IRApply(LOG, (_k,)),  # 61st log
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -61642,6 +61737,7 @@ class TestPhase418FiveSqrtSixtyOneLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -61817,6 +61913,7 @@ class TestPhase419ZeroSqrtSixtyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 61st log
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
@@ -61866,6 +61963,7 @@ class TestPhase419ZeroSqrtSixtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -62049,6 +62147,7 @@ class TestPhase420OneSqrtSixtyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 61st log
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1,
@@ -62099,6 +62198,7 @@ class TestPhase420OneSqrtSixtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
@@ -62282,6 +62382,7 @@ class TestPhase421TwoSqrtSixtyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 61st log
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1,
@@ -62332,6 +62433,7 @@ class TestPhase421TwoSqrtSixtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k3))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
@@ -62515,6 +62617,7 @@ class TestPhase422ThreeSqrtSixtyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 61st log
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -62565,6 +62668,7 @@ class TestPhase422ThreeSqrtSixtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k4))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_4))
@@ -62748,6 +62852,7 @@ class TestPhase423FourSqrtSixtyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 61st log
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -62798,6 +62903,7 @@ class TestPhase423FourSqrtSixtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
         ))
         g_k = IRApply(DIV, (num_k, k5))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_5))
@@ -62981,6 +63087,7 @@ class TestPhase424FiveSqrtSixtyTwoLogPoly:
             IRApply(LOG, (_k,)),  # 61st log
             IRApply(LOG, (_k,)),  # 62nd log
             IRApply(LOG, (_k,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
         ))
         num_kp1 = IRApply(MUL, (
             sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
@@ -63031,6 +63138,1421 @@ class TestPhase424FiveSqrtSixtyTwoLogPoly:
             IRApply(LOG, (kp1,)),  # 61st log
             IRApply(LOG, (kp1,)),  # 62nd log
             IRApply(LOG, (kp1,)),  # 63rd log (over 62; refused)
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
+        ))
+        g_k = IRApply(DIV, (num_k, k6))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_6))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+class TestPhase425ZeroSqrtSixtyThreeLogPoly:
+    """Phase 425 -- Zero-Sqrt x Sixty-Three-Log x polynomial numerator."""
+
+    def test_zerosqrt_k_log63_k_over_k2_closes(self):
+        """sqrt(k)^0*log(k)^63/k^2: eff_x2=0; 2*2=4 > 0 -> closes"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+            IRApply(LOG, (_k,)),  # 58th log
+            IRApply(LOG, (_k,)),  # 59th log
+            IRApply(LOG, (_k,)),  # 60th log
+            IRApply(LOG, (_k,)),  # 61st log
+            IRApply(LOG, (_k,)),  # 62nd log
+            IRApply(LOG, (_k,)),  # 63rd log,
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+            IRApply(LOG, (kp1,)),  # 58th log
+            IRApply(LOG, (kp1,)),  # 59th log
+            IRApply(LOG, (kp1,)),  # 60th log
+            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
+            IRApply(LOG, (kp1,)),  # 63rd log,
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_zerosqrt_k_log63_k_over_k2_refused(self):
+        """sqrt(k)^0*log(k)^64/k^2: 64 logs -> not Phase 425 -> refused"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+            IRApply(LOG, (_k,)),  # 58th log
+            IRApply(LOG, (_k,)),  # 59th log
+            IRApply(LOG, (_k,)),  # 60th log
+            IRApply(LOG, (_k,)),  # 61st log
+            IRApply(LOG, (_k,)),  # 62nd log
+            IRApply(LOG, (_k,)),  # 63rd log
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
+            IRApply(LOG, (_k,)),  # 65th log (over 64; refused),
+        ))
+        num_kp1 = IRApply(MUL, (
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+            IRApply(LOG, (kp1,)),  # 58th log
+            IRApply(LOG, (kp1,)),  # 59th log
+            IRApply(LOG, (kp1,)),  # 60th log
+            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
+            IRApply(LOG, (kp1,)),  # 63rd log
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
+            IRApply(LOG, (kp1,)),  # 65th log (over 64; refused),
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+class TestPhase426OneSqrtSixtyThreeLogPoly:
+    """Phase 426 -- One-Sqrt x Sixty-Three-Log x polynomial numerator."""
+
+    def test_onesqrt_k_log63_k_over_k2_closes(self):
+        """sqrt(k)^1*log(k)^63/k^2: eff_x2=1; 2*2=4 > 1 -> closes"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        sqrt_k = IRApply(SQRT, (_k,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_k = IRApply(MUL, (
+            sqrt_k,
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+            IRApply(LOG, (_k,)),  # 58th log
+            IRApply(LOG, (_k,)),  # 59th log
+            IRApply(LOG, (_k,)),  # 60th log
+            IRApply(LOG, (_k,)),  # 61st log
+            IRApply(LOG, (_k,)),  # 62nd log
+            IRApply(LOG, (_k,)),  # 63rd log,
+        ))
+        num_kp1 = IRApply(MUL, (
+            sqrt_kp1,
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+            IRApply(LOG, (kp1,)),  # 58th log
+            IRApply(LOG, (kp1,)),  # 59th log
+            IRApply(LOG, (kp1,)),  # 60th log
+            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
+            IRApply(LOG, (kp1,)),  # 63rd log,
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_onesqrt_k_log63_k_over_k2_refused(self):
+        """sqrt(k)^1*log(k)^64/k^2: 64 logs -> not Phase 426 -> refused"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        sqrt_k = IRApply(SQRT, (_k,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_k = IRApply(MUL, (
+            sqrt_k,
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+            IRApply(LOG, (_k,)),  # 58th log
+            IRApply(LOG, (_k,)),  # 59th log
+            IRApply(LOG, (_k,)),  # 60th log
+            IRApply(LOG, (_k,)),  # 61st log
+            IRApply(LOG, (_k,)),  # 62nd log
+            IRApply(LOG, (_k,)),  # 63rd log
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
+            IRApply(LOG, (_k,)),  # 65th log (over 64; refused),
+        ))
+        num_kp1 = IRApply(MUL, (
+            sqrt_kp1,
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+            IRApply(LOG, (kp1,)),  # 58th log
+            IRApply(LOG, (kp1,)),  # 59th log
+            IRApply(LOG, (kp1,)),  # 60th log
+            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
+            IRApply(LOG, (kp1,)),  # 63rd log
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
+            IRApply(LOG, (kp1,)),  # 65th log (over 64; refused),
+        ))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+class TestPhase427TwoSqrtSixtyThreeLogPoly:
+    """Phase 427 -- Two-Sqrt x Sixty-Three-Log x polynomial numerator."""
+
+    def test_twosqrt_k_log63_k_over_k3_closes(self):
+        """sqrt(k)^2*log(k)^63/k^3: eff_x2=2; 2*3=6 > 2 -> closes"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        sqrt_k = IRApply(SQRT, (_k,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_k = IRApply(MUL, (
+            sqrt_k, sqrt_k,
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+            IRApply(LOG, (_k,)),  # 58th log
+            IRApply(LOG, (_k,)),  # 59th log
+            IRApply(LOG, (_k,)),  # 60th log
+            IRApply(LOG, (_k,)),  # 61st log
+            IRApply(LOG, (_k,)),  # 62nd log
+            IRApply(LOG, (_k,)),  # 63rd log,
+        ))
+        num_kp1 = IRApply(MUL, (
+            sqrt_kp1, sqrt_kp1,
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+            IRApply(LOG, (kp1,)),  # 58th log
+            IRApply(LOG, (kp1,)),  # 59th log
+            IRApply(LOG, (kp1,)),  # 60th log
+            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
+            IRApply(LOG, (kp1,)),  # 63rd log,
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_twosqrt_k_log63_k_over_k3_refused(self):
+        """sqrt(k)^2*log(k)^64/k^3: 64 logs -> not Phase 427 -> refused"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        sqrt_k = IRApply(SQRT, (_k,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_k = IRApply(MUL, (
+            sqrt_k, sqrt_k,
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+            IRApply(LOG, (_k,)),  # 58th log
+            IRApply(LOG, (_k,)),  # 59th log
+            IRApply(LOG, (_k,)),  # 60th log
+            IRApply(LOG, (_k,)),  # 61st log
+            IRApply(LOG, (_k,)),  # 62nd log
+            IRApply(LOG, (_k,)),  # 63rd log
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
+            IRApply(LOG, (_k,)),  # 65th log (over 64; refused),
+        ))
+        num_kp1 = IRApply(MUL, (
+            sqrt_kp1, sqrt_kp1,
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+            IRApply(LOG, (kp1,)),  # 58th log
+            IRApply(LOG, (kp1,)),  # 59th log
+            IRApply(LOG, (kp1,)),  # 60th log
+            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
+            IRApply(LOG, (kp1,)),  # 63rd log
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
+            IRApply(LOG, (kp1,)),  # 65th log (over 64; refused),
+        ))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+class TestPhase428ThreeSqrtSixtyThreeLogPoly:
+    """Phase 428 -- Three-Sqrt x Sixty-Three-Log x polynomial numerator."""
+
+    def test_threesqrt_k_log63_k_over_k4_closes(self):
+        """sqrt(k)^3*log(k)^63/k^4: eff_x2=3; 2*4=8 > 3 -> closes"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k4 = IRApply(POW, (_k, IRInteger(4)))
+        kp1_4 = IRApply(POW, (kp1, IRInteger(4)))
+        sqrt_k = IRApply(SQRT, (_k,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_k = IRApply(MUL, (
+            sqrt_k, sqrt_k, sqrt_k,
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+            IRApply(LOG, (_k,)),  # 58th log
+            IRApply(LOG, (_k,)),  # 59th log
+            IRApply(LOG, (_k,)),  # 60th log
+            IRApply(LOG, (_k,)),  # 61st log
+            IRApply(LOG, (_k,)),  # 62nd log
+            IRApply(LOG, (_k,)),  # 63rd log,
+        ))
+        num_kp1 = IRApply(MUL, (
+            sqrt_kp1, sqrt_kp1, sqrt_kp1,
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+            IRApply(LOG, (kp1,)),  # 58th log
+            IRApply(LOG, (kp1,)),  # 59th log
+            IRApply(LOG, (kp1,)),  # 60th log
+            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
+            IRApply(LOG, (kp1,)),  # 63rd log,
+        ))
+        g_k = IRApply(DIV, (num_k, k4))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_4))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_threesqrt_k_log63_k_over_k4_refused(self):
+        """sqrt(k)^3*log(k)^64/k^4: 64 logs -> not Phase 428 -> refused"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k4 = IRApply(POW, (_k, IRInteger(4)))
+        kp1_4 = IRApply(POW, (kp1, IRInteger(4)))
+        sqrt_k = IRApply(SQRT, (_k,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_k = IRApply(MUL, (
+            sqrt_k, sqrt_k, sqrt_k,
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+            IRApply(LOG, (_k,)),  # 58th log
+            IRApply(LOG, (_k,)),  # 59th log
+            IRApply(LOG, (_k,)),  # 60th log
+            IRApply(LOG, (_k,)),  # 61st log
+            IRApply(LOG, (_k,)),  # 62nd log
+            IRApply(LOG, (_k,)),  # 63rd log
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
+            IRApply(LOG, (_k,)),  # 65th log (over 64; refused),
+        ))
+        num_kp1 = IRApply(MUL, (
+            sqrt_kp1, sqrt_kp1, sqrt_kp1,
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+            IRApply(LOG, (kp1,)),  # 58th log
+            IRApply(LOG, (kp1,)),  # 59th log
+            IRApply(LOG, (kp1,)),  # 60th log
+            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
+            IRApply(LOG, (kp1,)),  # 63rd log
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
+            IRApply(LOG, (kp1,)),  # 65th log (over 64; refused),
+        ))
+        g_k = IRApply(DIV, (num_k, k4))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_4))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+class TestPhase429FourSqrtSixtyThreeLogPoly:
+    """Phase 429 -- Four-Sqrt x Sixty-Three-Log x polynomial numerator."""
+
+    def test_foursqrt_k_log63_k_over_k5_closes(self):
+        """sqrt(k)^4*log(k)^63/k^5: eff_x2=4; 2*5=10 > 4 -> closes"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k5 = IRApply(POW, (_k, IRInteger(5)))
+        kp1_5 = IRApply(POW, (kp1, IRInteger(5)))
+        sqrt_k = IRApply(SQRT, (_k,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_k = IRApply(MUL, (
+            sqrt_k, sqrt_k, sqrt_k, sqrt_k,
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+            IRApply(LOG, (_k,)),  # 58th log
+            IRApply(LOG, (_k,)),  # 59th log
+            IRApply(LOG, (_k,)),  # 60th log
+            IRApply(LOG, (_k,)),  # 61st log
+            IRApply(LOG, (_k,)),  # 62nd log
+            IRApply(LOG, (_k,)),  # 63rd log,
+        ))
+        num_kp1 = IRApply(MUL, (
+            sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+            IRApply(LOG, (kp1,)),  # 58th log
+            IRApply(LOG, (kp1,)),  # 59th log
+            IRApply(LOG, (kp1,)),  # 60th log
+            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
+            IRApply(LOG, (kp1,)),  # 63rd log,
+        ))
+        g_k = IRApply(DIV, (num_k, k5))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_5))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_foursqrt_k_log63_k_over_k5_refused(self):
+        """sqrt(k)^4*log(k)^64/k^5: 64 logs -> not Phase 429 -> refused"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k5 = IRApply(POW, (_k, IRInteger(5)))
+        kp1_5 = IRApply(POW, (kp1, IRInteger(5)))
+        sqrt_k = IRApply(SQRT, (_k,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_k = IRApply(MUL, (
+            sqrt_k, sqrt_k, sqrt_k, sqrt_k,
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+            IRApply(LOG, (_k,)),  # 58th log
+            IRApply(LOG, (_k,)),  # 59th log
+            IRApply(LOG, (_k,)),  # 60th log
+            IRApply(LOG, (_k,)),  # 61st log
+            IRApply(LOG, (_k,)),  # 62nd log
+            IRApply(LOG, (_k,)),  # 63rd log
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
+            IRApply(LOG, (_k,)),  # 65th log (over 64; refused),
+        ))
+        num_kp1 = IRApply(MUL, (
+            sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+            IRApply(LOG, (kp1,)),  # 58th log
+            IRApply(LOG, (kp1,)),  # 59th log
+            IRApply(LOG, (kp1,)),  # 60th log
+            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
+            IRApply(LOG, (kp1,)),  # 63rd log
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
+            IRApply(LOG, (kp1,)),  # 65th log (over 64; refused),
+        ))
+        g_k = IRApply(DIV, (num_k, k5))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_5))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+class TestPhase430FiveSqrtSixtyThreeLogPoly:
+    """Phase 430 -- Five-Sqrt x Sixty-Three-Log x polynomial numerator."""
+
+    def test_fivesqrt_k_log63_k_over_k6_closes(self):
+        """sqrt(k)^5*log(k)^63/k^6: eff_x2=5; 2*6=12 > 5 -> closes"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k6 = IRApply(POW, (_k, IRInteger(6)))
+        kp1_6 = IRApply(POW, (kp1, IRInteger(6)))
+        sqrt_k = IRApply(SQRT, (_k,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_k = IRApply(MUL, (
+            sqrt_k, sqrt_k, sqrt_k, sqrt_k, sqrt_k,
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+            IRApply(LOG, (_k,)),  # 58th log
+            IRApply(LOG, (_k,)),  # 59th log
+            IRApply(LOG, (_k,)),  # 60th log
+            IRApply(LOG, (_k,)),  # 61st log
+            IRApply(LOG, (_k,)),  # 62nd log
+            IRApply(LOG, (_k,)),  # 63rd log,
+        ))
+        num_kp1 = IRApply(MUL, (
+            sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+            IRApply(LOG, (kp1,)),  # 58th log
+            IRApply(LOG, (kp1,)),  # 59th log
+            IRApply(LOG, (kp1,)),  # 60th log
+            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
+            IRApply(LOG, (kp1,)),  # 63rd log,
+        ))
+        g_k = IRApply(DIV, (num_k, k6))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_6))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_fivesqrt_k_log63_k_over_k6_refused(self):
+        """sqrt(k)^5*log(k)^64/k^6: 64 logs -> not Phase 430 -> refused"""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k6 = IRApply(POW, (_k, IRInteger(6)))
+        kp1_6 = IRApply(POW, (kp1, IRInteger(6)))
+        sqrt_k = IRApply(SQRT, (_k,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_k = IRApply(MUL, (
+            sqrt_k, sqrt_k, sqrt_k, sqrt_k, sqrt_k,
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+            IRApply(LOG, (_k,)),  # 25th log
+            IRApply(LOG, (_k,)),  # 26th log
+            IRApply(LOG, (_k,)),  # 27th log
+            IRApply(LOG, (_k,)),  # 28th log
+            IRApply(LOG, (_k,)),  # 29th log
+            IRApply(LOG, (_k,)),  # 30th log
+            IRApply(LOG, (_k,)),  # 31st log
+            IRApply(LOG, (_k,)),  # 32nd log
+            IRApply(LOG, (_k,)),  # 33rd log
+            IRApply(LOG, (_k,)),  # 34th log
+            IRApply(LOG, (_k,)),  # 35th log
+            IRApply(LOG, (_k,)),  # 36th log
+            IRApply(LOG, (_k,)),  # 37th log
+            IRApply(LOG, (_k,)),  # 38th log
+            IRApply(LOG, (_k,)),  # 39th log
+            IRApply(LOG, (_k,)),  # 40th log
+            IRApply(LOG, (_k,)),  # 41st log
+            IRApply(LOG, (_k,)),  # 42nd log
+            IRApply(LOG, (_k,)),  # 43rd log
+            IRApply(LOG, (_k,)),  # 44th log
+            IRApply(LOG, (_k,)),  # 45th log
+            IRApply(LOG, (_k,)),  # 46th log
+            IRApply(LOG, (_k,)),  # 47th log
+            IRApply(LOG, (_k,)),  # 48th log
+            IRApply(LOG, (_k,)),  # 49th log
+            IRApply(LOG, (_k,)),  # 50th log
+            IRApply(LOG, (_k,)),  # 51st log
+            IRApply(LOG, (_k,)),  # 52nd log
+            IRApply(LOG, (_k,)),  # 53rd log
+            IRApply(LOG, (_k,)),  # 54th log
+            IRApply(LOG, (_k,)),  # 55th log
+            IRApply(LOG, (_k,)),  # 56th log
+            IRApply(LOG, (_k,)),  # 57th log
+            IRApply(LOG, (_k,)),  # 58th log
+            IRApply(LOG, (_k,)),  # 59th log
+            IRApply(LOG, (_k,)),  # 60th log
+            IRApply(LOG, (_k,)),  # 61st log
+            IRApply(LOG, (_k,)),  # 62nd log
+            IRApply(LOG, (_k,)),  # 63rd log
+            IRApply(LOG, (_k,)),  # 64th log (over 63; refused)
+            IRApply(LOG, (_k,)),  # 65th log (over 64; refused),
+        ))
+        num_kp1 = IRApply(MUL, (
+            sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1, sqrt_kp1,
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+            IRApply(LOG, (kp1,)),  # 25th log
+            IRApply(LOG, (kp1,)),  # 26th log
+            IRApply(LOG, (kp1,)),  # 27th log
+            IRApply(LOG, (kp1,)),  # 28th log
+            IRApply(LOG, (kp1,)),  # 29th log
+            IRApply(LOG, (kp1,)),  # 30th log
+            IRApply(LOG, (kp1,)),  # 31st log
+            IRApply(LOG, (kp1,)),  # 32nd log
+            IRApply(LOG, (kp1,)),  # 33rd log
+            IRApply(LOG, (kp1,)),  # 34th log
+            IRApply(LOG, (kp1,)),  # 35th log
+            IRApply(LOG, (kp1,)),  # 36th log
+            IRApply(LOG, (kp1,)),  # 37th log
+            IRApply(LOG, (kp1,)),  # 38th log
+            IRApply(LOG, (kp1,)),  # 39th log
+            IRApply(LOG, (kp1,)),  # 40th log
+            IRApply(LOG, (kp1,)),  # 41st log
+            IRApply(LOG, (kp1,)),  # 42nd log
+            IRApply(LOG, (kp1,)),  # 43rd log
+            IRApply(LOG, (kp1,)),  # 44th log
+            IRApply(LOG, (kp1,)),  # 45th log
+            IRApply(LOG, (kp1,)),  # 46th log
+            IRApply(LOG, (kp1,)),  # 47th log
+            IRApply(LOG, (kp1,)),  # 48th log
+            IRApply(LOG, (kp1,)),  # 49th log
+            IRApply(LOG, (kp1,)),  # 50th log
+            IRApply(LOG, (kp1,)),  # 51st log
+            IRApply(LOG, (kp1,)),  # 52nd log
+            IRApply(LOG, (kp1,)),  # 53rd log
+            IRApply(LOG, (kp1,)),  # 54th log
+            IRApply(LOG, (kp1,)),  # 55th log
+            IRApply(LOG, (kp1,)),  # 56th log
+            IRApply(LOG, (kp1,)),  # 57th log
+            IRApply(LOG, (kp1,)),  # 58th log
+            IRApply(LOG, (kp1,)),  # 59th log
+            IRApply(LOG, (kp1,)),  # 60th log
+            IRApply(LOG, (kp1,)),  # 61st log
+            IRApply(LOG, (kp1,)),  # 62nd log
+            IRApply(LOG, (kp1,)),  # 63rd log
+            IRApply(LOG, (kp1,)),  # 64th log (over 63; refused)
+            IRApply(LOG, (kp1,)),  # 65th log (over 64; refused),
         ))
         g_k = IRApply(DIV, (num_k, k6))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_6))

--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.367.0 — 2026-05-28
+
+### Added
+- Phase 425 (`sixty_three_log_poly_effective_x2`): Zero-Sqrt × Sixty-Three-Log × polynomial numerator recognizer.
+- Phase 426 (`one_sqrt_sixty_three_log_poly_effective_x2`): One-Sqrt × Sixty-Three-Log.
+- Phase 427 (`two_sqrt_sixty_three_log_poly_effective_x2`): Two-Sqrt × Sixty-Three-Log.
+- Phase 428 (`three_sqrt_sixty_three_log_poly_effective_x2`): Three-Sqrt × Sixty-Three-Log.
+- Phase 429 (`four_sqrt_sixty_three_log_poly_effective_x2`): Four-Sqrt × Sixty-Three-Log.
+- Phase 430 (`five_sqrt_sixty_three_log_poly_effective_x2`): Five-Sqrt × Sixty-Three-Log. Completes the Sixty-Three-Log family.
+- 12 new test functions covering Phase 425–430 (converges + refused for each).
+- Cascade fix: refused tests across all earlier phases that previously used exactly 63 logs as the "over-boundary" value updated to use 64 log factors, since Phase 425 now accepts exactly 63.
+
 ## 2.361.0 — 2026-05-28
 
 ### Added

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "2.361.0"
+version = "2.367.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -7983,6 +7983,182 @@ fn five_sqrt_fifty_seven_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Opt
     Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg_sum)
 }
 
+/// Phase 425 — Zero-Sqrt × Sixty-Three-Log × polynomial numerator.
+///
+/// The Sixty-Three-Log family (Phases 425–430) extends the recogniser to
+/// summands whose numerator contains exactly sixty-three logarithmic factors
+/// and zero to five square-root factors.  This is Phase 425: zero sqrts.
+fn sixty_three_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if sqrt_effective_half_degree_x2(arg, k).is_some() { return None; }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 63 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg;
+            continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if log_count != 63 { return None; }
+    Some(2 * poly_deg_sum)
+}
+
+/// Phase 426 — One-Sqrt × Sixty-Three-Log × polynomial numerator.
+fn one_sqrt_sixty_three_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut sqrt_deg: Option<i64> = None;
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_deg.is_some() { return None; }
+            sqrt_deg = Some(d);
+            continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 63 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg;
+            continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    let sd = sqrt_deg?;
+    if log_count != 63 { return None; }
+    Some(sd + 2 * poly_deg_sum)
+}
+
+/// Phase 427 — Two-Sqrt × Sixty-Three-Log × polynomial numerator.
+fn two_sqrt_sixty_three_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut sqrt_degs: Vec<i64> = Vec::new();
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs.len() >= 2 { return None; }
+            sqrt_degs.push(d);
+            continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 63 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg;
+            continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs.len() != 2 || log_count != 63 { return None; }
+    Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg_sum)
+}
+
+/// Phase 428 — Three-Sqrt × Sixty-Three-Log × polynomial numerator.
+fn three_sqrt_sixty_three_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut sqrt_degs: Vec<i64> = Vec::new();
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs.len() >= 3 { return None; }
+            sqrt_degs.push(d);
+            continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 63 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg;
+            continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs.len() != 3 || log_count != 63 { return None; }
+    Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg_sum)
+}
+
+/// Phase 429 — Four-Sqrt × Sixty-Three-Log × polynomial numerator.
+fn four_sqrt_sixty_three_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut sqrt_degs: Vec<i64> = Vec::new();
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs.len() >= 4 { return None; }
+            sqrt_degs.push(d);
+            continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 63 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg;
+            continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs.len() != 4 || log_count != 63 { return None; }
+    Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg_sum)
+}
+
+/// Phase 430 — Five-Sqrt × Sixty-Three-Log × polynomial numerator.
+///
+/// Completes the Sixty-Three-Log family (Phases 425–430).
+fn five_sqrt_sixty_three_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(app) = node else { return None; };
+    if app.head != sym(MUL) { return None; }
+    let mut sqrt_degs: Vec<i64> = Vec::new();
+    let mut log_count: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &app.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs.len() >= 5 { return None; }
+            sqrt_degs.push(d);
+            continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 63 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg_sum += deg;
+            continue;
+        }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs.len() != 5 || log_count != 63 { return None; }
+    Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg_sum)
+}
+
 /// Phase 419 — Zero-Sqrt × Sixty-Two-Log × polynomial numerator.
 ///
 /// The Sixty-Two-Log family (Phases 419–424) extends the recogniser to
@@ -12203,6 +12379,42 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
         } else if h_diverges_at_infinity(den, k) {
             return true;
         }
+    }
+    // Phase 430: Mul(Sqrt(P1)×5, Log(h1)×63, ...) numerator.
+    if let Some(s5l63_x2) = five_sqrt_sixty_three_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s5l63) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s5l63 > s5l63_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 429: Mul(Sqrt(P1)×4, Log(h1)×63, ...) numerator.
+    if let Some(s4l63_x2) = four_sqrt_sixty_three_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s4l63) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s4l63 > s4l63_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 428: Mul(Sqrt(P1)×3, Log(h1)×63, ...) numerator.
+    if let Some(s3l63_x2) = three_sqrt_sixty_three_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s3l63) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s3l63 > s3l63_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 427: Mul(Sqrt(P), Sqrt(P2), Log(h1)×63, ...) numerator.
+    if let Some(s2l63_x2) = two_sqrt_sixty_three_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s2l63) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s2l63 > s2l63_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 426: Mul(Sqrt(P), Log(h1)×63, ...) numerator.
+    if let Some(s1l63_x2) = one_sqrt_sixty_three_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s1l63) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s1l63 > s1l63_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 425: Mul(Log(h1)×63, ...) numerator.
+    if let Some(sl63_x2) = sixty_three_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_sl63) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_sl63 > sl63_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
     }
     // Phase 424: Mul(Sqrt(P1)×5, Log(h1)×62, ...) numerator.
     if let Some(s5l62_x2) = five_sqrt_sixty_two_log_poly_effective_x2(num, k) {

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -13282,7 +13282,8 @@ fn phase191_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 60th log (over 59; refused)
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -13322,7 +13323,8 @@ fn phase191_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 60th log (over 59; refused)
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -13453,7 +13455,8 @@ fn phase192_sqrt_k_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 60th log (over 59; refused)
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -13494,7 +13497,8 @@ fn phase192_sqrt_k_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 60th log (over 59; refused)
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -14038,7 +14042,8 @@ fn phase197_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 60th log (over 59; refused)
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -14078,7 +14083,8 @@ fn phase197_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 60th log (over 59; refused)
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -14828,7 +14834,8 @@ fn phase203_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 60th log (over 59; refused)
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -14868,7 +14875,8 @@ fn phase203_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 60th log (over 59; refused)
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -15623,7 +15631,8 @@ fn phase209_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 60th log (over 59; refused)
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -15664,7 +15673,8 @@ fn phase209_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 60th log (over 59; refused)
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -16449,7 +16459,8 @@ fn phase215_log29_k_times_k_over_k2_refused() {
         log_k.clone(), // 60th log (over 59; refused)
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -16490,7 +16501,8 @@ fn phase215_log29_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 60th log (over 59; refused)
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -17275,7 +17287,8 @@ fn phase221_log30_k_times_k_over_k2_refused() {
         log_k.clone(), // 60th log (over 59; refused)
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -17316,7 +17329,8 @@ fn phase221_log30_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 60th log (over 59; refused)
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -18101,7 +18115,8 @@ fn phase227_log31_k_times_k_over_k2_refused() {
         log_k.clone(), // 60th log (over 59; refused)
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -18142,7 +18157,8 @@ fn phase227_log31_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 60th log (over 59; refused)
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -18927,7 +18943,8 @@ fn phase233_log32_k_times_k_over_k2_refused() {
         log_k.clone(), // 60th log (over 59; refused)
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -18968,7 +18985,8 @@ fn phase233_log32_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 60th log (over 59; refused)
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -19754,7 +19772,8 @@ fn phase239_log33_k_times_k_over_k2_refused() {
         log_k.clone(), // 60th log (over 59; refused)
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -19794,7 +19813,8 @@ fn phase239_log33_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 60th log (over 59; refused)
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -20581,7 +20601,8 @@ fn phase245_log34_k_times_k_over_k2_refused() {
         log_k.clone(), // 60th log (over 59; refused)
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -20620,7 +20641,8 @@ fn phase245_log34_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 60th log (over 59; refused)
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -21406,7 +21428,8 @@ fn phase251_log36_k_times_k_over_k2_refused() {
         log_k.clone(), // 60th log (over 59; refused)
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -21444,7 +21467,8 @@ fn phase251_log36_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 60th log (over 59; refused)
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -22220,7 +22244,8 @@ fn phase257_log36_k_times_k_over_k2_refused() {
         log_k.clone(), // 60th log (over 59; refused)
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -22258,7 +22283,8 @@ fn phase257_log36_k_times_k_over_k2_refused() {
         log_kp1.clone(), // 60th log (over 59; refused)
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
         kp1.clone(),
     ]);
     let den_k = apply(sym(MUL), vec![k.clone(), k.clone()]);
@@ -23819,7 +23845,8 @@ fn phase269_log38_k_over_k2_refused() {
         log_k.clone(), // 60th log (over 59; refused)
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -23857,7 +23884,8 @@ fn phase269_log38_k_over_k2_refused() {
         log_kp1.clone(), // 60th log (over 59; refused)
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
         kp1.clone(),
     ]);
     let g_k269c = apply(sym(DIV), vec![num_k, k2]);
@@ -24002,7 +24030,8 @@ fn phase270_sqrt_k_log38_k_over_k2_refused() {
         log_k.clone(), // 60th log (over 59; refused)
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -24041,7 +24070,8 @@ fn phase270_sqrt_k_log38_k_over_k2_refused() {
         log_kp1.clone(), // 60th log (over 59; refused)
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
         kp1.clone(),
     ]);
     let g_k270c = apply(sym(DIV), vec![num_k, k2]);
@@ -24739,7 +24769,8 @@ fn phase275_log39_k_over_k2_refused() {
         log_k.clone(), // 60th log (over 59; refused)
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -24777,7 +24808,8 @@ fn phase275_log39_k_over_k2_refused() {
         log_kp1.clone(), // 60th log (over 59; refused)
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
         kp1.clone(),
     ]);
     let g_k275c = apply(sym(DIV), vec![num_k, k2]);
@@ -24926,7 +24958,8 @@ fn phase276_sqrt_k_log39_k_over_k2_refused() {
         log_k.clone(), // 60th log (over 59; refused)
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -24965,7 +24998,8 @@ fn phase276_sqrt_k_log39_k_over_k2_refused() {
         log_kp1.clone(), // 60th log (over 59; refused)
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
         kp1.clone(),
     ]);
     let g_k276c = apply(sym(DIV), vec![num_k, k2]);
@@ -25670,7 +25704,8 @@ fn phase281_log40_k_over_k2_refused() {
         log_k.clone(), // 60th log (over 59; refused)
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -25704,7 +25739,8 @@ fn phase281_log40_k_over_k2_refused() {
         log_kp1.clone(), // 60th log (over 59; refused)
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
         kp1.clone(),
     ]);
     let g_kphase281r = apply(sym(DIV), vec![num_k, k2]);
@@ -25841,7 +25877,8 @@ fn phase282_sqrt1_k_log40_k_over_k2_refused() {
         log_k.clone(), // 60th log (over 59; refused)
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
         k.clone(),
     ]);
     let num_kp1 = apply(sym(MUL), vec![
@@ -25876,7 +25913,8 @@ fn phase282_sqrt1_k_log40_k_over_k2_refused() {
         log_kp1.clone(), // 60th log (over 59; refused)
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
         kp1.clone(),
     ]);
     let g_kphase282r = apply(sym(DIV), vec![num_k, k2]);
@@ -26515,7 +26553,8 @@ fn phase287_log42_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -26547,7 +26586,8 @@ fn phase287_log42_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase287r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase287r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -26682,7 +26722,8 @@ fn phase288_sqrt1_k_log42_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -26715,7 +26756,8 @@ fn phase288_sqrt1_k_log42_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase288r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase288r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -26850,7 +26892,8 @@ fn phase289_sqrt2_k_log42_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -26883,7 +26926,8 @@ fn phase289_sqrt2_k_log42_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase289r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase289r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -27018,7 +27062,8 @@ fn phase290_sqrt3_k_log42_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -27051,7 +27096,8 @@ fn phase290_sqrt3_k_log42_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase290r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase290r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -27186,7 +27232,8 @@ fn phase291_sqrt4_k_log42_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -27219,7 +27266,8 @@ fn phase291_sqrt4_k_log42_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase291r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase291r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -27354,7 +27402,8 @@ fn phase292_sqrt5_k_log42_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -27387,7 +27436,8 @@ fn phase292_sqrt5_k_log42_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase292r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase292r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -27475,7 +27525,8 @@ fn phase293_log42_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -27507,7 +27558,8 @@ fn phase293_log42_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase293r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase293r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -27602,7 +27654,8 @@ fn phase294_sqrt1_k_log42_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -27635,7 +27688,8 @@ fn phase294_sqrt1_k_log42_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase294r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase294r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -27730,7 +27784,8 @@ fn phase295_sqrt2_k_log42_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -27763,7 +27818,8 @@ fn phase295_sqrt2_k_log42_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase295r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase295r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -27858,7 +27914,8 @@ fn phase296_sqrt3_k_log42_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -27891,7 +27948,8 @@ fn phase296_sqrt3_k_log42_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase296r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase296r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -27986,7 +28044,8 @@ fn phase297_sqrt4_k_log42_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -28019,7 +28078,8 @@ fn phase297_sqrt4_k_log42_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase297r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase297r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -28114,7 +28174,8 @@ fn phase298_sqrt5_k_log42_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -28147,7 +28208,8 @@ fn phase298_sqrt5_k_log42_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase298r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase298r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -28235,7 +28297,8 @@ fn phase299_log45_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -28267,7 +28330,8 @@ fn phase299_log45_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase299r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase299r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -28362,7 +28426,8 @@ fn phase300_sqrt1_k_log45_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -28395,7 +28460,8 @@ fn phase300_sqrt1_k_log45_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase300r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase300r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -28490,7 +28556,8 @@ fn phase301_sqrt2_k_log45_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -28523,7 +28590,8 @@ fn phase301_sqrt2_k_log45_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase301r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase301r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -28618,7 +28686,8 @@ fn phase302_sqrt3_k_log45_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -28651,7 +28720,8 @@ fn phase302_sqrt3_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase302r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase302r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -28746,7 +28816,8 @@ fn phase303_sqrt4_k_log45_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -28779,7 +28850,8 @@ fn phase303_sqrt4_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase303r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase303r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -28874,7 +28946,8 @@ fn phase304_sqrt5_k_log45_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -28907,7 +28980,8 @@ fn phase304_sqrt5_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase304r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase304r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -28995,7 +29069,8 @@ fn phase305_log45_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -29026,7 +29101,8 @@ fn phase305_log45_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase305r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase305r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -29120,7 +29196,8 @@ fn phase306_sqrt1_k_log45_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -29152,7 +29229,8 @@ fn phase306_sqrt1_k_log45_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase306r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase306r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -29246,7 +29324,8 @@ fn phase307_sqrt2_k_log45_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -29278,7 +29357,8 @@ fn phase307_sqrt2_k_log45_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase307r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase307r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -29372,7 +29452,8 @@ fn phase308_sqrt3_k_log45_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -29404,7 +29485,8 @@ fn phase308_sqrt3_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase308r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase308r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -29498,7 +29580,8 @@ fn phase309_sqrt4_k_log45_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -29530,7 +29613,8 @@ fn phase309_sqrt4_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase309r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase309r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -29624,7 +29708,8 @@ fn phase310_sqrt5_k_log45_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -29656,7 +29741,8 @@ fn phase310_sqrt5_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase310r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase310r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -29742,7 +29828,8 @@ fn phase311_log45_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -29772,7 +29859,8 @@ fn phase311_log45_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase311r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase311r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -29865,7 +29953,8 @@ fn phase312_sqrt1_k_log45_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -29896,7 +29985,8 @@ fn phase312_sqrt1_k_log45_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase312r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase312r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -29989,7 +30079,8 @@ fn phase313_sqrt2_k_log45_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -30020,7 +30111,8 @@ fn phase313_sqrt2_k_log45_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase313r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase313r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -30113,7 +30205,8 @@ fn phase314_sqrt3_k_log45_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -30144,7 +30237,8 @@ fn phase314_sqrt3_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase314r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase314r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -30237,7 +30331,8 @@ fn phase315_sqrt4_k_log45_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -30268,7 +30363,8 @@ fn phase315_sqrt4_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase315r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase315r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -30361,7 +30457,8 @@ fn phase316_sqrt5_k_log45_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -30392,7 +30489,8 @@ fn phase316_sqrt5_k_log45_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase316r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase316r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -30477,7 +30575,8 @@ fn phase317_log46_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -30506,7 +30605,8 @@ fn phase317_log46_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase317r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase317r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -30598,7 +30698,8 @@ fn phase318_sqrt1_k_log46_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -30628,7 +30729,8 @@ fn phase318_sqrt1_k_log46_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase318r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase318r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -30720,7 +30822,8 @@ fn phase319_sqrt2_k_log46_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -30750,7 +30853,8 @@ fn phase319_sqrt2_k_log46_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase319r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase319r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -30842,7 +30946,8 @@ fn phase320_sqrt3_k_log46_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -30872,7 +30977,8 @@ fn phase320_sqrt3_k_log46_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase320r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase320r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -30964,7 +31070,8 @@ fn phase321_sqrt4_k_log46_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -30994,7 +31101,8 @@ fn phase321_sqrt4_k_log46_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase321r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase321r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -31086,7 +31194,8 @@ fn phase322_sqrt5_k_log46_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -31116,7 +31225,8 @@ fn phase322_sqrt5_k_log46_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase322r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase322r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -31203,7 +31313,8 @@ fn phase323_log47_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -31232,7 +31343,8 @@ fn phase323_log47_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase323r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase323r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -31326,7 +31438,8 @@ fn phase324_sqrt1_k_log47_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -31356,7 +31469,8 @@ fn phase324_sqrt1_k_log47_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase324r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase324r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -31450,7 +31564,8 @@ fn phase325_sqrt2_k_log47_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -31480,7 +31595,8 @@ fn phase325_sqrt2_k_log47_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase325r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase325r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -31574,7 +31690,8 @@ fn phase326_sqrt3_k_log47_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -31604,7 +31721,8 @@ fn phase326_sqrt3_k_log47_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase326r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase326r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -31698,7 +31816,8 @@ fn phase327_sqrt4_k_log47_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -31728,7 +31847,8 @@ fn phase327_sqrt4_k_log47_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase327r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase327r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -31822,7 +31942,8 @@ fn phase328_sqrt5_k_log47_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -31852,7 +31973,8 @@ fn phase328_sqrt5_k_log47_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase328r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase328r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -31941,7 +32063,8 @@ fn phase329_log48_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -31970,7 +32093,8 @@ fn phase329_log48_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase329r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase329r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -32066,7 +32190,8 @@ fn phase330_sqrt1_k_log48_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -32096,7 +32221,8 @@ fn phase330_sqrt1_k_log48_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase330r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase330r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -32192,7 +32318,8 @@ fn phase331_sqrt2_k_log48_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -32222,7 +32349,8 @@ fn phase331_sqrt2_k_log48_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase331r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase331r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -32318,7 +32446,8 @@ fn phase332_sqrt3_k_log48_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -32348,7 +32477,8 @@ fn phase332_sqrt3_k_log48_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase332r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase332r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -32444,7 +32574,8 @@ fn phase333_sqrt4_k_log48_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -32474,7 +32605,8 @@ fn phase333_sqrt4_k_log48_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase333r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase333r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -32570,7 +32702,8 @@ fn phase334_sqrt5_k_log48_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -32600,7 +32733,8 @@ fn phase334_sqrt5_k_log48_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase334r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase334r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -32689,7 +32823,8 @@ fn phase335_log50_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -32718,7 +32853,8 @@ fn phase335_log50_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase335r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase335r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -32814,7 +32950,8 @@ fn phase336_sqrt1_k_log50_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -32844,7 +32981,8 @@ fn phase336_sqrt1_k_log50_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase336r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase336r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -32940,7 +33078,8 @@ fn phase337_sqrt2_k_log50_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -32970,7 +33109,8 @@ fn phase337_sqrt2_k_log50_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase337r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase337r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -33066,7 +33206,8 @@ fn phase338_sqrt3_k_log50_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -33096,7 +33237,8 @@ fn phase338_sqrt3_k_log50_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase338r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase338r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -33192,7 +33334,8 @@ fn phase339_sqrt4_k_log50_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -33222,7 +33365,8 @@ fn phase339_sqrt4_k_log50_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase339r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase339r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -33318,7 +33462,8 @@ fn phase340_sqrt5_k_log50_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -33348,7 +33493,8 @@ fn phase340_sqrt5_k_log50_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase340r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase340r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -33439,7 +33585,8 @@ fn phase341_log50_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -33468,7 +33615,8 @@ fn phase341_log50_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase341r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase341r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -33566,7 +33714,8 @@ fn phase342_sqrt1_k_log50_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -33596,7 +33745,8 @@ fn phase342_sqrt1_k_log50_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase342r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase342r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -33694,7 +33844,8 @@ fn phase343_sqrt2_k_log50_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -33724,7 +33875,8 @@ fn phase343_sqrt2_k_log50_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase343r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase343r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -33822,7 +33974,8 @@ fn phase344_sqrt3_k_log50_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -33852,7 +34005,8 @@ fn phase344_sqrt3_k_log50_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase344r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase344r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -33950,7 +34104,8 @@ fn phase345_sqrt4_k_log50_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -33980,7 +34135,8 @@ fn phase345_sqrt4_k_log50_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase345r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase345r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -34078,7 +34234,8 @@ fn phase346_sqrt5_k_log50_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -34108,7 +34265,8 @@ fn phase346_sqrt5_k_log50_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase346r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase346r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -34201,7 +34359,8 @@ fn phase347_log51_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -34230,7 +34389,8 @@ fn phase347_log51_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase347r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase347r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -34330,7 +34490,8 @@ fn phase348_sqrt1_k_log51_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -34360,7 +34521,8 @@ fn phase348_sqrt1_k_log51_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase348r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase348r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -34460,7 +34622,8 @@ fn phase349_sqrt2_k_log51_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -34490,7 +34653,8 @@ fn phase349_sqrt2_k_log51_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase349r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase349r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -34590,7 +34754,8 @@ fn phase350_sqrt3_k_log51_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -34620,7 +34785,8 @@ fn phase350_sqrt3_k_log51_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase350r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase350r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -34720,7 +34886,8 @@ fn phase351_sqrt4_k_log51_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -34750,7 +34917,8 @@ fn phase351_sqrt4_k_log51_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase351r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase351r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -34850,7 +35018,8 @@ fn phase352_sqrt5_k_log51_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -34880,7 +35049,8 @@ fn phase352_sqrt5_k_log51_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase352r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase352r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -34975,7 +35145,8 @@ fn phase353_log52_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -35004,7 +35175,8 @@ fn phase353_log52_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase353r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase353r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -35106,7 +35278,8 @@ fn phase354_sqrt1_k_log52_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -35136,7 +35309,8 @@ fn phase354_sqrt1_k_log52_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase354r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase354r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -35238,7 +35412,8 @@ fn phase355_sqrt2_k_log52_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -35268,7 +35443,8 @@ fn phase355_sqrt2_k_log52_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase355r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase355r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -35370,7 +35546,8 @@ fn phase356_sqrt3_k_log52_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -35400,7 +35577,8 @@ fn phase356_sqrt3_k_log52_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase356r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase356r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -35502,7 +35680,8 @@ fn phase357_sqrt4_k_log52_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -35532,7 +35711,8 @@ fn phase357_sqrt4_k_log52_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase357r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase357r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -35634,7 +35814,8 @@ fn phase358_sqrt5_k_log52_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -35664,7 +35845,8 @@ fn phase358_sqrt5_k_log52_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase358r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase358r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -35761,7 +35943,8 @@ fn phase359_log53_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -35790,7 +35973,8 @@ fn phase359_log53_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase359r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase359r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -35894,7 +36078,8 @@ fn phase360_sqrt1_k_log53_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -35924,7 +36109,8 @@ fn phase360_sqrt1_k_log53_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase360r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_phase360r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -36028,7 +36214,8 @@ fn phase361_sqrt2_k_log53_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -36058,7 +36245,8 @@ fn phase361_sqrt2_k_log53_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase361r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase361r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -36162,7 +36350,8 @@ fn phase362_sqrt3_k_log53_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -36192,7 +36381,8 @@ fn phase362_sqrt3_k_log53_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase362r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase362r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -36296,7 +36486,8 @@ fn phase363_sqrt4_k_log53_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -36326,7 +36517,8 @@ fn phase363_sqrt4_k_log53_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase363r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase363r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -36430,7 +36622,8 @@ fn phase364_sqrt5_k_log53_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -36460,7 +36653,8 @@ fn phase364_sqrt5_k_log53_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_kphase364r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_phase364r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -36558,7 +36752,8 @@ fn phase365_log53_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -36587,7 +36782,8 @@ fn phase365_log53_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k365r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_365r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -36693,7 +36889,8 @@ fn phase366_sqrt1_k_log53_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -36723,7 +36920,8 @@ fn phase366_sqrt1_k_log53_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k366r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_366r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -36829,7 +37027,8 @@ fn phase367_sqrt2_k_log53_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -36859,7 +37058,8 @@ fn phase367_sqrt2_k_log53_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k367r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_367r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -36965,7 +37165,8 @@ fn phase368_sqrt3_k_log53_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -36995,7 +37196,8 @@ fn phase368_sqrt3_k_log53_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k368r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_368r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -37101,7 +37303,8 @@ fn phase369_sqrt4_k_log53_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -37131,7 +37334,8 @@ fn phase369_sqrt4_k_log53_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k369r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_369r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -37237,7 +37441,8 @@ fn phase370_sqrt5_k_log53_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -37267,7 +37472,8 @@ fn phase370_sqrt5_k_log53_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k370r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_370r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -37368,7 +37574,8 @@ fn phase371_log54_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -37397,7 +37604,8 @@ fn phase371_log54_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k371r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_371r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -37505,7 +37713,8 @@ fn phase372_sqrt1_k_log54_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -37535,7 +37744,8 @@ fn phase372_sqrt1_k_log54_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k372r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_372r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -37643,7 +37853,8 @@ fn phase373_sqrt2_k_log54_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -37673,7 +37884,8 @@ fn phase373_sqrt2_k_log54_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k373r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_373r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -37781,7 +37993,8 @@ fn phase374_sqrt3_k_log54_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -37811,7 +38024,8 @@ fn phase374_sqrt3_k_log54_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k374r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_374r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -37919,7 +38133,8 @@ fn phase375_sqrt4_k_log54_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -37949,7 +38164,8 @@ fn phase375_sqrt4_k_log54_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k375r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_375r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -38057,7 +38273,8 @@ fn phase376_sqrt5_k_log54_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -38087,7 +38304,8 @@ fn phase376_sqrt5_k_log54_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k376r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_376r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -38190,7 +38408,8 @@ fn phase377_log55_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -38219,7 +38438,8 @@ fn phase377_log55_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k377r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_377r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -38329,7 +38549,8 @@ fn phase378_sqrt1_k_log55_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -38359,7 +38580,8 @@ fn phase378_sqrt1_k_log55_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k378r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_378r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -38469,7 +38691,8 @@ fn phase379_sqrt2_k_log55_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -38499,7 +38722,8 @@ fn phase379_sqrt2_k_log55_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k379r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_379r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -38609,7 +38833,8 @@ fn phase380_sqrt3_k_log55_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -38639,7 +38864,8 @@ fn phase380_sqrt3_k_log55_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k380r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_380r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -38749,7 +38975,8 @@ fn phase381_sqrt4_k_log55_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -38779,7 +39006,8 @@ fn phase381_sqrt4_k_log55_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k381r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_381r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -38889,7 +39117,8 @@ fn phase382_sqrt5_k_log55_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -38919,7 +39148,8 @@ fn phase382_sqrt5_k_log55_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k382r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_382r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -39026,7 +39256,8 @@ fn phase383_log56_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -39055,7 +39286,8 @@ fn phase383_log56_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k383r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_383r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -39167,7 +39399,8 @@ fn phase384_sqrt1_k_log56_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -39197,7 +39430,8 @@ fn phase384_sqrt1_k_log56_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k384r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_384r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -39309,7 +39543,8 @@ fn phase385_sqrt2_k_log56_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -39339,7 +39574,8 @@ fn phase385_sqrt2_k_log56_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k385r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_385r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -39451,7 +39687,8 @@ fn phase386_sqrt3_k_log56_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -39481,7 +39718,8 @@ fn phase386_sqrt3_k_log56_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k386r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_386r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -39593,7 +39831,8 @@ fn phase387_sqrt4_k_log56_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -39623,7 +39862,8 @@ fn phase387_sqrt4_k_log56_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k387r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_387r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -39735,7 +39975,8 @@ fn phase388_sqrt5_k_log56_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -39765,7 +40006,8 @@ fn phase388_sqrt5_k_log56_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k388r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_388r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -39872,7 +40114,8 @@ fn phase389_log57_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -39901,7 +40144,8 @@ fn phase389_log57_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k389r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_389r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -40015,7 +40259,8 @@ fn phase390_sqrt1_k_log57_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -40045,7 +40290,8 @@ fn phase390_sqrt1_k_log57_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k390r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_390r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -40159,7 +40405,8 @@ fn phase391_sqrt2_k_log57_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -40189,7 +40436,8 @@ fn phase391_sqrt2_k_log57_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k391r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_391r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -40303,7 +40551,8 @@ fn phase392_sqrt3_k_log57_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -40333,7 +40582,8 @@ fn phase392_sqrt3_k_log57_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k392r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_392r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -40447,7 +40697,8 @@ fn phase393_sqrt4_k_log57_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -40477,7 +40728,8 @@ fn phase393_sqrt4_k_log57_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k393r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_393r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -40591,7 +40843,8 @@ fn phase394_sqrt5_k_log57_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -40621,7 +40874,8 @@ fn phase394_sqrt5_k_log57_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k394r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_394r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -40732,7 +40986,8 @@ fn phase395_log58_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5 logs
@@ -40761,7 +41016,8 @@ fn phase395_log58_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k395r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_395r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -40879,7 +41135,8 @@ fn phase396_sqrt1_k_log58_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -40909,7 +41166,8 @@ fn phase396_sqrt1_k_log58_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k396r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_396r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -41027,7 +41285,8 @@ fn phase397_sqrt2_k_log58_k_over_k2_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -41057,7 +41316,8 @@ fn phase397_sqrt2_k_log58_k_over_k2_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k397r = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1_397r = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -41175,7 +41435,8 @@ fn phase398_sqrt3_k_log58_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -41205,7 +41466,8 @@ fn phase398_sqrt3_k_log58_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k398r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_398r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -41323,7 +41585,8 @@ fn phase399_sqrt4_k_log58_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -41353,7 +41616,8 @@ fn phase399_sqrt4_k_log58_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k399r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_399r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -41471,7 +41735,8 @@ fn phase400_sqrt5_k_log58_k_over_k3_refused() {
         log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -41501,7 +41766,8 @@ fn phase400_sqrt5_k_log58_k_over_k3_refused() {
         log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k400r = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1_400r = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -41556,7 +41822,7 @@ fn phase401_log59_k_over_k2_converges() {
 
 #[test]
 fn phase401_log59_k_over_k2_refused() {
-    // 63 logs → refused (Phase 419 handles exactly 62).
+    // 64 logs → refused (Phase 425/426/427/428/429/430 handles exactly 63).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -41578,7 +41844,8 @@ fn phase401_log59_k_over_k2_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
@@ -41595,7 +41862,8 @@ fn phase401_log59_k_over_k2_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 62nd log
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -41654,7 +41922,7 @@ fn phase402_sqrt1_log59_k_over_k2_converges() {
 
 #[test]
 fn phase402_sqrt1_log59_k_over_k2_refused() {
-    // 63 logs → refused (Phase 420 handles exactly 62).
+    // 64 logs → refused (Phase 425/426/427/428/429/430 handles exactly 63).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -41679,7 +41947,8 @@ fn phase402_sqrt1_log59_k_over_k2_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 62nd log
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -41697,7 +41966,8 @@ fn phase402_sqrt1_log59_k_over_k2_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -41756,7 +42026,7 @@ fn phase403_sqrt2_log59_k_over_k2_converges() {
 
 #[test]
 fn phase403_sqrt2_log59_k_over_k2_refused() {
-    // 63 logs → refused (Phase 421 handles exactly 62).
+    // 64 logs → refused (Phase 425/426/427/428/429/430 handles exactly 63).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -41781,7 +42051,8 @@ fn phase403_sqrt2_log59_k_over_k2_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -41799,7 +42070,8 @@ fn phase403_sqrt2_log59_k_over_k2_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -41858,7 +42130,7 @@ fn phase404_sqrt3_log59_k_over_k3_converges() {
 
 #[test]
 fn phase404_sqrt3_log59_k_over_k3_refused() {
-    // 63 logs → refused (Phase 422 handles exactly 62).
+    // 64 logs → refused (Phase 425/426/427/428/429/430 handles exactly 63).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
@@ -41883,7 +42155,8 @@ fn phase404_sqrt3_log59_k_over_k3_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -41901,7 +42174,8 @@ fn phase404_sqrt3_log59_k_over_k3_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -41960,7 +42234,7 @@ fn phase405_sqrt4_log59_k_over_k3_converges() {
 
 #[test]
 fn phase405_sqrt4_log59_k_over_k3_refused() {
-    // 63 logs → refused (Phase 423 handles exactly 62).
+    // 64 logs → refused (Phase 425/426/427/428/429/430 handles exactly 63).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
@@ -41985,7 +42259,8 @@ fn phase405_sqrt4_log59_k_over_k3_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -42003,7 +42278,8 @@ fn phase405_sqrt4_log59_k_over_k3_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -42062,7 +42338,7 @@ fn phase406_sqrt5_log59_k_over_k3_converges() {
 
 #[test]
 fn phase406_sqrt5_log59_k_over_k3_refused() {
-    // 63 logs → refused (Phase 424 handles exactly 62).
+    // 64 logs → refused (Phase 425/426/427/428/429/430 handles exactly 63).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
@@ -42087,7 +42363,8 @@ fn phase406_sqrt5_log59_k_over_k3_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th log (over 59; refused)
         log_k.clone(), // 61st log (over 60; refused)
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -42105,7 +42382,8 @@ fn phase406_sqrt5_log59_k_over_k3_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th log (over 59; refused)
         log_kp1.clone(), // 61st log (over 60; refused)
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -42160,7 +42438,7 @@ fn phase407_log60_k_over_k2_converges() {
 
 #[test]
 fn phase407_log60_k_over_k2_refused() {
-    // 63 logs → refused (Phase 419 handles exactly 62).
+    // 64 logs → refused (Phase 425/426/427/428/429/430 handles exactly 63).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -42182,7 +42460,8 @@ fn phase407_log60_k_over_k2_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
         log_k.clone(), // 61st log
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
@@ -42199,7 +42478,8 @@ fn phase407_log60_k_over_k2_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
         log_kp1.clone(), // 61st log
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -42258,7 +42538,7 @@ fn phase408_sqrt1_log60_k_over_k2_converges() {
 
 #[test]
 fn phase408_sqrt1_log60_k_over_k2_refused() {
-    // 63 logs → refused (Phase 420 handles exactly 62).
+    // 64 logs → refused (Phase 425/426/427/428/429/430 handles exactly 63).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -42283,7 +42563,8 @@ fn phase408_sqrt1_log60_k_over_k2_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
         log_k.clone(), // 61st log
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -42301,7 +42582,8 @@ fn phase408_sqrt1_log60_k_over_k2_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
         log_kp1.clone(), // 61st log
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -42360,7 +42642,7 @@ fn phase409_sqrt2_log60_k_over_k2_converges() {
 
 #[test]
 fn phase409_sqrt2_log60_k_over_k2_refused() {
-    // 63 logs → refused (Phase 421 handles exactly 62).
+    // 64 logs → refused (Phase 425/426/427/428/429/430 handles exactly 63).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -42385,7 +42667,8 @@ fn phase409_sqrt2_log60_k_over_k2_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
         log_k.clone(), // 61st log
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -42403,7 +42686,8 @@ fn phase409_sqrt2_log60_k_over_k2_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
         log_kp1.clone(), // 61st log
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -42462,7 +42746,7 @@ fn phase410_sqrt3_log60_k_over_k3_converges() {
 
 #[test]
 fn phase410_sqrt3_log60_k_over_k3_refused() {
-    // 63 logs → refused (Phase 422 handles exactly 62).
+    // 64 logs → refused (Phase 425/426/427/428/429/430 handles exactly 63).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
@@ -42487,7 +42771,8 @@ fn phase410_sqrt3_log60_k_over_k3_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
         log_k.clone(), // 61st log
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -42505,7 +42790,8 @@ fn phase410_sqrt3_log60_k_over_k3_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
         log_kp1.clone(), // 61st log
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -42564,7 +42850,7 @@ fn phase411_sqrt4_log60_k_over_k3_converges() {
 
 #[test]
 fn phase411_sqrt4_log60_k_over_k3_refused() {
-    // 63 logs → refused (Phase 423 handles exactly 62).
+    // 64 logs → refused (Phase 425/426/427/428/429/430 handles exactly 63).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
@@ -42589,7 +42875,8 @@ fn phase411_sqrt4_log60_k_over_k3_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
         log_k.clone(), // 61st log
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -42607,7 +42894,8 @@ fn phase411_sqrt4_log60_k_over_k3_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
         log_kp1.clone(), // 61st log
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -42664,7 +42952,7 @@ fn phase412_sqrt5_log60_k_over_k3_converges() {
 
 #[test]
 fn phase412_sqrt5_log60_k_over_k3_refused() {
-    // 63 logs → refused (Phase 424 handles exactly 62).
+    // 64 logs → refused (Phase 425/426/427/428/429/430 handles exactly 63).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
@@ -42689,7 +42977,8 @@ fn phase412_sqrt5_log60_k_over_k3_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
         log_k.clone(), // 61st log
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -42707,7 +42996,8 @@ fn phase412_sqrt5_log60_k_over_k3_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
         log_kp1.clone(), // 61st log
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -42786,7 +43076,8 @@ fn phase413_log61_k_over_k2_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
         log_k.clone(), // 61st log
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
@@ -42803,7 +43094,8 @@ fn phase413_log61_k_over_k2_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
         log_kp1.clone(), // 61st log
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -42889,7 +43181,8 @@ fn phase414_sqrt1_log61_k_over_k2_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
         log_k.clone(), // 61st log
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1,
@@ -42907,7 +43200,8 @@ fn phase414_sqrt1_log61_k_over_k2_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
         log_kp1.clone(), // 61st log
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -42993,7 +43287,8 @@ fn phase415_sqrt2_log61_k_over_k2_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
         log_k.clone(), // 61st log
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1,
@@ -43011,7 +43306,8 @@ fn phase415_sqrt2_log61_k_over_k2_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
         log_kp1.clone(), // 61st log
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -43097,7 +43393,8 @@ fn phase416_sqrt3_log61_k_over_k3_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
         log_k.clone(), // 61st log
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -43115,7 +43412,8 @@ fn phase416_sqrt3_log61_k_over_k3_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
         log_kp1.clone(), // 61st log
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -43201,7 +43499,8 @@ fn phase417_sqrt4_log61_k_over_k3_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
         log_k.clone(), // 61st log
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -43219,7 +43518,8 @@ fn phase417_sqrt4_log61_k_over_k3_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
         log_kp1.clone(), // 61st log
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -43303,7 +43603,8 @@ fn phase418_sqrt5_log61_k_over_k3_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
         log_k.clone(), // 61st log
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
@@ -43321,7 +43622,8 @@ fn phase418_sqrt5_log61_k_over_k3_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
         log_kp1.clone(), // 61st log
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -43381,7 +43683,7 @@ fn phase419_log62_k_over_k2_converges() {
 
 #[test]
 fn phase419_log62_k_over_k2_refused() {
-    // 63 logs → refused (Phase 419 handles exactly 62).
+    // 64 logs → refused (Phase 425/426/427/428/429/430 handles exactly 63).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -43403,7 +43705,8 @@ fn phase419_log62_k_over_k2_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
         log_k.clone(), // 61st log
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
@@ -43420,7 +43723,8 @@ fn phase419_log62_k_over_k2_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
         log_kp1.clone(), // 61st log
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -43483,7 +43787,7 @@ fn phase420_sqrt1_log62_k_over_k2_converges() {
 
 #[test]
 fn phase420_sqrt1_log62_k_over_k2_refused() {
-    // 63 logs → refused (Phase 420 handles exactly 62).
+    // 64 logs → refused (Phase 425/426/427/428/429/430 handles exactly 63).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
@@ -43508,7 +43812,8 @@ fn phase420_sqrt1_log62_k_over_k2_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
         log_k.clone(), // 61st log
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(),
@@ -43526,7 +43831,8 @@ fn phase420_sqrt1_log62_k_over_k2_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
         log_kp1.clone(), // 61st log
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k = apply(sym(DIV), vec![num_k, k2]);
     let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
@@ -43589,7 +43895,7 @@ fn phase421_sqrt2_log62_k_over_k3_converges() {
 
 #[test]
 fn phase421_sqrt2_log62_k_over_k3_refused() {
-    // 63 logs → refused (Phase 421 handles exactly 62).
+    // 64 logs → refused (Phase 425/426/427/428/429/430 handles exactly 63).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
@@ -43614,7 +43920,8 @@ fn phase421_sqrt2_log62_k_over_k3_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
         log_k.clone(), // 61st log
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(),
@@ -43632,7 +43939,8 @@ fn phase421_sqrt2_log62_k_over_k3_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
         log_kp1.clone(), // 61st log
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k = apply(sym(DIV), vec![num_k, k3]);
     let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_3]);
@@ -43695,7 +44003,7 @@ fn phase422_sqrt3_log62_k_over_k4_converges() {
 
 #[test]
 fn phase422_sqrt3_log62_k_over_k4_refused() {
-    // 63 logs → refused (Phase 422 handles exactly 62).
+    // 64 logs → refused (Phase 425/426/427/428/429/430 handles exactly 63).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k4 = apply(sym(POW), vec![k.clone(), int(4)]);
@@ -43720,7 +44028,8 @@ fn phase422_sqrt3_log62_k_over_k4_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
         log_k.clone(), // 61st log
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(),
@@ -43738,7 +44047,8 @@ fn phase422_sqrt3_log62_k_over_k4_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
         log_kp1.clone(), // 61st log
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k = apply(sym(DIV), vec![num_k, k4]);
     let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_4]);
@@ -43801,7 +44111,7 @@ fn phase423_sqrt4_log62_k_over_k5_converges() {
 
 #[test]
 fn phase423_sqrt4_log62_k_over_k5_refused() {
-    // 63 logs → refused (Phase 423 handles exactly 62).
+    // 64 logs → refused (Phase 425/426/427/428/429/430 handles exactly 63).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k5 = apply(sym(POW), vec![k.clone(), int(5)]);
@@ -43826,7 +44136,8 @@ fn phase423_sqrt4_log62_k_over_k5_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
         log_k.clone(), // 61st log
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(),
@@ -43844,7 +44155,8 @@ fn phase423_sqrt4_log62_k_over_k5_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
         log_kp1.clone(), // 61st log
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
     ]);
     let g_k = apply(sym(DIV), vec![num_k, k5]);
     let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_5]);
@@ -43907,7 +44219,7 @@ fn phase424_sqrt5_log62_k_over_k6_converges() {
 
 #[test]
 fn phase424_sqrt5_log62_k_over_k6_refused() {
-    // 63 logs → refused (Phase 424 handles exactly 62).
+    // 64 logs → refused (Phase 425/426/427/428/429/430 handles exactly 63).
     let k = sym("k");
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
     let k6 = apply(sym(POW), vec![k.clone(), int(6)]);
@@ -43932,7 +44244,8 @@ fn phase424_sqrt5_log62_k_over_k6_refused() {
         log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
         log_k.clone(), // 61st log
         log_k.clone(), // 62nd log
-        log_k, // 63rd log (over 62; refused)
+        log_k.clone(), // 63rd log (over 62; refused)
+        log_k, // 64th log (over 63; refused)
     ]);
     let num_kp1 = apply(sym(MUL), vec![
         sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(),
@@ -43950,7 +44263,712 @@ fn phase424_sqrt5_log62_k_over_k6_refused() {
         log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
         log_kp1.clone(), // 61st log
         log_kp1.clone(), // 62nd log
-        log_kp1, // 63rd log (over 62; refused)
+        log_kp1.clone(), // 63rd log (over 62; refused)
+        log_kp1, // 64th log (over 63; refused)
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k6]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_6]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase425_zero_sqrt_log63_k_over_k2_converges() {
+    // sqrt(k)^0*log(k)^63/k^2: zero sqrts. eff_x2=0; 2*2=4>0 -> closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 45th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 50th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 55th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
+        log_k.clone(), // 61st log
+        log_k.clone(), // 62nd log
+        log_k, // 63rd log
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 45th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 50th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 55th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
+        log_kp1.clone(), // 61st log
+        log_kp1.clone(), // 62nd log
+        log_kp1, // 63rd log
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase425_zero_sqrt_log63_k_over_k2_refused() {
+    // 64 logs → refused (Phase 425 handles exactly 63).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 45th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 50th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 55th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
+        log_k.clone(), // 61st log
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 63rd log
+        log_k.clone(), // 64th log (over 63; refused)
+        log_k, // 65th log (over 64; refused)
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 45th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 50th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 55th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
+        log_kp1.clone(), // 61st log
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 63rd log
+        log_kp1.clone(), // 64th log (over 63; refused)
+        log_kp1, // 65th log (over 64; refused)
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase426_one_sqrt_log63_k_over_k2_converges() {
+    // sqrt(k)^1*log(k)^63/k^2: one sqrt. eff_x2=1; 2*2=4>1 -> closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 45th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 50th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 55th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
+        log_k.clone(), // 61st log
+        log_k.clone(), // 62nd log
+        log_k, // 63rd log
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 45th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 50th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 55th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
+        log_kp1.clone(), // 61st log
+        log_kp1.clone(), // 62nd log
+        log_kp1, // 63rd log
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase426_one_sqrt_log63_k_over_k2_refused() {
+    // 64 logs → refused (Phase 426 handles exactly 63).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 45th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 50th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 55th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
+        log_k.clone(), // 61st log
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 63rd log
+        log_k.clone(), // 64th log (over 63; refused)
+        log_k, // 65th log (over 64; refused)
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 45th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 50th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 55th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
+        log_kp1.clone(), // 61st log
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 63rd log
+        log_kp1.clone(), // 64th log (over 63; refused)
+        log_kp1, // 65th log (over 64; refused)
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase427_two_sqrt_log63_k_over_k3_converges() {
+    // sqrt(k)^2*log(k)^63/k^3: two sqrts. eff_x2=2; 2*3=6>2 -> closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(),
+        sqrt_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 45th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 50th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 55th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
+        log_k.clone(), // 61st log
+        log_k.clone(), // 62nd log
+        log_k, // 63rd log
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(),
+        sqrt_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 45th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 50th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 55th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
+        log_kp1.clone(), // 61st log
+        log_kp1.clone(), // 62nd log
+        log_kp1, // 63rd log
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase427_two_sqrt_log63_k_over_k3_refused() {
+    // 64 logs → refused (Phase 427 handles exactly 63).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(),
+        sqrt_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 45th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 50th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 55th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
+        log_k.clone(), // 61st log
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 63rd log
+        log_k.clone(), // 64th log (over 63; refused)
+        log_k, // 65th log (over 64; refused)
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(),
+        sqrt_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 45th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 50th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 55th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
+        log_kp1.clone(), // 61st log
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 63rd log
+        log_kp1.clone(), // 64th log (over 63; refused)
+        log_kp1, // 65th log (over 64; refused)
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase428_three_sqrt_log63_k_over_k4_converges() {
+    // sqrt(k)^3*log(k)^63/k^4: three sqrts. eff_x2=3; 2*4=8>3 -> closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k4 = apply(sym(POW), vec![k.clone(), int(4)]);
+    let kp1_4 = apply(sym(POW), vec![kp1.clone(), int(4)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(),
+        sqrt_k.clone(),
+        sqrt_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 45th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 50th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 55th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
+        log_k.clone(), // 61st log
+        log_k.clone(), // 62nd log
+        log_k, // 63rd log
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(),
+        sqrt_kp1.clone(),
+        sqrt_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 45th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 50th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 55th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
+        log_kp1.clone(), // 61st log
+        log_kp1.clone(), // 62nd log
+        log_kp1, // 63rd log
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k4]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_4]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase428_three_sqrt_log63_k_over_k4_refused() {
+    // 64 logs → refused (Phase 428 handles exactly 63).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k4 = apply(sym(POW), vec![k.clone(), int(4)]);
+    let kp1_4 = apply(sym(POW), vec![kp1.clone(), int(4)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(),
+        sqrt_k.clone(),
+        sqrt_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 45th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 50th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 55th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
+        log_k.clone(), // 61st log
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 63rd log
+        log_k.clone(), // 64th log (over 63; refused)
+        log_k, // 65th log (over 64; refused)
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(),
+        sqrt_kp1.clone(),
+        sqrt_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 45th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 50th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 55th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
+        log_kp1.clone(), // 61st log
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 63rd log
+        log_kp1.clone(), // 64th log (over 63; refused)
+        log_kp1, // 65th log (over 64; refused)
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k4]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_4]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase429_four_sqrt_log63_k_over_k5_converges() {
+    // sqrt(k)^4*log(k)^63/k^5: four sqrts. eff_x2=4; 2*5=10>4 -> closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k5 = apply(sym(POW), vec![k.clone(), int(5)]);
+    let kp1_5 = apply(sym(POW), vec![kp1.clone(), int(5)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(),
+        sqrt_k.clone(),
+        sqrt_k.clone(),
+        sqrt_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 45th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 50th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 55th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
+        log_k.clone(), // 61st log
+        log_k.clone(), // 62nd log
+        log_k, // 63rd log
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(),
+        sqrt_kp1.clone(),
+        sqrt_kp1.clone(),
+        sqrt_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 45th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 50th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 55th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
+        log_kp1.clone(), // 61st log
+        log_kp1.clone(), // 62nd log
+        log_kp1, // 63rd log
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k5]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_5]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase429_four_sqrt_log63_k_over_k5_refused() {
+    // 64 logs → refused (Phase 429 handles exactly 63).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k5 = apply(sym(POW), vec![k.clone(), int(5)]);
+    let kp1_5 = apply(sym(POW), vec![kp1.clone(), int(5)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(),
+        sqrt_k.clone(),
+        sqrt_k.clone(),
+        sqrt_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 45th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 50th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 55th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
+        log_k.clone(), // 61st log
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 63rd log
+        log_k.clone(), // 64th log (over 63; refused)
+        log_k, // 65th log (over 64; refused)
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(),
+        sqrt_kp1.clone(),
+        sqrt_kp1.clone(),
+        sqrt_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 45th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 50th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 55th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
+        log_kp1.clone(), // 61st log
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 63rd log
+        log_kp1.clone(), // 64th log (over 63; refused)
+        log_kp1, // 65th log (over 64; refused)
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k5]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_5]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase430_five_sqrt_log63_k_over_k6_converges() {
+    // sqrt(k)^5*log(k)^63/k^6: five sqrts. eff_x2=5; 2*6=12>5 -> closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k6 = apply(sym(POW), vec![k.clone(), int(6)]);
+    let kp1_6 = apply(sym(POW), vec![kp1.clone(), int(6)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(),
+        sqrt_k.clone(),
+        sqrt_k.clone(),
+        sqrt_k.clone(),
+        sqrt_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 45th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 50th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 55th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
+        log_k.clone(), // 61st log
+        log_k.clone(), // 62nd log
+        log_k, // 63rd log
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(),
+        sqrt_kp1.clone(),
+        sqrt_kp1.clone(),
+        sqrt_kp1.clone(),
+        sqrt_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 45th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 50th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 55th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
+        log_kp1.clone(), // 61st log
+        log_kp1.clone(), // 62nd log
+        log_kp1, // 63rd log
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k6]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_6]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase430_five_sqrt_log63_k_over_k6_refused() {
+    // 64 logs → refused (Phase 430 handles exactly 63).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k6 = apply(sym(POW), vec![k.clone(), int(6)]);
+    let kp1_6 = apply(sym(POW), vec![kp1.clone(), int(6)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(),
+        sqrt_k.clone(),
+        sqrt_k.clone(),
+        sqrt_k.clone(),
+        sqrt_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 5th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 10th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 15th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 20th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 25th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 30th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 35th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 40th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 45th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 50th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 55th
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), // 60th
+        log_k.clone(), // 61st log
+        log_k.clone(), // 62nd log
+        log_k.clone(), // 63rd log
+        log_k.clone(), // 64th log (over 63; refused)
+        log_k, // 65th log (over 64; refused)
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(),
+        sqrt_kp1.clone(),
+        sqrt_kp1.clone(),
+        sqrt_kp1.clone(),
+        sqrt_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 5th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 10th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 15th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 20th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 25th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 30th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 35th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 40th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 45th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 50th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 55th
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), // 60th
+        log_kp1.clone(), // 61st log
+        log_kp1.clone(), // 62nd log
+        log_kp1.clone(), // 63rd log
+        log_kp1.clone(), // 64th log (over 63; refused)
+        log_kp1, // 65th log (over 64; refused)
     ]);
     let g_k = apply(sym(DIV), vec![num_k, k6]);
     let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_6]);

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.367.0 — 2026-05-28
+
+### Added
+- Phase 425 (`sixtyThreeLogPolyEffectiveDeg`): Zero-Sqrt × Sixty-Three-Log × polynomial numerator recognizer.
+- Phase 426 (`oneSqrtSixtyThreeLogPolyEffectiveDeg`): One-Sqrt × Sixty-Three-Log.
+- Phase 427 (`twoSqrtSixtyThreeLogPolyEffectiveDeg`): Two-Sqrt × Sixty-Three-Log.
+- Phase 428 (`threeSqrtSixtyThreeLogPolyEffectiveDeg`): Three-Sqrt × Sixty-Three-Log.
+- Phase 429 (`fourSqrtSixtyThreeLogPolyEffectiveDeg`): Four-Sqrt × Sixty-Three-Log.
+- Phase 430 (`fiveSqrtSixtyThreeLogPolyEffectiveDeg`): Five-Sqrt × Sixty-Three-Log. Completes the Sixty-Three-Log family.
+- 6 new describe blocks covering Phase 425–430 (closes + refused for each).
+- Cascade fix: refused tests across all earlier phases that previously used exactly 63 logs as the "over-boundary" value updated to use 64 log factors, since Phase 425 now accepts exactly 63.
+
 ## 2.361.0 — 2026-05-28
 
 ### Added

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "2.361.0",
+  "version": "2.367.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -7098,6 +7098,167 @@ function fiveSqrtFiftySevenLogPolyEffectiveDeg(node: IRNode, k: IRNode): number 
   return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + sqrtHalfDegs[3] + sqrtHalfDegs[4] + polyDeg;
 }
 
+/** Phase 425 — Zero-Sqrt × Sixty-Three-Log × polynomial numerator.
+ * effectiveDeg = polyDeg (no sqrt factors).
+ * Caller checks `denDeg > sixtyThreeLogPolyEffectiveDeg(num, k)`.
+ */
+function sixtyThreeLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    if (sqrtEffectiveHalfDegree(arg, k) !== undefined) return undefined;
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 63) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (logCount !== 63) return undefined;
+  return polyDeg;
+}
+
+/** Phase 426 — One-Sqrt × Sixty-Three-Log × polynomial numerator. */
+function oneSqrtSixtyThreeLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  let sqrtHalfDeg: number | undefined;
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const s = sqrtEffectiveHalfDegree(arg, k);
+    if (s !== undefined) {
+      if (sqrtHalfDeg !== undefined) return undefined;
+      sqrtHalfDeg = s;
+      continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 63) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDeg === undefined || logCount !== 63) return undefined;
+  return sqrtHalfDeg + polyDeg;
+}
+
+/** Phase 427 — Two-Sqrt × Sixty-Three-Log × polynomial numerator. */
+function twoSqrtSixtyThreeLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const s = sqrtEffectiveHalfDegree(arg, k);
+    if (s !== undefined) {
+      if (sqrtHalfDegs.length >= 2) return undefined;
+      sqrtHalfDegs.push(s);
+      continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 63) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 2 || logCount !== 63) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + polyDeg;
+}
+
+/** Phase 428 — Three-Sqrt × Sixty-Three-Log × polynomial numerator. */
+function threeSqrtSixtyThreeLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const s = sqrtEffectiveHalfDegree(arg, k);
+    if (s !== undefined) {
+      if (sqrtHalfDegs.length >= 3) return undefined;
+      sqrtHalfDegs.push(s);
+      continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 63) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 3 || logCount !== 63) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + polyDeg;
+}
+
+/** Phase 429 — Four-Sqrt × Sixty-Three-Log × polynomial numerator. */
+function fourSqrtSixtyThreeLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const s = sqrtEffectiveHalfDegree(arg, k);
+    if (s !== undefined) {
+      if (sqrtHalfDegs.length >= 4) return undefined;
+      sqrtHalfDegs.push(s);
+      continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 63) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 4 || logCount !== 63) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + sqrtHalfDegs[3] + polyDeg;
+}
+
+/** Phase 430 — Five-Sqrt × Sixty-Three-Log × polynomial numerator.
+ * Completes the Sixty-Three-Log family (Phases 425–430).
+ */
+function fiveSqrtSixtyThreeLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const s = sqrtEffectiveHalfDegree(arg, k);
+    if (s !== undefined) {
+      if (sqrtHalfDegs.length >= 5) return undefined;
+      sqrtHalfDegs.push(s);
+      continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 63) return undefined;
+      continue;
+    }
+    const d = polynomialDegreeInK(arg, k);
+    if (d !== undefined) { polyDeg += d; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 5 || logCount !== 63) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + sqrtHalfDegs[3] + sqrtHalfDegs[4] + polyDeg;
+}
+
 /** Phase 419 — Zero-Sqrt × Sixty-Two-Log × polynomial numerator.
  * effectiveDeg = polyDeg (no sqrt factors).
  * Caller checks `denDeg > sixtyTwoLogPolyEffectiveDeg(num, k)`.
@@ -11373,6 +11534,66 @@ function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
     const denDegS2l8 = polynomialDegreeInK(den, k);
     if (denDegS2l8 !== undefined) {
       if (denDegS2l8 > s2l8Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 430: five sqrt + 63 logs
+  const s5l63Deg = fiveSqrtSixtyThreeLogPolyEffectiveDeg(num, k);
+  if (s5l63Deg !== undefined) {
+    const denDegS5l63 = polynomialDegreeInK(den, k);
+    if (denDegS5l63 !== undefined) {
+      if (denDegS5l63 > s5l63Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 429: four sqrt + 63 logs
+  const s4l63Deg = fourSqrtSixtyThreeLogPolyEffectiveDeg(num, k);
+  if (s4l63Deg !== undefined) {
+    const denDegS4l63 = polynomialDegreeInK(den, k);
+    if (denDegS4l63 !== undefined) {
+      if (denDegS4l63 > s4l63Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 428: three sqrt + 63 logs
+  const s3l63Deg = threeSqrtSixtyThreeLogPolyEffectiveDeg(num, k);
+  if (s3l63Deg !== undefined) {
+    const denDegS3l63 = polynomialDegreeInK(den, k);
+    if (denDegS3l63 !== undefined) {
+      if (denDegS3l63 > s3l63Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 427: two sqrt + 63 logs
+  const s2l63Deg = twoSqrtSixtyThreeLogPolyEffectiveDeg(num, k);
+  if (s2l63Deg !== undefined) {
+    const denDegS2l63 = polynomialDegreeInK(den, k);
+    if (denDegS2l63 !== undefined) {
+      if (denDegS2l63 > s2l63Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 426: one sqrt + 63 logs
+  const s1l63Deg = oneSqrtSixtyThreeLogPolyEffectiveDeg(num, k);
+  if (s1l63Deg !== undefined) {
+    const denDegS1l63 = polynomialDegreeInK(den, k);
+    if (denDegS1l63 !== undefined) {
+      if (denDegS1l63 > s1l63Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 425: zero sqrt + 63 logs
+  const sl63Deg = sixtyThreeLogPolyEffectiveDeg(num, k);
+  if (sl63Deg !== undefined) {
+    const denDegSl63 = polynomialDegreeInK(den, k);
+    if (denDegSl63 !== undefined) {
+      if (denDegSl63 > sl63Deg) return true;
     } else if (hDivergesAtInfinity(den, k)) {
       return true;
     }

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -15271,8 +15271,8 @@ describe("Phase 167 — Twenty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK167r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1167r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK167r = { kind: "apply" as const, head: DIV, args: [numK167r, k2] };
@@ -15321,8 +15321,8 @@ describe("Phase 168 — One-Sqrt × Twenty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK168r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [k] }, ...logs29k, k] };
     const numKp1168r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [kp1] }, ...logs29kp1, kp1] };
     const gK168r = { kind: "apply" as const, head: DIV, args: [numK168r, k2] };
@@ -15375,8 +15375,8 @@ describe("Phase 169 — Two-Sqrt × Twenty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK169r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -15431,8 +15431,8 @@ describe("Phase 170 — Three-Sqrt × Twenty-Log × polynomial numerator", () =>
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK170r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15487,8 +15487,8 @@ describe("Phase 171 — Four-Sqrt × Twenty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK171r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15543,8 +15543,8 @@ describe("Phase 172 — Five-Sqrt × Twenty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK172r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15595,8 +15595,8 @@ describe("Phase 173 — Twenty-One-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK173r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1173r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK173r = { kind: "apply" as const, head: DIV, args: [numK173r, k2] };
@@ -15645,8 +15645,8 @@ describe("Phase 174 — One-Sqrt × Twenty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK174r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [k] }, ...logs29k, k] };
     const numKp1174r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [kp1] }, ...logs29kp1, kp1] };
     const gK174r = { kind: "apply" as const, head: DIV, args: [numK174r, k2] };
@@ -15699,8 +15699,8 @@ describe("Phase 175 — Two-Sqrt × Twenty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK175r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -15755,8 +15755,8 @@ describe("Phase 176 — Three-Sqrt × Twenty-One-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK176r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15811,8 +15811,8 @@ describe("Phase 177 — Four-Sqrt × Twenty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK177r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15867,8 +15867,8 @@ describe("Phase 178 — Five-Sqrt × Twenty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK178r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -15919,8 +15919,8 @@ describe("Phase 179 — Twenty-Two-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK179r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1179r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK179r = { kind: "apply" as const, head: DIV, args: [numK179r, k2] };
@@ -15969,8 +15969,8 @@ describe("Phase 180 — One-Sqrt × Twenty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK180r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [k] }, ...logs29k, k] };
     const numKp1180r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [kp1] }, ...logs29kp1, kp1] };
     const gK180r = { kind: "apply" as const, head: DIV, args: [numK180r, k2] };
@@ -16023,8 +16023,8 @@ describe("Phase 181 — Two-Sqrt × Twenty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK181r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -16079,8 +16079,8 @@ describe("Phase 182 — Three-Sqrt × Twenty-Two-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK182r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16135,8 +16135,8 @@ describe("Phase 183 — Four-Sqrt × Twenty-Two-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK183r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16191,8 +16191,8 @@ describe("Phase 184 — Five-Sqrt × Twenty-Two-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK184r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16243,8 +16243,8 @@ describe("Phase 185 — Twenty-Three-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK185r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1185r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK185r = { kind: "apply" as const, head: DIV, args: [numK185r, k2] };
@@ -16293,8 +16293,8 @@ describe("Phase 186 — One-Sqrt × Twenty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK186r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [k] }, ...logs29k, k] };
     const numKp1186r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [kp1] }, ...logs29kp1, kp1] };
     const gK186r = { kind: "apply" as const, head: DIV, args: [numK186r, k2] };
@@ -16347,8 +16347,8 @@ describe("Phase 187 — Two-Sqrt × Twenty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK187r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -16403,8 +16403,8 @@ describe("Phase 188 — Three-Sqrt × Twenty-Three-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK188r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16459,8 +16459,8 @@ describe("Phase 189 — Four-Sqrt × Twenty-Three-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK189r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16515,8 +16515,8 @@ describe("Phase 190 — Five-Sqrt × Twenty-Three-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK190r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16567,8 +16567,8 @@ describe("Phase 191 — Twenty-Four-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK191r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1191r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK191r = { kind: "apply" as const, head: DIV, args: [numK191r, k2] };
@@ -16621,8 +16621,8 @@ describe("Phase 192 — One-Sqrt × Twenty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK192r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs29k, k] };
@@ -16677,8 +16677,8 @@ describe("Phase 193 — Two-Sqrt × Twenty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK193r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -16733,8 +16733,8 @@ describe("Phase 194 — Three-Sqrt × Twenty-Four-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK194r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16789,8 +16789,8 @@ describe("Phase 195 — Four-Sqrt × Twenty-Four-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK195r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16845,8 +16845,8 @@ describe("Phase 196 — Five-Sqrt × Twenty-Four-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK196r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -16897,8 +16897,8 @@ describe("Phase 197 — Twenty-Five-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK197r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1197r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK197r = { kind: "apply" as const, head: DIV, args: [numK197r, k2] };
@@ -16951,8 +16951,8 @@ describe("Phase 198 — One-Sqrt × Twenty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK198r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs29k, k] };
@@ -17007,8 +17007,8 @@ describe("Phase 199 — Two-Sqrt × Twenty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK199r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -17063,8 +17063,8 @@ describe("Phase 200 — Three-Sqrt × Twenty-Five-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK200r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17119,8 +17119,8 @@ describe("Phase 201 — Four-Sqrt × Twenty-Five-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK201r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17175,8 +17175,8 @@ describe("Phase 202 — Five-Sqrt × Twenty-Five-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK202r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17227,8 +17227,8 @@ describe("Phase 203 — Twenty-Six-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK203r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1203r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK203r = { kind: "apply" as const, head: DIV, args: [numK203r, k2] };
@@ -17279,8 +17279,8 @@ describe("Phase 204 — One-Sqrt × Twenty-Six-Log × polynomial numerator", () 
   it("√k·log(k)²⁹·k/k² refused (30 logs — not Phase 204)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK204r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs29k, k] };
@@ -17333,8 +17333,8 @@ describe("Phase 205 — Two-Sqrt × Twenty-Six-Log × polynomial numerator", () 
   it("√k·√k·log(k)²⁹/k² refused (30 logs — not Phase 205)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK205r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k, k] };
@@ -17387,8 +17387,8 @@ describe("Phase 206 — Three-Sqrt × Twenty-Six-Log × polynomial numerator", (
   it("(√k)³·log(k)²⁹/k² refused (30 logs — not Phase 206)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK206r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k, k] };
@@ -17443,8 +17443,8 @@ describe("Phase 207 — Four-Sqrt × Twenty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK207r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k, k] };
@@ -17499,8 +17499,8 @@ describe("Phase 208 — Five-Sqrt × Twenty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK208r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17551,8 +17551,8 @@ describe("Phase 209 — Zero-Sqrt × Twenty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK209r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1209r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK209r = { kind: "apply" as const, head: DIV, args: [numK209r, k2] };
@@ -17603,8 +17603,8 @@ describe("Phase 210 — One-Sqrt × Twenty-Seven-Log × polynomial numerator", (
   it("√k·log(k)²⁹·k/k² refused (30 logs — not Phase 210)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK210r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs29k, k] };
@@ -17659,8 +17659,8 @@ describe("Phase 211 — Two-Sqrt × Twenty-Seven-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK211r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -17715,8 +17715,8 @@ describe("Phase 212 — Three-Sqrt × Twenty-Seven-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK212r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17771,8 +17771,8 @@ describe("Phase 213 — Four-Sqrt × Twenty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK213r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17827,8 +17827,8 @@ describe("Phase 214 — Five-Sqrt × Twenty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK214r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -17879,8 +17879,8 @@ describe("Phase 215 — Zero-Sqrt × Twenty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK215r = { kind: "apply" as const, head: MUL, args: [...logs29k, k] };
     const numKp1215r = { kind: "apply" as const, head: MUL, args: [...logs29kp1, kp1] };
     const gK215r = { kind: "apply" as const, head: DIV, args: [numK215r, k2] };
@@ -17933,8 +17933,8 @@ describe("Phase 216 — One-Sqrt × Twenty-Eight-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK216r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs29k, k] };
@@ -17989,8 +17989,8 @@ describe("Phase 217 — Two-Sqrt × Twenty-Eight-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK217r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs29k] };
@@ -18045,8 +18045,8 @@ describe("Phase 218 — Three-Sqrt × Twenty-Eight-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK218r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -18101,8 +18101,8 @@ describe("Phase 219 — Four-Sqrt × Twenty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK219r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -18157,8 +18157,8 @@ describe("Phase 220 — Five-Sqrt × Twenty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs29k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs29kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs29k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs29kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK220r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs29k] };
@@ -18209,8 +18209,8 @@ describe("Phase 221 — Zero-Sqrt × Twenty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK221r = { kind: "apply" as const, head: MUL, args: [...logs30k, k] };
     const numKp1221r = { kind: "apply" as const, head: MUL, args: [...logs30kp1, kp1] };
     const gK221r = { kind: "apply" as const, head: DIV, args: [numK221r, k2] };
@@ -18263,8 +18263,8 @@ describe("Phase 222 — One-Sqrt × Twenty-Nine-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK222r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs30k, k] };
@@ -18319,8 +18319,8 @@ describe("Phase 223 — Two-Sqrt × Twenty-Nine-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK223r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs30k, k] };
@@ -18375,8 +18375,8 @@ describe("Phase 224 — Three-Sqrt × Twenty-Nine-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK224r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs30k, k] };
@@ -18431,8 +18431,8 @@ describe("Phase 225 — Four-Sqrt × Twenty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK225r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs30k, k] };
@@ -18487,8 +18487,8 @@ describe("Phase 226 — Five-Sqrt × Twenty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs30k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs30kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs30k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs30kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK226r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs30k, k] };
@@ -18539,8 +18539,8 @@ describe("Phase 227 — Zero-Sqrt × Thirty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK227r = { kind: "apply" as const, head: MUL, args: [...logs31k, k] };
     const numKp1227r = { kind: "apply" as const, head: MUL, args: [...logs31kp1, kp1] };
     const gK227r = { kind: "apply" as const, head: DIV, args: [numK227r, k2] };
@@ -18593,8 +18593,8 @@ describe("Phase 228 — One-Sqrt × Thirty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK228r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs31k, k] };
@@ -18649,8 +18649,8 @@ describe("Phase 229 — Two-Sqrt × Thirty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK229r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs31k, k] };
@@ -18705,8 +18705,8 @@ describe("Phase 230 — Three-Sqrt × Thirty-Log × polynomial numerator", () =>
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK230r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs31k, k] };
@@ -18761,8 +18761,8 @@ describe("Phase 231 — Four-Sqrt × Thirty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK231r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs31k, k] };
@@ -18817,8 +18817,8 @@ describe("Phase 232 — Five-Sqrt × Thirty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs31k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs31kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs31k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs31kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK232r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs31k, k] };
@@ -18869,8 +18869,8 @@ describe("Phase 233 — Zero-Sqrt × Thirty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK233r = { kind: "apply" as const, head: MUL, args: [...logs32k, k] };
     const numKp1233r = { kind: "apply" as const, head: MUL, args: [...logs32kp1, kp1] };
     const gK233r = { kind: "apply" as const, head: DIV, args: [numK233r, k2] };
@@ -18923,8 +18923,8 @@ describe("Phase 234 — One-Sqrt × Thirty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK234r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs32k, k] };
@@ -18979,8 +18979,8 @@ describe("Phase 235 — Two-Sqrt × Thirty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK235r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs32k, k] };
@@ -19035,8 +19035,8 @@ describe("Phase 236 — Three-Sqrt × Thirty-One-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK236r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs32k, k] };
@@ -19091,8 +19091,8 @@ describe("Phase 237 — Four-Sqrt × Thirty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK237r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs32k, k] };
@@ -19147,8 +19147,8 @@ describe("Phase 238 — Five-Sqrt × Thirty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs32k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs32kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs32k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs32kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK238r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs32k, k] };
@@ -19199,8 +19199,8 @@ describe("Phase 239 — Thirty-Two-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs33k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK239r = { kind: "apply" as const, head: MUL, args: [...logs33k, k] };
     const numKp1239r = { kind: "apply" as const, head: MUL, args: [...logs33kp1, kp1] };
     const gK239r = { kind: "apply" as const, head: DIV, args: [numK239r, k2] };
@@ -19249,8 +19249,8 @@ describe("Phase 240 — One-Sqrt × Thirty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs33k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK240r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [k] }, ...logs33k, k] };
     const numKp1240r = { kind: "apply" as const, head: MUL, args: [{ kind: "apply" as const, head: SQRT, args: [kp1] }, ...logs33kp1, kp1] };
     const gK240r = { kind: "apply" as const, head: DIV, args: [numK240r, k2] };
@@ -19303,8 +19303,8 @@ describe("Phase 241 — Two-Sqrt × Thirty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs33k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK241r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs33k] };
@@ -19359,8 +19359,8 @@ describe("Phase 242 — Three-Sqrt × Thirty-Two-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs33k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK242r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs33k] };
@@ -19415,8 +19415,8 @@ describe("Phase 243 — Four-Sqrt × Thirty-Two-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs33k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK243r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs33k, k] };
@@ -19471,8 +19471,8 @@ describe("Phase 244 — Five-Sqrt × Thirty-Two-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs33k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs33kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs33k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs33kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK244r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs33k, k] };
@@ -19523,8 +19523,8 @@ describe("Phase 245 — Thirty-Three-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs34k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK245r = { kind: "apply" as const, head: MUL, args: [...logs34k, k] };
     const numKp1245r = { kind: "apply" as const, head: MUL, args: [...logs34kp1, kp1] };
     const gK245r = { kind: "apply" as const, head: DIV, args: [numK245r, k2] };
@@ -19577,8 +19577,8 @@ describe("Phase 246 — One-Sqrt × Thirty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs34k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK246r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs34k, k] };
@@ -19633,8 +19633,8 @@ describe("Phase 247 — Two-Sqrt × Thirty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs34k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK247r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs34k] };
@@ -19689,8 +19689,8 @@ describe("Phase 248 — Three-Sqrt × Thirty-Three-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs34k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK248r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs34k] };
@@ -19745,8 +19745,8 @@ describe("Phase 249 — Four-Sqrt × Thirty-Three-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs34k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK249r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs34k] };
@@ -19801,8 +19801,8 @@ describe("Phase 250 — Five-Sqrt × Thirty-Three-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs34k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs34kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs34k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs34kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK250r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs34k, k] };
@@ -19853,8 +19853,8 @@ describe("Phase 251 — Thirty-Four-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs36k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK251r = { kind: "apply" as const, head: MUL, args: [...logs36k, k] };
     const numKp1251r = { kind: "apply" as const, head: MUL, args: [...logs36kp1, kp1] };
     const gK251r = { kind: "apply" as const, head: DIV, args: [numK251r, k2] };
@@ -19907,8 +19907,8 @@ describe("Phase 252 — One-Sqrt × Thirty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs36k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK252r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs36k, k] };
@@ -19963,8 +19963,8 @@ describe("Phase 253 — Two-Sqrt × Thirty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
     const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
-    const logs36k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK253r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs36k] };
@@ -20019,8 +20019,8 @@ describe("Phase 254 — Three-Sqrt × Thirty-Four-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs36k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK254r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs36k] };
@@ -20075,8 +20075,8 @@ describe("Phase 255 — Four-Sqrt × Thirty-Four-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
     const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
-    const logs36k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK255r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs36k] };
@@ -20131,8 +20131,8 @@ describe("Phase 256 — Five-Sqrt × Thirty-Four-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK256r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs36k, k] };
@@ -20183,8 +20183,8 @@ describe("Phase 257 — Thirty-Five-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK257r = { kind: "apply" as const, head: MUL, args: [...logs36k, k] };
     const numKp1257r = { kind: "apply" as const, head: MUL, args: [...logs36kp1, kp1] };
     const gK257r = { kind: "apply" as const, head: DIV, args: [numK257r, k2] };
@@ -20237,8 +20237,8 @@ describe("Phase 258 — One-Sqrt × Thirty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK258r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs36k, k] };
@@ -20293,8 +20293,8 @@ describe("Phase 259 — Two-Sqrt × Thirty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK259r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs36k, k] };
@@ -20349,8 +20349,8 @@ describe("Phase 260 — Three-Sqrt × Thirty-Five-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK260r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs36k, k] };
@@ -20405,8 +20405,8 @@ describe("Phase 261 — Four-Sqrt × Thirty-Five-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK261r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs36k, k] };
@@ -20461,8 +20461,8 @@ describe("Phase 262 — Five-Sqrt × Thirty-Five-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs36k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs36kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs36k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs36kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK262r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs36k, k] };
@@ -20513,8 +20513,8 @@ describe("Phase 263 — Zero-Sqrt × Thirty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK263r = { kind: "apply" as const, head: MUL, args: [...logs37k, k] };
     const numKp1263r = { kind: "apply" as const, head: MUL, args: [...logs37kp1, kp1] };
     const gK263r = { kind: "apply" as const, head: DIV, args: [numK263r, k2] };
@@ -20567,8 +20567,8 @@ describe("Phase 264 — One-Sqrt × Thirty-Six-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK264r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs37k, k] };
@@ -20623,8 +20623,8 @@ describe("Phase 265 — Two-Sqrt × Thirty-Six-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK265r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs37k] };
@@ -20679,8 +20679,8 @@ describe("Phase 266 — Three-Sqrt × Thirty-Six-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK266r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs37k] };
@@ -20735,8 +20735,8 @@ describe("Phase 267 — Four-Sqrt × Thirty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK267r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs37k, k] };
@@ -20791,8 +20791,8 @@ describe("Phase 268 — Five-Sqrt × Thirty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs37k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs37kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs37k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs37kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK268r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs37k, k] };
@@ -20843,8 +20843,8 @@ describe("Phase 269 — Zero-Sqrt × Thirty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs38k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs38kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs38k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK269r = { kind: "apply" as const, head: MUL, args: [...logs38k, k] };
     const numKp1269r = { kind: "apply" as const, head: MUL, args: [...logs38kp1, kp1] };
     const gK269r = { kind: "apply" as const, head: DIV, args: [numK269r, k2] };
@@ -20897,8 +20897,8 @@ describe("Phase 270 — One-Sqrt × Thirty-Seven-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs38k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs38kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs38k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK270r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs38k, k] };
@@ -20953,8 +20953,8 @@ describe("Phase 271 — Two-Sqrt × Thirty-Seven-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs38k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs38kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs38k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK271r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs38k, k] };
@@ -21009,8 +21009,8 @@ describe("Phase 272 — Three-Sqrt × Thirty-Seven-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs38k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs38kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs38k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK272r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs38k, k] };
@@ -21065,8 +21065,8 @@ describe("Phase 273 — Four-Sqrt × Thirty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs38k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs38kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs38k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK273r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs38k, k] };
@@ -21121,8 +21121,8 @@ describe("Phase 274 — Five-Sqrt × Thirty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs38k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs38kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs38k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs38kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK274r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs38k, k] };
@@ -21173,8 +21173,8 @@ describe("Phase 275 — Zero-Sqrt × Thirty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs39k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs39kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs39k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs39kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK275r = { kind: "apply" as const, head: MUL, args: [...logs39k, k] };
     const numKp1275r = { kind: "apply" as const, head: MUL, args: [...logs39kp1, kp1] };
     const gK275r = { kind: "apply" as const, head: DIV, args: [numK275r, k2] };
@@ -21227,8 +21227,8 @@ describe("Phase 276 — One-Sqrt × Thirty-Eight-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs39k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs39kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs39k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs39kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK276r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs39k, k] };
@@ -21283,8 +21283,8 @@ describe("Phase 277 — Two-Sqrt × Thirty-Eight-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs39k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs39kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs39k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs39kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK277r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs39k, k] };
@@ -21339,8 +21339,8 @@ describe("Phase 278 — Three-Sqrt × Thirty-Eight-Log × polynomial numerator",
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs39k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs39kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs39k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs39kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK278r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs39k, k] };
@@ -21395,8 +21395,8 @@ describe("Phase 279 — Four-Sqrt × Thirty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs39k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs39kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs39k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs39kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK279r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs39k, k] };
@@ -21451,8 +21451,8 @@ describe("Phase 280 — Five-Sqrt × Thirty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2 = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2 = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs39k = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs39kp1 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs39k = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs39kp1 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK280r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs39k, k] };
@@ -21504,8 +21504,8 @@ describe("Phase 281 — Zero-Sqrt × Thirty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs40k281 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs40kp1281 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs40k281 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1281 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK281r = { kind: "apply" as const, head: MUL, args: [...logs40k281, k] };
     const numKp1281r = { kind: "apply" as const, head: MUL, args: [...logs40kp1281, kp1] };
     const gK281r = { kind: "apply" as const, head: DIV, args: [numK281r, k2r] };
@@ -21558,8 +21558,8 @@ describe("Phase 282 — One-Sqrt × Thirty-Nine-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs40k282 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs40kp1282 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs40k282 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1282 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK282r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs40k282, k] };
@@ -21614,8 +21614,8 @@ describe("Phase 283 — Two-Sqrt × Thirty-Nine-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs40k283 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs40kp1283 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs40k283 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1283 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK283r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs40k283, k] };
@@ -21670,8 +21670,8 @@ describe("Phase 284 — Three-Sqrt × Thirty-Nine-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs40k284 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs40kp1284 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs40k284 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1284 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK284r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs40k284, k] };
@@ -21726,8 +21726,8 @@ describe("Phase 285 — Four-Sqrt × Thirty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs40k285 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs40kp1285 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs40k285 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1285 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK285r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs40k285, k] };
@@ -21782,8 +21782,8 @@ describe("Phase 286 — Five-Sqrt × Thirty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs40k286 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs40kp1286 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs40k286 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs40kp1286 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK286r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs40k286, k] };
@@ -21834,8 +21834,8 @@ describe("Phase 287 — Zero-Sqrt × Forty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k287 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1287 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k287 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1287 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK287r = { kind: "apply" as const, head: MUL, args: [...logs42k287, k] };
     const numKp1287r = { kind: "apply" as const, head: MUL, args: [...logs42kp1287, kp1] };
     const gK287r = { kind: "apply" as const, head: DIV, args: [numK287r, k2r] };
@@ -21888,8 +21888,8 @@ describe("Phase 288 — One-Sqrt × Forty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k288 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1288 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k288 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1288 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK288r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs42k288, k] };
@@ -21944,8 +21944,8 @@ describe("Phase 289 — Two-Sqrt × Forty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k289 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1289 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k289 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1289 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK289r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs42k289, k] };
@@ -22000,8 +22000,8 @@ describe("Phase 290 — Three-Sqrt × Forty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k290 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1290 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k290 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1290 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK290r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs42k290, k] };
@@ -22056,8 +22056,8 @@ describe("Phase 291 — Four-Sqrt × Forty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k291 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1291 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k291 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1291 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK291r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs42k291, k] };
@@ -22112,8 +22112,8 @@ describe("Phase 292 — Five-Sqrt × Forty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k292 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1292 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k292 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1292 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK292r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs42k292, k] };
@@ -22164,8 +22164,8 @@ describe("Phase 293 — Zero-Sqrt × Forty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k293 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1293 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k293 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1293 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK293r = { kind: "apply" as const, head: MUL, args: [...logs42k293, k] };
     const numKp1293r = { kind: "apply" as const, head: MUL, args: [...logs42kp1293, kp1] };
     const gK293r = { kind: "apply" as const, head: DIV, args: [numK293r, k2r] };
@@ -22200,8 +22200,8 @@ describe("Phase 294 — One-Sqrt × Forty-One-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k294 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1294 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k294 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1294 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK294r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs42k294, k] };
@@ -22238,8 +22238,8 @@ describe("Phase 295 — Two-Sqrt × Forty-One-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k295 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1295 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k295 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1295 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK295r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs42k295, k] };
@@ -22276,8 +22276,8 @@ describe("Phase 296 — Three-Sqrt × Forty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k296 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1296 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k296 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1296 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK296r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs42k296, k] };
@@ -22314,8 +22314,8 @@ describe("Phase 297 — Four-Sqrt × Forty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k297 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1297 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k297 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1297 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK297r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs42k297, k] };
@@ -22352,8 +22352,8 @@ describe("Phase 298 — Five-Sqrt × Forty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs42k298 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs42kp1298 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs42k298 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs42kp1298 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK298r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs42k298, k] };
@@ -22388,8 +22388,8 @@ describe("Phase 299 — Zero-Sqrt × Forty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k299 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1299 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k299 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1299 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK299r = { kind: "apply" as const, head: MUL, args: [...logs44k299, k] };
     const numKp1299r = { kind: "apply" as const, head: MUL, args: [...logs44kp1299, kp1] };
     const gK299r = { kind: "apply" as const, head: DIV, args: [numK299r, k2r] };
@@ -22424,8 +22424,8 @@ describe("Phase 300 — One-Sqrt × Forty-Two-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k300 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1300 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k300 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1300 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK300r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs44k300, k] };
@@ -22462,8 +22462,8 @@ describe("Phase 301 — Two-Sqrt × Forty-Two-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k301 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1301 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k301 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1301 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK301r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs44k301, k] };
@@ -22500,8 +22500,8 @@ describe("Phase 302 — Three-Sqrt × Forty-Two-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k302 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1302 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k302 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1302 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK302r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs44k302, k] };
@@ -22538,8 +22538,8 @@ describe("Phase 303 — Four-Sqrt × Forty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k303 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1303 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k303 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1303 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK303r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs44k303, k] };
@@ -22576,8 +22576,8 @@ describe("Phase 304 — Five-Sqrt × Forty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k304 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1304 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k304 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1304 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK304r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs44k304, k] };
@@ -22612,8 +22612,8 @@ describe("Phase 305 — Zero-Sqrt × Forty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k305 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1305 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k305 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1305 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK305r = { kind: "apply" as const, head: MUL, args: [...logs44k305, k] };
     const numKp1305r = { kind: "apply" as const, head: MUL, args: [...logs44kp1305, kp1] };
     const gK305r = { kind: "apply" as const, head: DIV, args: [numK305r, k2r] };
@@ -22648,8 +22648,8 @@ describe("Phase 306 — One-Sqrt × Forty-Three-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k306 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1306 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k306 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1306 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK306r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs44k306, k] };
@@ -22686,8 +22686,8 @@ describe("Phase 307 — Two-Sqrt × Forty-Three-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k307 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1307 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k307 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1307 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK307r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs44k307, k] };
@@ -22724,8 +22724,8 @@ describe("Phase 308 — Three-Sqrt × Forty-Three-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1, kp1] };
-    const logs44k308 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1308 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k308 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1308 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK308r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs44k308, k] };
@@ -22762,8 +22762,8 @@ describe("Phase 309 — Four-Sqrt × Forty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1, kp1] };
-    const logs44k309 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1309 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k309 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1309 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK309r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs44k309, k] };
@@ -22800,8 +22800,8 @@ describe("Phase 310 — Five-Sqrt × Forty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs44k310 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs44kp1310 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs44k310 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs44kp1310 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK310r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs44k310, k] };
@@ -22836,8 +22836,8 @@ describe("Phase 311 — Forty-Four-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs45k311 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs45kp1311 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs45k311 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs45kp1311 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK311r = { kind: "apply" as const, head: MUL, args: [...logs45k311, k] };
     const numKp1311r = { kind: "apply" as const, head: MUL, args: [...logs45kp1311, kp1] };
     const gK311r = { kind: "apply" as const, head: DIV, args: [numK311r, k2r] };
@@ -22872,8 +22872,8 @@ describe("Phase 312 — One-Sqrt × Forty-Four-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs45k312 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs45kp1312 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs45k312 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs45kp1312 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK312r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs45k312, k] };
@@ -22910,8 +22910,8 @@ describe("Phase 313 — Two-Sqrt × Forty-Four-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs45k313 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs45kp1313 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs45k313 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs45kp1313 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK313r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs45k313, k] };
@@ -22948,8 +22948,8 @@ describe("Phase 314 — Three-Sqrt × Forty-Four-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs45k314 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs45kp1314 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs45k314 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs45kp1314 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK314r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs45k314, k] };
@@ -22986,8 +22986,8 @@ describe("Phase 315 — Four-Sqrt × Forty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs45k315 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs45kp1315 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs45k315 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs45kp1315 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK315r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs45k315, k] };
@@ -23024,8 +23024,8 @@ describe("Phase 316 — Five-Sqrt × Forty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs45k316 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs45kp1316 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs45k316 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs45kp1316 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK316r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs45k316, k] };
@@ -23060,8 +23060,8 @@ describe("Phase 317 — Forty-Five-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs46k317 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs46kp1317 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs46k317 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs46kp1317 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK317r = { kind: "apply" as const, head: MUL, args: [...logs46k317, k] };
     const numKp1317r = { kind: "apply" as const, head: MUL, args: [...logs46kp1317, kp1] };
     const gK317r = { kind: "apply" as const, head: DIV, args: [numK317r, k2r] };
@@ -23096,8 +23096,8 @@ describe("Phase 318 — One-Sqrt × Forty-Five-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs46k318 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs46kp1318 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs46k318 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs46kp1318 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK318r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs46k318, k] };
@@ -23134,8 +23134,8 @@ describe("Phase 319 — Two-Sqrt × Forty-Five-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs46k319 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs46kp1319 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs46k319 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs46kp1319 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK319r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs46k319, k] };
@@ -23172,8 +23172,8 @@ describe("Phase 320 — Three-Sqrt × Forty-Five-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs46k320 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs46kp1320 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs46k320 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs46kp1320 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK320r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs46k320, k] };
@@ -23210,8 +23210,8 @@ describe("Phase 321 — Four-Sqrt × Forty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs46k321 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs46kp1321 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs46k321 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs46kp1321 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK321r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs46k321, k] };
@@ -23248,8 +23248,8 @@ describe("Phase 322 — Five-Sqrt × Forty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs46k322 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs46kp1322 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs46k322 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs46kp1322 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK322r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs46k322, k] };
@@ -23284,8 +23284,8 @@ describe("Phase 323 — Forty-Six-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs47k323 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs47kp1323 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs47k323 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs47kp1323 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK323r = { kind: "apply" as const, head: MUL, args: [...logs47k323, k] };
     const numKp1323r = { kind: "apply" as const, head: MUL, args: [...logs47kp1323, kp1] };
     const gK323r = { kind: "apply" as const, head: DIV, args: [numK323r, k2r] };
@@ -23320,8 +23320,8 @@ describe("Phase 324 — One-Sqrt × Forty-Six-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs47k324 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs47kp1324 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs47k324 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs47kp1324 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK324r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs47k324, k] };
@@ -23358,8 +23358,8 @@ describe("Phase 325 — Two-Sqrt × Forty-Six-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs47k325 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs47kp1325 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs47k325 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs47kp1325 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK325r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs47k325, k] };
@@ -23396,8 +23396,8 @@ describe("Phase 326 — Three-Sqrt × Forty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs47k326 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs47kp1326 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs47k326 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs47kp1326 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK326r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs47k326, k] };
@@ -23434,8 +23434,8 @@ describe("Phase 327 — Four-Sqrt × Forty-Six-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs47k327 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs47kp1327 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs47k327 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs47kp1327 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK327r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs47k327, k] };
@@ -23472,8 +23472,8 @@ describe("Phase 328 — Five-Sqrt × Forty-Six-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs47k328 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs47kp1328 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs47k328 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs47kp1328 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK328r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs47k328, k] };
@@ -23508,8 +23508,8 @@ describe("Phase 329 — Forty-Seven-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k329 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1329 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k329 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1329 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK329r = { kind: "apply" as const, head: MUL, args: [...logs49k329, k] };
     const numKp1329r = { kind: "apply" as const, head: MUL, args: [...logs49kp1329, kp1] };
     const gK329r = { kind: "apply" as const, head: DIV, args: [numK329r, k2r] };
@@ -23544,8 +23544,8 @@ describe("Phase 330 — One-Sqrt × Forty-Seven-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k330 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1330 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k330 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1330 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK330r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs49k330, k] };
@@ -23582,8 +23582,8 @@ describe("Phase 331 — Two-Sqrt × Forty-Seven-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k331 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1331 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k331 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1331 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK331r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs49k331, k] };
@@ -23620,8 +23620,8 @@ describe("Phase 332 — Three-Sqrt × Forty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k332 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1332 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k332 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1332 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK332r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs49k332, k] };
@@ -23658,8 +23658,8 @@ describe("Phase 333 — Four-Sqrt × Forty-Seven-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k333 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1333 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k333 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1333 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK333r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs49k333, k] };
@@ -23696,8 +23696,8 @@ describe("Phase 334 — Five-Sqrt × Forty-Seven-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k334 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1334 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k334 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1334 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK334r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs49k334, k] };
@@ -23732,8 +23732,8 @@ describe("Phase 335 — Zero-Sqrt × Forty-Eight-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k335 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1335 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k335 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1335 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK335r = { kind: "apply" as const, head: MUL, args: [...logs49k335, k] };
     const numKp1335r = { kind: "apply" as const, head: MUL, args: [...logs49kp1335, kp1] };
     const gK335r = { kind: "apply" as const, head: DIV, args: [numK335r, k2r] };
@@ -23768,8 +23768,8 @@ describe("Phase 336 — One-Sqrt × Forty-Eight-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k336 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1336 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k336 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1336 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK336r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs49k336, k] };
@@ -23806,8 +23806,8 @@ describe("Phase 337 — Two-Sqrt × Forty-Eight-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k337 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1337 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k337 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1337 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK337r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs49k337, k] };
@@ -23844,8 +23844,8 @@ describe("Phase 338 — Three-Sqrt × Forty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k338 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1338 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k338 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1338 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK338r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs49k338, k] };
@@ -23882,8 +23882,8 @@ describe("Phase 339 — Four-Sqrt × Forty-Eight-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k339 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1339 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k339 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1339 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK339r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs49k339, k] };
@@ -23920,8 +23920,8 @@ describe("Phase 340 — Five-Sqrt × Forty-Eight-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs49k340 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs49kp1340 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs49k340 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs49kp1340 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK340r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs49k340, k] };
@@ -23956,8 +23956,8 @@ describe("Phase 341 — Zero-Sqrt × Forty-Nine-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k341 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1341 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k341 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1341 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK341r = { kind: "apply" as const, head: MUL, args: [...logs51k341, k] };
     const numKp1341r = { kind: "apply" as const, head: MUL, args: [...logs51kp1341, kp1] };
     const gK341r = { kind: "apply" as const, head: DIV, args: [numK341r, k2r] };
@@ -23992,8 +23992,8 @@ describe("Phase 342 — One-Sqrt × Forty-Nine-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k342 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1342 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k342 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1342 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK342r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs51k342, k] };
@@ -24030,8 +24030,8 @@ describe("Phase 343 — Two-Sqrt × Forty-Nine-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k343 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1343 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k343 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1343 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK343r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs51k343, k] };
@@ -24068,8 +24068,8 @@ describe("Phase 344 — Three-Sqrt × Forty-Nine-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k344 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1344 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k344 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1344 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK344r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs51k344, k] };
@@ -24106,8 +24106,8 @@ describe("Phase 345 — Four-Sqrt × Forty-Nine-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k345 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1345 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k345 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1345 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK345r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs51k345, k] };
@@ -24144,8 +24144,8 @@ describe("Phase 346 — Five-Sqrt × Forty-Nine-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k346 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1346 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k346 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1346 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK346r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs51k346, k] };
@@ -24180,8 +24180,8 @@ describe("Phase 347 — Zero-Sqrt × Fifty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k347 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1347 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k347 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1347 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK347r = { kind: "apply" as const, head: MUL, args: [...logs51k347, k] };
     const numKp1347r = { kind: "apply" as const, head: MUL, args: [...logs51kp1347, kp1] };
     const gK347r = { kind: "apply" as const, head: DIV, args: [numK347r, k2r] };
@@ -24216,8 +24216,8 @@ describe("Phase 348 — One-Sqrt × Fifty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k348 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1348 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k348 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1348 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK348r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs51k348, k] };
@@ -24254,8 +24254,8 @@ describe("Phase 349 — Two-Sqrt × Fifty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k349 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1349 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k349 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1349 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK349r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs51k349, k] };
@@ -24292,8 +24292,8 @@ describe("Phase 350 — Three-Sqrt × Fifty-Log × polynomial numerator", () => 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k350 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1350 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k350 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1350 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK350r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs51k350, k] };
@@ -24330,8 +24330,8 @@ describe("Phase 351 — Four-Sqrt × Fifty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k351 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1351 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k351 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1351 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK351r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs51k351, k] };
@@ -24368,8 +24368,8 @@ describe("Phase 352 — Five-Sqrt × Fifty-Log × polynomial numerator", () => {
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs51k352 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs51kp1352 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs51k352 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs51kp1352 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK352r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs51k352, k] };
@@ -24405,8 +24405,8 @@ describe("Phase 353 — Zero-Sqrt × Fifty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs52k353 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs52kp1353 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs52k353 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs52kp1353 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK353r = { kind: "apply" as const, head: MUL, args: [...logs52k353, k] };
     const numKp1353r = { kind: "apply" as const, head: MUL, args: [...logs52kp1353, kp1] };
     const gK353r = { kind: "apply" as const, head: DIV, args: [numK353r, k2r] };
@@ -24441,8 +24441,8 @@ describe("Phase 354 — One-Sqrt × Fifty-One-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs52k354 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs52kp1354 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs52k354 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs52kp1354 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK354r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs52k354, k] };
@@ -24479,8 +24479,8 @@ describe("Phase 355 — Two-Sqrt × Fifty-One-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs52k355 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs52kp1355 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs52k355 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs52kp1355 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK355r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs52k355, k] };
@@ -24517,8 +24517,8 @@ describe("Phase 356 — Three-Sqrt × Fifty-One-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs52k356 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs52kp1356 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs52k356 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs52kp1356 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK356r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs52k356, k] };
@@ -24555,8 +24555,8 @@ describe("Phase 357 — Four-Sqrt × Fifty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs52k357 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs52kp1357 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs52k357 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs52kp1357 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK357r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs52k357, k] };
@@ -24593,8 +24593,8 @@ describe("Phase 358 — Five-Sqrt × Fifty-One-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs52k358 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs52kp1358 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs52k358 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs52kp1358 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK358r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs52k358, k] };
@@ -24629,8 +24629,8 @@ describe("Phase 359 — Zero-Sqrt × Fifty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs53k359 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs53kp1359 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs53k359 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs53kp1359 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK359r = { kind: "apply" as const, head: MUL, args: [...logs53k359, k] };
     const numKp1359r = { kind: "apply" as const, head: MUL, args: [...logs53kp1359, kp1] };
     const gK359r = { kind: "apply" as const, head: DIV, args: [numK359r, k2r] };
@@ -24665,8 +24665,8 @@ describe("Phase 360 — One-Sqrt × Fifty-Two-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs53k360 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs53kp1360 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs53k360 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs53kp1360 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK360r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs53k360, k] };
@@ -24703,8 +24703,8 @@ describe("Phase 361 — Two-Sqrt × Fifty-Two-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs53k361 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs53kp1361 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs53k361 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs53kp1361 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK361r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs53k361, k] };
@@ -24741,8 +24741,8 @@ describe("Phase 362 — Three-Sqrt × Fifty-Two-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs53k362 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs53kp1362 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs53k362 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs53kp1362 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK362r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs53k362, k] };
@@ -24779,8 +24779,8 @@ describe("Phase 363 — Four-Sqrt × Fifty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs53k363 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs53kp1363 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs53k363 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs53kp1363 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK363r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs53k363, k] };
@@ -24817,8 +24817,8 @@ describe("Phase 364 — Five-Sqrt × Fifty-Two-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs53k364 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs53kp1364 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs53k364 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs53kp1364 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK364r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs53k364, k] };
@@ -24853,8 +24853,8 @@ describe("Phase 365 — Zero-Sqrt × Fifty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs54k365 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs54kp1365 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs54k365 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs54kp1365 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK365r = { kind: "apply" as const, head: MUL, args: [...logs54k365, k] };
     const numKp1365r = { kind: "apply" as const, head: MUL, args: [...logs54kp1365, kp1] };
     const gK365r = { kind: "apply" as const, head: DIV, args: [numK365r, k2r] };
@@ -24889,8 +24889,8 @@ describe("Phase 366 — One-Sqrt × Fifty-Three-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs54k366 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs54kp1366 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs54k366 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs54kp1366 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK366r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs54k366, k] };
@@ -24927,8 +24927,8 @@ describe("Phase 367 — Two-Sqrt × Fifty-Three-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs54k367 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs54kp1367 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs54k367 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs54kp1367 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK367r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs54k367, k] };
@@ -24965,8 +24965,8 @@ describe("Phase 368 — Three-Sqrt × Fifty-Three-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs54k368 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs54kp1368 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs54k368 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs54kp1368 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK368r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs54k368, k] };
@@ -25003,8 +25003,8 @@ describe("Phase 369 — Four-Sqrt × Fifty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs54k369 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs54kp1369 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs54k369 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs54kp1369 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK369r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs54k369, k] };
@@ -25041,8 +25041,8 @@ describe("Phase 370 — Five-Sqrt × Fifty-Three-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs54k370 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs54kp1370 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs54k370 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs54kp1370 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK370r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs54k370] };
@@ -25077,8 +25077,8 @@ describe("Phase 371 — Zero-Sqrt × Fifty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs56k371 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs56kp1371 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs56k371 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs56kp1371 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK371r = { kind: "apply" as const, head: MUL, args: [...logs56k371, k] };
     const numKp1371r = { kind: "apply" as const, head: MUL, args: [...logs56kp1371, kp1] };
     const gK371r = { kind: "apply" as const, head: DIV, args: [numK371r, k2r] };
@@ -25113,8 +25113,8 @@ describe("Phase 372 — One-Sqrt × Fifty-Four-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs56k372 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs56kp1372 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs56k372 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs56kp1372 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK372r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs56k372, k] };
@@ -25151,8 +25151,8 @@ describe("Phase 373 — Two-Sqrt × Fifty-Four-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs56k373 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs56kp1373 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs56k373 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs56kp1373 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK373r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs56k373, k] };
@@ -25189,8 +25189,8 @@ describe("Phase 374 — Three-Sqrt × Fifty-Four-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs56k374 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs56kp1374 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs56k374 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs56kp1374 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK374r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs56k374, k] };
@@ -25227,8 +25227,8 @@ describe("Phase 375 — Four-Sqrt × Fifty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs56k375 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs56kp1375 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs56k375 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs56kp1375 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK375r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs56k375, k] };
@@ -25265,8 +25265,8 @@ describe("Phase 376 — Five-Sqrt × Fifty-Four-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs56k376 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs56kp1376 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs56k376 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs56kp1376 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK376r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs56k376] };
@@ -25301,8 +25301,8 @@ describe("Phase 377 — Zero-Sqrt × Fifty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs56k377 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs56kp1377 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs56k377 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs56kp1377 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK377r = { kind: "apply" as const, head: MUL, args: [...logs56k377] };
     const numKp1377r = { kind: "apply" as const, head: MUL, args: [...logs56kp1377] };
     const gK377r = { kind: "apply" as const, head: DIV, args: [numK377r, k2r] };
@@ -25337,8 +25337,8 @@ describe("Phase 378 — One-Sqrt × Fifty-Five-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs56k378 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs56kp1378 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs56k378 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs56kp1378 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK378r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs56k378] };
@@ -25375,8 +25375,8 @@ describe("Phase 379 — Two-Sqrt × Fifty-Five-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs56k379 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs56kp1379 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs56k379 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs56kp1379 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK379r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs56k379] };
@@ -25413,8 +25413,8 @@ describe("Phase 380 — Three-Sqrt × Fifty-Five-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs56k380 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs56kp1380 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs56k380 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs56kp1380 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK380r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs56k380] };
@@ -25451,8 +25451,8 @@ describe("Phase 381 — Four-Sqrt × Fifty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs56k381 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs56kp1381 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs56k381 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs56kp1381 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK381r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs56k381] };
@@ -25489,8 +25489,8 @@ describe("Phase 382 — Five-Sqrt × Fifty-Five-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs56k382 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs56kp1382 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs56k382 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs56kp1382 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK382r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs56k382] };
@@ -25525,8 +25525,8 @@ describe("Phase 383 — Zero-Sqrt × Fifty-Six-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs57k383 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs57kp1383 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs57k383 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs57kp1383 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK383r = { kind: "apply" as const, head: MUL, args: [...logs57k383] };
     const numKp1383r = { kind: "apply" as const, head: MUL, args: [...logs57kp1383] };
     const gK383r = { kind: "apply" as const, head: DIV, args: [numK383r, k2r] };
@@ -25561,8 +25561,8 @@ describe("Phase 384 — One-Sqrt × Fifty-Six-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs57k384 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs57kp1384 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs57k384 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs57kp1384 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK384r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs57k384] };
@@ -25599,8 +25599,8 @@ describe("Phase 385 — Two-Sqrt × Fifty-Six-Log × polynomial numerator", () =
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs57k385 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs57kp1385 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs57k385 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs57kp1385 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK385r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs57k385] };
@@ -25637,8 +25637,8 @@ describe("Phase 386 — Three-Sqrt × Fifty-Six-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs57k386 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs57kp1386 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs57k386 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs57kp1386 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK386r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs57k386] };
@@ -25675,8 +25675,8 @@ describe("Phase 387 — Four-Sqrt × Fifty-Six-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs57k387 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs57kp1387 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs57k387 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs57kp1387 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK387r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs57k387] };
@@ -25713,8 +25713,8 @@ describe("Phase 388 — Five-Sqrt × Fifty-Six-Log × polynomial numerator", () 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs57k388 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs57kp1388 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs57k388 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs57kp1388 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK388r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs57k388] };
@@ -25749,8 +25749,8 @@ describe("Phase 389 — Zero-Sqrt × Fifty-Seven-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs59k389 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs59kp1389 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs59k389 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs59kp1389 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK389r = { kind: "apply" as const, head: MUL, args: [...logs59k389] };
     const numKp1389r = { kind: "apply" as const, head: MUL, args: [...logs59kp1389] };
     const gK389r = { kind: "apply" as const, head: DIV, args: [numK389r, k2r] };
@@ -25785,8 +25785,8 @@ describe("Phase 390 — One-Sqrt × Fifty-Seven-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs59k390 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs59kp1390 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs59k390 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs59kp1390 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK390r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs59k390] };
@@ -25823,8 +25823,8 @@ describe("Phase 391 — Two-Sqrt × Fifty-Seven-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs59k391 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs59kp1391 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs59k391 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs59kp1391 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK391r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs59k391] };
@@ -25861,8 +25861,8 @@ describe("Phase 392 — Three-Sqrt × Fifty-Seven-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs59k392 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs59kp1392 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs59k392 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs59kp1392 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK392r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs59k392] };
@@ -25899,8 +25899,8 @@ describe("Phase 393 — Four-Sqrt × Fifty-Seven-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs59k393 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs59kp1393 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs59k393 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs59kp1393 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK393r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs59k393] };
@@ -25937,8 +25937,8 @@ describe("Phase 394 — Five-Sqrt × Fifty-Seven-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs59k394 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs59kp1394 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs59k394 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs59kp1394 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK394r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs59k394] };
@@ -25973,8 +25973,8 @@ describe("Phase 395 — Zero-Sqrt × Fifty-Eight-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs59k395 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs59kp1395 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs59k395 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs59kp1395 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK395r = { kind: "apply" as const, head: MUL, args: [...logs59k395] };
     const numKp1395r = { kind: "apply" as const, head: MUL, args: [...logs59kp1395] };
     const gK395r = { kind: "apply" as const, head: DIV, args: [numK395r, k2r] };
@@ -26009,8 +26009,8 @@ describe("Phase 396 — One-Sqrt × Fifty-Eight-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs59k396 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs59kp1396 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs59k396 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs59kp1396 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK396r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs59k396] };
@@ -26047,8 +26047,8 @@ describe("Phase 397 — Two-Sqrt × Fifty-Eight-Log × polynomial numerator", ()
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs59k397 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs59kp1397 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs59k397 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs59kp1397 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK397r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs59k397] };
@@ -26085,8 +26085,8 @@ describe("Phase 398 — Three-Sqrt × Fifty-Eight-Log × polynomial numerator", 
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs59k398 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs59kp1398 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs59k398 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs59kp1398 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK398r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs59k398] };
@@ -26123,8 +26123,8 @@ describe("Phase 399 — Four-Sqrt × Fifty-Eight-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs59k399 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs59kp1399 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs59k399 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs59kp1399 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK399r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs59k399] };
@@ -26161,8 +26161,8 @@ describe("Phase 400 — Five-Sqrt × Fifty-Eight-Log × polynomial numerator", (
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs59k400 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs59kp1400 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs59k400 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs59kp1400 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK400r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs59k400] };
@@ -26192,13 +26192,13 @@ describe("Phase 401 — Zero-Sqrt × Fifty-Nine-Log × polynomial numerator", ()
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("log(k)⁵⁹/k² refused (63 logs — not Phase 413)", () => {
+  it("log(k)⁵⁹/k² refused (64 logs — not Phase 413)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs61k401 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs61kp1401 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs61k401 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs61kp1401 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK401r = { kind: "apply" as const, head: MUL, args: [...logs61k401] };
     const numKp1401r = { kind: "apply" as const, head: MUL, args: [...logs61kp1401] };
     const gK401r = { kind: "apply" as const, head: DIV, args: [numK401r, k2r] };
@@ -26228,13 +26228,13 @@ describe("Phase 402 — One-Sqrt × Fifty-Nine-Log × polynomial numerator", () 
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("√k·log(k)⁵⁹/k² refused (63 logs — not Phase 414)", () => {
+  it("√k·log(k)⁵⁹/k² refused (64 logs — not Phase 414)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs61k402 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs61kp1402 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs61k402 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs61kp1402 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK402r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs61k402] };
@@ -26266,13 +26266,13 @@ describe("Phase 403 — Two-Sqrt × Fifty-Nine-Log × polynomial numerator", () 
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)²·log(k)⁵⁹/k² refused (63 logs — not Phase 415)", () => {
+  it("(√k)²·log(k)⁵⁹/k² refused (64 logs — not Phase 415)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs61k403 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs61kp1403 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs61k403 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs61kp1403 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK403r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs61k403] };
@@ -26304,13 +26304,13 @@ describe("Phase 404 — Three-Sqrt × Fifty-Nine-Log × polynomial numerator", (
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)³·log(k)⁵⁹/k³ refused (63 logs — not Phase 416)", () => {
+  it("(√k)³·log(k)⁵⁹/k³ refused (64 logs — not Phase 416)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs61k404 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs61kp1404 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs61k404 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs61kp1404 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK404r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs61k404] };
@@ -26342,13 +26342,13 @@ describe("Phase 405 — Four-Sqrt × Fifty-Nine-Log × polynomial numerator", ()
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)⁴·log(k)⁵⁹/k³ refused (63 logs — not Phase 417)", () => {
+  it("(√k)⁴·log(k)⁵⁹/k³ refused (64 logs — not Phase 417)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs61k405 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs61kp1405 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs61k405 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs61kp1405 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK405r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs61k405] };
@@ -26380,13 +26380,13 @@ describe("Phase 406 — Five-Sqrt × Fifty-Nine-Log × polynomial numerator", ()
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)^5·log(k)⁵⁹/k³ refused (63 logs — not Phase 418)", () => {
+  it("(√k)^5·log(k)⁵⁹/k³ refused (64 logs — not Phase 418)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs61k406 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs61kp1406 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs61k406 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs61kp1406 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK406r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs61k406] };
@@ -26416,13 +26416,13 @@ describe("Phase 407 — Zero-Sqrt × Sixty-Log × polynomial numerator", () => {
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("log(k)⁶⁰/k² refused (63 logs — not Phase 413)", () => {
+  it("log(k)⁶⁰/k² refused (64 logs — not Phase 413)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs62k413 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs62kp1413 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs62k413 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs62kp1413 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK407r = { kind: "apply" as const, head: MUL, args: [...logs62k413] };
     const numKp1407r = { kind: "apply" as const, head: MUL, args: [...logs62kp1413] };
     const gK407r = { kind: "apply" as const, head: DIV, args: [numK407r, k2r] };
@@ -26452,13 +26452,13 @@ describe("Phase 408 — One-Sqrt × Sixty-Log × polynomial numerator", () => {
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("√k·log(k)⁶⁰/k² refused (63 logs — not Phase 414)", () => {
+  it("√k·log(k)⁶⁰/k² refused (64 logs — not Phase 414)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs62k414 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs62kp1414 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs62k414 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs62kp1414 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK408r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs62k414] };
@@ -26490,13 +26490,13 @@ describe("Phase 409 — Two-Sqrt × Sixty-Log × polynomial numerator", () => {
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)²·log(k)⁶⁰/k² refused (63 logs — not Phase 415)", () => {
+  it("(√k)²·log(k)⁶⁰/k² refused (64 logs — not Phase 415)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs62k415 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs62kp1415 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs62k415 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs62kp1415 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK409r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs62k415] };
@@ -26528,13 +26528,13 @@ describe("Phase 410 — Three-Sqrt × Sixty-Log × polynomial numerator", () => 
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)³·log(k)⁶⁰/k³ refused (63 logs — not Phase 416)", () => {
+  it("(√k)³·log(k)⁶⁰/k³ refused (64 logs — not Phase 416)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs62k416 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs62kp1416 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs62k416 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs62kp1416 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK410r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs62k416] };
@@ -26566,13 +26566,13 @@ describe("Phase 411 — Four-Sqrt × Sixty-Log × polynomial numerator", () => {
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)⁴·log(k)⁶⁰/k³ refused (63 logs — not Phase 417)", () => {
+  it("(√k)⁴·log(k)⁶⁰/k³ refused (64 logs — not Phase 417)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs62k417 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs62kp1417 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs62k417 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs62kp1417 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK411r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs62k417] };
@@ -26604,13 +26604,13 @@ describe("Phase 412 — Five-Sqrt × Sixty-Log × polynomial numerator", () => {
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)^5·log(k)⁶⁰/k³ refused (63 logs — not Phase 418)", () => {
+  it("(√k)^5·log(k)⁶⁰/k³ refused (64 logs — not Phase 418)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs62k418 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs62kp1418 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs62k418 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs62kp1418 = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK412r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs62k418] };
@@ -26640,13 +26640,13 @@ describe("Phase 413 — Sixty-One-Log × polynomial numerator", () => {
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("log(k)⁶¹/k² refused (63 logs — not Phase 413)", () => {
+  it("log(k)⁶¹/k² refused (64 logs — not Phase 413)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs62k413r = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs62kp1413r = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs62k413r = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs62kp1413r = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK413r = { kind: "apply" as const, head: MUL, args: [...logs62k413r] };
     const numKp1413r = { kind: "apply" as const, head: MUL, args: [...logs62kp1413r] };
     const gK413r = { kind: "apply" as const, head: DIV, args: [numK413r, k2r] };
@@ -26676,13 +26676,13 @@ describe("Phase 414 — One-Sqrt × Sixty-One-Log × polynomial numerator", () =
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("√k·log(k)⁶¹/k² refused (63 logs — not Phase 414)", () => {
+  it("√k·log(k)⁶¹/k² refused (64 logs — not Phase 414)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs62k414r = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs62kp1414r = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs62k414r = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs62kp1414r = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK414r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs62k414r] };
@@ -26714,13 +26714,13 @@ describe("Phase 415 — Two-Sqrt × Sixty-One-Log × polynomial numerator", () =
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)²·log(k)⁶¹/k² refused (63 logs — not Phase 415)", () => {
+  it("(√k)²·log(k)⁶¹/k² refused (64 logs — not Phase 415)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs62k415r = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs62kp1415r = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs62k415r = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs62kp1415r = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK415r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs62k415r] };
@@ -26752,13 +26752,13 @@ describe("Phase 416 — Three-Sqrt × Sixty-One-Log × polynomial numerator", ()
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)³·log(k)⁶¹/k³ refused (63 logs — not Phase 416)", () => {
+  it("(√k)³·log(k)⁶¹/k³ refused (64 logs — not Phase 416)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs62k416r = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs62kp1416r = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs62k416r = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs62kp1416r = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK416r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs62k416r] };
@@ -26790,13 +26790,13 @@ describe("Phase 417 — Four-Sqrt × Sixty-One-Log × polynomial numerator", () 
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)⁴·log(k)⁶¹/k³ refused (63 logs — not Phase 417)", () => {
+  it("(√k)⁴·log(k)⁶¹/k³ refused (64 logs — not Phase 417)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs62k417r = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs62kp1417r = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs62k417r = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs62kp1417r = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK417r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs62k417r] };
@@ -26828,13 +26828,13 @@ describe("Phase 418 — Five-Sqrt × Sixty-One-Log × polynomial numerator", () 
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)^5·log(k)⁶¹/k³ refused (63 logs — not Phase 418)", () => {
+  it("(√k)^5·log(k)⁶¹/k³ refused (64 logs — not Phase 418)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs62k418r = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs62kp1418r = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs62k418r = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs62kp1418r = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK418r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs62k418r] };
@@ -26864,13 +26864,13 @@ describe("Phase 419 — Sixty-Two-Log × polynomial numerator", () => {
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("log(k)⁶²/k² refused (63 logs — not Phase 419)", () => {
+  it("log(k)⁶²/k² refused (64 logs — not Phase 425/426/427/428/429/430)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs63k419r = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs63kp1419r = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs63k419r = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs63kp1419r = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const numK419r = { kind: "apply" as const, head: MUL, args: [...logs63k419r] };
     const numKp1419r = { kind: "apply" as const, head: MUL, args: [...logs63kp1419r] };
     const gK419r = { kind: "apply" as const, head: DIV, args: [numK419r, k2r] };
@@ -26900,13 +26900,13 @@ describe("Phase 420 — One-Sqrt × Sixty-Two-Log × polynomial numerator", () =
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("√k·log(k)⁶²/k² refused (63 logs — not Phase 420)", () => {
+  it("√k·log(k)⁶²/k² refused (64 logs — not Phase 425/426/427/428/429/430)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs63k420r = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs63kp1420r = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs63k420r = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs63kp1420r = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK420r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs63k420r] };
@@ -26938,13 +26938,13 @@ describe("Phase 421 — Two-Sqrt × Sixty-Two-Log × polynomial numerator", () =
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)²·log(k)⁶²/k² refused (63 logs — not Phase 421)", () => {
+  it("(√k)²·log(k)⁶²/k² refused (64 logs — not Phase 425/426/427/428/429/430)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs63k421r = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs63kp1421r = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs63k421r = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs63kp1421r = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK421r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs63k421r] };
@@ -26976,13 +26976,13 @@ describe("Phase 422 — Three-Sqrt × Sixty-Two-Log × polynomial numerator", ()
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)³·log(k)⁶²/k³ refused (63 logs — not Phase 422)", () => {
+  it("(√k)³·log(k)⁶²/k³ refused (64 logs — not Phase 425/426/427/428/429/430)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs63k422r = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs63kp1422r = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs63k422r = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs63kp1422r = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK422r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs63k422r] };
@@ -27014,13 +27014,13 @@ describe("Phase 423 — Four-Sqrt × Sixty-Two-Log × polynomial numerator", () 
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)⁴·log(k)⁶²/k³ refused (63 logs — not Phase 423)", () => {
+  it("(√k)⁴·log(k)⁶²/k³ refused (64 logs — not Phase 425/426/427/428/429/430)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs63k423r = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs63kp1423r = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs63k423r = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs63kp1423r = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK423r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs63k423r] };
@@ -27052,13 +27052,13 @@ describe("Phase 424 — Five-Sqrt × Sixty-Two-Log × polynomial numerator", () 
     expect(result).not.toMatchObject({ kind: "apply", head: SUM });
   });
 
-  it("(√k)^5·log(k)⁶²/k³ refused (63 logs — not Phase 424)", () => {
+  it("(√k)^5·log(k)⁶²/k³ refused (64 logs — not Phase 425/426/427/428/429/430)", () => {
     const k = sym("k");
     const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
     const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
     const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
-    const logs63k424r = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
-    const logs63kp1424r = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const logs63k424r = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs63kp1424r = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
     const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
     const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
     const numK424r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs63k424r] };
@@ -27067,6 +27067,229 @@ describe("Phase 424 — Five-Sqrt × Sixty-Two-Log × polynomial numerator", () 
     const gKp1424r = { kind: "apply" as const, head: DIV, args: [numKp1424r, kp1_3r] };
     const f424r = { kind: "apply" as const, head: SUB, args: [gK424r, gKp1424r] };
     const result = evaluateSum(f424r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+describe("Phase 425 — Sixty-Three-Log × polynomial numerator", () => {
+  it("log(k)⁶³/k² closes (logCount=63, denDeg=2 > 1)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const logs63k425 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs63kp1425 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const numK425a = { kind: "apply" as const, head: MUL, args: [...logs63k425] };
+    const numKp1425a = { kind: "apply" as const, head: MUL, args: [...logs63kp1425] };
+    const gK425a = { kind: "apply" as const, head: DIV, args: [numK425a, k2] };
+    const gKp1425a = { kind: "apply" as const, head: DIV, args: [numKp1425a, kp1_2] };
+    const f425a = { kind: "apply" as const, head: SUB, args: [gK425a, gKp1425a] };
+    const result = evaluateSum(f425a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("log(k)⁶³/k² refused (64 logs — not Phase 425)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs64k425r = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs64kp1425r = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const numK425r = { kind: "apply" as const, head: MUL, args: [...logs64k425r] };
+    const numKp1425r = { kind: "apply" as const, head: MUL, args: [...logs64kp1425r] };
+    const gK425r = { kind: "apply" as const, head: DIV, args: [numK425r, k2r] };
+    const gKp1425r = { kind: "apply" as const, head: DIV, args: [numKp1425r, kp1_2r] };
+    const f425r = { kind: "apply" as const, head: SUB, args: [gK425r, gKp1425r] };
+    const result = evaluateSum(f425r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 426 — One-Sqrt × Sixty-Three-Log × polynomial numerator", () => {
+  it("√k·log(k)⁶³/k² closes (sqrtHalf=0.5, denDeg=2 > 1.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const logs63k426 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs63kp1426 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK426a = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs63k426] };
+    const numKp1426a = { kind: "apply" as const, head: MUL, args: [sqrtKp1, ...logs63kp1426] };
+    const gK426a = { kind: "apply" as const, head: DIV, args: [numK426a, k2] };
+    const gKp1426a = { kind: "apply" as const, head: DIV, args: [numKp1426a, kp1_2] };
+    const f426a = { kind: "apply" as const, head: SUB, args: [gK426a, gKp1426a] };
+    const result = evaluateSum(f426a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("√k·log(k)⁶³/k² refused (64 logs — not Phase 426)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs64k426r = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs64kp1426r = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK426r = { kind: "apply" as const, head: MUL, args: [sqrtK, ...logs64k426r] };
+    const numKp1426r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, ...logs64kp1426r] };
+    const gK426r = { kind: "apply" as const, head: DIV, args: [numK426r, k2r] };
+    const gKp1426r = { kind: "apply" as const, head: DIV, args: [numKp1426r, kp1_2r] };
+    const f426r = { kind: "apply" as const, head: SUB, args: [gK426r, gKp1426r] };
+    const result = evaluateSum(f426r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 427 — Two-Sqrt × Sixty-Three-Log × polynomial numerator", () => {
+  it("(√k)²·log(k)⁶³/k² closes (sqrtHalf=1, denDeg=2 > 2)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const logs63k427 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs63kp1427 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK427a = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs63k427] };
+    const numKp1427a = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, ...logs63kp1427] };
+    const gK427a = { kind: "apply" as const, head: DIV, args: [numK427a, k2] };
+    const gKp1427a = { kind: "apply" as const, head: DIV, args: [numKp1427a, kp1_2] };
+    const f427a = { kind: "apply" as const, head: SUB, args: [gK427a, gKp1427a] };
+    const result = evaluateSum(f427a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("(√k)²·log(k)⁶³/k² refused (64 logs — not Phase 427)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_2r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs64k427r = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs64kp1427r = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK427r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, ...logs64k427r] };
+    const numKp1427r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, ...logs64kp1427r] };
+    const gK427r = { kind: "apply" as const, head: DIV, args: [numK427r, k2r] };
+    const gKp1427r = { kind: "apply" as const, head: DIV, args: [numKp1427r, kp1_2r] };
+    const f427r = { kind: "apply" as const, head: SUB, args: [gK427r, gKp1427r] };
+    const result = evaluateSum(f427r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 428 — Three-Sqrt × Sixty-Three-Log × polynomial numerator", () => {
+  it("(√k)³·log(k)⁶³/k³ closes (sqrtHalf=1.5, denDeg=3 > 2.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const logs63k428 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs63kp1428 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK428a = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs63k428] };
+    const numKp1428a = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, ...logs63kp1428] };
+    const gK428a = { kind: "apply" as const, head: DIV, args: [numK428a, k3] };
+    const gKp1428a = { kind: "apply" as const, head: DIV, args: [numKp1428a, kp1_3] };
+    const f428a = { kind: "apply" as const, head: SUB, args: [gK428a, gKp1428a] };
+    const result = evaluateSum(f428a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("(√k)³·log(k)⁶³/k³ refused (64 logs — not Phase 428)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs64k428r = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs64kp1428r = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK428r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, ...logs64k428r] };
+    const numKp1428r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, ...logs64kp1428r] };
+    const gK428r = { kind: "apply" as const, head: DIV, args: [numK428r, k3r] };
+    const gKp1428r = { kind: "apply" as const, head: DIV, args: [numKp1428r, kp1_3r] };
+    const f428r = { kind: "apply" as const, head: SUB, args: [gK428r, gKp1428r] };
+    const result = evaluateSum(f428r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 429 — Four-Sqrt × Sixty-Three-Log × polynomial numerator", () => {
+  it("(√k)⁴·log(k)⁶³/k³ closes (sqrtHalf=2, denDeg=3 > 3)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const logs63k429 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs63kp1429 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK429a = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs63k429] };
+    const numKp1429a = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, ...logs63kp1429] };
+    const gK429a = { kind: "apply" as const, head: DIV, args: [numK429a, k3] };
+    const gKp1429a = { kind: "apply" as const, head: DIV, args: [numKp1429a, kp1_3] };
+    const f429a = { kind: "apply" as const, head: SUB, args: [gK429a, gKp1429a] };
+    const result = evaluateSum(f429a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("(√k)⁴·log(k)⁶³/k³ refused (64 logs — not Phase 429)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs64k429r = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs64kp1429r = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK429r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, ...logs64k429r] };
+    const numKp1429r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, ...logs64kp1429r] };
+    const gK429r = { kind: "apply" as const, head: DIV, args: [numK429r, k3r] };
+    const gKp1429r = { kind: "apply" as const, head: DIV, args: [numKp1429r, kp1_3r] };
+    const f429r = { kind: "apply" as const, head: SUB, args: [gK429r, gKp1429r] };
+    const result = evaluateSum(f429r, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 430 — Five-Sqrt × Sixty-Three-Log × polynomial numerator", () => {
+  it("(√k)^5·log(k)⁶³/k³ closes (sqrtHalf=2.5, denDeg=3 > 3.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const logs63k430 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs63kp1430 = Array.from({ length: 63 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK430a = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs63k430] };
+    const numKp1430a = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, ...logs63kp1430] };
+    const gK430a = { kind: "apply" as const, head: DIV, args: [numK430a, k3] };
+    const gKp1430a = { kind: "apply" as const, head: DIV, args: [numKp1430a, kp1_3] };
+    const f430a = { kind: "apply" as const, head: SUB, args: [gK430a, gKp1430a] };
+    const result = evaluateSum(f430a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("(√k)^5·log(k)⁶³/k³ refused (64 logs — not Phase 430)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3r = { kind: "apply" as const, head: MUL, args: [k, k] };
+    const kp1_3r = { kind: "apply" as const, head: MUL, args: [kp1, kp1] };
+    const logs64k430r = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [k] }));
+    const logs64kp1430r = Array.from({ length: 64 }, () => ({ kind: "apply" as const, head: LOG, args: [kp1] }));
+    const sqrtK = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrtKp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numK430r = { kind: "apply" as const, head: MUL, args: [sqrtK, sqrtK, sqrtK, sqrtK, sqrtK, ...logs64k430r] };
+    const numKp1430r = { kind: "apply" as const, head: MUL, args: [sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, sqrtKp1, ...logs64kp1430r] };
+    const gK430r = { kind: "apply" as const, head: DIV, args: [numK430r, k3r] };
+    const gKp1430r = { kind: "apply" as const, head: DIV, args: [numKp1430r, kp1_3r] };
+    const f430r = { kind: "apply" as const, head: SUB, args: [gK430r, gKp1430r] };
+    const result = evaluateSum(f430r, k, int(1), sym("%inf"), evalNode);
     expect(result).toMatchObject({ kind: "apply", head: SUM });
   });
 });


### PR DESCRIPTION
## Summary

Implements the Sixty-Three-Log family (Phases 425–430) across Python, Rust, and TypeScript for the `cas-summation` package.

Each phase adds a convergence recognizer for series whose numerator contains **exactly 63 logarithmic factors** combined with 0–5 sqrt factors and an optional polynomial.

## Phases

| Phase | Name | Sqrt count |
|-------|------|------------|
| 425 | `_sixty_three_log_poly_effective_x2` | 0 |
| 426 | `_one_sqrt_sixty_three_log_poly_effective_x2` | 1 |
| 427 | `_two_sqrt_sixty_three_log_poly_effective_x2` | 2 |
| 428 | `_three_sqrt_sixty_three_log_poly_effective_x2` | 3 |
| 429 | `_four_sqrt_sixty_three_log_poly_effective_x2` | 4 |
| 430 | `_five_sqrt_sixty_three_log_poly_effective_x2` | 5 |

## Convergence logic

- **Python/Rust**: `2 * den_deg > effective_x2` where `effective_x2 = sum(sqrt_degs_x2) + 2 * poly_deg`
- **TypeScript**: `den_deg > effectiveDeg` where `effectiveDeg = sum(sqrtHalfDegs) + poly_deg`

## Cascade fix

All "refused" tests that previously used exactly 63 log factors as the over-boundary sentinel have been bumped to 64 log factors, since Phase 425 now accepts exactly 63 logs.

## Tests

| Language | Tests passing |
|----------|--------------|
| Python | 1151 |
| Rust | 1044 |
| TypeScript | 1062 |

## Version

`2.361.0` → `2.367.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)