### PR TITLE
feat(ruby-to-semantic-ir): Phase 8b (FC) — short-circuit `||=` / `&&=` lowering

### DIFF
--- a/code/packages/rust/ruby-parser/.pr-body-fc-8b.md
+++ b/code/packages/rust/ruby-parser/.pr-body-fc-8b.md
@@ -1,0 +1,61 @@
+## Summary
+
+Phase 8b fixes a long-standing semantic bug in `||=` and `&&=` lowering: the Phase 6p implementation **eagerly evaluated the RHS** even when the short-circuit branch should have skipped it.
+
+Ruby's documented semantics:
+
+```ruby
+x ||= y   # ≡  x || (x = y)    — if x is truthy, y is NEVER evaluated and x is NEVER re-assigned
+x &&= y   # ≡  x && (x = y)    — if x is falsy,  y is NEVER evaluated and x is NEVER re-assigned
+```
+
+The old SIR shape was `Stmt::Assign(x, Expr::BuiltinCall("or", [VarRef(x), <y>]))` — eager argument evaluation means `y`'s side effects fire whether or not `x` was truthy.  Silently wrong any time `y` has side effects or `x` already has a meaningful value.
+
+## Lowering — new SIR shape
+
+`lower_assignment` now intercepts `||=` and `&&=` **before** the generic compound-assign `BuiltinCall` dispatch and emits a gated `Expr::If`:
+
+| Source     | SIR shape                                                                          |
+|------------|------------------------------------------------------------------------------------|
+| `x ||= y`  | `ExprStmt(If(VarRef(x), Block{[], VarRef(x)}, Block{[Assign(x,y)], VarRef(x)}))`  |
+| `x &&= y`  | `ExprStmt(If(VarRef(x), Block{[Assign(x,y)], VarRef(x)}, Block{[], VarRef(x)}))`  |
+
+- **cond** is `VarRef(x)` (Ruby's truthiness rules apply).
+- The branch that should "do nothing" is an **empty `Block.stmts`** with `value: VarRef(x)` (statement-position evaluation discards the value; it's there because `Block` requires a tail expression).
+- The other branch contains `Stmt::Assign(x, y)` followed by `value: VarRef(x)`.
+
+`Feature::MutableBindings` is still required (the gated branch is a re-bind), and `x` is recorded as a declared local so any subsequent `x = …` doesn't trip the rebinding-into-undeclared-name error.
+
+## Why this is safe for the other compound forms
+
+`||=` and `&&=` are the **only** Ruby compound assignments with short-circuit semantics.  The arithmetic / bitwise / shift family (`+=`, `-=`, `*=`, `/=`, `%=`, `**=`, `<<=`, `>>=`, `&=`, `|=`, `^=`) all eagerly evaluate the RHS in real Ruby, so their existing eager `Assign + BuiltinCall` lowering is unchanged.  The dispatch happens via two parallel paths inside `lower_assignment`:
+
+1. `if op == "||=" || op == "&&="` → short-circuit `Expr::If` (new in 8b)
+2. `match op { "+=" => …, "-=" => …, … }` → eager `BuiltinCall` (unchanged, with the `||=` / `&&=` arms removed since they're handled above)
+
+## Lexer / Grammar
+
+**No changes.**  The lexer already fuses `||=` and `&&=` into single `Name` tokens, and the grammar's `assignment` rule already accepts them.  This PR is pure semantic-IR plumbing.
+
+## Tests
+
+- `coding-adventures-ruby-lexer`: 173 → **173** (no change)
+- `coding-adventures-ruby-parser`: 149 → **149** (no change — round-trip tests for both ops already exist)
+- `ruby-to-semantic-ir`: 162 → **165** (+3 net = -1 replaced + 4 added):
+  - Replaced `logical_compound_assigns_lower_to_or_and_builtins` (asserted the OLD eager shape)
+  - Added `or_assign_lowers_to_short_circuit_if_with_assign_in_else_branch`
+  - Added `and_assign_lowers_to_short_circuit_if_with_assign_in_then_branch`
+  - Added `short_circuit_op_assign_marks_mutable_bindings_feature`
+  - Added `short_circuit_op_assign_module_passes_sir_validator` (validator E2E for both ops)
+
+## Test plan
+
+- [x] `cargo test -p coding-adventures-ruby-lexer` (173/173 pass)
+- [x] `cargo test -p coding-adventures-ruby-parser` (149/149 pass)
+- [x] `cargo test -p ruby-to-semantic-ir` (165/165 pass)
+- [x] Self-reviewed (no I/O, no unsafe — pure SIR shape rearrangement: the new `Expr::If` is constructed from spans + existing `Expr::VarRef` / `Stmt::Assign` building blocks already in the codebase)
+- [ ] CI green
+
+Follows PR #4550 (Phase 8a-2).  Next chunk: Phase 9a (parallel assign `a, b = 1, 2`).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.36.0] - 2026-05-28
+
+### Changed (Phase 8b (FC) — short-circuit `||=` / `&&=` lowering)
+
+Phase 6p originally lowered `x ||= y` and `x &&= y` eagerly to
+`Assign(x, BuiltinCall("or"/"and", [VarRef(x), y]))`.  That form
+ALWAYS evaluates `y` and ALWAYS re-binds `x`, which silently breaks
+Ruby's documented short-circuit semantics whenever `y` has side
+effects.  Phase 8b replaces it with a gated `Expr::If` so the RHS and
+the re-bind are skipped when the short-circuit branch fires.
+
+| Source     | SIR shape                                                          |
+|------------|--------------------------------------------------------------------|
+| `x ||= y`  | `ExprStmt(If(VarRef(x), Block{[], VarRef(x)}, Block{[Assign(x,y)], VarRef(x)}))` |
+| `x &&= y`  | `ExprStmt(If(VarRef(x), Block{[Assign(x,y)], VarRef(x)}, Block{[], VarRef(x)}))` |
+
+`Feature::MutableBindings` is still required (the gated branch
+re-binds `x`), and `x` is recorded as a declared local so any
+subsequent `x = …` doesn't trip the rebinding-into-undeclared-name
+error.  All other compound-assign forms (`+=`, `-=`, `*=`, `/=`, `%=`,
+`**=`, `<<=`, `>>=`, `&=`, `|=`, `^=`) keep their eager
+`Assign + BuiltinCall` lowering — they have no short-circuit
+semantics, so the previous shape is correct for them.
+
+### Tests
+
+- `ruby-to-semantic-ir`: 162 → **165** (+3 net):
+  - Replaced `logical_compound_assigns_lower_to_or_and_builtins`
+    (asserted the old eager shape) with four new tests:
+    - `or_assign_lowers_to_short_circuit_if_with_assign_in_else_branch`
+    - `and_assign_lowers_to_short_circuit_if_with_assign_in_then_branch`
+    - `short_circuit_op_assign_marks_mutable_bindings_feature`
+    - `short_circuit_op_assign_module_passes_sir_validator` (validator E2E for both ops)
+
 ## [0.35.0] - 2026-05-26
 
 ### Added (Phase 8a-2 (FC) — `>>=` right-shift compound-assign lowering)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -1526,23 +1526,147 @@ mod tests {
         }
     }
 
+    // -----------------------------------------------------------------
+    // Phase 8b — short-circuit op-assign (`||=`, `&&=`)
+    // -----------------------------------------------------------------
+    //
+    // Ruby semantics:
+    //   `x ||= y`  ≡  `x || (x = y)`
+    //   `x &&= y`  ≡  `x && (x = y)`
+    //
+    // RHS must NOT be evaluated when the short-circuit branch fires,
+    // so the lowering uses a gated `Expr::If`:
+    //
+    //   `x ||= y` → ExprStmt(If(
+    //                  cond:        VarRef(x),
+    //                  then_branch: Block { [],            VarRef(x) },
+    //                  else_branch: Block { [Assign(x,y)], VarRef(x) },
+    //                ))
+    //
+    // For `&&=` the two branches swap.  Phase 6p used to lower these to
+    // an eager `Assign(x, BuiltinCall("or"/"and", [VarRef(x), y]))`,
+    // which silently broke side-effect ordering when `y` had any.
+
     #[test]
-    fn logical_compound_assigns_lower_to_or_and_builtins() {
-        // ||= → "or"; &&= → "and".  Same binary-op encoding as the
-        // arithmetic forms.
-        for (op_src, op_builtin) in [("||=", "or"), ("&&=", "and")] {
+    fn or_assign_lowers_to_short_circuit_if_with_assign_in_else_branch() {
+        // `x ||= 2` after `x = 1`:
+        //   - cond branch: VarRef(x)
+        //   - then_branch: empty stmts, value VarRef(x)  (truthy → keep)
+        //   - else_branch: [Assign(x, 2)], value VarRef(x)  (falsy → assign)
+        let m = lower("x = 1\nx ||= 2\n");
+        let b = main_body(&m);
+        match &b.stmts[1] {
+            Stmt::ExprStmt {
+                expr: Expr::If { cond, then_branch, else_branch, .. },
+                ..
+            } => {
+                assert!(
+                    matches!(cond.as_ref(), Expr::VarRef { name, .. } if name == "x"),
+                    "||= cond should be VarRef(x), got {:?}",
+                    cond
+                );
+                assert!(
+                    then_branch.stmts.is_empty(),
+                    "||= then-branch should be empty (no-op when x is truthy), got {:?}",
+                    then_branch.stmts
+                );
+                assert_eq!(
+                    else_branch.stmts.len(),
+                    1,
+                    "||= else-branch should contain exactly one Assign"
+                );
+                match &else_branch.stmts[0] {
+                    Stmt::Assign { name, value, .. } => {
+                        assert_eq!(name, "x");
+                        assert!(
+                            matches!(value, Expr::IntLit { value: 2, .. }),
+                            "||= else-branch should assign x = 2, got {:?}",
+                            value
+                        );
+                    }
+                    other => panic!("expected Assign in ||= else-branch, got {:?}", other),
+                }
+            }
+            other => panic!("expected ExprStmt(If(...)) for ||=, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn and_assign_lowers_to_short_circuit_if_with_assign_in_then_branch() {
+        // `x &&= 2` after `x = 1`:
+        //   - cond branch: VarRef(x)
+        //   - then_branch: [Assign(x, 2)], value VarRef(x)  (truthy → assign)
+        //   - else_branch: empty stmts, value VarRef(x)     (falsy → keep)
+        let m = lower("x = 1\nx &&= 2\n");
+        let b = main_body(&m);
+        match &b.stmts[1] {
+            Stmt::ExprStmt {
+                expr: Expr::If { cond, then_branch, else_branch, .. },
+                ..
+            } => {
+                assert!(
+                    matches!(cond.as_ref(), Expr::VarRef { name, .. } if name == "x"),
+                    "&&= cond should be VarRef(x), got {:?}",
+                    cond
+                );
+                assert_eq!(
+                    then_branch.stmts.len(),
+                    1,
+                    "&&= then-branch should contain exactly one Assign"
+                );
+                match &then_branch.stmts[0] {
+                    Stmt::Assign { name, value, .. } => {
+                        assert_eq!(name, "x");
+                        assert!(
+                            matches!(value, Expr::IntLit { value: 2, .. }),
+                            "&&= then-branch should assign x = 2, got {:?}",
+                            value
+                        );
+                    }
+                    other => panic!("expected Assign in &&= then-branch, got {:?}", other),
+                }
+                assert!(
+                    else_branch.stmts.is_empty(),
+                    "&&= else-branch should be empty (no-op when x is falsy), got {:?}",
+                    else_branch.stmts
+                );
+            }
+            other => panic!("expected ExprStmt(If(...)) for &&=, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn short_circuit_op_assign_marks_mutable_bindings_feature() {
+        // Both ||= and &&= must declare `MutableBindings` in the
+        // module's feature manifest, exactly like the eager compound
+        // forms — the assignment in the gated branch is still a
+        // re-binding from the validator's perspective.
+        for op_src in ["||=", "&&="] {
             let src = format!("x = 1\nx {op_src} 2\n");
             let m = lower(&src);
-            let b = main_body(&m);
-            match &b.stmts[1] {
-                Stmt::Assign { value, .. } => match value {
-                    Expr::BuiltinCall { name, .. } => {
-                        assert_eq!(name, op_builtin, "wrong builtin for {op_src}");
-                    }
-                    other => panic!("expected BuiltinCall for {op_src}, got {:?}", other),
-                },
-                other => panic!("expected Assign for {op_src}, got {:?}", other),
-            }
+            assert!(
+                m.manifest.contains(semantic_ir::Feature::MutableBindings),
+                "{op_src} module should require MutableBindings, got: {:?}",
+                m.manifest
+            );
+        }
+    }
+
+    #[test]
+    fn short_circuit_op_assign_module_passes_sir_validator() {
+        // End-to-end smoke check for both forms.  The validator must
+        // accept the `If` shape with an `Assign` nested in one branch
+        // (which is a less-common construction than top-level Assign,
+        // but well within SIR's grammar).
+        for op_src in ["||=", "&&="] {
+            let src = format!("x = 1\nx {op_src} 2\n");
+            let m = lower(&src);
+            let result = semantic_ir::validate(&m);
+            assert!(
+                result.is_ok(),
+                "validator rejected {op_src} short-circuit lowering: {:?}",
+                result
+            );
         }
     }
 

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -1765,6 +1765,95 @@ impl Lowerer {
         });
 
         let span = self.span_of(node);
+
+        // ── Phase 8b — short-circuit op-assign (`||=`, `&&=`) ───────────
+        //
+        // Ruby's short-circuit compound assignments do NOT eagerly
+        // evaluate the RHS when the LHS already short-circuits the
+        // expression.  Specifically:
+        //
+        //   `x ||= y`  ≡  `x || (x = y)`
+        //                — if `x` is truthy, `y` is NOT evaluated and
+        //                  `x` is NOT re-assigned (side effects on `y`
+        //                  must not fire).
+        //   `x &&= y`  ≡  `x && (x = y)`
+        //                — if `x` is falsy, `y` is NOT evaluated and
+        //                  `x` is NOT re-assigned.
+        //
+        // Phase 6p lowered both forms eagerly to
+        // `Assign(x, BuiltinCall("or"/"and", [VarRef(x), y]))` — that
+        // ALWAYS evaluates `y` and ALWAYS re-binds `x`, which silently
+        // breaks side-effect ordering when `y` has them.  Phase 8b
+        // replaces that with a gated `Expr::If` so the assignment is
+        // skipped entirely when the short-circuit condition fires.
+        //
+        // SIR shape for `x ||= y` (and analogously for `&&=`):
+        //
+        //   ExprStmt(If(
+        //     cond:        VarRef(x),
+        //     then_branch: Block { stmts: [],            value: VarRef(x) },  // truthy → keep x
+        //     else_branch: Block { stmts: [Assign(x,y)], value: VarRef(x) },  // falsy → assign
+        //   ))
+        //
+        // For `&&=`, the two branches swap (truthy → assign, falsy → keep).
+        //
+        // The compound-assign path below stays in charge of all the
+        // arithmetic/bitwise/shift forms (`+=`, `-=`, `*=`, …, `>>=`) —
+        // those have no short-circuit semantics, so the existing
+        // BuiltinCall lowering is correct for them.
+        if let Some(op) = op_token.as_deref() {
+            if op == "||=" || op == "&&=" {
+                // Mark mutation + record local so subsequent `x = …`
+                // statements don't re-binding-error.  Matches the
+                // bookkeeping the generic compound path does below.
+                self.features_used.insert(Feature::MutableBindings);
+                self.declared_locals.insert(name.clone());
+
+                let cond_ref = Expr::VarRef {
+                    name: name.clone(),
+                    scope: Scope::Local,
+                    span: span.clone(),
+                };
+                let result_ref = Expr::VarRef {
+                    name: name.clone(),
+                    scope: Scope::Local,
+                    span: span.clone(),
+                };
+                let assign_stmt = Stmt::Assign {
+                    name: name.clone(),
+                    scope: Scope::Local,
+                    value: rhs,
+                    span: span.clone(),
+                };
+                let empty_block = Block {
+                    stmts: vec![],
+                    value: result_ref.clone(),
+                    span: span.clone(),
+                };
+                let assign_block = Block {
+                    stmts: vec![assign_stmt],
+                    value: result_ref,
+                    span: span.clone(),
+                };
+                // `||=`: truthy → keep (empty); falsy → assign
+                // `&&=`: truthy → assign;        falsy → keep (empty)
+                let (then_branch, else_branch) = if op == "||=" {
+                    (empty_block, assign_block)
+                } else {
+                    (assign_block, empty_block)
+                };
+                return Ok(Stmt::ExprStmt {
+                    expr: Expr::If {
+                        cond: Box::new(cond_ref),
+                        then_branch: Box::new(then_branch),
+                        else_branch: Box::new(else_branch),
+                        span: span.clone(),
+                    },
+                    span,
+                });
+            }
+        }
+
         // Build the effective RHS.  For plain `=`, it's just `rhs`.
         // For compound forms, wrap it as `BuiltinCall(op, [VarRef(x), rhs])`
         // where `op` is the underlying binary operator (`+` for `+=`,
@@ -1798,9 +1887,9 @@ impl Lowerer {
                 "&=" => ("&", EffectSet::PURE),
                 "|=" => ("|", EffectSet::PURE),
                 "^=" => ("^", EffectSet::PURE),
-                "||=" => ("or", EffectSet::PURE),
-                "&&=" => ("and", EffectSet::PURE),
-                _ => unreachable!("op_token matched only the compound forms above"),
+                // `||=` and `&&=` are handled by the short-circuit
+                // branch above (Phase 8b) and never reach this match.
+                _ => unreachable!("op_token matched only the eager compound forms above"),
             };
             let lhs_ref = Expr::VarRef {
                 name: name.clone(),


### PR DESCRIPTION
## Summary

Phase 8b fixes a long-standing semantic bug in `||=` and `&&=` lowering: the Phase 6p implementation **eagerly evaluated the RHS** even when the short-circuit branch should have skipped it.

Ruby's documented semantics:

```ruby
x ||= y   # ≡  x || (x = y)    — if x is truthy, y is NEVER evaluated and x is NEVER re-assigned
x &&= y   # ≡  x && (x = y)    — if x is falsy,  y is NEVER evaluated and x is NEVER re-assigned
```

The old SIR shape was `Stmt::Assign(x, Expr::BuiltinCall("or", [VarRef(x), <y>]))` — eager argument evaluation means `y`'s side effects fire whether or not `x` was truthy.  Silently wrong any time `y` has side effects or `x` already has a meaningful value.

## Lowering — new SIR shape

`lower_assignment` now intercepts `||=` and `&&=` **before** the generic compound-assign `BuiltinCall` dispatch and emits a gated `Expr::If`:

| Source     | SIR shape                                                                          |
|------------|------------------------------------------------------------------------------------|
| `x ||= y`  | `ExprStmt(If(VarRef(x), Block{[], VarRef(x)}, Block{[Assign(x,y)], VarRef(x)}))`  |
| `x &&= y`  | `ExprStmt(If(VarRef(x), Block{[Assign(x,y)], VarRef(x)}, Block{[], VarRef(x)}))`  |

- **cond** is `VarRef(x)` (Ruby's truthiness rules apply).
- The branch that should "do nothing" is an **empty `Block.stmts`** with `value: VarRef(x)` (statement-position evaluation discards the value; it's there because `Block` requires a tail expression).
- The other branch contains `Stmt::Assign(x, y)` followed by `value: VarRef(x)`.

`Feature::MutableBindings` is still required (the gated branch is a re-bind), and `x` is recorded as a declared local so any subsequent `x = …` doesn't trip the rebinding-into-undeclared-name error.

## Why this is safe for the other compound forms

`||=` and `&&=` are the **only** Ruby compound assignments with short-circuit semantics.  The arithmetic / bitwise / shift family (`+=`, `-=`, `*=`, `/=`, `%=`, `**=`, `<<=`, `>>=`, `&=`, `|=`, `^=`) all eagerly evaluate the RHS in real Ruby, so their existing eager `Assign + BuiltinCall` lowering is unchanged.  The dispatch happens via two parallel paths inside `lower_assignment`:

1. `if op == "||=" || op == "&&="` → short-circuit `Expr::If` (new in 8b)
2. `match op { "+=" => …, "-=" => …, … }` → eager `BuiltinCall` (unchanged, with the `||=` / `&&=` arms removed since they're handled above)

## Lexer / Grammar

**No changes.**  The lexer already fuses `||=` and `&&=` into single `Name` tokens, and the grammar's `assignment` rule already accepts them.  This PR is pure semantic-IR plumbing.

## Tests

- `coding-adventures-ruby-lexer`: 173 → **173** (no change)
- `coding-adventures-ruby-parser`: 149 → **149** (no change — round-trip tests for both ops already exist)
- `ruby-to-semantic-ir`: 162 → **165** (+3 net = -1 replaced + 4 added):
  - Replaced `logical_compound_assigns_lower_to_or_and_builtins` (asserted the OLD eager shape)
  - Added `or_assign_lowers_to_short_circuit_if_with_assign_in_else_branch`
  - Added `and_assign_lowers_to_short_circuit_if_with_assign_in_then_branch`
  - Added `short_circuit_op_assign_marks_mutable_bindings_feature`
  - Added `short_circuit_op_assign_module_passes_sir_validator` (validator E2E for both ops)

## Test plan

- [x] `cargo test -p coding-adventures-ruby-lexer` (173/173 pass)
- [x] `cargo test -p coding-adventures-ruby-parser` (149/149 pass)
- [x] `cargo test -p ruby-to-semantic-ir` (165/165 pass)
- [x] Self-reviewed (no I/O, no unsafe — pure SIR shape rearrangement: the new `Expr::If` is constructed from spans + existing `Expr::VarRef` / `Stmt::Assign` building blocks already in the codebase)
- [ ] CI green

Follows PR #4550 (Phase 8a-2).  Next chunk: Phase 9a (parallel assign `a, b = 1, 2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
