### PR TITLE
feat(cas-summation): Phase 86 port — generic log × sqrt × poly recogniser (TS + Rust, 2.23.0)

### DIFF
--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## 2.23.0 — 2026-05-28
+
+### Added — Phase 86 cleanup (generic log × sqrt × polynomial recogniser)
+
+Mirrors the Python `2.23.0` cleanup: a single generic helper supersedes the
+hand-written grid of `N-Sqrt × M-Log × polynomial` recognisers (Phases 59-85).
+The convergence math is identical for every non-negative `(N, M, K)`:
+
+- The product of `N` `Log(diverging)` factors is sub-polynomial
+  (`log^N(k) = o(k^ε)`), so `N` contributes 0 to the effective growth degree.
+- Each `Sqrt(P_i)` contributes `deg(P_i)/2` (recorded ×2 for integer arithmetic).
+- Each polynomial factor `Q_j` contributes its own `deg(Q_j)` (×2 here).
+- Bounded factors contribute 0.
+
+`log_sqrt_poly_effective_x2_generic(node, k)` returns
+`Σ sqrt_inner_deg_x2 + 2·Σ poly_deg` when the numerator matches; the dispatcher
+in `g_vanishes_at_infinity` inserts this branch between Phase 58 and Phase 59
+so it preempts the entire grid for every shape the grid was meant to cover
+(and many it wasn't — e.g. seven `Log` factors, six `Sqrt` factors, arbitrary
+mixes).
+
+The hand-written grid helpers (`two_sqrt_poly_effective_x2`,
+`five_log_poly_effective_x2`, …) remain in place for now but are now dead
+code; a follow-up cleanup PR will delete them.
+
+6 new integration tests in `tests/tests.rs`:
+
+- `phase86_seven_log_over_k2_closes_via_generic` (grid stops at 6).
+- `phase86_six_sqrt_k_over_k4_closes_via_generic` (grid stops at 5).
+- `phase86_three_sqrt_seven_log_poly_closes_via_generic` (mixed; outside grid).
+- `phase86_unrecognised_exp_refused` (must not silently close a divergent sum).
+- `phase86_sqrt_negative_refused` (complex-valued — refuse).
+- `phase86_pure_bounded_falls_through_to_phase49` (regression: generic
+  returns `None` so Phase 49 takes over).
+
 ## 2.22.0 — 2026-05-26
 
 ### Added

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "2.22.0"
+version = "2.23.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -1331,6 +1331,90 @@ fn bounded_log_poly_degree(node: &IRNode, k: &IRNode) -> Option<i64> {
     Some(poly_deg)
 }
 
+/// Return `Σ sqrt_inner_deg_x2 + 2·Σ poly_deg` when `node` is a `Mul` whose
+/// factors split into any combination of:
+///
+/// * `Log(diverging)` factors (any count, including zero),
+/// * `Sqrt(positive-leading polynomial)` factors (any count),
+/// * polynomial factors in `k` (any count),
+/// * bounded-in-`k` factors (any count, e.g. `Sin`, `Cos`, constants),
+///
+/// and at least one of the Log/Sqrt/polynomial factors is present.  Returns
+/// `None` when any factor is unrecognised (e.g. `Exp(k)`) or when the
+/// numerator is purely bounded.
+///
+/// **Phase 86 — cleanup.**  Supersedes the hand-written grid of
+/// `N-Sqrt × M-Log × polynomial` helpers from Phases 59-85.  The convergence
+/// math is identical for every non-negative `(N, M)` pair:
+///
+/// * Product of `N` `Log(diverging)` factors is sub-polynomial —
+///   `log^N(k) = o(k^ε)` for any `ε > 0` — so `N` contributes 0 to the
+///   effective growth degree.
+/// * Each `Sqrt(P_i)` contributes `deg(P_i)/2` (recorded ×2 to stay in
+///   integer arithmetic).
+/// * Each polynomial factor `Q_j` contributes its own `deg(Q_j)`
+///   (multiplied ×2 here).
+/// * Bounded factors contribute 0.
+///
+/// Effective growth ×2:
+///
+/// ```text
+/// effective_x2 = sum_i sqrt_inner_deg_x2(Sqrt(P_i))
+///              + 2 * sum_j deg(Q_j)
+/// ```
+///
+/// The caller compares `2 * den_deg > effective_x2` (polynomial denominator)
+/// or short-circuits on non-polynomial diverging denominator.
+///
+/// Conservative refusals:
+///
+/// * Empty `Mul` (no recognised growth factor) → `None`.
+/// * `Sqrt` of a polynomial whose leading coefficient is negative → `None`.
+/// * Any unrecognised factor (Exp, free symbol, …) → `None`.
+fn log_sqrt_poly_effective_x2_generic(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let apply_node = match node {
+        IRNode::Apply(a) => a,
+        _ => return None,
+    };
+    if !head_is(&apply_node.head, MUL) {
+        return None;
+    }
+    let mut sqrt_inner_deg_x2_sum: i64 = 0;
+    let mut poly_deg_sum: i64 = 0;
+    let mut found_log = false;
+    let mut found_sqrt = false;
+    let mut found_poly = false;
+    for arg in &apply_node.args {
+        if is_log_of_diverging_in_k(arg, k) {
+            found_log = true;
+            continue;
+        }
+        if let Some(sqrt_deg_x2) = sqrt_effective_half_degree_x2(arg, k) {
+            sqrt_inner_deg_x2_sum += sqrt_deg_x2;
+            found_sqrt = true;
+            continue;
+        }
+        if is_bounded_in_k(arg, k) {
+            // Constants and Sin/Cos/closures — contribute nothing.
+            continue;
+        }
+        if let Some(poly_deg) = polynomial_degree_in_k(arg, k) {
+            if poly_deg >= 1 {
+                poly_deg_sum += poly_deg;
+                found_poly = true;
+                continue;
+            }
+        }
+        // Unrecognised factor (Exp, free symbol, …) — bail.
+        return None;
+    }
+    if !found_log && !found_sqrt && !found_poly {
+        // Pure-bounded numerator — let Phase 49 handle it.
+        return None;
+    }
+    Some(sqrt_inner_deg_x2_sum + 2 * poly_deg_sum)
+}
+
 /// Return `sqrt_inner_deg + 2 * poly_deg` when `node` is a `Mul` with
 /// exactly one `Sqrt(positive-leading polynomial P)` factor, any polynomial
 /// factors (total degree `poly_deg`), and any number of bounded factors in
@@ -2402,6 +2486,33 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     if let Some(blp_deg) = bounded_log_poly_degree(num, k) {
         if let Some(den_deg_blp) = polynomial_degree_in_k(den, k) {
             if den_deg_blp > blp_deg {
+                return true;
+            }
+        } else if h_diverges_at_infinity(den, k) {
+            return true;
+        }
+    }
+    // ---- Generic recogniser (Phase 86 cleanup) ----
+    //
+    // `Mul(bounded..., Log_1, ..., Log_N, Sqrt_1, ..., Sqrt_M, Poly_1, ..., Poly_K)`
+    // over diverging denominator.  The product of any number of
+    // `Log(diverging)` factors is still sub-polynomial
+    // (`log^N(k) = o(k^ε)`), so `N` drops out of the comparison.  The Sqrt
+    // factors contribute `Σ deg(P_i)/2` and the polynomial factors
+    // contribute `Σ deg(Q_j)`.  Effective ×2:
+    //
+    //     effective_x2 = Σ sqrt_inner_deg_x2 + 2·Σ poly_deg
+    //
+    // Vanishes when `2·den_deg > effective_x2` (polynomial denominator) or
+    // short-circuits on non-polynomial diverging denominator.
+    //
+    // Supersedes the hand-written grid of `N-Sqrt × M-Log × polynomial`
+    // helpers (Phases 59-85): the math is identical for every (N, M) ≥ (0, 0).
+    // The hardcoded helpers remain in place for now but are preempted by
+    // this branch; a follow-up cleanup PR will delete them.
+    if let Some(gen_x2) = log_sqrt_poly_effective_x2_generic(num, k) {
+        if let Some(den_deg_gen) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_gen > gen_x2 {
                 return true;
             }
         } else if h_diverges_at_infinity(den, k) {

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -3444,3 +3444,172 @@ fn phase85_two_sqrt_k_log6_k_times_k_over_k2_refused() {
     let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
     assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }
+
+// ---------------------------------------------------------------------------
+// Phase 86 (Rust port): generic log × sqrt × polynomial recogniser cleanup.
+//
+// A single generic helper supersedes the hand-written grid of Phases 59-85.
+// These tests prove it handles cases the grid cannot (>5 Sqrts, >6 Logs,
+// mixed shapes) and that it refuses unrecognised factors so divergent sums
+// stay unevaluated.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase86_seven_log_over_k2_closes_via_generic() {
+    // log(k)^7 / k²: log^7 sub-polynomial, effective_x2=0, 2·2=4 > 0 → closes.
+    // The hand-written grid stops at 6 logs.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let num_k = apply(sym(MUL), vec![
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k,
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1,
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase86_six_sqrt_k_over_k4_closes_via_generic() {
+    // √k × 6 over k⁴: effective_x2 = 6·1 = 6, 2·4=8 > 6 → closes.
+    // The hand-written grid stops at 5 Sqrt factors.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let k4 = apply(sym(POW), vec![k.clone(), int(4)]);
+    let kp1_4 = apply(sym(POW), vec![kp1.clone(), int(4)]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(),
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(),
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k4]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_4]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase86_three_sqrt_seven_log_poly_closes_via_generic() {
+    // sin(k)·log(k)^7·√(k³)·√k·√(k²)·k / k⁵:
+    //   sqrt_x2 sum = 3+1+2 = 6, poly_deg sum = 1, effective_x2 = 6 + 2 = 8,
+    //   2·5 = 10 > 8 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let k5 = apply(sym(POW), vec![k.clone(), int(5)]);
+    let kp1_5 = apply(sym(POW), vec![kp1.clone(), int(5)]);
+    let sqrt_k3 = apply(sym("Sqrt"), vec![k3]);
+    let sqrt_kp1_3 = apply(sym("Sqrt"), vec![kp1_3]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let sqrt_k2 = apply(sym("Sqrt"), vec![k2]);
+    let sqrt_kp1_2 = apply(sym("Sqrt"), vec![kp1_2]);
+    let sin_k = apply(sym("Sin"), vec![k.clone()]);
+    let sin_kp1 = apply(sym("Sin"), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sin_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k,
+        sqrt_k3, sqrt_k, sqrt_k2,
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sin_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1,
+        sqrt_kp1_3, sqrt_kp1, sqrt_kp1_2,
+        kp1.clone(),
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k5]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_5]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase86_unrecognised_exp_refused() {
+    // log(k)·√k·exp(k) / k³: exp grows exponentially → divergent.
+    // Generic must refuse so sum stays unevaluated.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let exp_k = apply(sym(EXP), vec![k.clone()]);
+    let exp_kp1 = apply(sym(EXP), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let num_k = apply(sym(MUL), vec![log_k, sqrt_k, exp_k]);
+    let num_kp1 = apply(sym(MUL), vec![log_kp1, sqrt_kp1, exp_kp1]);
+    let g_k = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase86_sqrt_negative_refused() {
+    // log(k)·√(-k) / k³: Sqrt of negative-leading polynomial → refuse.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let neg_k = apply(sym(MUL), vec![int(-1), k.clone()]);
+    let neg_kp1 = apply(sym(MUL), vec![int(-1), kp1.clone()]);
+    let sqrt_neg_k = apply(sym("Sqrt"), vec![neg_k]);
+    let sqrt_neg_kp1 = apply(sym("Sqrt"), vec![neg_kp1]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let num_k = apply(sym(MUL), vec![log_k, sqrt_neg_k]);
+    let num_kp1 = apply(sym(MUL), vec![log_kp1, sqrt_neg_kp1]);
+    let g_k = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase86_pure_bounded_falls_through_to_phase49() {
+    // sin(k)·cos(k) / k²: no Log / Sqrt / polynomial growth factor.
+    // Generic returns None → Phase 49 (bounded × diverging) handles it; sum closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sin_k = apply(sym("Sin"), vec![k.clone()]);
+    let sin_kp1 = apply(sym("Sin"), vec![kp1.clone()]);
+    let cos_k = apply(sym("Cos"), vec![k.clone()]);
+    let cos_kp1 = apply(sym("Cos"), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let num_k = apply(sym(MUL), vec![sin_k, cos_k]);
+    let num_kp1 = apply(sym(MUL), vec![sin_kp1, cos_kp1]);
+    let g_k = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## 2.23.0 — 2026-05-28
+
+### Added — Phase 86 cleanup (generic log × sqrt × polynomial recogniser)
+
+Mirrors the Python `2.23.0` cleanup: a single generic helper supersedes the
+hand-written grid of `N-Sqrt × M-Log × polynomial` recognisers (Phases 59-85).
+The convergence math is identical for every non-negative `(N, M, K)`:
+
+- The product of `N` `Log(diverging)` factors is sub-polynomial
+  (`log^N(k) = o(k^ε)`), so `N` contributes 0 to the effective growth degree.
+- Each `Sqrt(P_i)` contributes `deg(P_i)/2`.
+- Each polynomial factor `Q_j` contributes its own `deg(Q_j)`.
+- Bounded factors contribute 0.
+
+`logSqrtPolyEffectiveDegGeneric(node, k)` returns `Σ sqrtHalfDeg + Σ polyDeg`
+when the numerator matches; the dispatcher in `gVanishesAtInfinity` inserts
+this branch between Phase 58 and Phase 59 so it preempts the entire grid for
+every shape the grid was meant to cover (and many it wasn't — e.g. seven
+`Log` factors, six `Sqrt` factors, arbitrary mixes).
+
+The hand-written grid helpers (`twoSqrtPolyEffectiveDeg`, `fiveLogPolyEffectiveDeg`,
+…) remain in place for now but are now dead code; a follow-up cleanup PR will
+delete them.
+
+6 new tests in the "Phase 86 generic" describe block:
+
+- `seven logs over k²` (grid stops at 6 — generic handles it).
+- `six sqrts of k over k⁴` (grid stops at 5 — generic handles it).
+- `three sqrts × seven logs × k over k⁵` (mixed; outside the grid).
+- `refuses unrecognised factor (Exp)` (must not silently close a divergent sum).
+- `refuses Sqrt of negative polynomial` (complex-valued — refuse).
+- `pure bounded falls through to Phase 49` (regression — generic returns
+  undefined so Phase 49 takes over).
+
 ## 2.22.0 — 2026-05-26
 
 ### Added

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "2.22.0",
+  "version": "2.23.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -1028,6 +1028,85 @@ function boundedLogPolyDegree(node: IRNode, k: IRNode): number | undefined {
 }
 
 /**
+ * Return ``Σ sqrtHalfDeg + Σ polyDeg`` when ``node`` is a ``Mul`` whose
+ * factors split into any combination of:
+ *
+ *   - ``Log(diverging)`` factors (any count, including zero),
+ *   - ``Sqrt(positive-leading polynomial)`` factors (any count),
+ *   - polynomial factors in ``k`` (any count),
+ *   - bounded-in-``k`` factors (any count, e.g. ``Sin``, ``Cos``, constants),
+ *
+ * and at least one of the Log/Sqrt/polynomial factors is present.  Returns
+ * ``undefined`` when any factor is unrecognised (e.g. ``Exp(k)``) or when
+ * the numerator is purely bounded.
+ *
+ * **Phase 86 — cleanup.**  Supersedes the hand-written grid of
+ * ``N-Sqrt × M-Log × polynomial`` helpers (Phases 59-85).  The convergence
+ * math is identical for every non-negative ``(N, M)`` pair:
+ *
+ *   - The product of ``N`` ``Log(diverging)`` factors is sub-polynomial —
+ *     ``log^N(k) = o(k^ε)`` for any ``ε > 0`` — so ``N`` contributes ``0``
+ *     to the effective growth degree.
+ *   - Each ``Sqrt(P_i)`` contributes ``deg(P_i)/2`` (here as a fractional
+ *     half-degree, matching the existing TS-port convention).
+ *   - Each polynomial factor ``Q_j`` contributes its own ``deg(Q_j)``.
+ *   - Bounded factors contribute ``0``.
+ *
+ * Effective growth:
+ *
+ *   effective = Σ_i sqrtHalfDeg(Sqrt(P_i)) + Σ_j deg(Q_j)
+ *
+ * Caller compares ``denDeg > effective`` (polynomial denominator) or
+ * short-circuits on non-polynomial diverging denominator.
+ *
+ * Conservative refusals:
+ *
+ *   - Empty ``Mul`` (no recognised growth factor) → undefined.
+ *   - ``Sqrt`` of a polynomial whose leading coefficient is negative → undefined.
+ *   - Any unrecognised factor (Exp, free symbol, …) → undefined.
+ */
+function logSqrtPolyEffectiveDegGeneric(
+  node: IRNode,
+  k: IRNode,
+): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  let sqrtHalfDegSum = 0;
+  let polyDegSum = 0;
+  let foundLog = false;
+  let foundSqrt = false;
+  let foundPoly = false;
+  for (const arg of node.args) {
+    if (isLogOfDivergingInK(arg, k)) {
+      foundLog = true;
+      continue;
+    }
+    const sqrtHalfDeg = sqrtEffectiveHalfDegree(arg, k);
+    if (sqrtHalfDeg !== undefined) {
+      sqrtHalfDegSum += sqrtHalfDeg;
+      foundSqrt = true;
+      continue;
+    }
+    if (isBoundedInK(arg, k)) {
+      // Constants and Sin/Cos/closures — contribute nothing.
+      continue;
+    }
+    const polyDeg = polynomialDegreeInK(arg, k);
+    if (polyDeg !== undefined && polyDeg >= 1) {
+      polyDegSum += polyDeg;
+      foundPoly = true;
+      continue;
+    }
+    // Unrecognised factor (Exp, free symbol, …) — bail.
+    return undefined;
+  }
+  if (!foundLog && !foundSqrt && !foundPoly) {
+    // Pure-bounded numerator — let Phase 49 handle it.
+    return undefined;
+  }
+  return sqrtHalfDegSum + polyDegSum;
+}
+
+/**
  * Return ``sqrtHalfDeg + polyDeg`` when ``node`` is a ``Mul`` with
  * exactly one ``Sqrt(positive-leading polynomial P)`` factor, any polynomial
  * factors (total degree ``polyDeg``), and any number of bounded factors;
@@ -2184,6 +2263,35 @@ function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
     const denDegBlp = polynomialDegreeInK(den, k);
     if (denDegBlp !== undefined) {
       if (denDegBlp > blpDeg) {
+        return true;
+      }
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // ---- Generic recogniser (Phase 86 cleanup) ----
+  //
+  // Mul(bounded..., Log_1, ..., Log_N, Sqrt_1, ..., Sqrt_M, Poly_1, ..., Poly_K)
+  // over diverging denominator: the product of any number of
+  // ``Log(diverging)`` factors is still sub-polynomial
+  // (``log^N(k) = o(k^ε)``), so ``N`` drops out of the comparison.  The
+  // Sqrt factors contribute ``Σ deg(P_i)/2`` and the polynomial factors
+  // contribute ``Σ deg(Q_j)``.  Effective:
+  //
+  //   effective = Σ sqrtHalfDeg + Σ polyDeg
+  //
+  // Vanishes when ``denDeg > effective``; non-polynomial diverging
+  // denominators dominate automatically.
+  //
+  // Supersedes the hand-written grid of ``N-Sqrt × M-Log × polynomial``
+  // helpers (Phases 59-85): the math is identical for every (N, M) ≥ (0, 0).
+  // The hardcoded helpers remain in place for now but are preempted by this
+  // branch; a follow-up cleanup PR will delete them.
+  const genDeg = logSqrtPolyEffectiveDegGeneric(num, k);
+  if (genDeg !== undefined) {
+    const denDegGen = polynomialDegreeInK(den, k);
+    if (denDegGen !== undefined) {
+      if (denDegGen > genDeg) {
         return true;
       }
     } else if (hDivergesAtInfinity(den, k)) {

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -3793,3 +3793,116 @@ describe("Phase 85 — Two-Sqrt × Six-Log × polynomial numerator", () => {
     expect(result).toMatchObject({ kind: "apply", head: SUM });
   });
 });
+
+// ---------------------------------------------------------------------------
+// Phase 86 (TS port): generic log × sqrt × polynomial recogniser cleanup.
+//
+// A single helper handles arbitrary (N, M, K) — supersedes the hand-written
+// grid from Phases 59-85.  These tests prove the generic closes cases the
+// hardcoded grid cannot reach (more than 5 Sqrts, more than 6 Logs, mixed).
+// ---------------------------------------------------------------------------
+
+describe("summation: Phase 86 generic log × sqrt × polynomial recogniser", () => {
+  it("seven logs over k² closes via generic (hand-written grid stops at 6)", () => {
+    const k = sym("k");
+    const kp1 = app(ADD, [k, int(1)]);
+    const logsK = Array.from({ length: 7 }, () => app(LOG, [k]));
+    const logsKp1 = Array.from({ length: 7 }, () => app(LOG, [kp1]));
+    const numK = app(MUL, logsK);
+    const numKp1 = app(MUL, logsKp1);
+    const gK = app(DIV, [numK, app(POW, [k, int(2)])]);
+    const gKp1 = app(DIV, [numKp1, app(POW, [kp1, int(2)])]);
+    const f = app(SUB, [gK, gKp1]);
+    const result = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(result.kind === "apply" ? result.head : undefined).not.toEqual(SUM);
+  });
+
+  it("six sqrts of k over k⁴ closes via generic (grid stops at 5)", () => {
+    const k = sym("k");
+    const kp1 = app(ADD, [k, int(1)]);
+    const sqrtsK = Array.from({ length: 6 }, () => app(SQRT, [k]));
+    const sqrtsKp1 = Array.from({ length: 6 }, () => app(SQRT, [kp1]));
+    const numK = app(MUL, sqrtsK);
+    const numKp1 = app(MUL, sqrtsKp1);
+    const gK = app(DIV, [numK, app(POW, [k, int(4)])]);
+    const gKp1 = app(DIV, [numKp1, app(POW, [kp1, int(4)])]);
+    const f = app(SUB, [gK, gKp1]);
+    const result = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    // sqrtHalfSum = 6 * 0.5 = 3; denDeg = 4 > 3 → closes.
+    expect(result.kind === "apply" ? result.head : undefined).not.toEqual(SUM);
+  });
+
+  it("three sqrts × seven logs × k over k⁵ closes via generic", () => {
+    const k = sym("k");
+    const kp1 = app(ADD, [k, int(1)]);
+    const logsK = Array.from({ length: 7 }, () => app(LOG, [k]));
+    const logsKp1 = Array.from({ length: 7 }, () => app(LOG, [kp1]));
+    const sqrtFactorsK = [
+      app(SQRT, [app(POW, [k, int(3)])]),
+      app(SQRT, [k]),
+      app(SQRT, [app(POW, [k, int(2)])]),
+    ];
+    const sqrtFactorsKp1 = [
+      app(SQRT, [app(POW, [kp1, int(3)])]),
+      app(SQRT, [kp1]),
+      app(SQRT, [app(POW, [kp1, int(2)])]),
+    ];
+    const numK = app(MUL, [app(sym("Sin"), [k]), ...logsK, ...sqrtFactorsK, k]);
+    const numKp1 = app(MUL, [
+      app(sym("Sin"), [kp1]),
+      ...logsKp1,
+      ...sqrtFactorsKp1,
+      kp1,
+    ]);
+    const gK = app(DIV, [numK, app(POW, [k, int(5)])]);
+    const gKp1 = app(DIV, [numKp1, app(POW, [kp1, int(5)])]);
+    const f = app(SUB, [gK, gKp1]);
+    const result = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    // sqrtHalfSum = 1.5 + 0.5 + 1 = 3, polyDegSum = 1, effective = 4, denDeg = 5 → closes.
+    expect(result.kind === "apply" ? result.head : undefined).not.toEqual(SUM);
+  });
+
+  it("refuses unrecognised factor (Exp) so divergent sum stays unevaluated", () => {
+    const k = sym("k");
+    const kp1 = app(ADD, [k, int(1)]);
+    const numK = app(MUL, [app(LOG, [k]), app(SQRT, [k]), app(EXP, [k])]);
+    const numKp1 = app(MUL, [
+      app(LOG, [kp1]),
+      app(SQRT, [kp1]),
+      app(EXP, [kp1]),
+    ]);
+    const gK = app(DIV, [numK, app(POW, [k, int(3)])]);
+    const gKp1 = app(DIV, [numKp1, app(POW, [kp1, int(3)])]);
+    const f = app(SUB, [gK, gKp1]);
+    const result = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    // exp(k)·log(k)·sqrt(k) grows exponentially → must NOT vanish.
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("refuses Sqrt of negative polynomial (complex-valued)", () => {
+    const k = sym("k");
+    const kp1 = app(ADD, [k, int(1)]);
+    const negK = app(MUL, [int(-1), k]);
+    const negKp1 = app(MUL, [int(-1), kp1]);
+    const numK = app(MUL, [app(LOG, [k]), app(SQRT, [negK])]);
+    const numKp1 = app(MUL, [app(LOG, [kp1]), app(SQRT, [negKp1])]);
+    const gK = app(DIV, [numK, app(POW, [k, int(3)])]);
+    const gKp1 = app(DIV, [numKp1, app(POW, [kp1, int(3)])]);
+    const f = app(SUB, [gK, gKp1]);
+    const result = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("pure bounded falls through to Phase 49 (sum still closes)", () => {
+    const k = sym("k");
+    const kp1 = app(ADD, [k, int(1)]);
+    const numK = app(MUL, [app(sym("Sin"), [k]), app(sym("Cos"), [k])]);
+    const numKp1 = app(MUL, [app(sym("Sin"), [kp1]), app(sym("Cos"), [kp1])]);
+    const gK = app(DIV, [numK, app(POW, [k, int(2)])]);
+    const gKp1 = app(DIV, [numKp1, app(POW, [kp1, int(2)])]);
+    const f = app(SUB, [gK, gKp1]);
+    const result = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    // Phase 49 (bounded × diverging) catches it — generic returns undefined.
+    expect(result.kind === "apply" ? result.head : undefined).not.toEqual(SUM);
+  });
+});


### PR DESCRIPTION
## Summary

**Track A1** of [`code/specs/macsyma-finish-plan.md`](../blob/main/code/specs/macsyma-finish-plan.md): port the Phase 86 generic recogniser cleanup (Python PR #4545) to TypeScript and Rust.

A single generic helper supersedes the hand-written grid of `N-Sqrt × M-Log × polynomial` recognisers (Phases 59–85 ports). The hardcoded grid helpers remain in place for now but are preempted by the new branch in the `gVanishesAtInfinity` / `g_vanishes_at_infinity` dispatcher; Track A2 will delete them.

### Math (identical for every non-negative N, M, K)

- `log^N(k) = o(k^ε)` for any `ε > 0`, so `N` contributes 0.
- Each `Sqrt(P_i)` contributes `deg(P_i) / 2`.
- Each polynomial factor `Q_j` contributes `deg(Q_j)`.
- Bounded factors contribute 0.

### Per-language naming

- TS: `logSqrtPolyEffectiveDegGeneric` — returns `Σ sqrtHalfDeg + Σ polyDeg` (fractional, matching TS-port convention).
- Rust: `log_sqrt_poly_effective_x2_generic` — returns `Σ sqrt_inner_deg_x2 + 2·Σ poly_deg` (×2 integer arithmetic, matching Rust-port convention).

### Tests

- **TypeScript**: 179 passed (was 173) — 6 new in the "Phase 86 generic" `describe` block.
- **Rust**: 162 passed integration tests (was 156) — 6 new `phase86_*` tests.

Each language gets the same 6 tests:

1. 7 logs over k² — closes via generic (grid stops at 6).
2. 6 sqrts of k over k⁴ — closes via generic (grid stops at 5).
3. 3 sqrts × 7 logs × k over k⁵ — mixed shape; outside the grid.
4. Refuses unrecognised factor (`Exp`) — must not silently close a divergent sum.
5. Refuses `Sqrt` of negative polynomial (complex-valued).
6. Pure-bounded falls through to Phase 49 (regression).

### Version bumps

- `@coding-adventures/cas-summation` 2.22.0 → 2.23.0
- `cas-summation` (Rust crate) 2.22.0 → 2.23.0

## Test plan

- [x] `npm test` in `code/packages/typescript/cas-summation/` → 179 passed
- [x] `cargo test` in `code/packages/rust/cas-summation/` → 162 passed + 0 doctests
- [x] Security review (sub-agent) — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)