### PR TITLE
feat(symbolic-vm): Track B1 — Apart simple-roots to TS + Rust (0.13.0)

### DIFF
--- a/code/packages/rust/symbolic-vm/CHANGELOG.md
+++ b/code/packages/rust/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog — symbolic-vm (Rust)
 
+## [0.13.0] — 2026-05-28
+
+**Track B1 — Apart simple-roots partial-fraction decomposition (Rust port).**
+
+Ports the Phase 1 simple-root subset of Python's ``apart_handler`` from
+``symbolic-vm/cas_handlers.py``.  ``Apart(P(x)/Q(x), x)`` now decomposes
+rational functions whose denominator has only *distinct rational* roots
+using the residue formula ``A_i = P(r_i) / Q'(r_i)``.  Improper fractions
+(deg P ≥ deg Q) get a polynomial-division step first, then Apart on the
+proper remainder.  Repeated roots (Phase 48 in the Python tree) and
+denominators with irreducible quadratic factors leave the expression
+wrapped in ``Apart(...)`` for downstream pipelines to handle.
+
+This unblocks the deferred Rust port of the Phase 40 / 46 Apart-retry
+telescope chain in ``cas-summation``.
+
+### Added
+
+- ``apart_handler`` registered under the ``"Apart"`` head in the symbolic
+  backend's handler table.
+- ``to_rational_ir`` IR → ``(num, den)`` bridge built on the existing
+  ``RatPoly`` / ``RatC`` machinery (no new arithmetic substrate).
+- ``rp_normalize`` / ``rp_evaluate`` / ``rp_rational_roots`` /
+  ``rp_root_multiplicities`` / ``rp_power`` polynomial helpers and
+  ``rp_to_ir_apart`` IR emitter, all sitting beside the existing
+  rational-integration ``rp_*`` family.
+- ``apart_simple_roots`` + ``apart_proper`` implementing the residue-
+  formula decomposition.  ``apart_proper`` returns ``None`` (caller
+  emits unevaluated ``Apart(...)``) when *any* multiplicity > 1 —
+  Phase 48 is explicitly out of scope for this PR.
+- ``tests/apart.rs`` with 6 acceptance cases mirroring the Track B1
+  test plan in ``code/specs/macsyma-finish-plan.md``.
+
+### Out of scope (deferred to follow-on tracks)
+
+- Repeated linear factors (Phase 48 algorithm) — Track B3.
+- Apart-retry telescope chain (Phase 40 + 46 composition) — Track B2.
+
 ## [0.12.0] — 2026-05-22
 
 **Phase 47 — Nested-Add flattening (Rust port).**

--- a/code/packages/rust/symbolic-vm/Cargo.toml
+++ b/code/packages/rust/symbolic-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symbolic-vm"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Generic symbolic expression evaluator over the symbolic-ir tree representation"
 license = "MIT"

--- a/code/packages/rust/symbolic-vm/src/handlers.rs
+++ b/code/packages/rust/symbolic-vm/src/handlers.rs
@@ -4498,6 +4498,442 @@ fn is_head_name(head: &IRNode, expected: &str) -> bool {
 }
 
 // ---------------------------------------------------------------------------
+// Apart (Track B1) — partial-fraction decomposition over Q(x).
+//
+// Phase 1 only: every root of the denominator must be a *simple* rational
+// root.  Repeated roots and irreducible quadratic factors leave the
+// expression wrapped in ``Apart(...)``.  This mirrors the Python
+// ``apart_handler`` / ``_apart_simple_roots`` / ``_apart_proper`` chain in
+// ``cas_handlers.py`` but stays inside the existing ``RatC`` / ``RatPoly``
+// machinery so we don't introduce a new arithmetic substrate.
+//
+// Polynomials use the same ``RatPoly`` representation as the rest of this
+// file: lowest degree first, coefficient at index k is the coefficient of
+// x^k.  Polynomials are not auto-normalised; callers strip trailing zeros
+// via ``rp_normalize`` when needed.
+// ---------------------------------------------------------------------------
+
+const APART: &str = "Apart";
+
+/// Strip trailing zero coefficients in place.
+fn rp_normalize(p: &[RatC]) -> RatPoly {
+    let mut out: RatPoly = p.to_vec();
+    while out.last().map_or(false, |c| rc_is_zero(*c)) {
+        out.pop();
+    }
+    out
+}
+
+/// Horner evaluation at a rational point.
+fn rp_evaluate(p: &[RatC], x: RatC) -> Option<RatC> {
+    let n = rp_normalize(p);
+    if n.is_empty() {
+        return Some(RC_ZERO);
+    }
+    let mut acc = RC_ZERO;
+    for &c in n.iter().rev() {
+        acc = rc_add(rc_mul(acc, x)?, c)?;
+    }
+    Some(acc)
+}
+
+/// Rational roots via the Rational-Roots Theorem.  Returns roots in
+/// ascending order — matches Python's ``sorted(roots)`` so the IR output
+/// shape stays stable across regression tests.
+fn rp_rational_roots(p: &[RatC]) -> Option<Vec<RatC>> {
+    let n = rp_normalize(p);
+    if n.len() <= 1 {
+        return Some(vec![]);
+    }
+
+    // Clear denominators so candidates come from integer divisors of p.
+    let mut lcm_den: i128 = 1;
+    for &(_, d) in &n {
+        let g = gcd128(lcm_den.unsigned_abs(), d.unsigned_abs()) as i128;
+        lcm_den = lcm_den.checked_mul(d)? / g;
+    }
+    let mut int_coeffs: Vec<i128> = n
+        .iter()
+        .map(|&(num, den)| num.checked_mul(lcm_den).map(|p| p / den))
+        .collect::<Option<Vec<_>>>()?;
+    if *int_coeffs.last()? < 0 {
+        for c in int_coeffs.iter_mut() {
+            *c = -*c;
+        }
+    }
+
+    let a0 = int_coeffs[0];
+    let an = *int_coeffs.last()?;
+
+    if a0 == 0 {
+        // x = 0 is a root; strip it and recurse on the tail.
+        let tail_int = &int_coeffs[1..];
+        let tail_poly: RatPoly = tail_int.iter().map(|&c| (c, 1i128)).collect();
+        let mut tail_roots = rp_rational_roots(&tail_poly)?;
+        if !tail_roots.iter().any(|r| rc_is_zero(*r)) {
+            tail_roots.push(RC_ZERO);
+        }
+        // Keep ascending order.
+        tail_roots.sort_by(|a, b| {
+            // a = (an, ad), b = (bn, bd) — compare an*bd vs bn*ad.
+            let lhs = a.0 as i128 * b.1 as i128;
+            let rhs = b.0 as i128 * a.1 as i128;
+            lhs.cmp(&rhs)
+        });
+        return Some(tail_roots);
+    }
+
+    fn divisors(m: i128) -> Vec<i128> {
+        let abs = m.unsigned_abs();
+        let mut out = Vec::new();
+        let mut d: u128 = 1;
+        while d <= abs {
+            if abs % d == 0 {
+                out.push(d as i128);
+            }
+            d += 1;
+        }
+        out
+    }
+
+    let p_divs = divisors(a0);
+    let q_divs = divisors(an);
+
+    // Use a tuple-keyed set via Vec + dedup; counts are small.
+    let mut candidates: Vec<RatC> = Vec::new();
+    for &u in &p_divs {
+        for &v in &q_divs {
+            for sign in [1i128, -1] {
+                if let Some(cand) = rc(sign * u, v) {
+                    candidates.push(cand);
+                }
+            }
+        }
+    }
+    candidates.sort();
+    candidates.dedup();
+
+    let int_poly: RatPoly = int_coeffs.iter().map(|&c| (c, 1i128)).collect();
+    let mut roots: Vec<RatC> = Vec::new();
+    for cand in candidates {
+        if let Some(v) = rp_evaluate(&int_poly, cand) {
+            if rc_is_zero(v) && !roots.iter().any(|r| *r == cand) {
+                roots.push(cand);
+            }
+        }
+    }
+    // Sort ascending — matches Python's ``sorted(roots)``.
+    roots.sort_by(|a, b| {
+        let lhs = a.0 * b.1;
+        let rhs = b.0 * a.1;
+        lhs.cmp(&rhs)
+    });
+    Some(roots)
+}
+
+/// For each rational root, count the multiplicity of ``(x − r)`` in ``den``.
+/// Returns ``None`` when the multiplicities don't sum to ``deg(den)``
+/// (irreducible factor present), so the caller can bail to the unevaluated
+/// form.
+fn rp_root_multiplicities(den: &[RatC], roots: &[RatC]) -> Option<Vec<(RatC, usize)>> {
+    let mut out: Vec<(RatC, usize)> = Vec::new();
+    let mut remaining: RatPoly = rp_normalize(den);
+    let mut total = 0usize;
+    for &r in roots {
+        let linear: RatPoly = vec![rc_neg(r), RC_ONE]; // (x − r)
+        let mut m: usize = 0;
+        loop {
+            let (q, rem) = rp_div(&remaining, &linear)?;
+            if rp_is_zero(&rem) {
+                remaining = q;
+                m += 1;
+            } else {
+                break;
+            }
+        }
+        if m == 0 {
+            return None;
+        }
+        total += m;
+        out.push((r, m));
+    }
+    let deg_den = rp_deg(den)?;
+    if total != deg_den {
+        return None;
+    }
+    Some(out)
+}
+
+/// Rational form of an IR sub-expression in variable ``x``.
+type RpRational = (RatPoly, RatPoly); // (num, den)
+
+const fn rp_one_const() -> [RatC; 1] {
+    [(1i128, 1i128)]
+}
+
+fn rp_one() -> RatPoly {
+    rp_one_const().to_vec()
+}
+
+/// Attempt to represent ``node`` as a rational function ``num / den`` of
+/// ``x``.  Returns ``None`` for floats, free symbols, transcendentals, or
+/// any subtree outside Q(x).  Mirrors Python ``polynomial_bridge.to_rational``
+/// (and the analogous TS port).
+fn to_rational_ir(node: &IRNode, x: &str) -> Option<RpRational> {
+    match node {
+        IRNode::Integer(n) => Some((vec![(*n as i128, 1)], rp_one())),
+        IRNode::Rational(n, d) => {
+            let c = rc(*n as i128, *d as i128)?;
+            Some((vec![c], rp_one()))
+        }
+        IRNode::Float(_) => None,
+        IRNode::Symbol(s) => {
+            if s == x {
+                Some((vec![RC_ZERO, RC_ONE], rp_one()))
+            } else {
+                None
+            }
+        }
+        IRNode::Apply(apply) => {
+            let IRNode::Symbol(head) = &apply.head else {
+                return None;
+            };
+            match (head.as_str(), apply.args.as_slice()) {
+                (ADD, args) if !args.is_empty() => {
+                    let mut acc = to_rational_ir(&args[0], x)?;
+                    for arg in &args[1..] {
+                        let other = to_rational_ir(arg, x)?;
+                        acc = rational_add(acc, other)?;
+                    }
+                    Some(acc)
+                }
+                (SUB, [a, b]) => {
+                    let ra = to_rational_ir(a, x)?;
+                    let rb = to_rational_ir(b, x)?;
+                    rational_sub(ra, rb)
+                }
+                (NEG, [a]) => {
+                    let (num, den) = to_rational_ir(a, x)?;
+                    let neg_num: RatPoly = num.into_iter().map(rc_neg).collect();
+                    Some((neg_num, den))
+                }
+                (MUL, args) if !args.is_empty() => {
+                    let mut acc = to_rational_ir(&args[0], x)?;
+                    for arg in &args[1..] {
+                        let other = to_rational_ir(arg, x)?;
+                        acc = rational_mul(acc, other)?;
+                    }
+                    Some(acc)
+                }
+                (DIV, [a, b]) => {
+                    let ra = to_rational_ir(a, x)?;
+                    let rb = to_rational_ir(b, x)?;
+                    rational_div(ra, rb)
+                }
+                (POW, [base, exp]) => {
+                    let IRNode::Integer(n) = exp else {
+                        return None;
+                    };
+                    rational_pow(base, *n, x)
+                }
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+fn rational_add(a: RpRational, b: RpRational) -> Option<RpRational> {
+    let num = rp_add(&rp_mul(&a.0, &b.1)?, &rp_mul(&b.0, &a.1)?)?;
+    let den = rp_mul(&a.1, &b.1)?;
+    Some((num, den))
+}
+
+fn rational_sub(a: RpRational, b: RpRational) -> Option<RpRational> {
+    let num = rp_sub_poly(&rp_mul(&a.0, &b.1)?, &rp_mul(&b.0, &a.1)?)?;
+    let den = rp_mul(&a.1, &b.1)?;
+    Some((num, den))
+}
+
+fn rational_mul(a: RpRational, b: RpRational) -> Option<RpRational> {
+    Some((rp_mul(&a.0, &b.0)?, rp_mul(&a.1, &b.1)?))
+}
+
+fn rational_div(a: RpRational, b: RpRational) -> Option<RpRational> {
+    let new_den = rp_mul(&a.1, &b.0)?;
+    if rp_is_zero(&new_den) {
+        return None;
+    }
+    Some((rp_mul(&a.0, &b.1)?, new_den))
+}
+
+fn rational_pow(base: &IRNode, n: i64, x: &str) -> Option<RpRational> {
+    let (num, den) = to_rational_ir(base, x)?;
+    if n == 0 {
+        return Some((rp_one(), rp_one()));
+    }
+    if n < 0 {
+        if rp_is_zero(&num) {
+            return None;
+        }
+        let k = (-n) as usize;
+        return Some((rp_power(&den, k)?, rp_power(&num, k)?));
+    }
+    let k = n as usize;
+    Some((rp_power(&num, k)?, rp_power(&den, k)?))
+}
+
+fn rp_power(p: &[RatC], n: usize) -> Option<RatPoly> {
+    let mut result: RatPoly = rp_one();
+    for _ in 0..n {
+        result = rp_mul(&result, p)?;
+    }
+    Some(result)
+}
+
+/// Build canonical IR for a polynomial coefficient tuple.  Mirrors
+/// ``polynomial_bridge.from_polynomial`` — left-associated ``Add`` chain,
+/// drops zero terms, special-cases ±1 coefficients.
+fn rp_to_ir_apart(p: &[RatC], x: &str) -> Option<IRNode> {
+    let n = rp_normalize(p);
+    if n.is_empty() {
+        return Some(IRNode::Integer(0));
+    }
+    if n.len() == 1 {
+        return rc_to_ir(n[0]);
+    }
+    let x_sym = IRNode::Symbol(x.to_string());
+    let mut terms: Vec<IRNode> = Vec::new();
+    for (i, &c) in n.iter().enumerate() {
+        if rc_is_zero(c) {
+            continue;
+        }
+        let monomial = if i == 0 {
+            rc_to_ir(c)?
+        } else {
+            let power: IRNode = if i == 1 {
+                x_sym.clone()
+            } else {
+                apply_node(POW, vec![x_sym.clone(), IRNode::Integer(i as i64)])
+            };
+            if rc_is_one(c) {
+                power
+            } else if c == (-1, 1) {
+                apply_node(NEG, vec![power])
+            } else {
+                apply_node(MUL, vec![rc_to_ir(c)?, power])
+            }
+        };
+        terms.push(monomial);
+    }
+    if terms.is_empty() {
+        return Some(IRNode::Integer(0));
+    }
+    Some(
+        terms
+            .into_iter()
+            .reduce(|acc, t| apply_node(ADD, vec![acc, t]))
+            .unwrap(),
+    )
+}
+
+fn apart_simple_roots(
+    num: &[RatC],
+    den: &[RatC],
+    roots: &[RatC],
+    x: &str,
+) -> Option<IRNode> {
+    let den_deriv = rp_deriv(den)?;
+    let mut terms: Vec<IRNode> = Vec::new();
+    for &r in roots {
+        let num_val = rp_evaluate(num, r)?;
+        let den_d_val = rp_evaluate(&den_deriv, r)?;
+        if rc_is_zero(den_d_val) {
+            return None;
+        }
+        let coef = rc_div(num_val, den_d_val)?;
+        // (x − r) IR via from_polynomial([-r, 1], x).
+        let factor_ir = rp_to_ir_apart(&[rc_neg(r), RC_ONE], x)?;
+        let term = if rc_is_one(coef) {
+            apply_node(DIV, vec![IRNode::Integer(1), factor_ir])
+        } else if coef == (-1, 1) {
+            apply_node(NEG, vec![apply_node(DIV, vec![IRNode::Integer(1), factor_ir])])
+        } else {
+            apply_node(DIV, vec![rc_to_ir(coef)?, factor_ir])
+        };
+        terms.push(term);
+    }
+    if terms.is_empty() {
+        return Some(IRNode::Integer(0));
+    }
+    Some(
+        terms
+            .into_iter()
+            .reduce(|acc, t| apply_node(ADD, vec![acc, t]))
+            .unwrap(),
+    )
+}
+
+fn apart_proper(num: &[RatC], den: &[RatC], x: &str) -> Option<IRNode> {
+    let roots = rp_rational_roots(den)?;
+    if roots.is_empty() {
+        return None;
+    }
+    let mults = rp_root_multiplicities(den, &roots)?;
+    if mults.iter().any(|(_, m)| *m > 1) {
+        // Phase 48 — out of scope for this PR.
+        return None;
+    }
+    apart_simple_roots(num, den, &roots, x)
+}
+
+fn apart_handler(_vm: &mut VM, expr: IRApply) -> IRNode {
+    let fallback = IRNode::Apply(Box::new(expr.clone()));
+    if expr.args.len() != 2 {
+        return fallback;
+    }
+    let inner = &expr.args[0];
+    let var = &expr.args[1];
+    let IRNode::Symbol(x) = var else {
+        return fallback;
+    };
+    let Some((num, den)) = to_rational_ir(inner, x) else {
+        return fallback;
+    };
+    let den_norm = rp_normalize(&den);
+    let num_norm = rp_normalize(&num);
+
+    // Already a polynomial (denominator ≡ 1).
+    if den_norm.len() == 1 && rc_is_one(den_norm[0]) {
+        return rp_to_ir_apart(&num_norm, x).unwrap_or(fallback);
+    }
+
+    let num_deg = rp_deg(&num_norm).unwrap_or(0);
+    let den_deg = match rp_deg(&den_norm) {
+        Some(d) => d,
+        None => return fallback,
+    };
+
+    if num_deg >= den_deg {
+        let Some((q, r)) = rp_div(&num_norm, &den_norm) else {
+            return fallback;
+        };
+        if rp_is_zero(&r) {
+            return rp_to_ir_apart(&q, x).unwrap_or(fallback);
+        }
+        let Some(proper) = apart_proper(&r, &den_norm, x) else {
+            return fallback;
+        };
+        let Some(poly_part) = rp_to_ir_apart(&q, x) else {
+            return fallback;
+        };
+        return apply_node(ADD, vec![poly_part, proper]);
+    }
+
+    apart_proper(&num_norm, &den_norm, x).unwrap_or(fallback)
+}
+
+// ---------------------------------------------------------------------------
 // Build handler table
 // ---------------------------------------------------------------------------
 
@@ -4568,6 +5004,8 @@ pub fn build_handler_table(simplify: bool) -> HashMap<String, Handler> {
         m.insert(D.to_string(), derivative_handler());
         m.insert(INTEGRATE.to_string(), integrate_handler());
         m.insert(FACTOR.to_string(), handler_fn(factor_handler));
+        // Track B1 — Apart simple-roots partial-fraction decomposition.
+        m.insert(APART.to_string(), handler_fn(apart_handler));
     }
     m
 }

--- a/code/packages/rust/symbolic-vm/tests/apart.rs
+++ b/code/packages/rust/symbolic-vm/tests/apart.rs
@@ -1,0 +1,139 @@
+//! Track B1 — Apart simple-roots partial-fraction decomposition.
+//!
+//! Mirrors the six TypeScript test cases (and the Python reference)
+//! exercised by ``code/specs/macsyma-finish-plan.md`` Track B1.
+//! Apart is registered under the symbol name ``"Apart"`` in the
+//! symbolic backend's handler table.
+
+use symbolic_ir::{apply, int, rat, sym, ADD, DIV, MUL, NEG, POW, SUB};
+use symbolic_vm::{SymbolicBackend, VM};
+
+fn vm() -> VM {
+    VM::new(Box::new(SymbolicBackend::new()))
+}
+
+fn apart(inner: symbolic_ir::IRNode) -> symbolic_ir::IRNode {
+    apply(sym("Apart"), vec![inner, sym("x")])
+}
+
+#[test]
+fn apart_one_over_x_squared_minus_one_acceptance() {
+    let mut v = vm();
+    // 1 / (x^2 - 1)
+    let inner = apply(
+        sym(DIV),
+        vec![
+            int(1),
+            apply(sym(SUB), vec![apply(sym(POW), vec![sym("x"), int(2)]), int(1)]),
+        ],
+    );
+    let result = v.eval(apart(inner));
+    // Roots sort ascending: -1 first, then 1.  Matches Python's output:
+    // Add(Div(-1/2, (1+x)), Div(1/2, (-1+x))).
+    let expected = apply(
+        sym(ADD),
+        vec![
+            apply(sym(DIV), vec![rat(-1, 2), apply(sym(ADD), vec![int(1), sym("x")])]),
+            apply(sym(DIV), vec![rat(1, 2), apply(sym(ADD), vec![int(-1), sym("x")])]),
+        ],
+    );
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn apart_three_distinct_simple_roots() {
+    let mut v = vm();
+    let f1 = apply(sym(SUB), vec![sym("x"), int(1)]);
+    let f2 = apply(sym(SUB), vec![sym("x"), int(2)]);
+    let f3 = apply(sym(SUB), vec![sym("x"), int(3)]);
+    let inner = apply(
+        sym(DIV),
+        vec![int(1), apply(sym(MUL), vec![apply(sym(MUL), vec![f1, f2]), f3])],
+    );
+    let result = v.eval(apart(inner));
+    // Residues: A_1 = 1/2, A_2 = -1, A_3 = 1/2.
+    // ``A = -1`` renders as Neg(Div(1, ...)).
+    let expected = apply(
+        sym(ADD),
+        vec![
+            apply(
+                sym(ADD),
+                vec![
+                    apply(sym(DIV), vec![rat(1, 2), apply(sym(ADD), vec![int(-1), sym("x")])]),
+                    apply(
+                        sym(NEG),
+                        vec![apply(sym(DIV), vec![int(1), apply(sym(ADD), vec![int(-2), sym("x")])])],
+                    ),
+                ],
+            ),
+            apply(sym(DIV), vec![rat(1, 2), apply(sym(ADD), vec![int(-3), sym("x")])]),
+        ],
+    );
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn apart_improper_fraction_x_cubed_over_x_squared_minus_one() {
+    let mut v = vm();
+    let inner = apply(
+        sym(DIV),
+        vec![
+            apply(sym(POW), vec![sym("x"), int(3)]),
+            apply(sym(SUB), vec![apply(sym(POW), vec![sym("x"), int(2)]), int(1)]),
+        ],
+    );
+    let result = v.eval(apart(inner));
+    // x^3/(x^2-1) = x + 1/(2(x-1)) + 1/(2(x+1)).
+    // ``from_polynomial([0, 1], x)`` collapses to bare x.
+    let expected = apply(
+        sym(ADD),
+        vec![
+            sym("x"),
+            apply(
+                sym(ADD),
+                vec![
+                    apply(sym(DIV), vec![rat(1, 2), apply(sym(ADD), vec![int(1), sym("x")])]),
+                    apply(sym(DIV), vec![rat(1, 2), apply(sym(ADD), vec![int(-1), sym("x")])]),
+                ],
+            ),
+        ],
+    );
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn apart_irreducible_quadratic_stays_unevaluated() {
+    let mut v = vm();
+    let inner = apply(
+        sym(DIV),
+        vec![int(1), apply(sym(ADD), vec![apply(sym(POW), vec![sym("x"), int(2)]), int(1)])],
+    );
+    let result = v.eval(apart(inner.clone()));
+    // No rational roots — Apart stays wrapped.
+    assert_eq!(result, apply(sym("Apart"), vec![inner, sym("x")]));
+}
+
+#[test]
+fn apart_repeated_root_stays_unevaluated() {
+    let mut v = vm();
+    // 1 / (x - 1)^2
+    let inner = apply(
+        sym(DIV),
+        vec![int(1), apply(sym(POW), vec![apply(sym(SUB), vec![sym("x"), int(1)]), int(2)])],
+    );
+    let result = v.eval(apart(inner.clone()));
+    // Phase 48 explicitly out of scope; handler bails to unevaluated form.
+    assert_eq!(result, apply(sym("Apart"), vec![inner, sym("x")]));
+}
+
+#[test]
+fn apart_already_polynomial_passes_through() {
+    let mut v = vm();
+    // Apart(x + 1, x) → x + 1
+    let inner = apply(sym(ADD), vec![sym("x"), int(1)]);
+    let result = v.eval(apart(inner));
+    // ``to_rational(x+1, x)`` → num = [1, 1], den = [1]; the early-return
+    // path emits ``from_polynomial(num, x)`` = Add(1, x).
+    let expected = apply(sym(ADD), vec![int(1), sym("x")]);
+    assert_eq!(result, expected);
+}

--- a/code/packages/typescript/symbolic-vm/CHANGELOG.md
+++ b/code/packages/typescript/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,44 @@
 # Changelog
 
+## [0.13.0] — 2026-05-28
+
+**Track B1 — Apart simple-roots partial-fraction decomposition (TypeScript port).**
+
+Ports the Phase 1 simple-root subset of Python's ``apart_handler`` from
+``symbolic-vm/cas_handlers.py``.  ``Apart(P(x)/Q(x), x)`` now decomposes
+rational functions whose denominator has only *distinct rational* roots
+using the residue formula ``A_i = P(r_i) / Q'(r_i)``.  Improper fractions
+(deg P ≥ deg Q) get a polynomial-division step first, then Apart on the
+proper remainder.  Repeated roots (Phase 48 in the Python tree) and
+denominators with irreducible quadratic factors leave the expression
+wrapped in ``Apart(...)`` for downstream pipelines to handle.
+
+This unblocks the deferred TS port of the Phase 40 / 46 Apart-retry
+telescope chain in ``cas-summation``.
+
+### Added
+
+- ``apartHandler`` registered under the ``"Apart"`` head in the symbolic
+  backend's handler table.
+- Self-contained ``RatQ`` (BigInt rational) coefficient type plus
+  polynomial primitives ``polyQNormalize`` / ``polyQDegree`` /
+  ``polyQEvaluate`` / ``polyQDeriv`` / ``polyQDivmod`` /
+  ``polyQRationalRoots`` / ``polyQRootMultiplicities``.
+- IR ↔ polynomial bridges ``toRational`` and ``fromPolynomial``,
+  mirroring ``polynomial_bridge.py`` (left-associated ``Add`` chains,
+  ±1 coefficient elision, zero-term skipping).
+- ``apartSimpleRoots`` + ``apartProper`` implementing the residue-formula
+  decomposition.  ``apartProper`` bails to ``undefined`` (caller emits
+  unevaluated ``Apart(...)``) when *any* multiplicity > 1 — Phase 48 is
+  explicitly out of scope for this PR.
+- 6 new test cases in ``tests/apart.test.ts`` mirroring the Track B1
+  acceptance cases in ``code/specs/macsyma-finish-plan.md``.
+
+### Out of scope (deferred to follow-on tracks)
+
+- Repeated linear factors (Phase 48 algorithm) — Track B3.
+- Apart-retry telescope chain (Phase 40 + 46 composition) — Track B2.
+
 ## [0.12.0] — 2026-05-22
 
 **Phase 47 — Nested-Add flattening (TypeScript port).**

--- a/code/packages/typescript/symbolic-vm/package.json
+++ b/code/packages/typescript/symbolic-vm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/symbolic-vm",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Pure TypeScript symbolic expression evaluator with strict and symbolic backends",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/symbolic-vm/src/index.ts
+++ b/code/packages/typescript/symbolic-vm/src/index.ts
@@ -941,6 +941,11 @@ function buildHandlerTable(simplify: boolean): ReadonlyMap<string, Handler> {
   });
   table.set(LIST.name, (_vm, expr) => expr);
   table.set(FACTOR.name, factorHandler);
+  // Track B1 (Phase 1 partial-fraction decomposition).  Registered by string
+  // name because ``Apart`` has no exported constant in symbolic-ir.
+  if (simplify) {
+    table.set("Apart", apartHandler);
+  }
   if (simplify) {
     table.set(D.name, differentiate());
     table.set(INTEGRATE.name, integrate());
@@ -1618,6 +1623,534 @@ function nodeKey(node: IRNode): string {
     case "apply":
       return `a:${nodeKey(node.head)}(${node.args.map((arg) => nodeKey(arg)).join(",")})`;
   }
+}
+
+// ---------------------------------------------------------------------------
+// Apart (Track B1) — partial-fraction decomposition over Q(x).
+//
+// Phase 1 only: every root of the denominator must be a *simple* rational
+// root.  Repeated roots and irreducible quadratic factors bail to the
+// unevaluated ``Apart(...)`` (Phase 48 is out of scope for this PR).
+//
+// Polynomials here use a coefficient-tuple representation indexed by power
+// (lowest degree first) — same convention as ``polynomial-bridge.py``:
+//
+//     [c0, c1, c2]  ↔  c0 + c1·x + c2·x²
+//
+// Coefficients are ``RatQ`` values (bigint numerator + bigint denominator,
+// always lowest terms with denom > 0).  We deliberately roll our own thin
+// fraction type rather than reusing ``Numeric`` because Numeric also admits
+// floats — Apart must stay exact.
+// ---------------------------------------------------------------------------
+
+/** Exact rational coefficient: numerator + positive denominator in lowest terms. */
+type RatQ = readonly [bigint, bigint];
+
+const RQ_ZERO: RatQ = [0n, 1n];
+const RQ_ONE: RatQ = [1n, 1n];
+
+function rqAbs(n: bigint): bigint {
+  return n < 0n ? -n : n;
+}
+
+/** Greatest common divisor of two non-negative bigints. */
+function rqGcd(a: bigint, b: bigint): bigint {
+  let x = a < 0n ? -a : a;
+  let y = b < 0n ? -b : b;
+  while (y !== 0n) {
+    [x, y] = [y, x % y];
+  }
+  return x;
+}
+
+/** Build a RatQ from raw numer/denom, reducing to lowest terms with denom > 0. */
+function rqMake(n: bigint, d: bigint): RatQ {
+  if (d === 0n) throw new RangeError("zero denominator in RatQ");
+  if (d < 0n) {
+    n = -n;
+    d = -d;
+  }
+  if (n === 0n) return RQ_ZERO;
+  const g = rqGcd(rqAbs(n), d);
+  return [n / g, d / g];
+}
+
+function rqIsZero(r: RatQ): boolean {
+  return r[0] === 0n;
+}
+
+function rqEquals(a: RatQ, b: RatQ): boolean {
+  return a[0] === b[0] && a[1] === b[1];
+}
+
+function rqAdd(a: RatQ, b: RatQ): RatQ {
+  return rqMake(a[0] * b[1] + b[0] * a[1], a[1] * b[1]);
+}
+
+function rqSub(a: RatQ, b: RatQ): RatQ {
+  return rqMake(a[0] * b[1] - b[0] * a[1], a[1] * b[1]);
+}
+
+function rqMul(a: RatQ, b: RatQ): RatQ {
+  return rqMake(a[0] * b[0], a[1] * b[1]);
+}
+
+function rqDiv(a: RatQ, b: RatQ): RatQ {
+  if (b[0] === 0n) throw new RangeError("division by zero in RatQ");
+  return rqMake(a[0] * b[1], a[1] * b[0]);
+}
+
+function rqNeg(r: RatQ): RatQ {
+  return [-r[0], r[1]];
+}
+
+/** Convert a RatQ to IR (Integer when denom == 1, otherwise Rational). */
+function rqToIr(r: RatQ): IRNode {
+  if (r[0] === 0n) return int(0);
+  if (r[1] === 1n) return int(r[0]);
+  return rational(r[0], r[1]);
+}
+
+/** Coefficient tuple (lowest-degree first); empty array == zero polynomial. */
+type PolyQ = readonly RatQ[];
+
+/** Strip trailing zeros — analog of ``polynomial.normalize``. */
+function polyQNormalize(p: PolyQ): RatQ[] {
+  const result = [...p];
+  while (result.length > 0 && rqIsZero(result[result.length - 1])) result.pop();
+  return result;
+}
+
+/** Degree (-1 for the zero polynomial). */
+function polyQDegree(p: PolyQ): number {
+  const n = polyQNormalize(p);
+  return n.length - 1;
+}
+
+/** Horner evaluation at a rational point. */
+function polyQEvaluate(p: PolyQ, x: RatQ): RatQ {
+  const n = polyQNormalize(p);
+  if (n.length === 0) return RQ_ZERO;
+  let acc: RatQ = RQ_ZERO;
+  for (let i = n.length - 1; i >= 0; i -= 1) {
+    acc = rqAdd(rqMul(acc, x), n[i]);
+  }
+  return acc;
+}
+
+/** Formal derivative; constant / zero polynomial → []. */
+function polyQDeriv(p: PolyQ): RatQ[] {
+  const n = polyQNormalize(p);
+  if (n.length <= 1) return [];
+  const result: RatQ[] = [];
+  for (let i = 1; i < n.length; i += 1) {
+    result.push(rqMul(n[i], [BigInt(i), 1n]));
+  }
+  return polyQNormalize(result);
+}
+
+/** Polynomial long division: returns { q, r } such that ``a = b·q + r``. */
+function polyQDivmod(a: PolyQ, b: PolyQ): { q: RatQ[]; r: RatQ[] } {
+  const nb = polyQNormalize(b);
+  if (nb.length === 0) throw new RangeError("polynomial division by zero");
+  const na = polyQNormalize(a);
+  const degA = na.length - 1;
+  const degB = nb.length - 1;
+  if (degA < degB) return { q: [], r: na };
+  const rem: RatQ[] = [...na];
+  const quot: RatQ[] = Array.from({ length: degA - degB + 1 }, () => RQ_ZERO);
+  const leadB = nb[degB];
+  let degRem = degA;
+  while (degRem >= degB) {
+    const coeff = rqDiv(rem[degRem], leadB);
+    const power = degRem - degB;
+    quot[power] = coeff;
+    for (let j = 0; j < nb.length; j += 1) {
+      rem[power + j] = rqSub(rem[power + j], rqMul(coeff, nb[j]));
+    }
+    degRem -= 1;
+    while (degRem >= 0 && rqIsZero(rem[degRem])) degRem -= 1;
+  }
+  return { q: polyQNormalize(quot), r: polyQNormalize(rem) };
+}
+
+/** Distinct rational roots via the Rational-Roots Theorem.  Returns roots
+ *  as ``RatQ`` values in arbitrary order. */
+function polyQRationalRoots(p: PolyQ): RatQ[] {
+  const n = polyQNormalize(p);
+  if (n.length <= 1) return [];
+
+  // Clear denominators so candidates come from integer divisors of p.
+  let lcmDen = 1n;
+  for (const [, d] of n) {
+    lcmDen = (lcmDen * d) / rqGcd(lcmDen, d);
+  }
+  let intCoeffs = n.map(([num, den]) => (num * lcmDen) / den);
+  if (intCoeffs[intCoeffs.length - 1] < 0n) {
+    intCoeffs = intCoeffs.map((c) => -c);
+  }
+
+  const a0 = intCoeffs[0];
+  const an = intCoeffs[intCoeffs.length - 1];
+
+  if (a0 === 0n) {
+    // x = 0 is a root; strip it and recurse on the tail.
+    const tailInt = intCoeffs.slice(1);
+    const tailPoly: RatQ[] = tailInt.map((c) => rqMake(c, 1n));
+    const tailRoots = polyQRationalRoots(tailPoly);
+    const found = new Map<string, RatQ>();
+    found.set("0/1", RQ_ZERO);
+    for (const r of tailRoots) found.set(`${r[0]}/${r[1]}`, r);
+    return [...found.values()];
+  }
+
+  const divisors = (m: bigint): bigint[] => {
+    const abs = m < 0n ? -m : m;
+    const out: bigint[] = [];
+    for (let d = 1n; d <= abs; d += 1n) {
+      if (abs % d === 0n) out.push(d);
+    }
+    return out;
+  };
+
+  const pDivs = divisors(a0);
+  const qDivs = divisors(an);
+
+  const candidates = new Map<string, RatQ>();
+  for (const u of pDivs) {
+    for (const v of qDivs) {
+      const pos = rqMake(u, v);
+      const neg = rqMake(-u, v);
+      candidates.set(`${pos[0]}/${pos[1]}`, pos);
+      candidates.set(`${neg[0]}/${neg[1]}`, neg);
+    }
+  }
+
+  const intPoly: RatQ[] = intCoeffs.map((c) => rqMake(c, 1n));
+  const roots: RatQ[] = [];
+  for (const cand of candidates.values()) {
+    if (rqIsZero(polyQEvaluate(intPoly, cand))) roots.push(cand);
+  }
+  // Sort ascending by rational value to match Python's ``sorted(roots)``
+  // — keeps the IR output shape stable across regression tests.
+  roots.sort((a, b) => {
+    const lhs = a[0] * b[1];
+    const rhs = b[0] * a[1];
+    if (lhs < rhs) return -1;
+    if (lhs > rhs) return 1;
+    return 0;
+  });
+  return roots;
+}
+
+/** For each rational root r, count how many times (x − r) divides ``den``.
+ *  Returns a Map keyed by RatQ string-key; returns ``undefined`` if the
+ *  multiplicities don't sum to deg(den) (irreducible factor present). */
+function polyQRootMultiplicities(
+  den: PolyQ,
+  roots: readonly RatQ[],
+): Map<string, { root: RatQ; mult: number }> | undefined {
+  const out = new Map<string, { root: RatQ; mult: number }>();
+  let remaining: RatQ[] = polyQNormalize(den);
+  let total = 0;
+  for (const r of roots) {
+    let m = 0;
+    const linear: RatQ[] = [rqNeg(r), RQ_ONE]; // (x − r)
+    // Repeatedly divide while exact.
+    /* eslint-disable no-constant-condition */
+    while (true) {
+      const { q, r: rem } = polyQDivmod(remaining, linear);
+      if (polyQNormalize(rem).length === 0) {
+        remaining = q;
+        m += 1;
+      } else {
+        break;
+      }
+    }
+    /* eslint-enable no-constant-condition */
+    if (m === 0) return undefined;
+    out.set(`${r[0]}/${r[1]}`, { root: r, mult: m });
+    total += m;
+  }
+  if (total !== polyQDegree(den)) return undefined;
+  return out;
+}
+
+// --- IR ↔ polynomial bridge -------------------------------------------------
+
+type RationalForm = { num: RatQ[]; den: RatQ[] };
+
+/** Mirror of Python ``polynomial_bridge.to_rational``: walks an IR tree and
+ *  returns ``{ num, den }`` if it lives in Q(x); otherwise ``undefined``. */
+function toRational(node: IRNode, x: IRSymbol): RationalForm | undefined {
+  return toRationalWalk(node, x);
+}
+
+function toRationalWalk(node: IRNode, x: IRSymbol): RationalForm | undefined {
+  if (node.kind === "integer") {
+    return { num: [rqMake(node.value, 1n)], den: [RQ_ONE] };
+  }
+  if (node.kind === "rational") {
+    return { num: [rqMake(node.numer, node.denom)], den: [RQ_ONE] };
+  }
+  if (node.kind === "float") return undefined; // exact only
+  if (node.kind === "symbol") {
+    if (node.name === x.name) {
+      return { num: [RQ_ZERO, RQ_ONE], den: [RQ_ONE] };
+    }
+    return undefined;
+  }
+  if (node.kind !== "apply") return undefined;
+  const head = node.head;
+
+  if (equals(head, ADD)) {
+    return reduceRational(node.args, x, addRational);
+  }
+  if (equals(head, SUB)) {
+    if (node.args.length !== 2) return undefined;
+    const a = toRationalWalk(node.args[0], x);
+    const b = toRationalWalk(node.args[1], x);
+    if (!a || !b) return undefined;
+    return subRational(a, b);
+  }
+  if (equals(head, NEG)) {
+    if (node.args.length !== 1) return undefined;
+    const a = toRationalWalk(node.args[0], x);
+    if (!a) return undefined;
+    return { num: a.num.map(rqNeg), den: a.den };
+  }
+  if (equals(head, MUL)) {
+    return reduceRational(node.args, x, mulRational);
+  }
+  if (equals(head, DIV)) {
+    if (node.args.length !== 2) return undefined;
+    const a = toRationalWalk(node.args[0], x);
+    const b = toRationalWalk(node.args[1], x);
+    if (!a || !b) return undefined;
+    return divRational(a, b);
+  }
+  if (equals(head, POW)) {
+    if (node.args.length !== 2) return undefined;
+    return powRational(node.args[0], node.args[1], x);
+  }
+  return undefined;
+}
+
+function polyQAdd(a: PolyQ, b: PolyQ): RatQ[] {
+  const n = Math.max(a.length, b.length);
+  const out: RatQ[] = [];
+  for (let i = 0; i < n; i += 1) {
+    const av = i < a.length ? a[i] : RQ_ZERO;
+    const bv = i < b.length ? b[i] : RQ_ZERO;
+    out.push(rqAdd(av, bv));
+  }
+  return polyQNormalize(out);
+}
+
+function polyQSub(a: PolyQ, b: PolyQ): RatQ[] {
+  const n = Math.max(a.length, b.length);
+  const out: RatQ[] = [];
+  for (let i = 0; i < n; i += 1) {
+    const av = i < a.length ? a[i] : RQ_ZERO;
+    const bv = i < b.length ? b[i] : RQ_ZERO;
+    out.push(rqSub(av, bv));
+  }
+  return polyQNormalize(out);
+}
+
+function polyQMul(a: PolyQ, b: PolyQ): RatQ[] {
+  if (a.length === 0 || b.length === 0) return [];
+  const out: RatQ[] = Array.from({ length: a.length + b.length - 1 }, () => RQ_ZERO);
+  for (let i = 0; i < a.length; i += 1) {
+    if (rqIsZero(a[i])) continue;
+    for (let j = 0; j < b.length; j += 1) {
+      if (rqIsZero(b[j])) continue;
+      out[i + j] = rqAdd(out[i + j], rqMul(a[i], b[j]));
+    }
+  }
+  return polyQNormalize(out);
+}
+
+function polyQPow(p: PolyQ, n: number): RatQ[] {
+  let result: RatQ[] = [RQ_ONE];
+  for (let i = 0; i < n; i += 1) {
+    result = polyQMul(result, p);
+  }
+  return result;
+}
+
+function addRational(a: RationalForm, b: RationalForm): RationalForm {
+  return {
+    num: polyQAdd(polyQMul(a.num, b.den), polyQMul(b.num, a.den)),
+    den: polyQMul(a.den, b.den),
+  };
+}
+
+function subRational(a: RationalForm, b: RationalForm): RationalForm {
+  return {
+    num: polyQSub(polyQMul(a.num, b.den), polyQMul(b.num, a.den)),
+    den: polyQMul(a.den, b.den),
+  };
+}
+
+function mulRational(a: RationalForm, b: RationalForm): RationalForm {
+  return { num: polyQMul(a.num, b.num), den: polyQMul(a.den, b.den) };
+}
+
+function divRational(a: RationalForm, b: RationalForm): RationalForm | undefined {
+  const newDen = polyQMul(a.den, b.num);
+  if (polyQNormalize(newDen).length === 0) return undefined;
+  return { num: polyQMul(a.num, b.den), den: newDen };
+}
+
+function powRational(
+  baseNode: IRNode,
+  expNode: IRNode,
+  x: IRSymbol,
+): RationalForm | undefined {
+  if (expNode.kind !== "integer") return undefined;
+  const baseR = toRationalWalk(baseNode, x);
+  if (!baseR) return undefined;
+  const n = Number(expNode.value);
+  if (!Number.isFinite(n)) return undefined;
+  if (n === 0) return { num: [RQ_ONE], den: [RQ_ONE] };
+  if (n < 0) {
+    if (polyQNormalize(baseR.num).length === 0) return undefined;
+    return { num: polyQPow(baseR.den, -n), den: polyQPow(baseR.num, -n) };
+  }
+  return { num: polyQPow(baseR.num, n), den: polyQPow(baseR.den, n) };
+}
+
+function reduceRational(
+  args: readonly IRNode[],
+  x: IRSymbol,
+  op: (a: RationalForm, b: RationalForm) => RationalForm | undefined,
+): RationalForm | undefined {
+  if (args.length === 0) return undefined;
+  let acc = toRationalWalk(args[0], x);
+  if (!acc) return undefined;
+  for (let i = 1; i < args.length; i += 1) {
+    const other = toRationalWalk(args[i], x);
+    if (!other) return undefined;
+    const next = op(acc, other);
+    if (!next) return undefined;
+    acc = next;
+  }
+  return acc;
+}
+
+/** Build the canonical IR tree for a polynomial.  Mirrors
+ *  ``polynomial_bridge.from_polynomial``: emits ``Add(term_0, term_1, …)``
+ *  left-associated, drops zero terms, special-cases ±1 coefficients. */
+function fromPolynomial(p: PolyQ, x: IRSymbol): IRNode {
+  const n = polyQNormalize(p);
+  if (n.length === 0) return int(0);
+  if (n.length === 1) return rqToIr(n[0]);
+  const terms: IRNode[] = [];
+  for (let i = 0; i < n.length; i += 1) {
+    const c = n[i];
+    if (rqIsZero(c)) continue;
+    terms.push(polyTerm(c, i, x));
+  }
+  if (terms.length === 0) return int(0);
+  if (terms.length === 1) return terms[0];
+  let acc: IRNode = terms[0];
+  for (let i = 1; i < terms.length; i += 1) {
+    acc = app(ADD, [acc, terms[i]]);
+  }
+  return acc;
+}
+
+function polyTerm(c: RatQ, i: number, x: IRSymbol): IRNode {
+  if (i === 0) return rqToIr(c);
+  const power: IRNode = i === 1 ? x : app(POW, [x, int(i)]);
+  if (rqEquals(c, RQ_ONE)) return power;
+  if (rqEquals(c, [-1n, 1n])) return app(NEG, [power]);
+  return app(MUL, [rqToIr(c), power]);
+}
+
+// --- Apart simple-roots (Phase 1) -------------------------------------------
+
+/** Phase 1 simple-root path; mirrors ``_apart_simple_roots`` in Python.
+ *  Returns ``undefined`` when any residue blows up (repeated root that
+ *  slipped through — defensive, the caller already gates on this). */
+function apartSimpleRoots(
+  num: PolyQ,
+  den: PolyQ,
+  roots: readonly RatQ[],
+  x: IRSymbol,
+): IRNode | undefined {
+  const denDeriv = polyQDeriv(den);
+  const terms: IRNode[] = [];
+  for (const r of roots) {
+    const numVal = polyQEvaluate(num, r);
+    const denDVal = polyQEvaluate(denDeriv, r);
+    if (rqIsZero(denDVal)) return undefined;
+    const A = rqDiv(numVal, denDVal);
+    const negR = rqNeg(r);
+    const factorIr = fromPolynomial([negR, RQ_ONE], x);
+    if (rqEquals(A, RQ_ONE)) {
+      terms.push(app(DIV, [int(1), factorIr]));
+    } else if (rqEquals(A, [-1n, 1n])) {
+      terms.push(app(NEG, [app(DIV, [int(1), factorIr])]));
+    } else {
+      terms.push(app(DIV, [rqToIr(A), factorIr]));
+    }
+  }
+  if (terms.length === 0) return int(0);
+  if (terms.length === 1) return terms[0];
+  let acc: IRNode = terms[0];
+  for (let i = 1; i < terms.length; i += 1) {
+    acc = app(ADD, [acc, terms[i]]);
+  }
+  return acc;
+}
+
+/** Decompose a *proper* rational function (deg num < deg den).  Returns
+ *  ``undefined`` if any root has multiplicity > 1 (Phase 48 — out of scope)
+ *  or if the denominator contains an irreducible factor on top of the
+ *  rational roots. */
+function apartProper(num: PolyQ, den: PolyQ, x: IRSymbol): IRNode | undefined {
+  const roots = polyQRationalRoots(den);
+  if (roots.length === 0) return undefined;
+  const mults = polyQRootMultiplicities(den, roots);
+  if (mults === undefined) return undefined;
+  for (const { mult } of mults.values()) {
+    if (mult > 1) return undefined; // Phase 48 path — explicitly out of scope.
+  }
+  return apartSimpleRoots(num, den, roots, x);
+}
+
+function apartHandler(_vm: VM, expr: IRApply): IRNode {
+  if (expr.args.length !== 2) return expr;
+  const inner = expr.args[0];
+  const varNode = expr.args[1];
+  if (varNode.kind !== "symbol") return expr;
+  const rational = toRational(inner, varNode);
+  if (!rational) return expr;
+  const num = polyQNormalize(rational.num);
+  const den = polyQNormalize(rational.den);
+  if (den.length === 1 && rqEquals(den[0], RQ_ONE)) {
+    // Already a polynomial.
+    return fromPolynomial(num, varNode);
+  }
+  const numDeg = polyQDegree(num);
+  const denDeg = polyQDegree(den);
+  if (numDeg >= denDeg) {
+    // Improper fraction — polynomial division first, then Apart on the
+    // proper remainder.
+    const { q, r } = polyQDivmod(num, den);
+    if (polyQNormalize(r).length === 0) {
+      return fromPolynomial(q, varNode);
+    }
+    const properResult = apartProper(r, den, varNode);
+    if (properResult === undefined) return expr;
+    const polyPart = fromPolynomial(q, varNode);
+    return app(ADD, [polyPart, properResult]);
+  }
+  const result = apartProper(num, den, varNode);
+  if (result === undefined) return expr;
+  return result;
 }
 
 function integrate(): Handler {

--- a/code/packages/typescript/symbolic-vm/tests/apart.test.ts
+++ b/code/packages/typescript/symbolic-vm/tests/apart.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import {
+  ADD,
+  DIV,
+  IRNode,
+  MUL,
+  NEG,
+  POW,
+  SUB,
+  app,
+  int,
+  rational,
+  sym,
+} from "@coding-adventures/symbolic-ir";
+import { SymbolicBackend, VM } from "../src/index.js";
+
+// Helpers — Track B1 (Apart simple-roots port) acceptance tests.
+//
+// Mirrors the six Python test cases enumerated in macsyma-finish-plan.md
+// (Track B1).  Apart is registered by string-name "Apart" because no
+// symbolic-ir constant exists for it.
+const APART = sym("Apart");
+const x = sym("x");
+
+function apart(inner: IRNode): IRNode {
+  return app(APART, [inner, x]);
+}
+
+describe("Apart — Track B1 (Phase 1 simple roots)", () => {
+  it("decomposes 1/(x^2 - 1) into 1/(2(x-1)) - 1/(2(x+1)) (acceptance)", () => {
+    const vm = new VM(new SymbolicBackend());
+    // 1 / (x^2 - 1)
+    const inner = app(DIV, [int(1), app(SUB, [app(POW, [x, int(2)]), int(1)])]);
+    const result = vm.eval(apart(inner));
+    // Roots sort ascending: -1 first, then 1.  Matches Python's output shape
+    // exactly: Add(Div(-1/2, (1+x)), Div(1/2, (-1+x))).
+    expect(result).toEqual(
+      app(ADD, [
+        app(DIV, [rational(-1, 2), app(ADD, [int(1), x])]),
+        app(DIV, [rational(1, 2), app(ADD, [int(-1), x])]),
+      ]),
+    );
+  });
+
+  it("decomposes 1/((x-1)(x-2)(x-3)) — three distinct simple roots", () => {
+    const vm = new VM(new SymbolicBackend());
+    const factor1 = app(SUB, [x, int(1)]);
+    const factor2 = app(SUB, [x, int(2)]);
+    const factor3 = app(SUB, [x, int(3)]);
+    const inner = app(DIV, [int(1), app(MUL, [app(MUL, [factor1, factor2]), factor3])]);
+    const result = vm.eval(apart(inner));
+    // Residues: A_1 = 1/2, A_2 = -1, A_3 = 1/2 (verified against Python).
+    // Roots sort 1 < 2 < 3.  ``A = -1`` renders as ``Neg(Div(1, ...))``.
+    expect(result).toEqual(
+      app(ADD, [
+        app(ADD, [
+          app(DIV, [rational(1, 2), app(ADD, [int(-1), x])]),
+          app(NEG, [app(DIV, [int(1), app(ADD, [int(-2), x])])]),
+        ]),
+        app(DIV, [rational(1, 2), app(ADD, [int(-3), x])]),
+      ]),
+    );
+  });
+
+  it("handles improper fraction x^3/(x^2-1) via polynomial division", () => {
+    const vm = new VM(new SymbolicBackend());
+    const inner = app(DIV, [
+      app(POW, [x, int(3)]),
+      app(SUB, [app(POW, [x, int(2)]), int(1)]),
+    ]);
+    const result = vm.eval(apart(inner));
+    // x^3 / (x^2 - 1) = x + x/(x^2-1) = x + 1/(2(x-1)) + 1/(2(x+1)).
+    // ``from_polynomial([0, 1], x)`` for the quotient ``x`` collapses to bare x.
+    expect(result).toEqual(
+      app(ADD, [
+        x,
+        app(ADD, [
+          app(DIV, [rational(1, 2), app(ADD, [int(1), x])]),
+          app(DIV, [rational(1, 2), app(ADD, [int(-1), x])]),
+        ]),
+      ]),
+    );
+  });
+
+  it("leaves 1/(x^2 + 1) unevaluated (no rational roots, Phase 48 out of scope)", () => {
+    const vm = new VM(new SymbolicBackend());
+    const inner = app(DIV, [int(1), app(ADD, [app(POW, [x, int(2)]), int(1)])]);
+    const result = vm.eval(apart(inner));
+    // After VM args-eval, ``inner`` itself is already normalised; the
+    // handler returns ``expr`` (the Apart application) when rational
+    // roots are absent.  Result remains wrapped in Apart.
+    expect(result).toEqual(app(APART, [inner, x]));
+  });
+
+  it("leaves 1/(x-1)^2 unevaluated (repeated root — Phase 48 out of scope)", () => {
+    const vm = new VM(new SymbolicBackend());
+    const inner = app(DIV, [int(1), app(POW, [app(SUB, [x, int(1)]), int(2)])]);
+    const result = vm.eval(apart(inner));
+    expect(result).toEqual(app(APART, [inner, x]));
+  });
+
+  it("passes a bare polynomial Apart(x+1, x) through as x+1", () => {
+    const vm = new VM(new SymbolicBackend());
+    const inner = app(ADD, [x, int(1)]);
+    const result = vm.eval(apart(inner));
+    // ``to_rational(x+1, x)`` → num = [1, 1], den = [1]; the early-return
+    // path emits ``from_polynomial(num, x)`` = Add(1, x).
+    expect(result).toEqual(app(ADD, [int(1), x]));
+  });
+});


### PR DESCRIPTION
## Summary

- Ports the Phase 1 simple-root subset of Python's ``apart_handler`` from ``symbolic-vm/cas_handlers.py`` to **TypeScript** and **Rust**.
- ``Apart(P(x)/Q(x), x)`` now decomposes proper rational functions whose denominator has only *distinct rational* roots via the residue formula ``A_i = P(r_i) / Q'(r_i)``.  Improper fractions split off the polynomial part first.
- Repeated roots (Phase 48) and irreducible quadratic factors leave the expression wrapped in ``Apart(...)`` per the explicit Track B1 scope.
- Unblocks the deferred TS+Rust ports of the Phase 40/46 Apart-retry telescope chain (Track B2) and Phase 48 repeated-roots Apart (Track B3).

Per-language scope:

- **TypeScript** (`code/packages/typescript/symbolic-vm/src/index.ts`): self-contained ``RatQ`` (BigInt) coefficient type + polynomial primitives (normalize/degree/evaluate/deriv/divmod/rational_roots/root_multiplicities) + ``toRational`` / ``fromPolynomial`` IR bridges + ``apartSimpleRoots`` / ``apartProper`` / ``apartHandler``, registered under the string head ``\"Apart\"``.
- **Rust** (`code/packages/rust/symbolic-vm/src/handlers.rs`): adds ``rp_normalize`` / ``rp_evaluate`` / ``rp_rational_roots`` / ``rp_root_multiplicities`` / ``rp_power`` / ``rp_to_ir_apart`` beside the existing ``RatPoly`` / ``RatC`` machinery (no new arithmetic substrate), plus ``to_rational_ir`` IR bridge and ``apart_simple_roots`` / ``apart_proper`` / ``apart_handler``.

## Acceptance criterion

``Apart(1/(x²−1), x)`` returns the equivalent of ``1/(2(x−1)) − 1/(2(x+1))`` in both languages.  Concretely:

```
Add(
  Div(-1/2, Add(1, x)),   // residue at r = -1
  Div( 1/2, Add(-1, x))   // residue at r =  1
)
```

(Roots emitted in ascending order to match Python's ``sorted(roots)``.)

## Test plan

- [x] ``npm test`` in ``code/packages/typescript/symbolic-vm`` (167 tests pass, including 6 new in ``tests/apart.test.ts``).
- [x] ``cargo test`` in ``code/packages/rust/symbolic-vm`` (194 integration + 6 new Apart + 2 doc-tests pass).
- [x] ``cargo build`` and ``cargo clippy`` on the workspace — no new warnings from the new code.
- [x] Type-check via ``npx tsc --noEmit`` — clean.
- [x] Inline security review:
  - No I/O, no untrusted parsing, no FFI, no ``unsafe``.
  - Integer overflow in Rust handled via ``checked_*`` ops bubbling to ``None`` → unevaluated ``Apart(...)`` fallback; TS uses unbounded ``bigint``.
  - Division by zero gated in every ``rqDiv`` / ``rc_div`` and explicitly in ``apartSimpleRoots`` before the residue division.
  - Floats explicitly rejected in ``toRational`` / ``to_rational_ir`` — keeps Apart on Q(x) only.
  - Pattern matches prior Track A1 / A2 CAS code reviews (pure-symbolic).

## Test cases (6 per language)

1. **Acceptance**: ``Apart(1/(x²−1), x)`` → simplified form equivalent to ``1/(2(x−1)) − 1/(2(x+1))``.
2. **Three distinct simple roots**: ``Apart(1/((x−1)(x−2)(x−3)), x)`` → residues 1/2, −1, 1/2.
3. **Improper fraction**: ``Apart(x³/(x²−1), x)`` → ``x + 1/(2(x−1)) + 1/(2(x+1))``.
4. **Bail on irreducible quadratic**: ``Apart(1/(x²+1), x)`` → unevaluated ``Apart(...)``.
5. **Bail on repeated root**: ``Apart(1/(x−1)², x)`` → unevaluated ``Apart(...)`` (Phase 48 out of scope).
6. **Already polynomial**: ``Apart(x+1, x)`` → ``x+1``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)