### PR TITLE
feat(ruby-lexer): Phase 8a-2 (FC) — fuse `>>` and `>>=` tokens

### DIFF
--- a/code/grammars/ruby.grammar
+++ b/code/grammars/ruby.grammar
@@ -260,7 +260,7 @@ ensure_clause   = "ensure" { !"end" statement } ;
 # on Op tokens (Plus/Minus/Star/Slash) and the two Name-typed
 # logicals (`||`/`&&`) to avoid colliding with comparison ops which
 # the lexer fuses directly.
-assignment   = NAME ( EQUALS | "+=" | "-=" | "*=" | "/=" | "%=" | "**=" | "<<=" | "&=" | "|=" | "^=" | "||=" | "&&=" ) expression ;
+assignment   = NAME ( EQUALS | "+=" | "-=" | "*=" | "/=" | "%=" | "**=" | "<<=" | ">>=" | "&=" | "|=" | "^=" | "||=" | "&&=" ) expression ;
 # Phase 7e — Ruby 3.0 rightward (single-line) assignment `expr => var`.
 #
 # Mirror image of the normal `var = expr` assignment: the value is on

--- a/code/packages/rust/ruby-lexer/CHANGELOG.md
+++ b/code/packages/rust/ruby-lexer/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to the `coding-adventures-ruby-lexer` crate will be documented in this file.
 
+## [0.24.0] - 2026-05-26
+
+### Added (Phase 8a-2 (FC) — `>>` and `>>=` token fusion)
+
+New pre-fusion pass `fuse_right_shifts()` runs immediately before `fuse_compound_assigns()`:
+
+| Incoming pair (adjacent, no whitespace gap) | Folded into     |
+|---------------------------------------------|-----------------|
+| `Name(">")` + `Name(">")`                   | `Name(">>")`    |
+| `Name(">")` + `Name(">=")`                  | `Name(">>=")`   |
+
+This sidesteps the 1.8-era state-machine quirk where the greedy `>=` classifier already ate the `=` from `>>=` before the compound-assign pass got a chance.  Same adjacency rules as the existing compound-assign fusion: same line, no whitespace gap.
+
+### Tests
+
+- `coding-adventures-ruby-lexer`: 169 → **173** (+4):
+  - `right_shift_compound_assign_fuses_into_single_token`
+  - `right_shift_binary_operator_fuses_into_single_token`
+  - `right_shift_fusion_respects_whitespace_gap`
+  - `right_shift_fusion_leaves_unrelated_ge_alone` (regression)
+
 ## [0.23.0] - 2026-05-26
 
 ### Added (Phase 8a (FC) companion — fuse more compound-assign operators)

--- a/code/packages/rust/ruby-lexer/src/lib.rs
+++ b/code/packages/rust/ruby-lexer/src/lib.rs
@@ -446,6 +446,25 @@ impl RubyLexer {
         // so `1..5` (which the range pass converts to `Int ".." Int`)
         // doesn't get mistaken for a float.
         self.fuse_float_literals();
+        // Phase 8a-2 (FC) companion — pre-fuse `>>` and `>>=`.
+        //
+        // The 1.8-baseline state machine emits `>>` as two separate
+        // `Name(">")` tokens (no dedicated right-shift token), and the
+        // greedy `>=` classifier folds `>` immediately followed by `=`
+        // into `Name(">=")`.  That means `x >>= 5` arrives here as
+        // `Name("x")`, `Name(">")`, `Name(">=")`, `Number("5")` — the
+        // second `>` got eaten by the `>=` rule.
+        //
+        // This pre-fusion pass restores the right shapes:
+        //   `Name(">")` + `Name(">")`  (no ws) → `Name(">>")`
+        //   `Name(">")` + `Name(">=")` (no ws) → `Name(">>=")`
+        //
+        // Must run BEFORE `fuse_compound_assigns` so the standalone `=`
+        // case (e.g. `x = 5`) is unaffected, and so that any future
+        // `Name(">>")` left-shift token gets a chance to participate in
+        // compound-assign fusion (currently moot — `>>=` is folded
+        // directly here, but the pattern stays consistent).
+        self.fuse_right_shifts();
         // Phase 6p companion — fuse compound-assignment operators
         // (`+=`, `-=`, `*=`, `/=`, `||=`, `&&=`).  Pre-1.0 Ruby, so
         // no era gating.  Runs AFTER float/radix fusions (which fold
@@ -751,6 +770,94 @@ impl RubyLexer {
             } else {
                 i += 1;
             }
+        }
+    }
+
+    /// Phase 8a-2 (FC) companion — fold `>>` and `>>=`.
+    ///
+    /// The state machine doesn't carry a dedicated right-shift token
+    /// (unlike `<<`, which the heredoc opener already emits as a
+    /// single `Name("<<")`).  Two-character `>>` therefore arrives as
+    /// two separate `Name(">")` tokens.  Worse, when followed by `=`
+    /// the greedy `>=` classifier eats the second `>` together with
+    /// the trailing `=`, so `x >>= 5` arrives as `>`, `>=` — *neither*
+    /// `>>` nor `=` survives intact.
+    ///
+    /// This pass scans for the two shapes:
+    ///
+    /// | Incoming pair (adjacent, no whitespace gap) | Folded into     |
+    /// |---------------------------------------------|-----------------|
+    /// | `Name(">")` + `Name(">")`                   | `Name(">>")`    |
+    /// | `Name(">")` + `Name(">=")`                  | `Name(">>=")`   |
+    ///
+    /// Adjacency gate: same line, no whitespace before the second
+    /// token.  Same gating as `fuse_compound_assigns` — a space breaks
+    /// the fusion (`x > > 5` stays two tokens, which is a syntax error
+    /// in Ruby but not a right shift / compound-shift).
+    ///
+    /// Why a separate pass rather than extending
+    /// `fuse_compound_assigns`?  Because the input shape is `>`, `>=`
+    /// — there is no standalone `=` for the existing fuse pass to fold
+    /// against.  The `>=` token is already a unit by the time the
+    /// fusion pipeline runs.
+    ///
+    /// Era: pre-1.0 Ruby — every era ≥ 1.8 emits the same problematic
+    /// pre-fusion shape, so no gating.
+    fn fuse_right_shifts(&mut self) {
+        let mut i = 0;
+        while i + 1 < self.tokens.len() {
+            // Left token must be `Name(">")`.
+            let is_gt = {
+                let a = &self.tokens[i];
+                a.type_ == TokenType::Name && a.value == ">"
+            };
+            if !is_gt {
+                i += 1;
+                continue;
+            }
+            // Right token must be `Name(">")` or `Name(">=")`, on the
+            // same line, with no whitespace gap.
+            let (new_value_opt, same_line, no_ws) = {
+                let a = &self.tokens[i];
+                let b = &self.tokens[i + 1];
+                let same_line = a.line == b.line;
+                let no_ws = !self
+                    .whitespace_before_token
+                    .get(i + 1)
+                    .copied()
+                    .unwrap_or(false);
+                let nv: Option<&'static str> = if b.type_ == TokenType::Name {
+                    match b.value.as_str() {
+                        ">" => Some(">>"),
+                        ">=" => Some(">>="),
+                        _ => None,
+                    }
+                } else {
+                    None
+                };
+                (nv, same_line, no_ws)
+            };
+            if let Some(nv) = new_value_opt {
+                if same_line && no_ws {
+                    let span_line = self.tokens[i].line;
+                    let span_col = self.tokens[i].column;
+                    self.tokens.remove(i + 1);
+                    self.whitespace_before_token.remove(i + 1);
+                    self.tokens[i] = Token {
+                        type_: TokenType::Name,
+                        value: nv.to_string(),
+                        line: span_line,
+                        column: span_col,
+                        type_name: None,
+                        flags: None,
+                    };
+                    // Don't advance — three-`>` sequences (e.g. `a>>>b`,
+                    // which is illegal in Ruby anyway) get correctly
+                    // partial-folded on the next iteration.
+                    continue;
+                }
+            }
+            i += 1;
         }
     }
 
@@ -4099,6 +4206,83 @@ mod tests {
         let has_plus = toks.iter().any(|t| t.type_ == TokenType::Plus);
         let has_eq = toks.iter().any(|t| t.type_ == TokenType::Equals);
         assert!(has_plus && has_eq, "expected separate Plus + Equals, got {toks:?}");
+    }
+
+    // Phase 8a-2 (FC) — `>>` and `>>=` pre-fusion.
+
+    #[test]
+    fn right_shift_compound_assign_fuses_into_single_token() {
+        // `x >>= 5` should produce a single `Name(">>=")` token —
+        // not the pre-fusion shape `>`, `>=`.
+        let toks = tokenize_ruby_for_version("x >>= 5", "1.8").unwrap();
+        let has_fused = toks
+            .iter()
+            .any(|t| t.type_ == TokenType::Name && t.value == ">>=");
+        assert!(
+            has_fused,
+            "expected `>>=` Name token after fusion, got {toks:?}"
+        );
+        // And no orphan `>=` left over.
+        let has_orphan_ge = toks
+            .iter()
+            .any(|t| t.type_ == TokenType::Name && t.value == ">=");
+        assert!(
+            !has_orphan_ge,
+            "expected no orphan `>=` after `>>=` fusion, got {toks:?}"
+        );
+    }
+
+    #[test]
+    fn right_shift_binary_operator_fuses_into_single_token() {
+        // `5 >> 3` should produce a single `Name(">>")` — not two
+        // separate `Name(">")` tokens.
+        let toks = tokenize_ruby_for_version("5 >> 3", "1.8").unwrap();
+        let shift_count = toks
+            .iter()
+            .filter(|t| t.type_ == TokenType::Name && t.value == ">>")
+            .count();
+        let bare_gt_count = toks
+            .iter()
+            .filter(|t| t.type_ == TokenType::Name && t.value == ">")
+            .count();
+        assert_eq!(shift_count, 1, "expected exactly one `>>` token in {toks:?}");
+        assert_eq!(bare_gt_count, 0, "expected no bare `>` tokens in {toks:?}");
+    }
+
+    #[test]
+    fn right_shift_fusion_respects_whitespace_gap() {
+        // `5 > > 3` (with a space between the two `>`s) must NOT fuse.
+        let toks = tokenize_ruby_for_version("5 > > 3", "1.8").unwrap();
+        let shift_count = toks
+            .iter()
+            .filter(|t| t.type_ == TokenType::Name && t.value == ">>")
+            .count();
+        let gt_count = toks
+            .iter()
+            .filter(|t| t.type_ == TokenType::Name && t.value == ">")
+            .count();
+        assert_eq!(shift_count, 0, "should NOT fuse across whitespace: {toks:?}");
+        assert_eq!(gt_count, 2, "expected two bare `>` tokens: {toks:?}");
+    }
+
+    #[test]
+    fn right_shift_fusion_leaves_unrelated_ge_alone() {
+        // `a >= b` must stay as a single `Name(">=")` — only the
+        // post-`>` form is folded.
+        let toks = tokenize_ruby_for_version("a >= b", "1.8").unwrap();
+        let ge_count = toks
+            .iter()
+            .filter(|t| t.type_ == TokenType::Name && t.value == ">=")
+            .count();
+        assert_eq!(ge_count, 1, "expected one `>=` token unchanged: {toks:?}");
+        // No spurious `>>=` or `>>` tokens.
+        for forbidden in [">>=", ">>"] {
+            let n = toks
+                .iter()
+                .filter(|t| t.type_ == TokenType::Name && t.value == forbidden)
+                .count();
+            assert_eq!(n, 0, "did not expect `{forbidden}` in {toks:?}");
+        }
     }
 
     #[test]

--- a/code/packages/rust/ruby-parser/.pr-body-fc-8a-2.md
+++ b/code/packages/rust/ruby-parser/.pr-body-fc-8a-2.md
@@ -1,0 +1,52 @@
+## Summary
+
+Phase 8a-2 closes the one remaining compound-assignment deferral from Phase 8a — **`>>=` right-shift compound assign**.  With this PR, Ruby's full compound-assignment family on local variables is supported end-to-end.
+
+## Lexer
+
+The 1.8-baseline state machine emits `>>` as two separate `Name(">")` tokens, and its greedy `>=` classifier folds `>` followed by `=` into `Name(">=")`.  Net effect: `x >>= 5` arrives at the fusion pipeline as `Name("x")`, `Name(">")`, `Name(">=")`, `Number("5")` — *neither* `>>` nor `=` survives intact.
+
+New pre-fusion pass `fuse_right_shifts()` runs immediately before `fuse_compound_assigns()` and restores the right token shapes:
+
+| Incoming pair (adjacent, no whitespace gap) | Folded into     |
+|---------------------------------------------|-----------------|
+| `Name(">")` + `Name(">")`                   | `Name(">>")`    |
+| `Name(">")` + `Name(">=")`                  | `Name(">>=")`   |
+
+Same adjacency gate as the existing compound-assign fusion: same line, no whitespace gap.  `a >= b` stays a single `Name(">=")` (the leading token isn't `>`), and `5 > > 3` (with a space) stays two `Name(">")` tokens.
+
+## Grammar
+
+```ebnf
+assignment = NAME ( EQUALS | "+=" | "-=" | "*=" | "/=" | "%=" | "**=" | "<<=" | ">>=" | "&=" | "|=" | "^=" | "||=" | "&&=" ) expression ;
+```
+
+`_grammar.rs` regenerated via `grammar-tools compile-grammar`.
+
+## Lowering
+
+`lower_assignment` gains one more case arm:
+
+| Source     | SIR shape                                                       |
+|------------|-----------------------------------------------------------------|
+| `x >>= y`  | `Assign(x, BuiltinCall(">>", [VarRef(x, Local), <y>]))` + `Feature::MutableBindings` |
+
+Same convention as `<<=` → `BuiltinCall("<<", ...)`: BuiltinCall name = surface operator string.
+
+## Tests
+
+- `coding-adventures-ruby-lexer`: 169 → **173** (+4 lexer-fusion tests, incl. whitespace regression and unrelated-`>=` regression).
+- `coding-adventures-ruby-parser`: 147 → **149** (+2 grammar tests).
+- `ruby-to-semantic-ir`: 160 → **162** (+2 lowering tests incl. validator E2E).
+
+## Test plan
+
+- [x] `cargo test -p coding-adventures-ruby-lexer` (173/173 pass)
+- [x] `cargo test -p coding-adventures-ruby-parser` (149/149 pass)
+- [x] `cargo test -p ruby-to-semantic-ir` (162/162 pass)
+- [x] Self-reviewed (no I/O, no unsafe — lexer adds one bounded scan-and-fold pass; grammar adds one literal alternative; lowerer adds one match arm)
+- [ ] CI green
+
+Follows PR #4546 (Phase 8a).  Next chunk: Phase 8b (short-circuit op-assign — `||=`, `&&=` already wired but needs the same coverage treatment).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.35.0] - 2026-05-26
+
+### Added (Phase 8a-2 (FC) — `>>=` right-shift compound assign)
+
+`assignment` rule extended with `">>="` alongside the Phase 8a additions:
+
+```ebnf
+assignment = NAME ( EQUALS | "+=" | "-=" | "*=" | "/=" | "%=" | "**=" | "<<=" | ">>=" | "&=" | "|=" | "^=" | "||=" | "&&=" ) expression ;
+```
+
+The lexer's new `fuse_right_shifts()` pass folds `>>=` into a single `Name(">>=")` token before this rule runs, so parsing is mechanical.  Combined with Phase 8a, the parser now accepts Ruby's **complete** compound-assignment family on local variables (no further deferrals).
+
+Regenerated `_grammar.rs` via `grammar-tools compile-grammar`.
+
+### Tests
+
+- `coding-adventures-ruby-parser`: 147 → **149** (+2):
+  - `test_parse_right_shift_op_assign`
+  - `test_parse_left_and_right_shift_op_assigns_round_trip`
+
 ## [0.34.0] - 2026-05-26
 
 ### Added (Phase 8a (FC) — additional arithmetic / bitwise / shift op-assigns)

--- a/code/packages/rust/ruby-parser/src/_grammar.rs
+++ b/code/packages/rust/ruby-parser/src/_grammar.rs
@@ -548,6 +548,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::Literal { value: r#"%="#.to_string() },
                         GrammarElement::Literal { value: r#"**="#.to_string() },
                         GrammarElement::Literal { value: r#"<<="#.to_string() },
+                        GrammarElement::Literal { value: r#">>="#.to_string() },
                         GrammarElement::Literal { value: r#"&="#.to_string() },
                         GrammarElement::Literal { value: r#"|="#.to_string() },
                         GrammarElement::Literal { value: r#"^="#.to_string() },

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -2615,5 +2615,52 @@ mod tests {
         let ast = parse_ruby("x = 5");
         assert!(find_descendant(&ast, "assignment").is_some());
     }
+
+    // -----------------------------------------------------------------------
+    // Phase 8a-2 (FC) — right-shift compound assign `>>=`.
+    //
+    // The lexer now pre-fuses `>>` and `>>=` into single Name tokens,
+    // so the parser's `assignment` rule accepts `>>=` the same way it
+    // already accepts `<<=`.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_right_shift_op_assign() {
+        let ast = parse_ruby("x >>= 1");
+        let a = find_descendant(&ast, "assignment").expect("expected assignment");
+        let has_op = a.children.iter().any(|c| {
+            matches!(c, ASTNodeOrToken::Token(t) if t.value == ">>=")
+        });
+        assert!(has_op, "expected `>>=` token under assignment");
+    }
+
+    #[test]
+    fn test_parse_left_and_right_shift_op_assigns_round_trip() {
+        // Two statements, `x <<= 1` and `x >>= 1`, each parses to a
+        // separate assignment with its respective fused operator token.
+        let ast = parse_ruby("x <<= 1\nx >>= 1");
+        let stmts: Vec<&GrammarASTNode> = ast
+            .children
+            .iter()
+            .filter_map(|c| match c {
+                ASTNodeOrToken::Node(n) if n.rule_name == "statement" => Some(n),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(stmts.len(), 2);
+        let ops: Vec<String> = stmts
+            .iter()
+            .filter_map(|s| {
+                let a = find_descendant(s, "assignment")?;
+                a.children.iter().find_map(|c| match c {
+                    ASTNodeOrToken::Token(t) if t.value == "<<=" || t.value == ">>=" => {
+                        Some(t.value.clone())
+                    }
+                    _ => None,
+                })
+            })
+            .collect();
+        assert_eq!(ops, vec!["<<=".to_string(), ">>=".to_string()]);
+    }
 }
 

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.35.0] - 2026-05-26
+
+### Added (Phase 8a-2 (FC) — `>>=` right-shift compound-assign lowering)
+
+`lower_assignment` gains one more case arm — `">>="` maps to `BuiltinCall(">>", ...)` with the same `Stmt::Assign` + `Feature::MutableBindings` shape as the rest of the compound-assign family.
+
+| Source     | SIR shape                                                       |
+|------------|-----------------------------------------------------------------|
+| `x >>= y`  | `Assign(x, BuiltinCall(">>", [VarRef(x, Local), <y>]))` + `Feature::MutableBindings` |
+
+Combined with Phase 8a, Ruby's complete compound-assignment family on local variables is now fully lowered to first-class SIR.
+
+### Tests
+
+- `ruby-to-semantic-ir`: 160 → **162** (+2):
+  - `right_shift_assign_desugars_to_assign_with_rshift_builtin`
+  - `right_shift_assign_module_passes_sir_validator` (E2E smoke)
+
 ## [0.34.0] - 2026-05-26
 
 ### Added (Phase 8a (FC) — additional compound-assignment lowering)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -3416,4 +3416,44 @@ puts("hi #{name}")
             result
         );
     }
+
+    // -----------------------------------------------------------------
+    // Phase 8a-2 (FC) — right-shift compound assign `>>=`.
+    //
+    // The lexer now folds `>>` and `>>=` into single Name tokens,
+    // the grammar accepts `>>=` in the assignment rule's alternation,
+    // and the lowerer routes it through the same desugar path as
+    // `<<=`: `x >>= y` → `x = x >> y` → `Assign(x, BuiltinCall(">>",
+    // [VarRef(x), y]))`.
+    //
+    // Two tests below: shape assertion and validator E2E smoke.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn right_shift_assign_desugars_to_assign_with_rshift_builtin() {
+        let m = lower("x = 16\nx >>= 2\n");
+        let b = main_body(&m);
+        match &b.stmts[1] {
+            Stmt::Assign { value: Expr::BuiltinCall { name, args, .. }, .. } => {
+                assert_eq!(name, ">>");
+                assert_eq!(args.len(), 2);
+                assert!(matches!(&args[0], Expr::VarRef { name, .. } if name == "x"));
+                assert!(matches!(&args[1], Expr::IntLit { value: 2, .. }));
+            }
+            other => panic!("expected Assign(BuiltinCall(>>)), got {:?}", other),
+        }
+        assert!(m.manifest.contains(semantic_ir::Feature::MutableBindings));
+    }
+
+    #[test]
+    fn right_shift_assign_module_passes_sir_validator() {
+        // End-to-end smoke pairing left- and right-shift compounds.
+        let m = lower("x = 1\nx <<= 4\nx >>= 2\nputs(x)\n");
+        let result = semantic_ir::validate(&m);
+        assert!(
+            result.is_ok(),
+            "validator rejected shift-assign module: {:?}",
+            result
+        );
+    }
 }

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -1749,6 +1749,7 @@ impl Lowerer {
                         | "%="
                         | "**="
                         | "<<="
+                        | ">>="
                         | "&="
                         | "|="
                         | "^="
@@ -1793,6 +1794,7 @@ impl Lowerer {
                 "%=" => ("%", EffectSet::PURE),
                 "**=" => ("**", EffectSet::PURE),
                 "<<=" => ("<<", EffectSet::PURE),
+                ">>=" => (">>", EffectSet::PURE),
                 "&=" => ("&", EffectSet::PURE),
                 "|=" => ("|", EffectSet::PURE),
                 "^=" => ("^", EffectSet::PURE),


### PR DESCRIPTION
## Summary

Phase 8a-2 closes the one remaining compound-assignment deferral from Phase 8a — **`>>=` right-shift compound assign**.  With this PR, Ruby's full compound-assignment family on local variables is supported end-to-end.

## Lexer

The 1.8-baseline state machine emits `>>` as two separate `Name(">")` tokens, and its greedy `>=` classifier folds `>` followed by `=` into `Name(">=")`.  Net effect: `x >>= 5` arrives at the fusion pipeline as `Name("x")`, `Name(">")`, `Name(">=")`, `Number("5")` — *neither* `>>` nor `=` survives intact.

New pre-fusion pass `fuse_right_shifts()` runs immediately before `fuse_compound_assigns()` and restores the right token shapes:

| Incoming pair (adjacent, no whitespace gap) | Folded into     |
|---------------------------------------------|-----------------|
| `Name(">")` + `Name(">")`                   | `Name(">>")`    |
| `Name(">")` + `Name(">=")`                  | `Name(">>=")`   |

Same adjacency gate as the existing compound-assign fusion: same line, no whitespace gap.  `a >= b` stays a single `Name(">=")` (the leading token isn't `>`), and `5 > > 3` (with a space) stays two `Name(">")` tokens.

## Grammar

```ebnf
assignment = NAME ( EQUALS | "+=" | "-=" | "*=" | "/=" | "%=" | "**=" | "<<=" | ">>=" | "&=" | "|=" | "^=" | "||=" | "&&=" ) expression ;
```

`_grammar.rs` regenerated via `grammar-tools compile-grammar`.

## Lowering

`lower_assignment` gains one more case arm:

| Source     | SIR shape                                                       |
|------------|-----------------------------------------------------------------|
| `x >>= y`  | `Assign(x, BuiltinCall(">>", [VarRef(x, Local), <y>]))` + `Feature::MutableBindings` |

Same convention as `<<=` → `BuiltinCall("<<", ...)`: BuiltinCall name = surface operator string.

## Tests

- `coding-adventures-ruby-lexer`: 169 → **173** (+4 lexer-fusion tests, incl. whitespace regression and unrelated-`>=` regression).
- `coding-adventures-ruby-parser`: 147 → **149** (+2 grammar tests).
- `ruby-to-semantic-ir`: 160 → **162** (+2 lowering tests incl. validator E2E).

## Test plan

- [x] `cargo test -p coding-adventures-ruby-lexer` (173/173 pass)
- [x] `cargo test -p coding-adventures-ruby-parser` (149/149 pass)
- [x] `cargo test -p ruby-to-semantic-ir` (162/162 pass)
- [x] Self-reviewed (no I/O, no unsafe — lexer adds one bounded scan-and-fold pass; grammar adds one literal alternative; lowerer adds one match arm)
- [ ] CI green

Follows PR #4546 (Phase 8a).  Next chunk: Phase 8b (short-circuit op-assign — `||=`, `&&=` already wired but needs the same coverage treatment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
