### PR TITLE
feat(symbolic-vm): Track B3 — Apart repeated linear factors (Phase 48) to TS + Rust (0.14.0)

### DIFF
--- a/code/packages/rust/symbolic-vm/CHANGELOG.md
+++ b/code/packages/rust/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,64 @@
 # Changelog — symbolic-vm (Rust)
 
+## [0.14.0] — 2026-05-28
+
+**Track B3 — Apart for repeated linear factors (Phase 48, Rust port).**
+
+Lifts the multiplicity > 1 bail introduced in Track B1.
+``Apart(P(x)/Q(x), x)`` now decomposes rational functions whose
+denominator factors as ``∏_r (x − r)^{m_r}`` for *rational* ``r`` with
+arbitrary multiplicity.  Each pole ``r`` of multiplicity ``m`` contributes
+terms ``A_{r,1}/(x − r) + A_{r,2}/(x − r)² + … + A_{r,m}/(x − r)^m``
+where the coefficients come from the Taylor expansion of
+``φ(t) = P(r + t)/Q(r + t)`` around ``t = 0`` with
+``Q(x) = den(x)/(x − r)^m``.  Then ``A_{r, m − j} = φ_j``.
+
+This mirrors the Phase 48 algorithm added to Python ``symbolic-vm`` in
+PR \#3927 and the TypeScript port at ``@coding-adventures/symbolic-vm``
+0.14.0.  Acceptance: ``Apart(1/(k²(k+1)²), k)`` decomposes to
+``2/(k+1) + 1/(k+1)² − 2/k + 1/k²`` (left-associated, roots ascending),
+matching the Python reference byte-for-byte.
+
+Denominators that still contain an irreducible quadratic factor on top of
+the rational roots continue to bail to the unevaluated ``Apart(...)``
+form — partial fractions over the rationals can't go further there.
+
+### Added
+
+- ``poly_taylor_expand_around_r`` — Taylor-expand a ``RatPoly`` around a
+  rational point ``r`` to ``length`` coefficients using the binomial
+  identity ``poly(r+t)_j = ∑_{i≥j} c_i · C(i, j) · r^(i−j)``.  Exact
+  ``i128`` arithmetic throughout.
+- ``poly_series_div`` — formal power-series division ``N(t)/D(t)`` to
+  ``length`` terms via the recurrence
+  ``Q_j = (N_j − ∑_{k≥1} D_k · Q_{j−k}) / D_0``.  Returns ``None`` when
+  ``D(0) = 0`` (defensive guard against a repeated-root miscount).
+- ``build_apart_term`` — IR builder for ``A / (x − r)^power`` with
+  ``±1`` numerator elision matching ``apart_simple_roots``.
+- ``binomial_i128`` — exact ``i128`` binomial helper used by the
+  Taylor expansion.
+
+### Changed
+
+- ``apart_proper`` — Phase 48 generic path lifted in: when any
+  multiplicity > 1, compute ``Q(x) = den(x)/(x − r)^m`` per root via
+  successive ``rp_div``, Taylor-expand ``num`` and ``Q`` around ``r``,
+  series-divide, and emit ascending-power terms via ``build_apart_term``.
+  Phase 1 simple-roots fast path retained for the B1 regression tests
+  (cheaper than Taylor + series division, preserves the existing IR
+  shape).
+
+### Removed
+
+- The ``mult > 1 → None`` bail in ``apart_proper`` — the new code path
+  handles the repeated-root case directly.
+
+### Out of scope (deferred)
+
+- Irreducible quadratic factors (``Apart`` over the rationals only).
+- Algebraic-number roots beyond Q — would require an irrational-roots
+  extension.
+
 ## [0.13.0] — 2026-05-28
 
 **Track B1 — Apart simple-roots partial-fraction decomposition (Rust port).**

--- a/code/packages/rust/symbolic-vm/Cargo.toml
+++ b/code/packages/rust/symbolic-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symbolic-vm"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 description = "Generic symbolic expression evaluator over the symbolic-ir tree representation"
 license = "MIT"

--- a/code/packages/rust/symbolic-vm/src/handlers.rs
+++ b/code/packages/rust/symbolic-vm/src/handlers.rs
@@ -4874,17 +4874,157 @@ fn apart_simple_roots(
     )
 }
 
+/// Binomial coefficient ``C(n, k)``.  Returns ``0`` when ``k`` is out of
+/// range so callers can sum unconditionally.  Mirrors Python ``_binomial``.
+fn binomial_i128(n: usize, k: usize) -> i128 {
+    if k > n {
+        return 0;
+    }
+    if k == 0 || k == n {
+        return 1;
+    }
+    let kk = k.min(n - k);
+    let mut result: i128 = 1;
+    for i in 0..kk {
+        result = result * (n - i) as i128 / (i + 1) as i128;
+    }
+    result
+}
+
+/// First ``length`` Taylor coefficients of ``poly(r + t)`` as a polynomial
+/// in ``t``.  Mirrors Python ``_taylor_expand_around_r``: for
+/// ``poly(x) = ∑ c_i x^i``,
+///     poly(r + t)_j = ∑_{i ≥ j} c_i · C(i, j) · r^(i − j).
+/// When ``length`` exceeds ``deg poly`` trailing entries are 0.
+fn poly_taylor_expand_around_r(poly: &[RatC], r: RatC, length: usize) -> Option<RatPoly> {
+    let deg = if poly.is_empty() { 0 } else { poly.len() - 1 };
+    let mut result: RatPoly = Vec::with_capacity(length);
+    for j in 0..length {
+        let mut cj: RatC = RC_ZERO;
+        let mut r_pow: RatC = RC_ONE; // r^(i - j) starts at r^0 when i == j
+        let start = j;
+        for i in start..=deg {
+            if i >= poly.len() {
+                break;
+            }
+            let binom = binomial_i128(i, j);
+            if binom != 0 {
+                let coef = poly[i];
+                let term = rc_mul(rc_mul(coef, (binom, 1))?, r_pow)?;
+                cj = rc_add(cj, term)?;
+            }
+            r_pow = rc_mul(r_pow, r)?;
+        }
+        result.push(cj);
+    }
+    Some(result)
+}
+
+/// Formal power-series division ``N(t)/D(t)`` to ``length`` terms.
+/// Requires ``D(0) ≠ 0`` — returns ``None`` otherwise (signal of a
+/// repeated-root miscount upstream).  Mirrors Python ``_series_div``.
+fn poly_series_div(n_coeffs: &[RatC], d_coeffs: &[RatC], length: usize) -> Option<RatPoly> {
+    if d_coeffs.is_empty() || rc_is_zero(d_coeffs[0]) {
+        return None;
+    }
+    let d0 = d_coeffs[0];
+    let mut q: RatPoly = Vec::with_capacity(length);
+    for j in 0..length {
+        let nj = if j < n_coeffs.len() { n_coeffs[j] } else { RC_ZERO };
+        let mut s: RatC = RC_ZERO;
+        for k in 1..=j {
+            let dk = if k < d_coeffs.len() { d_coeffs[k] } else { RC_ZERO };
+            s = rc_add(s, rc_mul(dk, q[j - k])?)?;
+        }
+        q.push(rc_div(rc_sub(nj, s)?, d0)?);
+    }
+    Some(q)
+}
+
+/// Build the IR for ``A / (x − r)^power``.  Drops ``±1`` numerator
+/// coefficients to match the formatting in ``apart_simple_roots``.
+/// Mirrors Python ``_build_apart_term``.
+fn build_apart_term(a: RatC, r: RatC, power: usize, x: &str) -> Option<IRNode> {
+    let factor_ir = rp_to_ir_apart(&[rc_neg(r), RC_ONE], x)?;
+    let denom_ir = if power == 1 {
+        factor_ir
+    } else {
+        apply_node(POW, vec![factor_ir, IRNode::Integer(power as i64)])
+    };
+    let node = if rc_is_one(a) {
+        apply_node(DIV, vec![IRNode::Integer(1), denom_ir])
+    } else if a == (-1, 1) {
+        apply_node(NEG, vec![apply_node(DIV, vec![IRNode::Integer(1), denom_ir])])
+    } else {
+        apply_node(DIV, vec![rc_to_ir(a)?, denom_ir])
+    };
+    Some(node)
+}
+
+/// Decompose a *proper* rational function (deg num < deg den).
+///
+/// Phase 1 (simple roots) — residue formula ``A_i = P(r_i)/Q'(r_i)``.
+///
+/// Phase 48 (repeated linear factors) — for each rational root ``r`` of
+/// multiplicity ``m`` compute ``Q(x) = den(x)/(x − r)^m`` and expand
+/// ``φ(t) = P(r + t)/Q(r + t)`` as a Taylor series in ``t`` up to
+/// ``t^(m − 1)``.  Then ``A_{r, m − j} = φ_j``.  Emits terms
+/// ``A / (x − r)^power`` for ``power = 1..=m`` in ascending order.
+///
+/// Returns ``None`` when ``den`` has an irreducible factor on top of its
+/// rational roots (partial fractions over the rationals cannot decompose
+/// further).
 fn apart_proper(num: &[RatC], den: &[RatC], x: &str) -> Option<IRNode> {
     let roots = rp_rational_roots(den)?;
     if roots.is_empty() {
         return None;
     }
     let mults = rp_root_multiplicities(den, &roots)?;
-    if mults.iter().any(|(_, m)| *m > 1) {
-        // Phase 48 — out of scope for this PR.
-        return None;
+
+    // Phase 1 fast path — preserves the existing output shape for the
+    // regression tests written against B1.
+    if mults.iter().all(|(_, m)| *m == 1) {
+        return apart_simple_roots(num, den, &roots, x);
     }
-    apart_simple_roots(num, den, &roots, x)
+
+    // Phase 48 generic path: Taylor + series-division per root.
+    let mut terms: Vec<IRNode> = Vec::new();
+    for &r in &roots {
+        let m = mults
+            .iter()
+            .find_map(|(rr, mm)| if *rr == r { Some(*mm) } else { None })?;
+        // Q(x) = den(x) / (x − r)^m.  Successive divisions are exact
+        // because we just verified the multiplicity above.
+        let mut q_poly: RatPoly = rp_normalize(den);
+        let linear: RatPoly = vec![rc_neg(r), RC_ONE];
+        for _ in 0..m {
+            let (q, _rem) = rp_div(&q_poly, &linear)?;
+            q_poly = q;
+        }
+        // Taylor-expand both P(r + t) and Q(r + t) up to t^(m − 1).
+        let n_taylor = poly_taylor_expand_around_r(num, r, m)?;
+        let d_taylor = poly_taylor_expand_around_r(&q_poly, r, m)?;
+        let phi = poly_series_div(&n_taylor, &d_taylor, m)?;
+        // A_{r, m − j} = phi[j].  Emit ascending power order:
+        // 1/(x − r), 1/(x − r)^2, …, 1/(x − r)^m.
+        for power in 1..=m {
+            let j = m - power;
+            let a = phi[j];
+            if rc_is_zero(a) {
+                continue;
+            }
+            terms.push(build_apart_term(a, r, power, x)?);
+        }
+    }
+    if terms.is_empty() {
+        return Some(IRNode::Integer(0));
+    }
+    Some(
+        terms
+            .into_iter()
+            .reduce(|acc, t| apply_node(ADD, vec![acc, t]))
+            .unwrap(),
+    )
 }
 
 fn apart_handler(_vm: &mut VM, expr: IRApply) -> IRNode {

--- a/code/packages/rust/symbolic-vm/tests/apart.rs
+++ b/code/packages/rust/symbolic-vm/tests/apart.rs
@@ -1,9 +1,12 @@
-//! Track B1 — Apart simple-roots partial-fraction decomposition.
+//! Track B1 + B3 — Apart partial-fraction decomposition (Rust port).
 //!
-//! Mirrors the six TypeScript test cases (and the Python reference)
-//! exercised by ``code/specs/macsyma-finish-plan.md`` Track B1.
-//! Apart is registered under the symbol name ``"Apart"`` in the
-//! symbolic backend's handler table.
+//! B1: simple roots (residue formula).
+//! B3: repeated linear factors (Phase 48 — Taylor expansion + formal
+//!     power-series division).
+//!
+//! Mirrors the TypeScript test cases (and the Python reference) listed in
+//! ``code/specs/macsyma-finish-plan.md`` (Tracks B1 + B3) and verified
+//! byte-for-byte against the Python output.
 
 use symbolic_ir::{apply, int, rat, sym, ADD, DIV, MUL, NEG, POW, SUB};
 use symbolic_vm::{SymbolicBackend, VM};
@@ -14,6 +17,10 @@ fn vm() -> VM {
 
 fn apart(inner: symbolic_ir::IRNode) -> symbolic_ir::IRNode {
     apply(sym("Apart"), vec![inner, sym("x")])
+}
+
+fn apart_k(inner: symbolic_ir::IRNode) -> symbolic_ir::IRNode {
+    apply(sym("Apart"), vec![inner, sym("k")])
 }
 
 #[test]
@@ -114,19 +121,6 @@ fn apart_irreducible_quadratic_stays_unevaluated() {
 }
 
 #[test]
-fn apart_repeated_root_stays_unevaluated() {
-    let mut v = vm();
-    // 1 / (x - 1)^2
-    let inner = apply(
-        sym(DIV),
-        vec![int(1), apply(sym(POW), vec![apply(sym(SUB), vec![sym("x"), int(1)]), int(2)])],
-    );
-    let result = v.eval(apart(inner.clone()));
-    // Phase 48 explicitly out of scope; handler bails to unevaluated form.
-    assert_eq!(result, apply(sym("Apart"), vec![inner, sym("x")]));
-}
-
-#[test]
 fn apart_already_polynomial_passes_through() {
     let mut v = vm();
     // Apart(x + 1, x) → x + 1
@@ -135,5 +129,149 @@ fn apart_already_polynomial_passes_through() {
     // ``to_rational(x+1, x)`` → num = [1, 1], den = [1]; the early-return
     // path emits ``from_polynomial(num, x)`` = Add(1, x).
     let expected = apply(sym(ADD), vec![int(1), sym("x")]);
+    assert_eq!(result, expected);
+}
+
+// --- Track B3 (Phase 48 repeated linear factors) ---------------------------
+
+#[test]
+fn apart_k_sq_kp1_sq_acceptance() {
+    let mut v = vm();
+    // 1 / (k^2 * (k+1)^2)
+    let k2 = apply(sym(POW), vec![sym("k"), int(2)]);
+    let kp1 = apply(sym(ADD), vec![sym("k"), int(1)]);
+    let kp1_sq = apply(sym(POW), vec![kp1, int(2)]);
+    let inner = apply(sym(DIV), vec![int(1), apply(sym(MUL), vec![k2, kp1_sq])]);
+    let result = v.eval(apart_k(inner));
+    // Roots sorted ascending: -1 (mult 2), 0 (mult 2).
+    // For r = -1: Q(x) = k^2, Q(-1+t) = 1 - 2t + t^2; φ_0 = 1, φ_1 = 2.
+    //   A_{-1, 2} = 1,  A_{-1, 1} = 2.
+    // For r = 0: Q(x) = (k+1)^2, Q(0+t) = 1 + 2t + t^2; φ_0 = 1, φ_1 = -2.
+    //   A_{0, 2} = 1,  A_{0, 1} = -2.
+    // Emit (left-associated): 2/(1+k), 1/(1+k)^2, -2/k, 1/k^2.
+    let expected = apply(
+        sym(ADD),
+        vec![
+            apply(
+                sym(ADD),
+                vec![
+                    apply(
+                        sym(ADD),
+                        vec![
+                            apply(sym(DIV), vec![int(2), apply(sym(ADD), vec![int(1), sym("k")])]),
+                            apply(
+                                sym(DIV),
+                                vec![
+                                    int(1),
+                                    apply(
+                                        sym(POW),
+                                        vec![apply(sym(ADD), vec![int(1), sym("k")]), int(2)],
+                                    ),
+                                ],
+                            ),
+                        ],
+                    ),
+                    apply(sym(DIV), vec![int(-2), sym("k")]),
+                ],
+            ),
+            apply(sym(DIV), vec![int(1), apply(sym(POW), vec![sym("k"), int(2)])]),
+        ],
+    );
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn apart_triple_root_one_over_k_minus_one_cubed() {
+    let mut v = vm();
+    let inner = apply(
+        sym(DIV),
+        vec![
+            int(1),
+            apply(sym(POW), vec![apply(sym(SUB), vec![sym("k"), int(1)]), int(3)]),
+        ],
+    );
+    let result = v.eval(apart_k(inner));
+    // r = 1, m = 3, Q(x) = 1.  φ_0 = 1, φ_1 = φ_2 = 0.
+    // Single term emitted: 1/(k-1)^3 in normalised form 1/(-1+k)^3.
+    let expected = apply(
+        sym(DIV),
+        vec![
+            int(1),
+            apply(sym(POW), vec![apply(sym(ADD), vec![int(-1), sym("k")]), int(3)]),
+        ],
+    );
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn apart_mixed_simple_plus_repeated() {
+    let mut v = vm();
+    // 1 / ((k-1)(k-2)^2)
+    let f1 = apply(sym(SUB), vec![sym("k"), int(1)]);
+    let f2_sq = apply(sym(POW), vec![apply(sym(SUB), vec![sym("k"), int(2)]), int(2)]);
+    let inner = apply(sym(DIV), vec![int(1), apply(sym(MUL), vec![f1, f2_sq])]);
+    let result = v.eval(apart_k(inner));
+    // Roots ascending: 1 (simple) then 2 (mult 2).
+    // For r = 1: Q(x) = (k-2)^2, Q(1) = 1.  φ_0 = 1. → A = 1.
+    // For r = 2: Q(x) = (k-1); Q(2+t) = 1 + t.  φ_0 = 1, φ_1 = -1.
+    //   A_{2, 2} = 1,  A_{2, 1} = -1.
+    // Emit: 1/(-1+k), -1/(-2+k) [Neg(Div(1, …))], 1/(-2+k)^2.
+    let expected = apply(
+        sym(ADD),
+        vec![
+            apply(
+                sym(ADD),
+                vec![
+                    apply(sym(DIV), vec![int(1), apply(sym(ADD), vec![int(-1), sym("k")])]),
+                    apply(
+                        sym(NEG),
+                        vec![apply(sym(DIV), vec![int(1), apply(sym(ADD), vec![int(-2), sym("k")])])],
+                    ),
+                ],
+            ),
+            apply(
+                sym(DIV),
+                vec![
+                    int(1),
+                    apply(sym(POW), vec![apply(sym(ADD), vec![int(-2), sym("k")]), int(2)]),
+                ],
+            ),
+        ],
+    );
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn apart_irreducible_plus_repeated_stays_unevaluated() {
+    let mut v = vm();
+    // 1 / ((x^2 + 1) * (x - 1)^2)
+    let quad = apply(sym(ADD), vec![apply(sym(POW), vec![sym("x"), int(2)]), int(1)]);
+    let lin_sq = apply(sym(POW), vec![apply(sym(SUB), vec![sym("x"), int(1)]), int(2)]);
+    let inner = apply(sym(DIV), vec![int(1), apply(sym(MUL), vec![quad, lin_sq])]);
+    let result = v.eval(apart(inner.clone()));
+    // x^2 + 1 has no rational roots; only x = 1 (mult 2) is found.  Sum of
+    // multiplicities (2) ≠ deg(den) (4) → bail to unevaluated form.
+    assert_eq!(result, apply(sym("Apart"), vec![inner, sym("x")]));
+}
+
+#[test]
+fn apart_single_repeated_root_one_over_x_minus_two_sq() {
+    let mut v = vm();
+    let inner = apply(
+        sym(DIV),
+        vec![
+            int(1),
+            apply(sym(POW), vec![apply(sym(SUB), vec![sym("x"), int(2)]), int(2)]),
+        ],
+    );
+    let result = v.eval(apart(inner));
+    // r = 2, m = 2, Q(x) = 1.  φ_0 = 1, φ_1 = 0.  Single term.
+    let expected = apply(
+        sym(DIV),
+        vec![
+            int(1),
+            apply(sym(POW), vec![apply(sym(ADD), vec![int(-2), sym("x")]), int(2)]),
+        ],
+    );
     assert_eq!(result, expected);
 }

--- a/code/packages/typescript/symbolic-vm/CHANGELOG.md
+++ b/code/packages/typescript/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,68 @@
 # Changelog
 
+## [0.14.0] — 2026-05-28
+
+**Track B3 — Apart for repeated linear factors (Phase 48, TypeScript port).**
+
+Lifts the multiplicity > 1 bail introduced in Track B1.
+``Apart(P(x)/Q(x), x)`` now decomposes rational functions whose denominator
+factors as ``∏_r (x − r)^{m_r}`` for *rational* ``r`` with arbitrary
+multiplicity.  Each pole ``r`` of multiplicity ``m`` contributes terms
+``A_{r,1}/(x − r) + A_{r,2}/(x − r)² + … + A_{r,m}/(x − r)^m`` where the
+coefficients come from the Taylor expansion of
+``φ(t) = P(r + t)/Q(r + t)`` around ``t = 0`` with
+``Q(x) = den(x)/(x − r)^m``.  Then ``A_{r, m − j} = φ_j``.
+
+This mirrors the Phase 48 algorithm added to Python ``symbolic-vm`` in PR
+\#3927.  Acceptance: ``Apart(1/(k²(k+1)²), k)`` decomposes to
+``2/(k+1) + 1/(k+1)² − 2/k + 1/k²`` (left-associated, roots sorted
+ascending), matching the Python reference byte-for-byte.
+
+Denominators that still contain an irreducible quadratic factor on top of
+the rational roots continue to bail to the unevaluated ``Apart(...)``
+form — partial fractions over the rationals can't go further there.
+
+### Added
+
+- ``polyTaylorExpandAroundR`` — Taylor-expand a ``PolyQ`` around a
+  rational point ``r`` to ``length`` coefficients.  Uses the binomial
+  identity ``poly(r+t)_j = ∑_{i≥j} c_i · C(i, j) · r^(i−j)`` with exact
+  arbitrary-precision ``BigInt`` arithmetic.
+- ``polySeriesDiv`` — formal power-series division ``N(t)/D(t)`` to
+  ``length`` terms via the standard recurrence
+  ``Q_j = (N_j − ∑_{k≥1} D_k · Q_{j−k}) / D_0``.  Returns ``undefined``
+  when ``D(0) = 0`` (defensive guard against a repeated-root miscount).
+- ``buildApartTerm`` — IR builder for ``A / (x − r)^power`` with
+  ``±1`` numerator elision (matches the formatting in
+  ``apartSimpleRoots``).
+- ``binomialBig`` — exact ``BigInt`` binomial helper used by the
+  Taylor expansion.
+
+### Changed
+
+- ``apartProper`` — Phase 48 generic path lifted in: when any
+  multiplicity > 1, compute ``Q(x) = den(x)/(x − r)^m`` per root via
+  successive division, Taylor-expand ``num`` and ``Q`` around ``r``,
+  series-divide, and emit ascending-power terms via ``buildApartTerm``.
+  Phase 1 simple-roots fast path retained (cheaper than Taylor + series
+  division and preserves the existing B1 regression-test IR shapes).
+- ``polyQRationalRoots`` — the ``a₀ = 0`` (x = 0 is a root) branch now
+  sorts its returned roots ascending, matching the non-zero-root path
+  and the Python ``sorted(roots)`` reference.  B1's simple-root tests
+  never exercised this branch; Phase 48 needs a stable order across
+  multi-root denominators including ``x = 0``.
+
+### Removed
+
+- The ``mult > 1 → undefined`` bail in ``apartProper`` — the new code
+  path handles the repeated-root case directly.
+
+### Out of scope (deferred)
+
+- Irreducible quadratic factors (``Apart`` over the rationals only).
+- Algebraic-number roots beyond Q — would require an irrational-roots
+  extension.
+
 ## [0.13.0] — 2026-05-28
 
 **Track B1 — Apart simple-roots partial-fraction decomposition (TypeScript port).**

--- a/code/packages/typescript/symbolic-vm/package.json
+++ b/code/packages/typescript/symbolic-vm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/symbolic-vm",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Pure TypeScript symbolic expression evaluator with strict and symbolic backends",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/symbolic-vm/src/index.ts
+++ b/code/packages/typescript/symbolic-vm/src/index.ts
@@ -1801,7 +1801,18 @@ function polyQRationalRoots(p: PolyQ): RatQ[] {
     const found = new Map<string, RatQ>();
     found.set("0/1", RQ_ZERO);
     for (const r of tailRoots) found.set(`${r[0]}/${r[1]}`, r);
-    return [...found.values()];
+    // Sort ascending — matches Python's ``sorted(roots)`` (Phase 48 needs
+    // a stable ascending order across multi-root denominators that include
+    // ``x = 0``; B1's simple-root tests never exercised this branch).
+    const all = [...found.values()];
+    all.sort((a, b) => {
+      const lhs = a[0] * b[1];
+      const rhs = b[0] * a[1];
+      if (lhs < rhs) return -1;
+      if (lhs > rhs) return 1;
+      return 0;
+    });
+    return all;
   }
 
   const divisors = (m: bigint): bigint[] => {
@@ -2069,7 +2080,7 @@ function polyTerm(c: RatQ, i: number, x: IRSymbol): IRNode {
   return app(MUL, [rqToIr(c), power]);
 }
 
-// --- Apart simple-roots (Phase 1) -------------------------------------------
+// --- Apart simple-roots (Phase 1) + repeated linear factors (Phase 48) -----
 
 /** Phase 1 simple-root path; mirrors ``_apart_simple_roots`` in Python.
  *  Returns ``undefined`` when any residue blows up (repeated root that
@@ -2106,19 +2117,150 @@ function apartSimpleRoots(
   return acc;
 }
 
-/** Decompose a *proper* rational function (deg num < deg den).  Returns
- *  ``undefined`` if any root has multiplicity > 1 (Phase 48 — out of scope)
- *  or if the denominator contains an irreducible factor on top of the
- *  rational roots. */
+/** Binomial coefficient ``C(n, k)``.  Returns ``0n`` when k is out of
+ *  range so callers can sum unconditionally.  Mirrors Python ``_binomial``. */
+function binomialBig(n: number, k: number): bigint {
+  if (k < 0 || k > n) return 0n;
+  if (k === 0 || k === n) return 1n;
+  const kk = Math.min(k, n - k);
+  let result = 1n;
+  for (let i = 0; i < kk; i += 1) {
+    result = (result * BigInt(n - i)) / BigInt(i + 1);
+  }
+  return result;
+}
+
+/** Return the first ``length`` Taylor coefficients of ``poly(r + t)`` as
+ *  a polynomial in ``t``.  Mirrors Python ``_taylor_expand_around_r``:
+ *  for ``poly(x) = ∑ c_i x^i``,
+ *      poly(r + t) = ∑_j t^j · [∑_{i ≥ j} c_i · C(i, j) · r^(i − j)].
+ *  When ``length`` exceeds ``deg poly`` trailing entries are filled with 0. */
+function polyTaylorExpandAroundR(poly: PolyQ, r: RatQ, length: number): RatQ[] {
+  const deg = poly.length - 1;
+  const result: RatQ[] = [];
+  for (let j = 0; j < length; j += 1) {
+    let cj: RatQ = RQ_ZERO;
+    let rPow: RatQ = RQ_ONE; // r^(i - j) starts at r^0 when i == j
+    for (let i = j; i <= deg; i += 1) {
+      const coef = poly[i];
+      const binom = binomialBig(i, j);
+      if (binom !== 0n) {
+        const term = rqMul(rqMul(coef, [binom, 1n]), rPow);
+        cj = rqAdd(cj, term);
+      }
+      rPow = rqMul(rPow, r);
+    }
+    result.push(cj);
+  }
+  return result;
+}
+
+/** Formal power-series division ``N(t) / D(t)`` up to ``t^(length − 1)``.
+ *  Requires ``D(0) ≠ 0`` — returns ``undefined`` otherwise (signal of a
+ *  repeated-root miscount upstream).  Mirrors Python ``_series_div``. */
+function polySeriesDiv(
+  nCoeffs: readonly RatQ[],
+  dCoeffs: readonly RatQ[],
+  length: number,
+): RatQ[] | undefined {
+  if (dCoeffs.length === 0 || rqIsZero(dCoeffs[0])) return undefined;
+  const d0 = dCoeffs[0];
+  const q: RatQ[] = [];
+  for (let j = 0; j < length; j += 1) {
+    const nj = j < nCoeffs.length ? nCoeffs[j] : RQ_ZERO;
+    let s: RatQ = RQ_ZERO;
+    for (let k = 1; k <= j; k += 1) {
+      const dk = k < dCoeffs.length ? dCoeffs[k] : RQ_ZERO;
+      s = rqAdd(s, rqMul(dk, q[j - k]));
+    }
+    q.push(rqDiv(rqSub(nj, s), d0));
+  }
+  return q;
+}
+
+/** Build the IR for ``A / (x − r)^power``.  Drops ±1 numerator coefficients
+ *  to match the formatting convention in ``apartSimpleRoots``.  Mirrors
+ *  Python ``_build_apart_term``. */
+function buildApartTerm(A: RatQ, r: RatQ, power: number, x: IRSymbol): IRNode {
+  const negR = rqNeg(r);
+  const factorIr = fromPolynomial([negR, RQ_ONE], x);
+  const denomIr: IRNode = power === 1 ? factorIr : app(POW, [factorIr, int(power)]);
+  if (rqEquals(A, RQ_ONE)) {
+    return app(DIV, [int(1), denomIr]);
+  }
+  if (rqEquals(A, [-1n, 1n])) {
+    return app(NEG, [app(DIV, [int(1), denomIr])]);
+  }
+  return app(DIV, [rqToIr(A), denomIr]);
+}
+
+/** Decompose a *proper* rational function (deg num < deg den).
+ *
+ *  Phase 1 (simple roots) — uses the residue formula ``A_i = P(r_i)/Q'(r_i)``
+ *  for each distinct rational root ``r_i``.
+ *
+ *  Phase 48 (repeated linear factors) — for each root ``r`` of multiplicity
+ *  ``m`` compute ``Q(x) = den(x)/(x − r)^m`` and expand
+ *  ``φ(t) = P(r + t)/Q(r + t)`` as a Taylor series in ``t`` up to ``t^(m−1)``.
+ *  Then ``A_{r, m − j} = φ_j``.  Emits terms ``A / (x − r)^power`` for
+ *  ``power = 1..m``.
+ *
+ *  Returns ``undefined`` when ``den`` has an irreducible factor on top of
+ *  its rational roots — partial fractions over the rationals can't go
+ *  further in that case. */
 function apartProper(num: PolyQ, den: PolyQ, x: IRSymbol): IRNode | undefined {
   const roots = polyQRationalRoots(den);
   if (roots.length === 0) return undefined;
   const mults = polyQRootMultiplicities(den, roots);
   if (mults === undefined) return undefined;
+
+  // Phase 1 fast path — preserves the existing output shape for the
+  // regression tests written against B1.
+  let allSimple = true;
   for (const { mult } of mults.values()) {
-    if (mult > 1) return undefined; // Phase 48 path — explicitly out of scope.
+    if (mult > 1) {
+      allSimple = false;
+      break;
+    }
   }
-  return apartSimpleRoots(num, den, roots, x);
+  if (allSimple) return apartSimpleRoots(num, den, roots, x);
+
+  // Phase 48 generic path: Taylor + series-division per root.
+  const terms: IRNode[] = [];
+  for (const r of roots) {
+    const key = `${r[0]}/${r[1]}`;
+    const entry = mults.get(key);
+    if (entry === undefined) return undefined; // defensive — shouldn't happen
+    const m = entry.mult;
+    // Q(x) = den(x) / (x − r)^m.  Successive divisions are exact because
+    // we just verified the multiplicity above.
+    let qPoly: RatQ[] = polyQNormalize(den);
+    const linear: RatQ[] = [rqNeg(r), RQ_ONE];
+    for (let i = 0; i < m; i += 1) {
+      const { q } = polyQDivmod(qPoly, linear);
+      qPoly = q;
+    }
+    // Taylor-expand both P(r + t) and Q(r + t) up to t^(m − 1).
+    const nTaylor = polyTaylorExpandAroundR(num, r, m);
+    const dTaylor = polyTaylorExpandAroundR(qPoly, r, m);
+    const phi = polySeriesDiv(nTaylor, dTaylor, m);
+    if (phi === undefined) return undefined;
+    // A_{r, m − j} = phi[j].  Emit ascending power order:
+    // 1/(x − r), 1/(x − r)^2, …, 1/(x − r)^m.
+    for (let power = 1; power <= m; power += 1) {
+      const j = m - power;
+      const A = phi[j];
+      if (rqIsZero(A)) continue;
+      terms.push(buildApartTerm(A, r, power, x));
+    }
+  }
+  if (terms.length === 0) return int(0);
+  if (terms.length === 1) return terms[0];
+  let acc: IRNode = terms[0];
+  for (let i = 1; i < terms.length; i += 1) {
+    acc = app(ADD, [acc, terms[i]]);
+  }
+  return acc;
 }
 
 function apartHandler(_vm: VM, expr: IRApply): IRNode {

--- a/code/packages/typescript/symbolic-vm/tests/apart.test.ts
+++ b/code/packages/typescript/symbolic-vm/tests/apart.test.ts
@@ -14,16 +14,19 @@ import {
 } from "@coding-adventures/symbolic-ir";
 import { SymbolicBackend, VM } from "../src/index.js";
 
-// Helpers — Track B1 (Apart simple-roots port) acceptance tests.
+// Helpers — Track B1 (Apart simple-roots) + Track B3 (Phase 48 repeated
+// linear factors) acceptance tests.
 //
-// Mirrors the six Python test cases enumerated in macsyma-finish-plan.md
-// (Track B1).  Apart is registered by string-name "Apart" because no
-// symbolic-ir constant exists for it.
+// Mirrors the Python test cases enumerated in
+// ``code/specs/macsyma-finish-plan.md`` (Tracks B1 + B3) and verified
+// against the Python reference output exactly.  Apart is registered by
+// string-name "Apart" because no symbolic-ir constant exists for it.
 const APART = sym("Apart");
 const x = sym("x");
+const k = sym("k");
 
-function apart(inner: IRNode): IRNode {
-  return app(APART, [inner, x]);
+function apart(inner: IRNode, variable: IRNode = x): IRNode {
+  return app(APART, [inner, variable]);
 }
 
 describe("Apart — Track B1 (Phase 1 simple roots)", () => {
@@ -92,13 +95,6 @@ describe("Apart — Track B1 (Phase 1 simple roots)", () => {
     expect(result).toEqual(app(APART, [inner, x]));
   });
 
-  it("leaves 1/(x-1)^2 unevaluated (repeated root — Phase 48 out of scope)", () => {
-    const vm = new VM(new SymbolicBackend());
-    const inner = app(DIV, [int(1), app(POW, [app(SUB, [x, int(1)]), int(2)])]);
-    const result = vm.eval(apart(inner));
-    expect(result).toEqual(app(APART, [inner, x]));
-  });
-
   it("passes a bare polynomial Apart(x+1, x) through as x+1", () => {
     const vm = new VM(new SymbolicBackend());
     const inner = app(ADD, [x, int(1)]);
@@ -106,5 +102,92 @@ describe("Apart — Track B1 (Phase 1 simple roots)", () => {
     // ``to_rational(x+1, x)`` → num = [1, 1], den = [1]; the early-return
     // path emits ``from_polynomial(num, x)`` = Add(1, x).
     expect(result).toEqual(app(ADD, [int(1), x]));
+  });
+});
+
+describe("Apart — Track B3 (Phase 48 repeated linear factors)", () => {
+  it("decomposes 1/(k^2 (k+1)^2) into -2/k + 1/k^2 + 2/(k+1) + 1/(k+1)^2 (acceptance)", () => {
+    const vm = new VM(new SymbolicBackend());
+    // 1 / (k^2 * (k+1)^2)
+    const k2 = app(POW, [k, int(2)]);
+    const kp1 = app(ADD, [k, int(1)]);
+    const kp1Sq = app(POW, [kp1, int(2)]);
+    const inner = app(DIV, [int(1), app(MUL, [k2, kp1Sq])]);
+    const result = vm.eval(apart(inner, k));
+    // Roots sorted ascending: -1 (mult 2) before 0 (mult 2).
+    // For r = -1: φ(t) = 1 / (r+t)^2 |_{r=-1}; Q(x) = k^2, so
+    //   Q(-1+t) = (-1+t)^2 = 1 - 2t + t^2  →  φ_0 = 1, φ_1 = 2.
+    //   A_{-1, 2} = φ_0 = 1,  A_{-1, 1} = φ_1 = 2.
+    // For r = 0: Q(x) = (k+1)^2; Q(t) = (1+t)^2 = 1 + 2t + t^2 →
+    //   φ_0 = 1, φ_1 = -2.  A_{0, 2} = 1, A_{0, 1} = -2.
+    // Emit in order: 2/(1+k), 1/(1+k)^2, -2/k, 1/k^2 (left-associated).
+    expect(result).toEqual(
+      app(ADD, [
+        app(ADD, [
+          app(ADD, [
+            app(DIV, [int(2), app(ADD, [int(1), k])]),
+            app(DIV, [int(1), app(POW, [app(ADD, [int(1), k]), int(2)])]),
+          ]),
+          app(DIV, [int(-2), k]),
+        ]),
+        app(DIV, [int(1), app(POW, [k, int(2)])]),
+      ]),
+    );
+  });
+
+  it("decomposes 1/(k-1)^3 to itself (single triple root, Q(x) = 1)", () => {
+    const vm = new VM(new SymbolicBackend());
+    const inner = app(DIV, [int(1), app(POW, [app(SUB, [k, int(1)]), int(3)])]);
+    const result = vm.eval(apart(inner, k));
+    // r = 1, m = 3, Q(x) = 1.  φ(t) = 1 / 1 = 1; φ_0 = 1, φ_1 = φ_2 = 0.
+    // A_{1, 3} = 1, A_{1, 2} = 0, A_{1, 1} = 0.  Single term emitted.
+    expect(result).toEqual(
+      app(DIV, [int(1), app(POW, [app(ADD, [int(-1), k]), int(3)])]),
+    );
+  });
+
+  it("decomposes 1/((k-1)(k-2)^2) (mixed simple + repeated)", () => {
+    const vm = new VM(new SymbolicBackend());
+    const f1 = app(SUB, [k, int(1)]);
+    const f2Sq = app(POW, [app(SUB, [k, int(2)]), int(2)]);
+    const inner = app(DIV, [int(1), app(MUL, [f1, f2Sq])]);
+    const result = vm.eval(apart(inner, k));
+    // Roots ascending: 1 (simple), 2 (mult 2).
+    // For r = 1 (simple): emitted via fall-through to the same Taylor
+    //   path; Q(x) = (k-2)^2, Q(1) = 1, so A = 1/Q(1) = 1.
+    // For r = 2 (mult 2): Q(x) = (k-1); Q(2+t) = 1 + t →
+    //   φ_0 = 1, φ_1 = -1.  A_{2, 2} = 1, A_{2, 1} = -1.
+    // Emit: 1/(-1+k), -1/(-2+k) [as Neg(Div(1, …))], 1/(-2+k)^2.
+    expect(result).toEqual(
+      app(ADD, [
+        app(ADD, [
+          app(DIV, [int(1), app(ADD, [int(-1), k])]),
+          app(NEG, [app(DIV, [int(1), app(ADD, [int(-2), k])])]),
+        ]),
+        app(DIV, [int(1), app(POW, [app(ADD, [int(-2), k]), int(2)])]),
+      ]),
+    );
+  });
+
+  it("leaves 1/((x^2+1)(x-1)^2) unevaluated (irreducible factor + repeated root)", () => {
+    const vm = new VM(new SymbolicBackend());
+    const quad = app(ADD, [app(POW, [x, int(2)]), int(1)]);
+    const linSq = app(POW, [app(SUB, [x, int(1)]), int(2)]);
+    const inner = app(DIV, [int(1), app(MUL, [quad, linSq])]);
+    const result = vm.eval(apart(inner));
+    // x^2 + 1 has no rational roots — the rational-roots theorem only
+    // finds x = 1 (mult 2), which doesn't sum to deg(den) = 4.  Bail.
+    expect(result).toEqual(app(APART, [inner, x]));
+  });
+
+  it("decomposes 1/(x-2)^2 to itself (single repeated root, Q(x) = 1)", () => {
+    const vm = new VM(new SymbolicBackend());
+    const inner = app(DIV, [int(1), app(POW, [app(SUB, [x, int(2)]), int(2)])]);
+    const result = vm.eval(apart(inner));
+    // r = 2, m = 2, Q(x) = 1.  φ_0 = 1, φ_1 = 0.
+    // A_{2, 2} = 1, A_{2, 1} = 0.  Single term.
+    expect(result).toEqual(
+      app(DIV, [int(1), app(POW, [app(ADD, [int(-2), x]), int(2)])]),
+    );
   });
 });


### PR DESCRIPTION
## Summary

Track B3 of `code/specs/macsyma-finish-plan.md`: ports the **Phase 48 algorithm — Apart for repeated linear factors** from Python `symbolic-vm/cas_handlers.py` to TypeScript and Rust `symbolic-vm`.  Lifts the multiplicity > 1 bail introduced in Track B1 (PR #4558).

For each rational root `r` of multiplicity `m`, Phase 48 computes `Q(x) = den(x)/(x − r)^m` and expands `φ(t) = P(r + t)/Q(r + t)` as a Taylor series in `t` up to `t^(m − 1)`.  Then `A_{r, m − j} = φ_j` and we emit terms `A/(x − r)^power` for `power = 1..m`.

Both ports share the existing `RatQ` / `RatC` + `RatPoly` machinery from B1 — no new arithmetic substrate.

## Acceptance check

`Apart(1/(k²(k+1)²), k)` decomposes to `2/(k+1) + 1/(k+1)² − 2/k + 1/k²` (left-associated, roots sorted ascending) in both languages, matching the Python reference byte-for-byte.

## Side fix (TS only)

`polyQRationalRoots`'s `a₀ = 0` (x = 0 is a root) fast-path used a `Map` and skipped the trailing sort.  Phase 48 needs a stable ascending order across multi-root denominators that include `x = 0`; the simple-root B1 tests never exercised this branch (none of them have 0 as a root).  Sort applied at the end of the fast-path now.

## Test plan

- [x] `cd code/packages/typescript/symbolic-vm && npm test` — 171 tests pass (5 new B3 cases + 5 existing B1 cases + the rest)
- [x] `cd code/packages/rust/symbolic-vm && cargo test` — 194 tests pass (10 cases in `tests/apart.rs` = 5 B1 + 5 B3)
- [x] `cd code/packages/typescript/cas-summation && npm test` — 89 tests pass (no regressions; B2 telescope chain still works)

New B3 cases per language:
1. **Acceptance**: `Apart(1/(k²(k+1)²), k)` → `2/(k+1) + 1/(k+1)² − 2/k + 1/k²`
2. **Triple root**: `Apart(1/(k-1)³, k)` → `1/(k-1)³` (Q(x)=1, single term)
3. **Mixed simple + repeated**: `Apart(1/((k-1)(k-2)²), k)` → `1/(k-1) − 1/(k-2) + 1/(k-2)²`
4. **Irreducible + repeated bail**: `Apart(1/((x²+1)(x-1)²), x)` stays unevaluated
5. **Single repeated root**: `Apart(1/(x-2)², x)` → `1/(x-2)²`

## Out of scope

- Irreducible quadratic factors (Apart over the rationals only).
- Algebraic-number roots beyond Q.

🤖 Generated with [Claude Code](https://claude.com/claude-code)