### PR TITLE
feat(ruby-to-semantic-ir): Phase 9a (FC) — swap-safe parallel multi-assignment

### DIFF
--- a/code/packages/rust/ruby-parser/.pr-body-fc-9a.md
+++ b/code/packages/rust/ruby-parser/.pr-body-fc-9a.md
@@ -1,0 +1,75 @@
+## Summary
+
+Phase 9a fixes a documented `Phase 6r` limitation: parallel assignment with cross-references between LHS and RHS (the canonical Ruby swap `a, b = b, a`) was lowered sequentially, so the second assignment read the *new* value of the first LHS instead of the original.  Phase 9a introduces a swap-safe temp-pass that only fires when needed.
+
+## The bug Phase 6r left behind
+
+Ruby's parallel assignment semantics: **all RHS values are collected before any LHS is rebound**.
+
+```ruby
+a = 1
+b = 2
+a, b = b, a
+# Ruby: a == 2, b == 1
+```
+
+Phase 6r lowered this to:
+
+```
+Stmt::Assign(a, VarRef(b))   # a := old_b == 2  ✓
+Stmt::Assign(b, VarRef(a))   # b := new_a == 2  ✗ (should be old_a == 1)
+```
+
+Silent miscompile — no error, no warning, just the wrong answer.  Phase 6r's source code explicitly flagged this as a deferred v0 limitation; this PR closes it.
+
+## The fix — needs-temps heuristic
+
+After lowering every RHS expression to a SIR `Expr`, the lowerer scans each one (structural recursion over every `Expr` variant) for any `VarRef` whose name is in the LHS list.
+
+- **No reference found** → keep the Phase 6r sequential shape (no temps, no `LetStarBinding`).  The simple `a, b = 1, 2` case stays at 2 SIR stmts.
+- **Reference found** → emit two passes:
+  1. `LetStarBinding(__multi_assign_t<N>_<i>, rhs[i])` for each `i` — captures the **original** RHS value before any LHS is rebound.  Uses `LetStarBinding` (sequential semantics) so each temp's name is visible to the subsequent LHS-binding pass; using plain `LetBinding` would put the temps in the same parallel-let validator group and hide them.
+  2. `Stmt::LetBinding` / `Stmt::Assign` for each LHS (existing first-sighting vs re-binding rule), reading its value from the corresponding temp via `VarRef`.
+
+The counter `multi_assign_counter` on the `Lowerer` struct increments once per temp-using multi-assignment, guaranteeing distinct temp names across nested or repeated multi-assignments in the same scope.  Names are `__`-prefixed so they can't collide with user-typeable Ruby locals.
+
+| Source                                  | SIR shape (Phase 9a)                                                                                                              |
+|-----------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| `a, b = 1, 2`                           | `LetBinding(a, 1); LetBinding(b, 2)` *(fast path — no temps)*                                                                     |
+| `a = 1; b = 2; a, b = b, a`             | `LetBinding(a, 1); LetBinding(b, 2); LetStarBinding(__multi_assign_t0_0, VarRef(b)); LetStarBinding(__multi_assign_t0_1, VarRef(a)); Assign(a, __multi_assign_t0_0); Assign(b, __multi_assign_t0_1)` |
+| `a = 7; b = 8; a, b = 1, a`             | Same temp-pass — partial dependency still triggers the uniform temp-pass so position 1 captures original `a`, not the new `a`.    |
+
+## Why the structural recursion over `Expr` is safe
+
+The helper `expr_references_any_name` is a `match` against every `semantic_ir::Expr` variant.  Rust's exhaustiveness check fail-stops at compile time if a new `Expr` variant is added to `semantic-ir` without updating this helper — important because a missed variant would silently re-introduce the swap miscompile under an exotic RHS shape (e.g. an `If`-expression RHS that references an LHS in one of its branches).
+
+`block_references_any_name` covers `Expr::If`, `Expr::Block` and any nested-block `Stmt` (`While`, `ForRange`, `ForEach`, `SeqSet`, `MapSet`) — also exhaustively.
+
+## Lexer / Grammar
+
+**No changes.**  `multi_assignment` already parses from Phase 6r.
+
+## Tests
+
+- `coding-adventures-ruby-lexer`: 173 → **173** (no change)
+- `coding-adventures-ruby-parser`: 149 → **149** (no change — round-trip tests for multi-assignment already exist)
+- `ruby-to-semantic-ir`: 165 → **170** (+5):
+  - `multi_assignment_swap_introduces_temps_to_preserve_parallel_semantics`
+  - `multi_assignment_simple_case_keeps_fast_path_with_no_temps`
+  - `multi_assignment_partial_dependency_still_uses_temps_for_all_positions`
+  - `multi_assignment_swap_module_passes_sir_validator` (validator E2E)
+  - `multi_assignment_two_swaps_use_distinct_temp_counters`
+
+The existing 4 Phase 6r tests (`multi_assignment_lowers_to_independent_let_bindings`, `_redeclaration_uses_assign`, `_three_names_emits_three_stmts`, `_arity_mismatch_errors`, `_module_passes_sir_validator`) all keep passing — none of them exercise the swap case, and the fast path preserves their expected shape.
+
+## Test plan
+
+- [x] `cargo test -p coding-adventures-ruby-lexer` (173/173 pass)
+- [x] `cargo test -p coding-adventures-ruby-parser` (149/149 pass)
+- [x] `cargo test -p ruby-to-semantic-ir` (170/170 pass)
+- [x] Self-reviewed (no I/O, no unsafe — pure structural recursion + SIR Stmt list construction; new `multi_assign_counter` is a monotonic `usize`)
+- [ ] CI green
+
+Follows PR #4554 (Phase 8b).  Next chunk: Phase 9b (splat LHS `a, *b = [1, 2, 3]`).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,49 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.37.0] - 2026-05-28
+
+### Changed (Phase 9a (FC) — swap-safe parallel multi-assignment)
+
+Phase 6r lowered `a, b = rhs0, rhs1` as a flat sequence of one SIR
+statement per pair: `Stmt(a := rhs0); Stmt(b := rhs1)`.  That's
+observably correct only when no LHS name appears in any RHS — the
+common case.  For the swap `a, b = b, a`, the sequential form reads
+the *post-assignment* value of `a` when evaluating the second pair,
+producing `a = old_b; b = old_b` instead of the true swap.
+
+Phase 9a introduces a "needs-temps" heuristic.  After lowering every
+RHS to an `Expr`, the lowerer scans each one (structural recursion
+over the SIR `Expr` tree) for any `VarRef` whose name appears in the
+LHS list.  If found:
+
+1. Each RHS value is bound to a fresh `LetStarBinding` temp named
+   `__multi_assign_t<N>_<i>` (counter `multi_assign_counter` ensures
+   uniqueness across multiple multi-assignments in the same scope).
+2. Each LHS is then assigned from its temp via the usual
+   first-sighting `LetBinding` / re-binding `Assign` decision.
+
+`LetStarBinding` (sequential semantics) is used for the temps so each
+temp's name is visible to the subsequent LHS-binding pass — `LetBinding`
+would put them in the same parallel-let validator group and hide them.
+
+If no LHS appears in any RHS, the lowerer keeps Phase 6r's sequential
+shape (no temps, no `LetStarBinding`) so the simple case stays cheap.
+
+| Source                  | SIR shape (after Phase 9a)                                                                                                         |
+|-------------------------|------------------------------------------------------------------------------------------------------------------------------------|
+| `a, b = 1, 2`           | `LetBinding(a, 1); LetBinding(b, 2)` *(no temps — fast path)*                                                                      |
+| `a = 1; b = 2; a, b = b, a` | `LetBinding(a, 1); LetBinding(b, 2); LetStarBinding(__multi_assign_t0_0, VarRef(b)); LetStarBinding(__multi_assign_t0_1, VarRef(a)); Assign(a, VarRef(__multi_assign_t0_0)); Assign(b, VarRef(__multi_assign_t0_1))` |
+
+### Tests
+
+- `ruby-to-semantic-ir`: 165 → **170** (+5):
+  - `multi_assignment_swap_introduces_temps_to_preserve_parallel_semantics`
+  - `multi_assignment_simple_case_keeps_fast_path_with_no_temps`
+  - `multi_assignment_partial_dependency_still_uses_temps_for_all_positions`
+  - `multi_assignment_swap_module_passes_sir_validator` (validator E2E)
+  - `multi_assignment_two_swaps_use_distinct_temp_counters`
+
 ## [0.36.0] - 2026-05-28
 
 ### Changed (Phase 8b (FC) — short-circuit `||=` / `&&=` lowering)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -1900,6 +1900,199 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
+    // Phase 9a (FC) — swap-safe parallel binding
+    // -----------------------------------------------------------------
+    //
+    // Phase 6r's lowering was sequential: `a, b = b, a` became
+    // `Assign(a, VarRef(b)); Assign(b, VarRef(a))` — the second assign
+    // reads the NEW `a`, silently producing `a = old_b; b = old_b`
+    // instead of a true swap.
+    //
+    // Phase 9a fixes this by detecting whether any LHS name appears in
+    // any RHS expression.  If so, the lowerer introduces fresh
+    // `LetStarBinding` temps (`__multi_assign_t<N>_<i>`) capturing the
+    // ORIGINAL RHS values first; the LHS-binding pass then reads each
+    // temp.  If no LHS appears in any RHS, the existing sequential
+    // shape is preserved (no temps).
+    //
+    // The "needs-temps" detector is a structural walk over Expr; any
+    // VarRef to an LHS name (no matter how deeply nested) triggers
+    // the temp-pass.
+
+    #[test]
+    fn multi_assignment_swap_introduces_temps_to_preserve_parallel_semantics() {
+        // `a, b = b, a` must NOT lower to the buggy sequential form.
+        // Expected SIR:
+        //   LetBinding(a, 1)
+        //   LetBinding(b, 2)
+        //   LetStarBinding(__multi_assign_t0_0, VarRef(b))   <- captures original b
+        //   LetStarBinding(__multi_assign_t0_1, VarRef(a))   <- captures original a
+        //   Assign(a, VarRef(__multi_assign_t0_0))
+        //   Assign(b, VarRef(__multi_assign_t0_1))
+        let m = lower("a = 1\nb = 2\na, b = b, a\n");
+        let body = main_body(&m);
+        assert_eq!(
+            body.stmts.len(),
+            6,
+            "swap should emit 6 stmts (2 priors + 2 temps + 2 assigns), got {:?}",
+            body.stmts
+        );
+        // Temp 0 captures original b.
+        match &body.stmts[2] {
+            Stmt::LetStarBinding { name, value, .. } => {
+                assert!(name.starts_with("__multi_assign_t"));
+                assert!(
+                    matches!(value, Expr::VarRef { name: n, .. } if n == "b"),
+                    "temp 0 should capture VarRef(b), got {:?}",
+                    value
+                );
+            }
+            other => panic!("expected LetStarBinding for temp 0, got {:?}", other),
+        }
+        // Temp 1 captures original a.
+        match &body.stmts[3] {
+            Stmt::LetStarBinding { name, value, .. } => {
+                assert!(name.starts_with("__multi_assign_t"));
+                assert!(
+                    matches!(value, Expr::VarRef { name: n, .. } if n == "a"),
+                    "temp 1 should capture VarRef(a), got {:?}",
+                    value
+                );
+            }
+            other => panic!("expected LetStarBinding for temp 1, got {:?}", other),
+        }
+        // a := temp 0
+        match &body.stmts[4] {
+            Stmt::Assign { name, value, .. } => {
+                assert_eq!(name, "a");
+                assert!(
+                    matches!(value, Expr::VarRef { name: n, .. } if n.starts_with("__multi_assign_t")),
+                    "a should be assigned from a temp, got {:?}",
+                    value
+                );
+            }
+            other => panic!("expected Assign(a, temp), got {:?}", other),
+        }
+        // b := temp 1
+        match &body.stmts[5] {
+            Stmt::Assign { name, value, .. } => {
+                assert_eq!(name, "b");
+                assert!(
+                    matches!(value, Expr::VarRef { name: n, .. } if n.starts_with("__multi_assign_t")),
+                    "b should be assigned from a temp, got {:?}",
+                    value
+                );
+            }
+            other => panic!("expected Assign(b, temp), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn multi_assignment_simple_case_keeps_fast_path_with_no_temps() {
+        // Sanity: the new heuristic must NOT introduce temps when no
+        // LHS appears in any RHS.  This preserves the Phase 6r shape
+        // assumption that `a, b = 1, 2` is 2 stmts (not 4).
+        let m = lower("a, b = 1, 2\n");
+        let body = main_body(&m);
+        assert_eq!(
+            body.stmts.len(),
+            2,
+            "simple-case multi-assign should stay 2 stmts, got {:?}",
+            body.stmts
+        );
+        // Nothing should be a `LetStarBinding` (those would be temps).
+        for s in &body.stmts {
+            assert!(
+                !matches!(s, Stmt::LetStarBinding { .. }),
+                "simple-case should not introduce temps, got {:?}",
+                s
+            );
+        }
+    }
+
+    #[test]
+    fn multi_assignment_partial_dependency_still_uses_temps_for_all_positions() {
+        // `a, b = 1, a` — only the SECOND RHS references an LHS, but
+        // the temp-pass kicks in for the whole multi-assignment so the
+        // capture is uniform.  Without this, position 1 would read the
+        // post-assignment `a` instead of the original.
+        let m = lower("a = 7\nb = 8\na, b = 1, a\n");
+        let body = main_body(&m);
+        // Expect: 2 prior LetBindings + 2 temps + 2 assigns = 6 stmts.
+        assert_eq!(body.stmts.len(), 6,
+            "partial-dep multi-assign should emit 6 stmts, got {:?}", body.stmts);
+        // Both temps must be LetStarBindings.
+        assert!(matches!(&body.stmts[2], Stmt::LetStarBinding { .. }));
+        assert!(matches!(&body.stmts[3], Stmt::LetStarBinding { .. }));
+        // Temp 0 captures literal 1 (no LHS reference in this RHS).
+        match &body.stmts[2] {
+            Stmt::LetStarBinding { value, .. } => {
+                assert!(
+                    matches!(value, Expr::IntLit { value: 1, .. }),
+                    "temp 0 should capture IntLit(1), got {:?}",
+                    value
+                );
+            }
+            _ => unreachable!(),
+        }
+        // Temp 1 captures the original VarRef(a).
+        match &body.stmts[3] {
+            Stmt::LetStarBinding { value, .. } => {
+                assert!(
+                    matches!(value, Expr::VarRef { name: n, .. } if n == "a"),
+                    "temp 1 should capture VarRef(a), got {:?}",
+                    value
+                );
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn multi_assignment_swap_module_passes_sir_validator() {
+        // Validator must accept the temp-pass lowering — LetStarBinding
+        // adds the temp name to the env immediately, so the subsequent
+        // Assign's VarRef sees it; `Feature::MutableBindings` is
+        // already requested for the re-binding LHS.
+        let m = lower("a = 1\nb = 2\na, b = b, a\nputs(a)\nputs(b)\n");
+        let result = semantic_ir::validate(&m);
+        assert!(
+            result.is_ok(),
+            "validator rejected swap-case multi-assign: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn multi_assignment_two_swaps_use_distinct_temp_counters() {
+        // Two consecutive swaps in the same scope must use DIFFERENT
+        // temp counters so the second swap's temps don't shadow or
+        // collide with the first.  This guards against accidental
+        // re-use of the counter inside a single scope.
+        let m = lower(
+            "a = 1\nb = 2\nc = 3\nd = 4\na, b = b, a\nc, d = d, c\n",
+        );
+        let body = main_body(&m);
+        // Collect temp names that appear as LetStarBinding declarations.
+        let mut temp_names: Vec<String> = body
+            .stmts
+            .iter()
+            .filter_map(|s| match s {
+                Stmt::LetStarBinding { name, .. } => Some(name.clone()),
+                _ => None,
+            })
+            .collect();
+        temp_names.sort();
+        temp_names.dedup();
+        assert_eq!(
+            temp_names.len(),
+            4,
+            "expected 4 distinct temp names across two swaps, got {:?}",
+            temp_names
+        );
+    }
+
+    // -----------------------------------------------------------------
     // Phase 6s — splat / double-splat
     // -----------------------------------------------------------------
     //

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -70,6 +70,7 @@ pub fn compile(program: &GrammarASTNode, module_name: &str) -> Result<Module, Ru
         user_functions: Vec::new(),
         features_used: HashSet::new(),
         block_counter: 0,
+        multi_assign_counter: 0,
     };
     // Phase 6a: hoist `def name(params) … end` declarations to
     // top-level Functions BEFORE walking the rest of the program so
@@ -140,6 +141,142 @@ pub fn compile(program: &GrammarASTNode, module_name: &str) -> Result<Module, Ru
 }
 
 // ---------------------------------------------------------------------------
+// Phase 9a (FC) — helper: detect VarRefs that name LHS targets
+// ---------------------------------------------------------------------------
+//
+// Used by `lower_multi_assignment` to decide whether the simple
+// sequential lowering is safe (`a, b = 1, 2`) or whether the swap-safe
+// temp-pass is needed (`a, b = b, a`).  Walks an `Expr` tree
+// recursively and returns true iff any `VarRef` it contains has a name
+// listed in `names`.
+//
+// This is a structural recursion over every `Expr` variant the SIR
+// defines.  Adding a new `Expr` variant to `semantic-ir` will cause
+// this match to fail-stop at compile time (Rust's exhaustiveness
+// check), prompting an update here — important because a missed
+// variant would silently re-introduce the swap mis-lowering.
+fn expr_references_any_name(expr: &Expr, names: &HashSet<String>) -> bool {
+    match expr {
+        Expr::VarRef { name, .. } => names.contains(name),
+
+        // Leaves: no children, no references possible.
+        Expr::IntLit { .. }
+        | Expr::BoolLit { .. }
+        | Expr::NilLit { .. }
+        | Expr::SymLit { .. }
+        | Expr::StrLit { .. }
+        | Expr::FloatLit { .. } => false,
+
+        Expr::If { cond, then_branch, else_branch, .. } => {
+            expr_references_any_name(cond, names)
+                || block_references_any_name(then_branch, names)
+                || block_references_any_name(else_branch, names)
+        }
+
+        Expr::Block(b) => block_references_any_name(b, names),
+
+        Expr::DirectCall { args, .. }
+        | Expr::BuiltinCall { args, .. }
+        | Expr::Intrinsic { args, .. } => {
+            args.iter().any(|a| expr_references_any_name(a, names))
+        }
+
+        Expr::IndirectCall { target, args, .. } => {
+            expr_references_any_name(target, names)
+                || args.iter().any(|a| expr_references_any_name(a, names))
+        }
+
+        Expr::MakeClosure { captures, .. } => captures
+            .iter()
+            .any(|c| expr_references_any_name(&c.value, names)),
+
+        Expr::SeqLit { items, .. } => {
+            items.iter().any(|i| expr_references_any_name(i, names))
+        }
+        Expr::SeqIndex { seq, index, .. } => {
+            expr_references_any_name(seq, names) || expr_references_any_name(index, names)
+        }
+        Expr::SeqLen { seq, .. } => expr_references_any_name(seq, names),
+
+        Expr::MapLit { entries, .. } => entries.iter().any(|e| {
+            expr_references_any_name(&e.key, names)
+                || expr_references_any_name(&e.value, names)
+        }),
+        Expr::MapGet { map, key, .. } => {
+            expr_references_any_name(map, names) || expr_references_any_name(key, names)
+        }
+
+        Expr::LogicalAnd { lhs, rhs, .. } | Expr::LogicalOr { lhs, rhs, .. } => {
+            expr_references_any_name(lhs, names) || expr_references_any_name(rhs, names)
+        }
+    }
+}
+
+fn block_references_any_name(block: &Block, names: &HashSet<String>) -> bool {
+    // Block stmts: scan each stmt's contained Expr(s).  We only need a
+    // shallow walk over the tree shapes that `lower_expression` itself
+    // can emit — and `lower_expression`'s output is by definition a
+    // single `Expr` so any sub-blocks were built by the same lowerer
+    // (and are subject to the same parent's scope rules).  We still
+    // scan them defensively in case future lowering paths nest blocks.
+    if expr_references_any_name(&block.value, names) {
+        return true;
+    }
+    for stmt in &block.stmts {
+        match stmt {
+            Stmt::LetBinding { value, .. }
+            | Stmt::LetStarBinding { value, .. }
+            | Stmt::ExprStmt { expr: value, .. }
+            | Stmt::Assign { value, .. } => {
+                if expr_references_any_name(value, names) {
+                    return true;
+                }
+            }
+            Stmt::While { cond, body, .. } => {
+                if expr_references_any_name(cond, names)
+                    || block_references_any_name(body, names)
+                {
+                    return true;
+                }
+            }
+            Stmt::ForRange { start, stop, step, body, .. } => {
+                if expr_references_any_name(start, names)
+                    || expr_references_any_name(stop, names)
+                    || expr_references_any_name(step, names)
+                    || block_references_any_name(body, names)
+                {
+                    return true;
+                }
+            }
+            Stmt::ForEach { iter, body, .. } => {
+                if expr_references_any_name(iter, names)
+                    || block_references_any_name(body, names)
+                {
+                    return true;
+                }
+            }
+            Stmt::SeqSet { seq, index, value, .. } => {
+                if expr_references_any_name(seq, names)
+                    || expr_references_any_name(index, names)
+                    || expr_references_any_name(value, names)
+                {
+                    return true;
+                }
+            }
+            Stmt::MapSet { map, key, value, .. } => {
+                if expr_references_any_name(map, names)
+                    || expr_references_any_name(key, names)
+                    || expr_references_any_name(value, names)
+                {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+// ---------------------------------------------------------------------------
 // Lowerer
 // ---------------------------------------------------------------------------
 
@@ -171,6 +308,13 @@ struct Lowerer {
     /// it once to mint a fresh `__block_<n>` name for the trailing
     /// block's hoisted Function.
     block_counter: usize,
+    /// Phase 9a (FC): monotonically-increasing counter for synthesised
+    /// multi-assignment temporary names.  Each `multi_assignment` whose
+    /// LHS appears in any RHS expression (e.g. the swap `a, b = b, a`)
+    /// increments it once and mints fresh `__multi_assign_t<n>_<i>`
+    /// temps so the original RHS values are captured *before* any LHS
+    /// is rebound — matching Ruby's parallel-binding semantics.
+    multi_assign_counter: usize,
 }
 
 impl Lowerer {
@@ -2135,41 +2279,132 @@ impl Lowerer {
 
         // Lower each RHS first — this matches Ruby's evaluation order
         // (RHS is fully evaluated, *then* the LHS bindings happen).
-        // For the parallel-binding case (`a, b = b, a` swap), Ruby
-        // collects all RHS values *before* writing any LHS.  Our v0
-        // sequential lowering (`a = expr0; b = expr1`) is equivalent
-        // for the common case where no LHS appears in the RHS — which
-        // is the only shape we test for v0.  The swap case
-        // (`a, b = b, a`) would silently mis-lower under v0; this is
-        // documented as a deferred limitation.
         let lowered_rhs: Vec<Expr> = rhs_exprs
             .iter()
             .map(|e| self.lower_expression(e))
             .collect::<Result<_, _>>()?;
 
-        // Emit one Stmt per pair.  Reuses the same LetBinding/Assign
-        // decision rule as `lower_assignment`.
-        let mut out: Vec<Stmt> = Vec::with_capacity(lhs_names.len());
-        for ((name, name_span), value) in lhs_names.into_iter().zip(lowered_rhs.into_iter()) {
-            let span = name_span.clone();
-            let stmt = if self.declared_locals.contains(&name) {
-                self.features_used.insert(Feature::MutableBindings);
-                Stmt::Assign {
-                    name: name.clone(),
-                    scope: Scope::Local,
-                    value,
-                    span,
-                }
-            } else {
-                self.declared_locals.insert(name.clone());
-                Stmt::LetBinding {
-                    name: name.clone(),
+        // ── Phase 9a (FC) — swap-safe parallel binding ───────────────
+        //
+        // Ruby's parallel assignment collects ALL RHS values *before*
+        // writing ANY LHS.  Phase 6r's lowering emitted statements
+        // sequentially: `Stmt(a := rhs0); Stmt(b := rhs1)`.  That's
+        // observably correct only when no LHS name appears in any RHS
+        // expression — the simple `a, b = 1, 2` case.  For the swap
+        // (`a, b = b, a`), the second statement reads the *new* `a`
+        // instead of the original, producing the wrong result.
+        //
+        // Phase 9a closes the gap with a "needs-temps" heuristic:
+        //
+        //   1. Build the set of LHS names.
+        //   2. Scan each lowered RHS expression for any `VarRef` whose
+        //      name is in that set.
+        //   3. If found → emit two passes:
+        //        a. `LetStarBinding(__multi_assign_t<N>_<i>, rhs[i])`
+        //           for each i — captures the ORIGINAL RHS value before
+        //           any LHS is rebound.  Uses `LetStarBinding` so each
+        //           temp's name is visible to the LHS-binding pass that
+        //           follows (LetBinding's parallel-let validator group
+        //           rule would hide them).
+        //        b. `Stmt::LetBinding`/`Assign` for each LHS, reading
+        //           from the corresponding temp via `VarRef`.
+        //   4. Otherwise → emit the sequential shape Phase 6r used
+        //      (one stmt per pair, no temps) — cheaper SIR and matches
+        //      the simple-case test expectations.
+        //
+        // The temp names use a monotonic counter (`multi_assign_counter`)
+        // so nested or repeated multi-assignments don't collide.  Names
+        // are double-underscore-prefixed so they can't collide with
+        // user-typeable Ruby locals.
+        let lhs_name_set: HashSet<String> =
+            lhs_names.iter().map(|(n, _)| n.clone()).collect();
+        let needs_temps = lowered_rhs
+            .iter()
+            .any(|e| expr_references_any_name(e, &lhs_name_set));
+
+        let mut out: Vec<Stmt> = Vec::new();
+
+        if needs_temps {
+            let counter = self.multi_assign_counter;
+            self.multi_assign_counter += 1;
+
+            // Pass 1: bind each RHS to a fresh temp via LetStarBinding
+            // so the LHS-binding pass below can read them by VarRef
+            // without hitting the LetBinding parallel-let validator
+            // visibility rule.
+            let mut temp_refs: Vec<Expr> = Vec::with_capacity(lowered_rhs.len());
+            for (i, (rhs_value, (_, name_span))) in
+                lowered_rhs.into_iter().zip(lhs_names.iter()).enumerate()
+            {
+                let tmp_name = format!("__multi_assign_t{}_{}", counter, i);
+                let tmp_span = name_span.clone();
+                // Record the temp so later VarRef lookups treat it as
+                // a local.  (It IS declared via LetStarBinding.)
+                self.declared_locals.insert(tmp_name.clone());
+                out.push(Stmt::LetStarBinding {
+                    name: tmp_name.clone(),
                     sir_type: None,
-                    value,
-                    span,
-                }
-            };
-            out.push(stmt);
+                    value: rhs_value,
+                    span: tmp_span.clone(),
+                });
+                temp_refs.push(Expr::VarRef {
+                    name: tmp_name,
+                    scope: Scope::Local,
+                    span: tmp_span,
+                });
+            }
+
+            // Pass 2: assign each LHS from its temp.
+            for ((name, name_span), tmp_ref) in
+                lhs_names.into_iter().zip(temp_refs.into_iter())
+            {
+                let span = name_span.clone();
+                let stmt = if self.declared_locals.contains(&name) {
+                    self.features_used.insert(Feature::MutableBindings);
+                    Stmt::Assign {
+                        name: name.clone(),
+                        scope: Scope::Local,
+                        value: tmp_ref,
+                        span,
+                    }
+                } else {
+                    self.declared_locals.insert(name.clone());
+                    Stmt::LetBinding {
+                        name: name.clone(),
+                        sir_type: None,
+                        value: tmp_ref,
+                        span,
+                    }
+                };
+                out.push(stmt);
+            }
+        } else {
+            // Fast path: no LHS appears in any RHS, so the sequential
+            // lowering Phase 6r used is observably equivalent to the
+            // truly-parallel form.  Emit one Stmt per pair.
+            for ((name, name_span), value) in
+                lhs_names.into_iter().zip(lowered_rhs.into_iter())
+            {
+                let span = name_span.clone();
+                let stmt = if self.declared_locals.contains(&name) {
+                    self.features_used.insert(Feature::MutableBindings);
+                    Stmt::Assign {
+                        name: name.clone(),
+                        scope: Scope::Local,
+                        value,
+                        span,
+                    }
+                } else {
+                    self.declared_locals.insert(name.clone());
+                    Stmt::LetBinding {
+                        name: name.clone(),
+                        sir_type: None,
+                        value,
+                        span,
+                    }
+                };
+                out.push(stmt);
+            }
         }
         Ok(out)
     }


### PR DESCRIPTION
## Summary

Phase 9a fixes a documented `Phase 6r` limitation: parallel assignment with cross-references between LHS and RHS (the canonical Ruby swap `a, b = b, a`) was lowered sequentially, so the second assignment read the *new* value of the first LHS instead of the original.  Phase 9a introduces a swap-safe temp-pass that only fires when needed.

## The bug Phase 6r left behind

Ruby's parallel assignment semantics: **all RHS values are collected before any LHS is rebound**.

```ruby
a = 1
b = 2
a, b = b, a
# Ruby: a == 2, b == 1
```

Phase 6r lowered this to:

```
Stmt::Assign(a, VarRef(b))   # a := old_b == 2  ✓
Stmt::Assign(b, VarRef(a))   # b := new_a == 2  ✗ (should be old_a == 1)
```

Silent miscompile — no error, no warning, just the wrong answer.  Phase 6r's source code explicitly flagged this as a deferred v0 limitation; this PR closes it.

## The fix — needs-temps heuristic

After lowering every RHS expression to a SIR `Expr`, the lowerer scans each one (structural recursion over every `Expr` variant) for any `VarRef` whose name is in the LHS list.

- **No reference found** → keep the Phase 6r sequential shape (no temps, no `LetStarBinding`).  The simple `a, b = 1, 2` case stays at 2 SIR stmts.
- **Reference found** → emit two passes:
  1. `LetStarBinding(__multi_assign_t<N>_<i>, rhs[i])` for each `i` — captures the **original** RHS value before any LHS is rebound.  Uses `LetStarBinding` (sequential semantics) so each temp's name is visible to the subsequent LHS-binding pass; using plain `LetBinding` would put the temps in the same parallel-let validator group and hide them.
  2. `Stmt::LetBinding` / `Stmt::Assign` for each LHS (existing first-sighting vs re-binding rule), reading its value from the corresponding temp via `VarRef`.

The counter `multi_assign_counter` on the `Lowerer` struct increments once per temp-using multi-assignment, guaranteeing distinct temp names across nested or repeated multi-assignments in the same scope.  Names are `__`-prefixed so they can't collide with user-typeable Ruby locals.

| Source                                  | SIR shape (Phase 9a)                                                                                                              |
|-----------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
| `a, b = 1, 2`                           | `LetBinding(a, 1); LetBinding(b, 2)` *(fast path — no temps)*                                                                     |
| `a = 1; b = 2; a, b = b, a`             | `LetBinding(a, 1); LetBinding(b, 2); LetStarBinding(__multi_assign_t0_0, VarRef(b)); LetStarBinding(__multi_assign_t0_1, VarRef(a)); Assign(a, __multi_assign_t0_0); Assign(b, __multi_assign_t0_1)` |
| `a = 7; b = 8; a, b = 1, a`             | Same temp-pass — partial dependency still triggers the uniform temp-pass so position 1 captures original `a`, not the new `a`.    |

## Why the structural recursion over `Expr` is safe

The helper `expr_references_any_name` is a `match` against every `semantic_ir::Expr` variant.  Rust's exhaustiveness check fail-stops at compile time if a new `Expr` variant is added to `semantic-ir` without updating this helper — important because a missed variant would silently re-introduce the swap miscompile under an exotic RHS shape (e.g. an `If`-expression RHS that references an LHS in one of its branches).

`block_references_any_name` covers `Expr::If`, `Expr::Block` and any nested-block `Stmt` (`While`, `ForRange`, `ForEach`, `SeqSet`, `MapSet`) — also exhaustively.

## Lexer / Grammar

**No changes.**  `multi_assignment` already parses from Phase 6r.

## Tests

- `coding-adventures-ruby-lexer`: 173 → **173** (no change)
- `coding-adventures-ruby-parser`: 149 → **149** (no change — round-trip tests for multi-assignment already exist)
- `ruby-to-semantic-ir`: 165 → **170** (+5):
  - `multi_assignment_swap_introduces_temps_to_preserve_parallel_semantics`
  - `multi_assignment_simple_case_keeps_fast_path_with_no_temps`
  - `multi_assignment_partial_dependency_still_uses_temps_for_all_positions`
  - `multi_assignment_swap_module_passes_sir_validator` (validator E2E)
  - `multi_assignment_two_swaps_use_distinct_temp_counters`

The existing 4 Phase 6r tests (`multi_assignment_lowers_to_independent_let_bindings`, `_redeclaration_uses_assign`, `_three_names_emits_three_stmts`, `_arity_mismatch_errors`, `_module_passes_sir_validator`) all keep passing — none of them exercise the swap case, and the fast path preserves their expected shape.

## Test plan

- [x] `cargo test -p coding-adventures-ruby-lexer` (173/173 pass)
- [x] `cargo test -p coding-adventures-ruby-parser` (149/149 pass)
- [x] `cargo test -p ruby-to-semantic-ir` (170/170 pass)
- [x] Self-reviewed (no I/O, no unsafe — pure structural recursion + SIR Stmt list construction; new `multi_assign_counter` is a monotonic `usize`)
- [ ] CI green

Follows PR #4554 (Phase 8b).  Next chunk: Phase 9b (splat LHS `a, *b = [1, 2, 3]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
