### PR TITLE
feat(cas-summation): Track B2 — Apart-retry telescope (Phase 40+46) to TS+Rust (2.25.0)

### DIFF
--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,69 @@
 # Changelog
 
+## 2.25.0 — 2026-05-28
+
+### Added — Track B2 (Apart-retry telescope chain port: Phase 40 + Phase 46)
+
+Ports the Python ``sum_handler`` Apart-retry composition (``symbolic-vm``
+Phase 40 + Phase 46) to Rust ``cas-summation``.  After the existing
+direct telescoping / vanishing-at-infinity / classic-series pipeline
+falls through on a rational summand ``Div(P(k), Q(k))``,
+``evaluate_sum`` now:
+
+1. Dispatches ``Apart(f, k)`` through the user-provided ``eval_fn`` —
+   typically a ``symbolic-vm`` ``VM`` with the Apart handler installed
+   (Track B1, ``symbolic-vm`` 0.13.0).
+2. If Apart actually decomposes ``f`` (returned shape structurally
+   differs from the input), normalises the ``Add(a, Neg(b))`` /
+   ``Add(a, Div(-c, d))`` shapes to ``Sub`` via the existing
+   ``normalise_add_neg_to_sub`` helper.
+3. Retries the full pipeline on the normalised result with a one-shot
+   ``apart_retried`` guard so we never recurse a second time.
+
+This closes the classic ``∑_{k=1}^∞ 1/(k(k+1)) = 1`` telescope: Apart
+decomposes the summand to ``Add(Div(1, k), Neg(Div(1, k+1)))``; the
+Phase 40+46 normaliser rewrites to ``Sub(1/k, 1/(k+1))``; the
+structural telescope detector fires and Phase 41 emits ``1`` (since
+``1/(k+1) → 0`` at infinity).
+
+### Changes
+
+- ``src/lib.rs``:
+  - Refactor ``evaluate_sum`` to delegate to a private
+    ``evaluate_sum_inner`` carrying an ``apart_retried`` flag.  The
+    closure is wrapped as ``&mut dyn FnMut(IRNode) -> IRNode`` so the
+    recursive call doesn't monomorphise to ever-deepening ``&mut &mut
+    ...`` layers and trip rustc's recursion limit.
+  - Add the Apart-retry block just above the unevaluated fallback —
+    only fires when ``f`` is structurally ``Div(...)`` (saves a wasted
+    VM round-trip on non-rational summands).
+  - Port ``_canonicalise_add_operand_order`` from Python: deep-rewrite
+    every ``Add`` so numeric literals come last among its arguments.
+    This makes the Apart-decomposed shape match the substituted half
+    in ``try_telescoping``'s structural equality check (Apart emits
+    ``Add(1, k)`` while substitution produces ``Add(k, 1)``).
+  - Wire the canonicaliser into ``normalise_add_neg_to_sub`` so it
+    runs after every rewrite.
+  - Relax ``try_telescoping`` to ``E: ?Sized + FnMut`` so it accepts
+    the ``&mut dyn FnMut`` reborrow.
+
+- ``Cargo.toml``: bump to 2.25.0; add ``symbolic-vm`` as a
+  ``dev-dependency`` so the Track B2 tests can construct a real VM with
+  the Apart handler installed.  The published crate's runtime
+  dependencies are unchanged.
+
+- ``tests/tests.rs``: new ``track_b2_*`` test functions — 6 cases:
+  acceptance ``1/(k(k+1)) = 1``, three-term shifted ``1/(k(k+2))``
+  (safety: no false closure), Phase 46 constant numerator ``2/(k(k+1))
+  = 2``, irreducible-denominator fallthrough, polynomial-summand
+  fallthrough, and non-telescoping-after-Apart fallthrough.
+
+When the user's ``eval_fn`` does not dispatch ``Apart`` (e.g. a bare
+arithmetic walker), the Apart attempt returns ``Apply(Apart, [f, k])``
+which structurally differs from ``f``, but the recursive retry on that
+shape also returns unevaluated — so the original unevaluated ``Sum``
+is preserved.  No spurious closure can leak out.
+
 ## 2.24.0 — 2026-05-28
 
 ### Removed — Track A2 cleanup (delete 27 grid helpers superseded by Phase 86)

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,9 +1,15 @@
 [package]
 name = "cas-summation"
-version = "2.24.0"
+version = "2.25.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"
 
 [dependencies]
 symbolic-ir = { path = "../symbolic-ir" }
+
+[dev-dependencies]
+# Track B2 — Apart-retry telescope chain tests need a real VM with the
+# Apart handler installed.  Dev-only — the published runtime does not
+# depend on symbolic-vm.
+symbolic-vm = { path = "../symbolic-vm" }

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -246,6 +246,44 @@ pub fn evaluate_sum<E>(f: IRNode, k: IRNode, lo: IRNode, hi: IRNode, mut eval_fn
 where
     E: FnMut(IRNode) -> IRNode,
 {
+    // Wrap as a trait object so the recursive call inside
+    // ``evaluate_sum_inner`` doesn't monomorphise to ever-deepening
+    // ``&mut &mut ...`` layers and trip the compiler's recursion limit.
+    let closure: &mut dyn FnMut(IRNode) -> IRNode = &mut eval_fn;
+    evaluate_sum_inner(f, k, lo, hi, closure, false)
+}
+
+/// Track B2 (Rust port of Phase 40 + Phase 46 from Python ``symbolic-vm``
+/// ``sum_handler``).  The ``apart_retried`` flag prevents infinite
+/// recursion when the retry path falls back into the same pipeline —
+/// Apart is attempted at most once per top-level call.
+///
+/// Apart-retry telescope chain
+/// ---------------------------
+/// When the structural telescope detector and every other narrow
+/// recogniser fall through to the unevaluated ``Sum(...)`` shape AND
+/// the summand is a proper rational ``Div(P(k), Q(k))``, we expand once
+/// via ``Apart(f, k)`` (dispatched through the user-provided
+/// ``eval_fn`` — typically a ``symbolic-vm`` VM with the Apart handler
+/// installed) and retry ``evaluate_sum`` on the partial-fraction
+/// decomposed shape.
+///
+/// The classic case is ``∑ 1/(k·(k+1))``: Apart emits
+/// ``Add(Div(1, k), Neg(Div(1, k+1)))`` which the Phase 40+46
+/// Add-with-negation normaliser rewrites to ``Sub(1/k, 1/(k+1))`` so the
+/// telescope detector fires and Phase 41 emits ``1`` at infinity (since
+/// ``1/(k+1) → 0``).  When ``eval_fn`` does not dispatch Apart the
+/// attempt returns ``Apply(Apart, [f, k])`` which structurally differs
+/// from ``f``, but the recursive retry won't close on it so the original
+/// unevaluated Sum is preserved.
+fn evaluate_sum_inner(
+    f: IRNode,
+    k: IRNode,
+    lo: IRNode,
+    hi: IRNode,
+    eval_fn: &mut dyn FnMut(IRNode) -> IRNode,
+    apart_retried: bool,
+) -> IRNode {
     let inf_upper = is_inf(&hi);
 
     if is_constant_in(&f, &k) {
@@ -279,7 +317,7 @@ where
     //   polynomial denominator, or any proper rational with
     //   deg(num) < deg(den)).  Otherwise fall through to the
     //   unevaluated SUM at the bottom.
-    if let Some((g_expr, sign)) = try_telescoping(&f, &k, &mut eval_fn) {
+    if let Some((g_expr, sign)) = try_telescoping(&f, &k, eval_fn) {
         if inf_upper {
             if g_vanishes_at_infinity(&g_expr, &k) {
                 let g_at_lo = substitute(&g_expr, &k, &lo);
@@ -332,7 +370,42 @@ where
         }
     }
 
+    // Track B2 — Apart-retry telescope chain.  Mirrors the Python
+    // ``sum_handler`` Phase 40 / Phase 46 retry path: when every direct
+    // rule above fails on a rational summand, expand once via
+    // ``Apart(f, k)`` (dispatched through the user-provided ``eval_fn``)
+    // and try the whole pipeline again.  The ``apart_retried`` guard
+    // pins the retry to at most one round, matching Python's structural
+    // one-shot behaviour and guaranteeing termination.
+    if !apart_retried && head_is_div(&f) {
+        let apart_attempt = eval_fn(apply(sym(APART), vec![f.clone(), k.clone()]));
+        if apart_attempt != f {
+            // Apart emits two-term partial fractions as
+            // ``Add(a, Neg(b))`` or ``Add(a, Div(-c, d))``.  The
+            // structural telescope detector keys off ``Sub`` heads, so
+            // normalise via the existing helper before retrying.
+            let normalised = normalise_add_neg_to_sub(&apart_attempt);
+            let retry = evaluate_sum_inner(normalised, k.clone(), lo.clone(), hi.clone(), eval_fn, true);
+            // Only return when the retry actually closed (i.e. it is
+            // no longer the unevaluated Sum head).  Otherwise fall
+            // through and return the original unevaluated form below.
+            if !is_unevaluated_sum(&retry) {
+                return retry;
+            }
+        }
+    }
+
     apply(sym(SUM), vec![f, k, lo, hi])
+}
+
+const APART: &str = "Apart";
+
+fn head_is_div(node: &IRNode) -> bool {
+    matches!(node, IRNode::Apply(a) if head_is(&a.head, DIV))
+}
+
+fn is_unevaluated_sum(node: &IRNode) -> bool {
+    matches!(node, IRNode::Apply(a) if head_is(&a.head, SUM))
 }
 
 pub fn evaluate_product<E>(f: IRNode, k: IRNode, lo: IRNode, hi: IRNode, mut eval_fn: E) -> IRNode
@@ -534,22 +607,70 @@ fn extract_negation(node: &IRNode) -> Option<IRNode> {
 fn normalise_add_neg_to_sub(node: &IRNode) -> IRNode {
     let apply_node = match node {
         IRNode::Apply(a) if head_is(&a.head, ADD) && a.args.len() == 2 => a,
-        _ => return node.clone(),
+        _ => return canonicalise_add_operand_order(node),
     };
     let left = &apply_node.args[0];
     let right = &apply_node.args[1];
     let left_pos = extract_negation(left);
     let right_pos = extract_negation(right);
-    match (left_pos, right_pos) {
+    let rewritten = match (left_pos, right_pos) {
         // Both sides genuinely negative — no telescope to expose.
         (Some(_), Some(_)) => node.clone(),
         (_, Some(rp)) => binary(SUB, left.clone(), rp),
         (Some(lp), _) => binary(SUB, right.clone(), lp),
         (None, None) => node.clone(),
-    }
+    };
+    canonicalise_add_operand_order(&rewritten)
 }
 
-fn try_telescoping<E>(f: &IRNode, k: &IRNode, eval_fn: &mut E) -> Option<(IRNode, i32)>
+/// Track B2 (Rust port of Python ``_canonicalise_add_operand_order``):
+/// deep-rewrite every ``Add`` so that numeric literals appear *last*
+/// among its arguments.
+///
+/// The symbolic VM doesn't currently impose a canonical operand order on
+/// ``Add``, so two structurally distinct trees can represent the same
+/// mathematical expression — e.g. ``Add(k, 1)`` vs ``Add(1, k)``.  The
+/// Phase 39 telescope detector relies on structural equality after
+/// ``eval_fn``, so these must look identical for the Apart-rewritten
+/// summand to match the substituted half (``Apart`` emits ``Add(1, k)``
+/// while substitution produces ``Add(k, 1)``).
+///
+/// Walks the tree and sorts each ``Add``'s arguments so that integer /
+/// rational / float literals come *last*, preserving the relative order
+/// of non-literal children.
+fn canonicalise_add_operand_order(node: &IRNode) -> IRNode {
+    let apply_node = match node {
+        IRNode::Apply(a) => a,
+        _ => return node.clone(),
+    };
+    let new_args: Vec<IRNode> = apply_node
+        .args
+        .iter()
+        .map(canonicalise_add_operand_order)
+        .collect();
+    if head_is(&apply_node.head, ADD) && new_args.len() >= 2 {
+        let (literals, non_literals): (Vec<IRNode>, Vec<IRNode>) =
+            new_args.iter().cloned().partition(|arg| {
+                matches!(
+                    arg,
+                    IRNode::Integer(_) | IRNode::Rational(_, _) | IRNode::Float(_)
+                )
+            });
+        if !literals.is_empty() && !non_literals.is_empty() {
+            let mut reordered = non_literals;
+            reordered.extend(literals);
+            if reordered != new_args {
+                return apply(apply_node.head.clone(), reordered);
+            }
+        }
+    }
+    if new_args != apply_node.args {
+        return apply(apply_node.head.clone(), new_args);
+    }
+    node.clone()
+}
+
+fn try_telescoping<E: ?Sized>(f: &IRNode, k: &IRNode, eval_fn: &mut E) -> Option<(IRNode, i32)>
 where
     E: FnMut(IRNode) -> IRNode,
 {

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -1709,3 +1709,113 @@ fn phase86_pure_bounded_falls_through_to_phase49() {
     let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
     assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }
+
+// ---------------------------------------------------------------------------
+// Track B2 — Apart-retry telescope chain (Phase 40 + Phase 46 composition).
+//
+// These tests drive ``evaluate_sum`` through a real ``symbolic-vm`` VM
+// (``SymbolicBackend`` has the Apart handler installed since 0.13.0), so
+// the ``Apply(Apart, ...)`` emitted by the new retry path is actually
+// dispatched to ``apart_handler``.  This is the only place in the
+// cas-summation Rust test suite that takes a runtime dependency on
+// symbolic-vm — it is a ``dev-dependency`` so the published runtime
+// crate still has no transitive tie to the VM.
+// ---------------------------------------------------------------------------
+
+use symbolic_vm::{SymbolicBackend, VM};
+
+fn vm_eval() -> impl FnMut(IRNode) -> IRNode {
+    let mut vm = VM::new(Box::new(SymbolicBackend::new()));
+    move |node: IRNode| vm.eval(node)
+}
+
+#[test]
+fn track_b2_acceptance_one_over_k_kplus1_closes_to_one() {
+    // The classic case: Apart decomposes 1/(k(k+1)) → 1/k − 1/(k+1).
+    // The Phase 40+46 Add-Neg normaliser rewrites Add(Div(1,k), Neg(Div(1,k+1)))
+    // to Sub(1/k, 1/(k+1)); Phase 41 closes the resulting antisymmetric
+    // telescope at ∞ to give g(1) = 1.
+    let k = sym("k");
+    let denom = apply(sym(MUL), vec![k.clone(), apply(sym(ADD), vec![k.clone(), int(1)])]);
+    let f = apply(sym(DIV), vec![int(1), denom]);
+    assert_eq!(evaluate_sum(f, k, int(1), sym("%inf"), vm_eval()), int(1));
+}
+
+#[test]
+fn track_b2_three_term_shifted_one_over_k_kplus2() {
+    // Apart: 1/(k(k+2)) = (1/2)/k − (1/2)/(k+2).  This is a shift-2
+    // telescope, *not* k → k+1, so the structural detector cannot close
+    // it directly.  Safety requirement: the Apart-retry must not falsely
+    // claim closure here.  Accept either a verified closed form (3/4)
+    // or unevaluated Sum.  A wrong rational is a regression.
+    let k = sym("k");
+    let denom = apply(sym(MUL), vec![k.clone(), apply(sym(ADD), vec![k.clone(), int(2)])]);
+    let f = apply(sym(DIV), vec![int(1), denom]);
+    let result = evaluate_sum(f, k, int(1), sym("%inf"), vm_eval());
+    match rational_value(&result) {
+        Some(r) => {
+            assert_eq!(r, Rational::new(3, 4));
+        }
+        None => {
+            assert!(matches!(&result, IRNode::Apply(a) if a.head == sym(SUM)));
+        }
+    }
+}
+
+#[test]
+fn track_b2_phase46_constant_numerator_two_over_k_kplus1() {
+    // Apart: 2/(k(k+1)) = 2/k − 2/(k+1).  Phase 46 widening recognises
+    // ``Add(Div(2, k), Neg(Div(2, k+1)))`` after the Add-Neg normaliser
+    // fires; antisymmetric Phase 41 closes it to 2.
+    let k = sym("k");
+    let denom = apply(sym(MUL), vec![k.clone(), apply(sym(ADD), vec![k.clone(), int(1)])]);
+    let f = apply(sym(DIV), vec![int(2), denom]);
+    assert_eq!(evaluate_sum(f, k, int(1), sym("%inf"), vm_eval()), int(2));
+}
+
+#[test]
+fn track_b2_irreducible_denom_returns_unevaluated() {
+    // ``k² + 1`` has no rational roots, so the Apart handler returns its
+    // input unchanged.  ``apart_attempt == f``, so no retry; the sum
+    // falls through to unevaluated ``Sum(...)``.
+    let k = sym("k");
+    let den = apply(sym(ADD), vec![apply(sym(POW), vec![k.clone(), int(2)]), int(1)]);
+    let f = apply(sym(DIV), vec![int(1), den]);
+    let result = evaluate_sum(f, k, int(1), sym("%inf"), vm_eval());
+    assert!(matches!(&result, IRNode::Apply(a) if a.head == sym(SUM)));
+}
+
+#[test]
+fn track_b2_polynomial_summand_skips_apart_uses_faulhaber() {
+    // ``k(k+1)`` is a polynomial, not a Div — the Apart-retry guard
+    // skips it entirely.  The existing power-of-k / Faulhaber path
+    // closes ∑_{k=1}^4 k(k+1) = ∑k² + ∑k = 30 + 10 = 40.
+    let k = sym("k");
+    let f = apply(sym(MUL), vec![k.clone(), apply(sym(ADD), vec![k.clone(), int(1)])]);
+    assert_eq!(evaluate_sum(f, k, int(1), int(4), vm_eval()), int(40));
+}
+
+#[test]
+fn track_b2_apart_fires_but_no_telescope_returns_unevaluated() {
+    // ``1/((k-1)(k+1)(k+2))`` from k=2 to ∞.  Apart produces a 3-term
+    // shift-mixed decomposition that has no direct shift-1 pairing, so
+    // the inner telescope detector returns None and we fall through to
+    // unevaluated SUM.  Safety: no wrong numeric value emitted.
+    let k = sym("k");
+    let km1 = apply(sym(SUB), vec![k.clone(), int(1)]);
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let kp2 = apply(sym(ADD), vec![k.clone(), int(2)]);
+    let den = apply(sym(MUL), vec![km1, apply(sym(MUL), vec![kp1, kp2])]);
+    let f = apply(sym(DIV), vec![int(1), den]);
+    let result = evaluate_sum(f, k, int(2), sym("%inf"), vm_eval());
+    match rational_value(&result) {
+        Some(_) => {
+            // Any closed numeric value here would need independent
+            // verification; currently this branch is not expected to
+            // trigger but is left in for a future widening.
+        }
+        None => {
+            assert!(matches!(&result, IRNode::Apply(a) if a.head == sym(SUM)));
+        }
+    }
+}

--- a/code/packages/typescript/cas-summation/BUILD
+++ b/code/packages/typescript/cas-summation/BUILD
@@ -1,4 +1,6 @@
 while ! mkdir /tmp/ts-symbolic-ir-npm.lock 2>/dev/null; do sleep 1; done; (cd ../symbolic-ir && npm ci --quiet); EC=$?; rmdir /tmp/ts-symbolic-ir-npm.lock 2>/dev/null; exit $EC
+cd ../cas-factor && npm ci --quiet
+cd ../symbolic-vm && npm ci --quiet
 npm ci --quiet
 npm run build
 npx vitest run --coverage

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog
 
+## 2.25.0 — 2026-05-28
+
+### Added — Track B2 (Apart-retry telescope chain port: Phase 40 + Phase 46)
+
+Ports the Python ``sum_handler`` Apart-retry composition (``symbolic-vm``
+Phase 40 + Phase 46) to TypeScript ``cas-summation``.  After the existing
+direct telescoping / vanishing-at-infinity / classic-series pipeline falls
+through on a rational summand ``Div(P(k), Q(k))``, ``evaluateSum`` now:
+
+1. Dispatches ``Apart(f, k)`` through the user-provided ``evalFn`` —
+   typically a ``symbolic-vm`` VM with the Apart handler installed
+   (Track B1, ``symbolic-vm`` 0.13.0).
+2. If Apart actually decomposes ``f`` (returned shape structurally differs
+   from the input), normalises the ``Add(a, Div(-c, d))`` /
+   ``Add(Neg(b), a)`` shapes to ``Sub`` via the existing
+   ``normaliseAddNegToSub`` helper.
+3. Retries the full pipeline on the normalised result with a one-shot
+   ``apartRetried`` guard so we never recurse a second time.
+
+This is the long-promised TypeScript closure of the classic
+``∑_{k=1}^∞ 1/(k(k+1)) = 1`` telescope: Apart decomposes the summand to
+``Add(Div(1, k), Div(-1, k+1))`` which the Phase 40+46 normaliser
+rewrites to ``Sub(1/k, 1/(k+1))``; the structural telescope detector
+fires and Phase 41 emits ``1`` (since ``1/(k+1) → 0`` at infinity).
+
+- ``src/index.ts``: refactor ``evaluateSum`` to delegate to a private
+  ``evaluateSumInner`` carrying an ``apartRetried`` flag; add the
+  Apart-retry block just above the unevaluated fallback.
+- ``package.json``: bump to 2.25.0; add ``@coding-adventures/symbolic-vm``
+  as a ``devDependency`` so the tests can construct a real VM with the
+  Apart handler installed.
+- ``BUILD``: chain-install ``cas-factor`` and ``symbolic-vm`` ahead of the
+  package install so CI has the transitive ``file:`` deps available.
+- ``tests/cas-summation.test.ts``: new ``"summation: Track B2 Apart-retry
+  telescope chain"`` describe block — 6 cases (acceptance, three-term,
+  Phase 46 constant numerator, irreducible-denominator fallthrough,
+  polynomial-summand fallthrough, non-telescoping-after-Apart fallthrough).
+
+When the user's ``evalFn`` does not dispatch ``Apart`` (e.g. a bare
+arithmetic walker without the symbolic-vm handler), the Apart attempt
+returns ``Apply(Apart, [f, k])`` which structurally differs from ``f``,
+but the recursive retry on that shape also returns unevaluated — so the
+original unevaluated ``Sum`` is preserved.  No spurious "closure" can
+leak out.
+
 ## 2.24.0 — 2026-05-28
 
 ### Removed — Track A2 cleanup (delete 27 grid helpers superseded by Phase 86)

--- a/code/packages/typescript/cas-summation/package-lock.json
+++ b/code/packages/typescript/cas-summation/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "2.22.0",
+  "version": "2.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coding-adventures/cas-summation",
-      "version": "2.22.0",
+      "version": "2.25.0",
       "license": "MIT",
       "dependencies": {
         "@coding-adventures/symbolic-ir": "file:../symbolic-ir"
       },
       "devDependencies": {
+        "@coding-adventures/symbolic-vm": "file:../symbolic-vm",
         "@types/node": "^22.0.0",
         "@vitest/coverage-v8": "^3.0.0",
         "typescript": "^5.0.0",
@@ -22,6 +23,21 @@
       "name": "@coding-adventures/symbolic-ir",
       "version": "0.2.0",
       "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../symbolic-vm": {
+      "name": "@coding-adventures/symbolic-vm",
+      "version": "0.13.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/cas-factor": "file:../cas-factor",
+        "@coding-adventures/symbolic-ir": "file:../symbolic-ir"
+      },
       "devDependencies": {
         "@vitest/coverage-v8": "^3.0.0",
         "typescript": "^5.0.0",
@@ -104,6 +120,10 @@
     },
     "node_modules/@coding-adventures/symbolic-ir": {
       "resolved": "../symbolic-ir",
+      "link": true
+    },
+    "node_modules/@coding-adventures/symbolic-vm": {
+      "resolved": "../symbolic-vm",
       "link": true
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/code/packages/typescript/cas-summation/package-lock.json
+++ b/code/packages/typescript/cas-summation/package-lock.json
@@ -12,8 +12,21 @@
         "@coding-adventures/symbolic-ir": "file:../symbolic-ir"
       },
       "devDependencies": {
+        "@coding-adventures/cas-factor": "file:../cas-factor",
         "@coding-adventures/symbolic-vm": "file:../symbolic-vm",
         "@types/node": "^22.0.0",
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../cas-factor": {
+      "name": "@coding-adventures/cas-factor",
+      "version": "0.1.0",
+      "dev": true,
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^22.19.18",
         "@vitest/coverage-v8": "^3.0.0",
         "typescript": "^5.0.0",
         "vitest": "^3.0.0"
@@ -117,6 +130,10 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@coding-adventures/cas-factor": {
+      "resolved": "../cas-factor",
+      "link": true
     },
     "node_modules/@coding-adventures/symbolic-ir": {
       "resolved": "../symbolic-ir",

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -16,6 +16,7 @@
     "@coding-adventures/symbolic-ir": "file:../symbolic-ir"
   },
   "devDependencies": {
+    "@coding-adventures/cas-factor": "file:../cas-factor",
     "@coding-adventures/symbolic-vm": "file:../symbolic-vm",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^3.0.0",

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "2.24.0",
+  "version": "2.25.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",
@@ -16,6 +16,7 @@
     "@coding-adventures/symbolic-ir": "file:../symbolic-ir"
   },
   "devDependencies": {
+    "@coding-adventures/symbolic-vm": "file:../symbolic-vm",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^3.0.0",
     "typescript": "^5.0.0",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -109,6 +109,42 @@ export function trySpecialInfinite(f: IRNode, k: IRNode, lo: IRNode): IRNode | u
 }
 
 export function evaluateSum(f: IRNode, k: IRNode, lo: IRNode, hi: IRNode, evalFn: EvalFn): IRNode {
+  return evaluateSumInner(f, k, lo, hi, evalFn, false);
+}
+
+/**
+ * Track B2 (TypeScript port of Phase 40 + Phase 46 from Python ``symbolic-vm``
+ * ``sum_handler``).  The ``apartRetried`` flag prevents infinite recursion
+ * when the retry path falls back to the outer entry point — Apart is
+ * attempted at most once per top-level call.
+ *
+ * Apart-retry telescope chain
+ * ---------------------------
+ * When the structural telescope detector and every other narrow recogniser
+ * fall through to the unevaluated ``Sum(...)`` shape AND the summand is a
+ * proper rational ``Div(P(k), Q(k))``, we expand once via
+ * ``Apart(f, k)`` (dispatched through the user-provided ``evalFn`` —
+ * typically a ``symbolic-vm`` VM with the Apart handler installed) and
+ * retry ``evaluateSum`` on the partial-fraction decomposed shape.
+ *
+ * The classic case is ``∑ 1/(k·(k+1))``: Apart emits
+ * ``Add(Div(1, k), Div(-1, k+1))`` which the Phase 40+46 Add-with-negation
+ * normaliser rewrites to ``Sub(1/k, 1/(k+1))`` so the telescope detector
+ * fires and emits ``1 − 1/(hi+1)`` (finite) or ``1`` (infinite, since
+ * ``1/(k+1) → 0``).  When ``evalFn`` does not dispatch Apart (e.g. a bare
+ * arithmetic evaluator), ``apart_attempt`` retains the same head
+ * (``Apply(Apart, ...)``), structurally differs from ``f``, but
+ * ``evaluateSumInner`` will not close on it so the original unevaluated
+ * Sum is returned — exactly the Python fall-through behaviour.
+ */
+function evaluateSumInner(
+  f: IRNode,
+  k: IRNode,
+  lo: IRNode,
+  hi: IRNode,
+  evalFn: EvalFn,
+  apartRetried: boolean,
+): IRNode {
   const infUpper = isInf(hi);
   if (isConstantIn(f, k)) {
     return evalFn(app(MUL, [f, app(ADD, [app(SUB, [hi, lo]), int(1)])]));
@@ -181,6 +217,38 @@ export function evaluateSum(f: IRNode, k: IRNode, lo: IRNode, hi: IRNode, evalFn
       total = addR(total, r);
     }
     if (ok) return rationalToIr(total);
+  }
+
+  // Track B2 — Apart-retry telescope chain.  Mirrors the Python
+  // ``sum_handler`` Phase 40 / Phase 46 retry path: when every direct rule
+  // above fails on a rational summand, expand once via ``Apart(f, k)``
+  // (dispatched through the user-provided ``evalFn``, i.e. a real VM with
+  // the Apart handler installed) and try the whole pipeline again.  The
+  // ``apartRetried`` guard pins the retry to at most one round, matching
+  // Python's structural one-shot behaviour and guaranteeing termination.
+  //
+  // Only attempted when ``f`` is structurally ``Div(num, den)`` — Apart
+  // leaves other heads unchanged, so this saves a wasted round-trip
+  // through the VM dispatch.  When ``apart_attempt`` is structurally
+  // equal to ``f`` (e.g. denominator irreducible over ℚ, or Apart isn't
+  // wired into ``evalFn``), no retry is performed.
+  if (!apartRetried && f.kind === "apply" && equals(f.head, DIV)) {
+    const apartAttempt = evalFn(app(sym("Apart"), [f, k]));
+    if (!equals(apartAttempt, f)) {
+      // Apart emits two-term partial fractions as ``Add(a, Div(-c, d))``
+      // or ``Add(Neg(a), b)``.  The structural telescope detector keys
+      // off ``Sub`` heads, so normalise via the existing helper before
+      // retrying.  ``normaliseAddNegToSub`` is a no-op when the head is
+      // not an Add — safe to apply unconditionally.
+      const normalised = normaliseAddNegToSub(apartAttempt);
+      const retry = evaluateSumInner(normalised, k, lo, hi, evalFn, true);
+      // Only return when the retry actually closed the sum (i.e. it is
+      // no longer the unevaluated ``Sum(...)`` head).  Otherwise fall
+      // through and return the original unevaluated form below.
+      if (!(retry.kind === "apply" && equals(retry.head, SUM))) {
+        return retry;
+      }
+    }
   }
 
   return app(SUM, [f, k, lo, hi]);
@@ -295,22 +363,65 @@ function extractNegation(node: IRNode): IRNode | undefined {
  */
 function normaliseAddNegToSub(node: IRNode): IRNode {
   if (node.kind !== "apply" || !irEquals(node.head, ADD) || node.args.length !== 2) {
-    return node;
+    return canonicaliseAddOperandOrder(node);
   }
   const [left, right] = node.args;
   const leftPos = extractNegation(left);
   const rightPos = extractNegation(right);
   if (leftPos !== undefined && rightPos !== undefined) {
     // Both sides genuinely negative — no telescope to expose.
-    return node;
+    return canonicaliseAddOperandOrder(node);
   }
   if (rightPos !== undefined) {
-    return app(SUB, [left, rightPos]);
+    return canonicaliseAddOperandOrder(app(SUB, [left, rightPos]));
   }
   if (leftPos !== undefined) {
-    return app(SUB, [right, leftPos]);
+    return canonicaliseAddOperandOrder(app(SUB, [right, leftPos]));
   }
-  return node;
+  return canonicaliseAddOperandOrder(node);
+}
+
+/**
+ * Track B2 (TypeScript port of Python ``_canonicalise_add_operand_order``):
+ * deep-rewrite every ``Add`` so that numeric literals appear *last* among
+ * its arguments.
+ *
+ * The symbolic VM doesn't currently impose a canonical operand order on
+ * ``Add``, so two structurally distinct trees can represent the same
+ * mathematical expression — e.g. ``Add(k, 1)`` vs ``Add(1, k)``.  The
+ * Phase 39 telescope detector relies on ``==`` after ``evalFn``, so
+ * these must look identical for the Apart-rewritten summand to match the
+ * substituted half (``Apart`` emits ``Add(1, k)`` while substitution
+ * produces ``Add(k, 1)``).
+ *
+ * Walks the tree and sorts each ``Add``'s arguments so that integer /
+ * rational / float literals come *last*, preserving the relative order of
+ * non-literal children.  Other heads recurse into their arguments unchanged.
+ */
+function canonicaliseAddOperandOrder(node: IRNode): IRNode {
+  if (node.kind !== "apply") return node;
+  const newArgs = node.args.map(canonicaliseAddOperandOrder);
+  if (irEquals(node.head, ADD) && newArgs.length >= 2) {
+    const literals: IRNode[] = [];
+    const nonLiterals: IRNode[] = [];
+    for (const arg of newArgs) {
+      if (arg.kind === "integer" || arg.kind === "rational" || arg.kind === "float") {
+        literals.push(arg);
+      } else {
+        nonLiterals.push(arg);
+      }
+    }
+    if (literals.length > 0 && nonLiterals.length > 0) {
+      const reordered = [...nonLiterals, ...literals];
+      // Only rebuild when the order actually changed.
+      const changed = reordered.some((arg, idx) => arg !== newArgs[idx]);
+      if (changed) {
+        return app(node.head, reordered);
+      }
+    }
+  }
+  const argsChanged = newArgs.some((arg, idx) => arg !== node.args[idx]);
+  return argsChanged ? app(node.head, newArgs) : node;
 }
 
 /**

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -29,6 +29,10 @@ import {
   trySpecialInfinite,
   type RationalValue,
 } from "../src/index";
+// Track B2 — Apart-retry telescope chain tests need a real VM with the
+// Apart handler installed.  symbolic-vm is a devDependency of
+// cas-summation; the published runtime does not depend on it.
+import { SymbolicBackend, VM } from "@coding-adventures/symbolic-vm";
 
 function evalNode(node: IRNode): IRNode {
   if (node.kind !== "apply") return node;
@@ -1401,5 +1405,124 @@ describe("summation: Phase 86 generic log × sqrt × polynomial recogniser", () 
     const result = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
     // Phase 49 (bounded × diverging) catches it — generic returns undefined.
     expect(result.kind === "apply" ? result.head : undefined).not.toEqual(SUM);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Track B2 — Apart-retry telescope chain (Phase 40 + Phase 46 composition).
+//
+// These tests drive ``evaluateSum`` through a real ``symbolic-vm`` VM
+// (``SymbolicBackend`` has the Apart handler installed since 0.13.0), so the
+// ``Apply(Apart, ...)`` emitted by the new retry path is actually dispatched
+// to ``apartHandler``.  This is the only place in the cas-summation TS test
+// suite that takes a runtime dependency on symbolic-vm — it is a
+// devDependency so the published package still has no runtime tie.
+// ---------------------------------------------------------------------------
+
+function vmEval(): (node: IRNode) => IRNode {
+  const vm = new VM(new SymbolicBackend());
+  return (node) => vm.eval(node);
+}
+
+describe("summation: Track B2 Apart-retry telescope chain (Phase 40+46)", () => {
+  it("acceptance — ∑_{k=1}^∞ 1/(k(k+1)) = 1 (closes via Apart-retry)", () => {
+    // The classic case: Apart decomposes 1/(k(k+1)) → 1/k − 1/(k+1).
+    // The Phase 40+46 Add-Neg normaliser rewrites Add(Div(1,k), Div(-1,k+1))
+    // to Sub(1/k, 1/(k+1)); Phase 41 closes the resulting telescope at
+    // ∞ to give 1/k|_{k=1} = 1.
+    const k = sym("k");
+    const f = app(DIV, [int(1), app(MUL, [k, app(ADD, [k, int(1)])])]);
+    expect(evaluateSum(f, k, int(1), sym("%inf"), vmEval())).toEqual(int(1));
+  });
+
+  it("three-term shifted: ∑_{k=1}^∞ 1/(k(k+2)) = 3/4", () => {
+    // Apart: 1/(k(k+2)) = (1/2)/k − (1/2)/(k+2).  This is *not* a
+    // direct k → k+1 telescope (shift is 2, not 1), so cas-summation
+    // doesn't immediately close it via the structural detector — but
+    // the sum still has a known value 3/4 = (1/2)(1 + 1/2).  Because
+    // the Apart-retry must not falsely claim closure here, we accept
+    // either a correct closed form (3/4) or a passthrough — the safety
+    // requirement is "do not produce a wrong value".  Currently the
+    // structural detector returns unevaluated for shift-2 telescopes,
+    // so this test pins the *no false closure* property.
+    const k = sym("k");
+    const f = app(DIV, [int(1), app(MUL, [k, app(ADD, [k, int(2)])])]);
+    const result = evaluateSum(f, k, int(1), sym("%inf"), vmEval());
+    // Acceptable outcomes: rational 3/4 (if a future shift-aware
+    // telescope detector closes it) or unevaluated Sum (current
+    // structural detector).  A wrong numeric result would fail.
+    const rv = rationalValue(result);
+    if (rv === undefined) {
+      expect(result.kind === "apply" ? result.head : undefined).toEqual(SUM);
+    } else {
+      expect(rv).toEqual({ numer: 3n, denom: 4n });
+    }
+  });
+
+  it("Phase 46 constant-numerator: ∑_{k=1}^∞ 2/(k(k+1)) = 2", () => {
+    // Apart: 2/(k(k+1)) = 2/k − 2/(k+1).  The Phase 46 widening
+    // recognises ``Add(Div(2, k), Div(-2, k+1))`` (negative-literal
+    // numerator) as a telescope after the Add-Neg normaliser fires.
+    const k = sym("k");
+    const f = app(DIV, [int(2), app(MUL, [k, app(ADD, [k, int(1)])])]);
+    expect(evaluateSum(f, k, int(1), sym("%inf"), vmEval())).toEqual(int(2));
+  });
+
+  it("irreducible denominator (Apart bails): ∑_{k=1}^∞ 1/(k²+1) returns unevaluated SUM", () => {
+    // ``k² + 1`` has no rational roots, so Apart returns its input
+    // unchanged (Phase 1 simple-roots path requires rational roots).
+    // The cas-summation Apart-retry then sees ``apart_attempt == f``
+    // and does not recurse; we fall through to the unevaluated Sum.
+    const k = sym("k");
+    const f = app(DIV, [int(1), app(ADD, [app(POW, [k, int(2)]), int(1)])]);
+    const result = evaluateSum(f, k, int(1), sym("%inf"), vmEval());
+    expect(result.kind === "apply" ? result.head : undefined).toEqual(SUM);
+  });
+
+  it("polynomial summand (not a Div, skips Apart): ∑_{k=1}^4 k(k+1) = 40 via Faulhaber", () => {
+    // ``k(k+1)`` is a polynomial, not ``Div(...)`` — the Apart-retry
+    // guard skips it entirely.  The existing Faulhaber / power-of-k
+    // path closes the sum directly: ∑_{k=1}^4 k(k+1) = ∑k² + ∑k = 30 + 10 = 40.
+    const k = sym("k");
+    const f = app(MUL, [k, app(ADD, [k, int(1)])]);
+    expect(evaluateSum(f, k, int(1), int(4), vmEval())).toEqual(int(40));
+  });
+
+  it("Apart fires but post-Apart shape still doesn't telescope: returns unevaluated SUM", () => {
+    // Construct a sum whose Apart decomposition produces terms that
+    // individually diverge or don't pair into a shift-1 telescope.
+    // ``∑_{k=1}^N 1/((k-1)(k+1))`` (k from 2) — Apart yields
+    // (1/2)/(k-1) − (1/2)/(k+1), a shift-2 telescope.  Finite hi makes
+    // it numerically summable via direct iteration but the structural
+    // telescope detector won't fire and the explicit numeric path
+    // closes it.  Use an infinite hi with a symbolic shape that
+    // structurally resists both — pick a hi=%inf with a 3-factor
+    // denominator: ``1/((k-1)(k+1)(k+2))`` from k=2 — Apart produces
+    // a 3-term shift-mixed decomposition that has no direct shift-1
+    // pairing, so the retry's inner telescope detector returns
+    // undefined and we fall through to unevaluated SUM (no spurious
+    // numeric closure, no wrong answer).
+    const k = sym("k");
+    const f = app(DIV, [
+      int(1),
+      app(MUL, [
+        app(SUB, [k, int(1)]),
+        app(MUL, [app(ADD, [k, int(1)]), app(ADD, [k, int(2)])]),
+      ]),
+    ]);
+    const result = evaluateSum(f, k, int(2), sym("%inf"), vmEval());
+    // Safety: must not produce a wrong numeric value.  Either it stays
+    // unevaluated (current detector limitation) or a correct future
+    // closed form (real value: (1/4)·H₂ + small) — either is fine; a
+    // wrong rational would be a regression.
+    const rv = rationalValue(result);
+    if (rv === undefined) {
+      expect(result.kind === "apply" ? result.head : undefined).toEqual(SUM);
+    } else {
+      // Any closed numeric value here would need independent verification;
+      // for now this branch is reserved for a future widening that knows
+      // how to close shift-3 telescopes.
+      expect(rv.denom).toBeGreaterThan(0n);
+    }
   });
 });


### PR DESCRIPTION
## Summary

Ports the Python ``sum_handler`` Apart-retry composition (Phase 40 + Phase 46 from ``symbolic-vm`` ``cas_handlers.py``) to the TypeScript and Rust ``cas-summation`` packages.

- ``evaluateSum`` / ``evaluate_sum`` now dispatches ``Apart(f, k)`` through the user-provided evaluator (typically a ``symbolic-vm`` VM with the Apart handler installed since Track B1 / 0.13.0) when the existing pipeline fails on a rational summand.
- The Apart-decomposed shape is normalised through the existing ``Add(a, Neg(b))`` / ``Add(a, Div(-c, d))`` → ``Sub`` rewriter, with a new ``canonicaliseAddOperandOrder`` walker (ported from Python's ``_canonicalise_add_operand_order``) so that ``Add(1, k)`` from Apart matches ``Add(k, 1)`` from variable substitution.
- A one-shot ``apartRetried`` / ``apart_retried`` guard pins the retry to a single round.

Track B1 (Apart simple-roots, PR #4558) is the foundation; Phase 47 (nested-Add flattening) is already in symbolic-vm; Phase 48 (repeated linear factors) remains explicitly out of scope (Track B3).

## Acceptance check

The acceptance target ``∑_{k=1}^∞ 1/(k(k+1)) = 1`` closes to integer ``1`` in both TS and Rust.  Verified by ``track_b2_acceptance_one_over_k_kplus1_closes_to_one`` (Rust) and ``acceptance — ∑_{k=1}^∞ 1/(k(k+1)) = 1 (closes via Apart-retry)`` (TS).  The Phase 46 widening ``∑ 2/(k(k+1)) = 2`` also closes (constant-numerator generalisation).

## Test plan

- [x] All 6 Track B2 cases pass in TypeScript (vitest, 89/89 total, 92.6% line coverage).
- [x] All 6 Track B2 cases pass in Rust (cargo test, 87/87 total).
- [x] All pre-existing 81 Rust and 83 TS cas-summation tests still pass unchanged.
- [x] ``tsc`` build succeeds with no errors.
- [x] No new ``unsafe`` blocks; no I/O; symbolic-IR-only code.
- [x] Safety contract: when ``evalFn`` does not dispatch Apart (e.g. a bare arithmetic walker), the unevaluated ``Sum`` shape is preserved — never a wrong numeric value.
- [ ] CI: watch for any chain-install ordering issues now that ``cas-summation``'s BUILD picks up ``cas-factor`` and ``symbolic-vm`` as devDep transitive installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)