### PR TITLE
refactor(cas-summation): Phase 86 — generic log × sqrt × polynomial recogniser (2.23.0)

### DIFF
--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,88 @@
 # Changelog
 
+## 2.23.0 — 2026-05-28
+
+**Phase 86 — Cleanup: generic log × sqrt × polynomial recogniser.**
+
+Closes a long-running design problem.  Phases 59-85 accumulated a
+hand-written grid of ``N-Sqrt × M-Log × polynomial`` helpers — one
+function per ``(N, M)`` combination, all with the same body modulo
+the hardcoded counts.  This PR replaces the entire grid with a
+single generic helper.
+
+### Motivation
+
+The convergence math is identical for every non-negative ``(N, M)``:
+
+- The product of ``N`` ``Log(diverging)`` factors is still
+  sub-polynomial — ``log^N(k) = o(k^ε)`` for any ``ε > 0`` — so ``N``
+  contributes ``0`` to the effective growth degree.
+- Each ``Sqrt(P_i)`` contributes ``deg(P_i)/2`` (recorded ×2 to stay
+  in integer arithmetic).
+- Each polynomial factor contributes its own degree (also ×2 here).
+- Bounded factors (constants in ``k``, ``Sin``, ``Cos``, closures)
+  contribute ``0``.
+
+Effective growth ×2: ``Σ sqrt_inner_deg_x2 + 2 · Σ poly_deg``.
+Vanishes when ``2·den_deg > effective_x2`` (polynomial denominator)
+or non-polynomial diverging denominator.
+
+The grid hardcoded ``(N, M)`` for ``N ∈ {0..5}`` and ``M ∈ {0..6}``
+— **42 helpers, all redundant**.  Cases beyond that grid
+(``M ≥ 7``, ``N ≥ 6``) silently failed.
+
+### Added
+
+- **``_log_sqrt_poly_effective_x2_generic(node, k) -> int | None``** —
+  one function that handles every ``(N, M, K)`` combination.  Returns
+  ``effective_x2`` (= ``Σ sqrt_deg_x2 + 2·Σ poly_deg``) when the ``Mul``
+  splits cleanly into Log / Sqrt / polynomial / bounded factors;
+  ``None`` for unrecognised factors (e.g. ``Exp(k)``,
+  ``Sqrt(negative)``).
+
+- **Phase 86 branch in ``_g_vanishes_at_infinity``** — inserted between
+  Phase 58 (bounded × Log × polynomial) and Phase 59 (bounded × Sqrt
+  × polynomial).  Catches every case the hand-written grid catches,
+  *plus* cases beyond the grid that previously failed.
+
+- **6 new tests** in ``TestPhase86GenericLogSqrtPoly`` proving the
+  generic handles cases the grid doesn't:
+
+  * 7-Log / k² closes (grid stops at 6 Log).
+  * 6-Sqrt / k⁴ closes (grid stops at 5 Sqrt).
+  * Mixed 3-Sqrt × 7-Log × poly closes.
+  * Regression: ``Exp(k)`` factor refused (would falsely close).
+  * Regression: ``Sqrt(-k)`` refused (complex-valued for large k).
+  * Regression: pure-bounded numerator falls through to Phase 49.
+
+### Status of the existing grid (Phases 59-85)
+
+The 42 hardcoded helpers remain in place for backward compatibility
+and are still wired into the dispatcher.  They are now redundant —
+the new Phase 86 branch catches every input they handle.  A
+follow-up PR can delete them in a single sweep without behavioral
+change.
+
+### Tests
+
+Full suite: **268 passed** (was 262; +6 net new — all from the
+generic).
+
+### Why this was needed
+
+74 open PRs (#4471-#4544) had queued up adding more ``(N, M)`` grid
+points up to ``N=64`` Log factors and beyond, each bumping the
+package version by ``0.006``.  Those PRs are now closed — the
+generic supersedes all of them.
+
+### Still deferred (genuine future work)
+
+- Deleting the redundant grid helpers (Phases 59-85) — pure
+  refactor, no behavior change.
+- Generalising further to ``Exp(non-positive)`` and other vanishing
+  transcendentals.
+- Two-Log-of-Sqrt patterns and similar nested compositions.
+
 ## 2.22.0 — 2026-05-26
 
 ### Added

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "2.22.0"
+version = "2.23.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -813,6 +813,35 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
                 return True
         elif _h_diverges_at_infinity(den, k):
             return True
+    # ---- Generic recogniser (Phase 86 cleanup) ----
+    #
+    # Mul(bounded..., Log_1, ..., Log_N, Sqrt_1, ..., Sqrt_M, Poly_1, ..., Poly_K)
+    # over diverging denominator: the product of any number of
+    # ``Log(diverging)`` factors is still sub-polynomial (``log^N(k) =
+    # o(k^ε)`` for any ``ε > 0``), so N drops out of the comparison.
+    # The Sqrt factors contribute ``Σ deg(P_i)/2`` and the polynomial
+    # factors contribute ``Σ deg(Q_j)``.  Effective growth:
+    #
+    #     effective = (Σ sqrt_deg) / 2 + Σ poly_deg
+    #
+    # Vanishes when ``den_deg > effective``, i.e.
+    # ``2·den_deg > Σ sqrt_deg + 2·Σ poly_deg``.  Non-polynomial
+    # diverging denominators dominate automatically.
+    #
+    # This branch supersedes the hand-written grid of ``N-Sqrt ×
+    # M-Log × polynomial`` helpers (Phases 59–85): the math is the
+    # same for every (N, M) ≥ (0, 0), so a single helper is enough.
+    # The hardcoded helpers remain in place for now (they still
+    # produce correct answers) but are now preempted by this branch.
+    # A follow-up cleanup PR will delete them.
+    gen_x2 = _log_sqrt_poly_effective_x2_generic(num, k)
+    if gen_x2 is not None:
+        den_deg_gen = _polynomial_degree_in_k(den, k)
+        if den_deg_gen is not None:
+            if 2 * den_deg_gen > gen_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
     # Phase 59: ``Mul(bounded, Sqrt(positive-poly), polynomial)`` numerator.
     # Bounded × Sqrt × polynomial: effective growth ``k^{deg(P)/2 + poly_deg}``.
     # Using ×2 trick: effective_x2 = deg(P) + 2·poly_deg.
@@ -1678,6 +1707,94 @@ def _bounded_log_poly_degree(node: IRNode, k: IRSymbol) -> int | None:
     if log_count != 1:
         return None
     return poly_deg_sum
+
+
+def _log_sqrt_poly_effective_x2_generic(
+    node: IRNode, k: IRSymbol
+) -> int | None:
+    """Return ``Σ sqrt_inner_deg_x2 + 2·Σ poly_deg`` when ``node`` is a
+    ``Mul`` whose factors split into any combination of:
+
+    * ``Log(diverging)`` factors (any count, including zero),
+    * ``Sqrt(positive-leading polynomial)`` factors (any count, including zero),
+    * polynomial factors in ``k`` (any count, including zero),
+    * bounded-in-``k`` factors (any count, including zero, e.g. ``Sin``, ``Cos``),
+
+    and at least one of the Log, Sqrt, or polynomial factors is
+    present.  Returns ``None`` if any factor is unrecognised (e.g.
+    ``Exp(k)``, free symbol other than ``k``, …).
+
+    **Phase 86 — cleanup.**  Supersedes the hand-written grid of
+    ``N-Sqrt × M-Log × polynomial`` helpers from Phases 59-85.  The
+    convergence math is identical for every non-negative ``(N, M)``
+    pair:
+
+    * Product of ``N`` ``Log(diverging)`` factors is still
+      sub-polynomial — ``log^N(k) = o(k^ε)`` for any ``ε > 0`` — so
+      ``N`` contributes 0 to the effective growth degree.
+    * Each ``Sqrt(P_i)`` contributes ``deg(P_i)/2`` (recorded ×2 to
+      stay in integer arithmetic).
+    * Each polynomial factor ``Q_j`` contributes its own ``deg(Q_j)``
+      (multiplied ×2 here).
+
+    Effective growth ×2:
+
+        effective_x2 = Σ_i sqrt_inner_deg_x2(Sqrt(P_i))
+                     + 2 · Σ_j deg(Q_j)
+
+    The caller compares ``2 · den_deg > effective_x2`` (polynomial
+    denominator) or short-circuits on non-polynomial diverging
+    denominator.
+
+    Examples
+    --------
+
+    * ``Mul(Sqrt(k³), Log(k), Log(k+1), k², Sin(k))`` →
+      ``3 + 0 + 2·2 = 7``.
+    * ``Mul(Log(k), Log(k+1), Log(k²+1))`` → ``0`` (sub-polynomial only;
+      caller's strict ``2·den_deg > 0`` reduces to "denominator must
+      diverge", i.e. ``den_deg ≥ 1``).
+    * ``Mul(Sqrt(k), Sqrt(k³))`` → ``1 + 3 = 4``.
+    * ``Mul(Exp(k), Log(k))`` → ``None`` (Exp is unrecognised here).
+
+    Conservative refusals:
+
+    * Empty ``Mul`` (no recognised factor) → ``None``.
+    * ``Sqrt`` of a polynomial whose leading coefficient is negative
+      (not real-valued for large ``k``) → ``None``.
+    * Any factor that isn't one of the four categories above → ``None``.
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_inner_deg_x2_sum = 0
+    poly_deg_sum = 0
+    found_log = False
+    found_sqrt = False
+    found_poly = False
+    for arg in node.args:
+        if _is_log_of_diverging_in_k(arg, k):
+            found_log = True
+            continue
+        sqrt_deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if sqrt_deg_x2 is not None:
+            sqrt_inner_deg_x2_sum += sqrt_deg_x2
+            found_sqrt = True
+            continue
+        if _is_bounded_in_k(arg, k):
+            # Constants and Sin/Cos and closures — contribute nothing
+            # to the growth rate.
+            continue
+        poly_deg = _polynomial_degree_in_k(arg, k)
+        if poly_deg is not None and poly_deg >= 1:
+            poly_deg_sum += poly_deg
+            found_poly = True
+            continue
+        # Unrecognised factor (Exp, ratio, free symbol, …) — bail.
+        return None
+    if not (found_log or found_sqrt or found_poly):
+        # Pure-bounded numerator falls through to Phase 49.
+        return None
+    return sqrt_inner_deg_x2_sum + 2 * poly_deg_sum
 
 
 def _bounded_sqrt_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -4757,3 +4757,168 @@ class TestPhase85TwoSqrtSixLogPoly:
         f = IRApply(SUB, (g_k, g_kp1))
         result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
         assert isinstance(result, IRApply) and result.head == SUM
+
+
+# ---------------------------------------------------------------------------
+# Phase 86 — Generic log×sqrt×polynomial recogniser cleanup.
+#
+# These tests prove a SINGLE generic helper handles cases beyond the
+# hand-written grid of Phases 59-85.  The grid only covers up to (5-Sqrt,
+# 6-Log) explicitly; the generic handles arbitrary (N, M, K).
+# ---------------------------------------------------------------------------
+
+
+class TestPhase86GenericLogSqrtPoly:
+    def test_seven_log_falls_through_grid_and_closes_via_generic(self):
+        """``Mul(Log, Log, Log, Log, Log, Log, Log) / k`` — 7 Log factors.
+
+        The hand-written grid stops at 6 logs.  The generic helper
+        handles arbitrary N: log^7(k) is still sub-polynomial, so the
+        sum converges with any positive-degree polynomial denominator.
+        """
+        from symbolic_ir import POW, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        logs_k = tuple(IRApply(LOG, (_k,)) for _ in range(7))
+        logs_kp1 = tuple(IRApply(LOG, (kp1,)) for _ in range(7))
+        num_k = IRApply(MUL, logs_k)
+        num_kp1 = IRApply(MUL, logs_kp1)
+        g_k = IRApply(DIV, (num_k, IRApply(POW, (_k, IRInteger(2)))))
+        g_kp1 = IRApply(DIV, (num_kp1, IRApply(POW, (kp1, IRInteger(2)))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM), (
+            f"Generic Phase 86 should close 7-Log/k²; got {result!r}"
+        )
+
+    def test_six_sqrt_falls_through_grid_and_closes_via_generic(self):
+        """``Mul(Sqrt(k), Sqrt(k), Sqrt(k), Sqrt(k), Sqrt(k), Sqrt(k)) / k^4``.
+
+        6 sqrt-of-k factors: effective ×2 = 1·6 = 6, so
+        ``2·den_deg = 8 > 6`` closes when ``den_deg = 4``.  The
+        hand-written grid only handles up to 5 Sqrt factors.
+        """
+        from symbolic_ir import POW, SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        sqrts_k = tuple(IRApply(SQRT, (_k,)) for _ in range(6))
+        sqrts_kp1 = tuple(IRApply(SQRT, (kp1,)) for _ in range(6))
+        num_k = IRApply(MUL, sqrts_k)
+        num_kp1 = IRApply(MUL, sqrts_kp1)
+        g_k = IRApply(DIV, (num_k, IRApply(POW, (_k, IRInteger(4)))))
+        g_kp1 = IRApply(DIV, (num_kp1, IRApply(POW, (kp1, IRInteger(4)))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_three_sqrt_seven_log_poly_closes_via_generic(self):
+        """``sin(k)·log^7(k)·sqrt(k³)·sqrt(k)·sqrt(k²)·k / k^5``.
+
+        Mixed (3 Sqrt, 7 Log, 1 poly factor, 1 bounded).  Outside the
+        hardcoded grid (which stops at 5/6).  Effective ×2 = sqrt
+        sum + 2·poly = (3+1+2) + 2·1 = 8, so 2·5 = 10 > 8 closes.
+        """
+        from symbolic_ir import POW, SIN, SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        logs_k = tuple(IRApply(LOG, (_k,)) for _ in range(7))
+        logs_kp1 = tuple(IRApply(LOG, (kp1,)) for _ in range(7))
+        sqrt_factors_k = (
+            IRApply(SQRT, (IRApply(POW, (_k, IRInteger(3))),)),
+            IRApply(SQRT, (_k,)),
+            IRApply(SQRT, (IRApply(POW, (_k, IRInteger(2))),)),
+        )
+        sqrt_factors_kp1 = (
+            IRApply(SQRT, (IRApply(POW, (kp1, IRInteger(3))),)),
+            IRApply(SQRT, (kp1,)),
+            IRApply(SQRT, (IRApply(POW, (kp1, IRInteger(2))),)),
+        )
+        num_k = IRApply(
+            MUL,
+            (IRApply(SIN, (_k,)), *logs_k, *sqrt_factors_k, _k),
+        )
+        num_kp1 = IRApply(
+            MUL,
+            (IRApply(SIN, (kp1,)), *logs_kp1, *sqrt_factors_kp1, kp1),
+        )
+        g_k = IRApply(DIV, (num_k, IRApply(POW, (_k, IRInteger(5)))))
+        g_kp1 = IRApply(DIV, (num_kp1, IRApply(POW, (kp1, IRInteger(5)))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_generic_refuses_unrecognised_factor(self):
+        """``Mul(Log(k), Sqrt(k), Exp(k)) / k³``: Exp(k) is unrecognised.
+
+        Generic must refuse so we don't silently close a sum that's
+        actually divergent (exp(k) grows faster than any poly denom).
+        """
+        from symbolic_ir import EXP, POW, SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        num_k = IRApply(
+            MUL,
+            (
+                IRApply(LOG, (_k,)),
+                IRApply(SQRT, (_k,)),
+                IRApply(EXP, (_k,)),
+            ),
+        )
+        num_kp1 = IRApply(
+            MUL,
+            (
+                IRApply(LOG, (kp1,)),
+                IRApply(SQRT, (kp1,)),
+                IRApply(EXP, (kp1,)),
+            ),
+        )
+        g_k = IRApply(DIV, (num_k, IRApply(POW, (_k, IRInteger(3)))))
+        g_kp1 = IRApply(DIV, (num_kp1, IRApply(POW, (kp1, IRInteger(3)))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        # exp(k)·log(k)·sqrt(k) grows exponentially → does NOT vanish.
+        # Generic must refuse so the sum stays unevaluated.
+        assert isinstance(result, IRApply) and result.head == SUM
+
+    def test_generic_refuses_negative_sqrt_argument(self):
+        """``Sqrt(Mul(-1, k))`` is complex-valued for large positive k;
+        generic must refuse.
+        """
+        from symbolic_ir import POW, SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        neg_k = IRApply(MUL, (IRInteger(-1), _k))
+        neg_kp1 = IRApply(MUL, (IRInteger(-1), kp1))
+        num_k = IRApply(
+            MUL,
+            (IRApply(LOG, (_k,)), IRApply(SQRT, (neg_k,))),
+        )
+        num_kp1 = IRApply(
+            MUL,
+            (IRApply(LOG, (kp1,)), IRApply(SQRT, (neg_kp1,))),
+        )
+        g_k = IRApply(DIV, (num_k, IRApply(POW, (_k, IRInteger(3)))))
+        g_kp1 = IRApply(DIV, (num_kp1, IRApply(POW, (kp1, IRInteger(3)))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        # Sqrt of negative polynomial is complex; refuse.
+        assert isinstance(result, IRApply) and result.head == SUM
+
+    def test_generic_pure_bounded_falls_through_to_phase49(self):
+        """``Mul(Sin(k), Cos(k)) / k²`` — no Log, no Sqrt, no polynomial.
+
+        Generic recognises 'no growth factor' and returns None, so
+        Phase 49 (bounded × diverging) handles it instead.  End-to-
+        end pin: sum still closes.
+        """
+        from symbolic_ir import COS, POW, SIN, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        num_k = IRApply(MUL, (IRApply(SIN, (_k,)), IRApply(COS, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(SIN, (kp1,)), IRApply(COS, (kp1,))))
+        g_k = IRApply(DIV, (num_k, IRApply(POW, (_k, IRInteger(2)))))
+        g_kp1 = IRApply(DIV, (num_kp1, IRApply(POW, (kp1, IRInteger(2)))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        # Phase 49 catches this — sum closes.
+        assert not (isinstance(result, IRApply) and result.head == SUM)


### PR DESCRIPTION
## Summary

Closes a long-running design problem: Phases 59–85 had accumulated a
**hand-written grid of 42 \`N-Sqrt × M-Log × polynomial\` helpers** —
one function per ``(N, M)`` combination, all with the same body modulo
hardcoded counts.  Plus 74 more PRs (#4471–#4544) were queued to
extend the grid to ``N=64+``, each bumping the package version by
``0.006``.  All 74 are now closed; this PR is the replacement.

Bumps ``cas-summation`` 2.22.0 → 2.23.0.

### Why one helper replaces 42 + 74 = 116

The convergence math is identical for every non-negative ``(N, M)``:

- Product of ``N`` ``Log(diverging)`` factors is sub-polynomial
  (``log^N(k) = o(k^ε)`` for any ``ε > 0``).  ``N`` contributes ``0``
  to effective growth.
- Each ``Sqrt(P_i)`` contributes ``deg(P_i)/2`` (recorded ×2 for
  integer arithmetic).
- Each polynomial factor contributes its own degree (×2 here).
- Bounded factors (``Sin``, ``Cos``, constants, closures) contribute
  ``0``.

Effective growth ×2: ``Σ sqrt_inner_deg_x2 + 2·Σ poly_deg``.  Vanishes
when ``2·den_deg > effective_x2`` (polynomial denominator) or
non-polynomial diverging denominator.

### Added

| Function | Returns |
|---|---|
| ``_log_sqrt_poly_effective_x2_generic(node, k)`` | ``effective_x2`` for any ``(N ≥ 0, M ≥ 0, K ≥ 0)``; ``None`` for unrecognised factors |

### Status of the existing grid

The 42 hand-written helpers (Phases 59–85) remain in place for
backward compatibility.  The new Phase 86 branch is inserted **before**
them in the dispatcher and catches every input they catch — plus
inputs beyond the grid that previously silently failed.

A follow-up PR can delete the 42 redundant helpers in a single sweep
without any behavioral change.

### Test plan

- [x] ``pytest tests/ -k phase86`` → 6 passed
- [x] ``pytest tests/`` → 268 passed (was 262; +6 — all from the generic)
- [x] No regressions
- [x] Security review (Agent) → SECURITY REVIEW PASSED
- [ ] CI green on all platforms

### Still deferred (genuine future work)

- Deleting the redundant grid helpers (Phases 59–85) — pure refactor.
- Cross-language port to TypeScript and Rust.
- Generalising to ``Exp(non-positive)`` and other vanishing
  transcendentals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)