### PR TITLE
feat(cas-ode): Track C2 — Frobenius ODE port to TS + Rust (0.3.0)

### DIFF
--- a/code/packages/rust/cas-ode/CHANGELOG.md
+++ b/code/packages/rust/cas-ode/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog — cas-ode (Rust)
 
+## [0.3.0] — 2026-05-28
+
+### Added
+
+- **Track C2 — Frobenius / power-series ODE solver** (`try_frobenius_series`):
+  - Solves second-order linear ODEs `P(x)·y'' + Q(x)·y' + R(x)·y = 0` with a
+    regular singular point at `x = 0` by substituting `y = x^r · Σ a_n x^n`.
+  - `poly_coeffs_extract` — extract rational polynomial coefficients of `expr`
+    in `x` up to arbitrary `max_deg`.
+  - `degree_of_monomial` — recursive `(coeff, degree)` decomposition for a
+    monomial `c·x^k`; handles `Mul`, `Neg`, `Pow(x, k≥0)`, rational literals.
+  - `frac_poly_mul` — truncated polynomial multiplication over `Frac`.
+  - `is_regular_singular` — verify x=0 is a regular singular point and
+    return the analytic Taylor series `tildeP = x·p(x)` and `tildeQ = x²·q(x)`.
+    Computes `1 / P_eff(x)` (where `P_eff = P/x^m`) via the standard
+    series-inverse recurrence; returns `None` for irregular singular points
+    (order `m > 2`) or when the leading-zero analyticity condition fails.
+  - `solve_indicial` — solve `r² + (p_0-1)r + q_0 = 0` for rational roots
+    using `exact_sqrt_frac`; returns `None` on complex / irrational roots.
+  - `roots_differ_by_integer` — guard for the logarithmic Frobenius case (bails).
+  - `build_series_ir` — assemble `Mul(Pow(x, r), Add(a_0, a_1·x, …, a_N·x^N))`
+    IR; signed `Frac` exponents encoded with `Neg(Rational(…))` for `r < 0`.
+  - Dispatch order: inserted in `solve_ode` after `try_var_coeff_named_ode`
+    and before `try_bernoulli`.  Mirrors the Python ordering: the named
+    families (Bessel, Legendre, Hermite, Chebyshev) get first shot, and
+    only un-named regular-singular-point ODEs reach the Frobenius helper.
+  - Default truncation `N = 10`; recurrence is exact over `Frac` so the
+    series matches the Python reference coefficient-for-coefficient
+    (verified: `2x²y'' + 3xy' − (1+x)y = 0` produces `a_1 = 1/5`,
+    `a_2 = 1/70`, `a_3 = 1/1890`, `a_4 = 1/83160`, …).
+- Scope (deliberate parity with Track C1):
+  - Singular point at `x = 0` only.
+  - Indicial roots must be rational and differ by a non-integer.
+  - Irregular singular points (order of vanishing of `P` > 2) bail.
+
 ## [0.2.0] — 2026-05-16
 
 ### Added

--- a/code/packages/rust/cas-ode/Cargo.toml
+++ b/code/packages/rust/cas-ode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-ode"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Symbolic ODE2 solver over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-ode/src/lib.rs
+++ b/code/packages/rust/cas-ode/src/lib.rs
@@ -1690,6 +1690,357 @@ fn try_var_coeff_named_ode(expr: &IRNode, y: &IRNode, x: &IRNode) -> Option<IRNo
         .or_else(|| try_hermite_ode(expr, y, x))
 }
 
+// ============================================================================
+// Track C2 — Frobenius / power-series method
+//
+// Solves second-order linear ODEs P(x)·y'' + Q(x)·y' + R(x)·y = 0 with a
+// regular singular point at x = 0 by substituting the Frobenius series
+//
+//   y(x) = x^r · Σ_{n≥0} a_n x^n
+//
+// and producing a truncated power-series IR.  Scope (matches Python C1 / TS):
+//   1. Singular point at x = 0 only.
+//   2. Indicial roots must be rational and differ by a non-integer.
+//      Equal or integer-difference roots produce logarithmic terms in the
+//      second solution and bail (return None).
+//
+// Pipeline:
+//   collect_var2_coeffs    — already exists (reused for named-ODE recogniser).
+//   poly_coeffs_extract    — turn IR polynomial expr into a Vec<Frac>.
+//   is_regular_singular    — verify x=0 regular-singular; return (tildeP, tildeQ)
+//                             where tildeP = x·p(x), tildeQ = x²·q(x).
+//   solve_indicial         — solve r² + (p_0-1) r + q_0 = 0 for rational roots.
+//   roots_differ_by_integer — bail flag for logarithmic case.
+//   build_series_ir        — assemble Equal(y, x^r · poly(x)) IR.
+//   try_frobenius_series   — top-level entry point.
+//
+// Default truncation N=10 matches the Python reference.
+// ============================================================================
+
+const FROBENIUS_DEFAULT_N: usize = 10;
+
+/// Return `Some((coeff, degree))` for a monomial `c·x^k`, else `None`.
+///
+/// Handles: rational literals (degree 0), bare x (degree 1),
+/// Pow(x, k≥0), Mul(c, x^k), Neg-wrapped variants.  Recursive over
+/// nested Mul/Neg trees.
+fn degree_of_monomial(term: &IRNode, x: &IRNode) -> Option<(Frac, usize)> {
+    // Neg unwrap.
+    if let Some(inner) = unary_arg(term, NEG) {
+        let (c, d) = degree_of_monomial(inner, x)?;
+        return Some((-c, d));
+    }
+    // Rational literal → (value, 0).
+    if let Some(f) = rational_value(term) {
+        return Some((f, 0));
+    }
+    // Bare symbol — must be x.
+    if matches!(term, IRNode::Symbol(_)) {
+        return if term == x { Some((Frac::ONE, 1)) } else { None };
+    }
+    // Pow(x, k) with non-negative integer k.
+    if let Some((base, expn)) = binary_args(term, POW) {
+        if base == x {
+            if let IRNode::Integer(k) = expn {
+                if *k >= 0 {
+                    return Some((Frac::ONE, *k as usize));
+                }
+            }
+        }
+        return None;
+    }
+    // Mul(a, b) — degree adds, coefficients multiply.
+    if let Some((a, b)) = binary_args(term, MUL) {
+        let (ca, da) = degree_of_monomial(a, x)?;
+        let (cb, db) = degree_of_monomial(b, x)?;
+        return Some((ca * cb, da + db));
+    }
+    None
+}
+
+/// Extract rational polynomial coefficients of `expr` in `x` of degree ≤
+/// `max_deg`.  Returns a Vec of length `max_deg + 1`, or `None` if `expr`
+/// is not a polynomial in `x` (or contains a term of degree > `max_deg`).
+fn poly_coeffs_extract(expr: &IRNode, x: &IRNode, max_deg: usize) -> Option<Vec<Frac>> {
+    let mut out = vec![Frac::ZERO; max_deg + 1];
+    for term in flatten_add(expr) {
+        let (coeff, deg) = degree_of_monomial(&term, x)?;
+        if deg > max_deg {
+            return None;
+        }
+        out[deg] = out[deg] + coeff;
+    }
+    Some(out)
+}
+
+/// Multiply two truncated polynomials (Vec<Frac>) and truncate result at
+/// degree `max_deg`.
+fn frac_poly_mul(a: &[Frac], b: &[Frac], max_deg: usize) -> Vec<Frac> {
+    let mut out = vec![Frac::ZERO; max_deg + 1];
+    for i in 0..a.len().min(max_deg + 1) {
+        if a[i].is_zero() {
+            continue;
+        }
+        for j in 0..b.len() {
+            if i + j > max_deg {
+                break;
+            }
+            if b[j].is_zero() {
+                continue;
+            }
+            out[i + j] = out[i + j] + a[i] * b[j];
+        }
+    }
+    out
+}
+
+/// Verify `x = 0` is a regular singular point of P(x)y'' + Q(x)y' + R(x)y = 0
+/// and return the analytic Taylor series `(tildeP, tildeQ)` where
+/// `tildeP = x·p(x)` and `tildeQ = x²·q(x)` with `p = Q/P`, `q = R/P`.
+///
+/// Returns `None` if:
+///   - `P(0) ≠ 0` (regular point, not singular — caller falls through).
+///   - Order of vanishing of `P` at 0 exceeds 2 (irregular / out of scope).
+///   - Analyticity condition on `x·p` or `x²·q` fails.
+fn is_regular_singular(
+    p_poly: &[Frac],
+    q_poly: &[Frac],
+    r_poly: &[Frac],
+) -> Option<(Vec<Frac>, Vec<Frac>)> {
+    let n = p_poly.len();
+    // Order of vanishing of P at 0.
+    let mut m = 0usize;
+    while m < n && p_poly[m].is_zero() {
+        m += 1;
+    }
+    if m == 0 {
+        return None; // regular (non-singular) point
+    }
+    if m > 2 {
+        return None; // beyond Frobenius scope
+    }
+
+    // P_eff(x) = P(x) / x^m  (analytic, P_eff(0) ≠ 0).
+    let mut p_eff = vec![Frac::ZERO; n];
+    for i in m..n {
+        p_eff[i - m] = p_poly[i];
+    }
+    if p_eff[0].is_zero() {
+        return None;
+    }
+
+    // Invert P_eff as Taylor series:
+    //   inv[0] = 1 / P_eff[0]
+    //   inv[k] = -(1/P_eff[0]) · Σ_{j=1..k} P_eff[j] · inv[k-j]
+    let mut inv = vec![Frac::ZERO; n];
+    inv[0] = Frac::ONE / p_eff[0];
+    for k in 1..n {
+        let mut s = Frac::ZERO;
+        for j in 1..=k {
+            if j >= n {
+                break;
+            }
+            s = s + p_eff[j] * inv[k - j];
+        }
+        inv[k] = -inv[0] * s;
+    }
+
+    // tildeP = x^{1-m} · Q · inv  (left-shift by m-1).
+    let q_inv = frac_poly_mul(q_poly, &inv, n - 1);
+    let shift_p = m - 1;
+    for i in 0..shift_p {
+        if !q_inv[i].is_zero() {
+            return None;
+        }
+    }
+    let mut tilde_p = vec![Frac::ZERO; n];
+    for k in 0..n {
+        let idx = k + shift_p;
+        if idx < n {
+            tilde_p[k] = q_inv[idx];
+        }
+    }
+
+    // tildeQ = x^{2-m} · R · inv  (m=2 → no shift; m=1 → right-shift by 1).
+    let r_inv = frac_poly_mul(r_poly, &inv, n - 1);
+    let mut tilde_q = vec![Frac::ZERO; n];
+    if m >= 2 {
+        let shift_q = m - 2;
+        for i in 0..shift_q {
+            if !r_inv[i].is_zero() {
+                return None;
+            }
+        }
+        for k in 0..n {
+            let idx = k + shift_q;
+            if idx < n {
+                tilde_q[k] = r_inv[idx];
+            }
+        }
+    } else {
+        // m == 1: shift_q = -1, so right-shift R_inv by 1.
+        for k in 1..n {
+            tilde_q[k] = r_inv[k - 1];
+        }
+    }
+
+    Some((tilde_p, tilde_q))
+}
+
+/// Solve `r(r-1) + p_0·r + q_0 = 0` for rational roots `(r1, r2)` with
+/// `r1 ≥ r2`.  Returns `None` on complex / irrational roots.
+fn solve_indicial(p0: Frac, q0: Frac) -> Option<(Frac, Frac)> {
+    // r² + (p0 − 1) r + q0 = 0.
+    let b = p0 - Frac::ONE;
+    let c = q0;
+    let disc = b * b - Frac::int(4) * c;
+    if disc < Frac::ZERO {
+        return None;
+    }
+    let sqrt_disc = exact_sqrt_frac(disc)?;
+    let half = Frac::new(1, 2);
+    let mut r1 = (-b + sqrt_disc) * half;
+    let mut r2 = (-b - sqrt_disc) * half;
+    if r1 < r2 {
+        std::mem::swap(&mut r1, &mut r2);
+    }
+    Some((r1, r2))
+}
+
+/// Return true iff `r1 − r2` is an integer (denominator 1).  Equal roots
+/// and positive-integer differences both trigger logarithmic Frobenius —
+/// out of scope.
+fn roots_differ_by_integer(r1: Frac, r2: Frac) -> bool {
+    (r1 - r2).d == 1
+}
+
+/// Build the IR for `x^r · (a_0 + a_1 x + … + a_N x^N)`.
+///
+/// Conventions:
+///   - Zero coefficients past `a_0` are omitted.
+///   - `r = 0` collapses to the bare polynomial.
+///   - `r = 1` emits `Mul(x, poly)`.
+///   - Otherwise emits `Mul(Pow(x, r), poly)` with `r` encoded as an
+///     integer or rational literal (signed via `Neg` wrapper for negative r).
+fn build_series_ir(r: Frac, a: &[Frac], x: &IRNode) -> IRNode {
+    // Build the polynomial Σ a_k x^k (a_0 always emitted, others only if nonzero).
+    let mut poly_terms: Vec<IRNode> = Vec::new();
+    for (k, ak) in a.iter().enumerate() {
+        let ak = *ak;
+        if ak.is_zero() && k > 0 {
+            continue;
+        }
+        // Build coefficient IR with explicit Neg wrapper when negative.
+        let coeff_ir: IRNode = if ak.n < 0 {
+            apply(sym(NEG), vec![(-ak).to_ir()])
+        } else {
+            ak.to_ir()
+        };
+        let term: IRNode = if k == 0 {
+            coeff_ir
+        } else if k == 1 {
+            if ak == Frac::ONE {
+                x.clone()
+            } else if ak == -Frac::ONE {
+                apply(sym(NEG), vec![x.clone()])
+            } else {
+                apply(sym(MUL), vec![coeff_ir, x.clone()])
+            }
+        } else {
+            let xk = apply(sym(POW), vec![x.clone(), int(k as i64)]);
+            if ak == Frac::ONE {
+                xk
+            } else if ak == -Frac::ONE {
+                apply(sym(NEG), vec![xk])
+            } else {
+                apply(sym(MUL), vec![coeff_ir, xk])
+            }
+        };
+        poly_terms.push(term);
+    }
+    if poly_terms.is_empty() {
+        poly_terms.push(zero());
+    }
+
+    let mut poly_ir = poly_terms[0].clone();
+    for t in poly_terms.into_iter().skip(1) {
+        poly_ir = apply(sym(ADD), vec![poly_ir, t]);
+    }
+
+    if r.is_zero() {
+        return poly_ir;
+    }
+    if r == Frac::ONE {
+        return apply(sym(MUL), vec![x.clone(), poly_ir]);
+    }
+    let r_ir: IRNode = if r.n < 0 {
+        apply(sym(NEG), vec![(-r).to_ir()])
+    } else {
+        r.to_ir()
+    };
+    let x_pow_r = apply(sym(POW), vec![x.clone(), r_ir]);
+    apply(sym(MUL), vec![x_pow_r, poly_ir])
+}
+
+/// Attempt to solve `expr = 0` as a Frobenius power series at `x = 0`.
+///
+/// Returns `Equal(y, x^r · Σ_{k=0..N} a_k x^k)` on success, or `None` on
+/// any of the out-of-scope conditions: non-2nd-order, non-polynomial
+/// coefficients, regular point at 0, irregular singular point,
+/// complex/irrational/integer-difference indicial roots.
+///
+/// Default truncation `N = 10` matches the Python reference's
+/// `_DEFAULT_TRUNCATION_N`.
+fn try_frobenius_series(expr: &IRNode, y: &IRNode, x: &IRNode) -> Option<IRNode> {
+    try_frobenius_series_n(expr, y, x, FROBENIUS_DEFAULT_N)
+}
+
+fn try_frobenius_series_n(expr: &IRNode, y: &IRNode, x: &IRNode, n: usize) -> Option<IRNode> {
+    let (p_node, q_node, r_node) = collect_var2_coeffs(expr, y, x)?;
+    let max_deg = n;
+    let p_poly = poly_coeffs_extract(&p_node, x, max_deg)?;
+    let q_poly = poly_coeffs_extract(&q_node, x, max_deg)?;
+    let r_poly = poly_coeffs_extract(&r_node, x, max_deg)?;
+
+    let (tilde_p, tilde_q) = is_regular_singular(&p_poly, &q_poly, &r_poly)?;
+    let p0 = tilde_p[0];
+    let q0 = tilde_q[0];
+
+    let (r1, r2) = solve_indicial(p0, q0)?;
+    if roots_differ_by_integer(r1, r2) {
+        return None;
+    }
+
+    // F(s) = s(s-1) + p0·s + q0.
+    let f = |s: Frac| -> Frac { s * (s - Frac::ONE) + p0 * s + q0 };
+
+    let mut a: Vec<Frac> = vec![Frac::ONE];
+    for n_idx in 1..=n {
+        let denom = f(Frac::int(n_idx as i64) + r1);
+        if denom.is_zero() {
+            return None; // defensive
+        }
+        let mut rhs = Frac::ZERO;
+        for k in 1..=n_idx {
+            let pk = if k < tilde_p.len() {
+                tilde_p[k]
+            } else {
+                Frac::ZERO
+            };
+            let qk = if k < tilde_q.len() {
+                tilde_q[k]
+            } else {
+                Frac::ZERO
+            };
+            rhs = rhs + a[n_idx - k] * (pk * (Frac::int((n_idx - k) as i64) + r1) + qk);
+        }
+        a.push(-rhs / denom);
+    }
+
+    let series_ir = build_series_ir(r1, &a, x);
+    Some(equal(y.clone(), series_ir))
+}
+
 fn try_vop(expr: &IRNode, y: &IRNode, x: &IRNode) -> Option<IRNode> {
     let (a, b, ccoef, f) = collect_second_order_nonhom(expr, y, x)?;
     let (u1p, u2p, y1, y2) = vop_integrand_pair(a, b, ccoef, f, x)?;
@@ -1720,6 +2071,13 @@ pub fn solve_ode(expr: IRNode, y: IRNode, x: IRNode) -> Option<IRNode> {
         return Some(solve_euler_cauchy_frac(a, b, ccoef, &y, &x));
     }
     if let Some(result) = try_var_coeff_named_ode(&expr, &y, &x) {
+        return Some(result);
+    }
+    // Track C2: Frobenius / power-series fallback for un-named regular
+    // singular-point ODEs.  Bails (returns None) on regular points, irregular
+    // singular points, and integer-difference / equal indicial roots
+    // (logarithmic case — out of scope).
+    if let Some(result) = try_frobenius_series(&expr, &y, &x) {
         return Some(result);
     }
     if let Some(result) = try_bernoulli(&expr, &y, &x) {
@@ -2152,5 +2510,116 @@ mod tests {
             !s.contains("LegendreP") && !s.contains("BesselJ"),
             "Euler-Cauchy result must not contain named-ODE heads: {s}"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Track C2 — Frobenius / power-series ODE
+    //
+    // Mirrors the Python `test_frobenius.py` end-to-end:
+    //   1. Acceptance: Bessel ν=1/2 — Phase 21 catches it; Frobenius would bail.
+    //   2. Acceptance: 2x²y'' + 3xy' − (1+x)y = 0 produces x^(1/2)·polynomial.
+    //   3. Bail on integer-difference indicial roots.
+    //   4. Bail on equal indicial roots.
+    //   5. Bail on irregular singular point.
+    //   6. Regular point falls through (caught by const-coeff).
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn c2_frobenius_acceptance_bessel_half_caught_by_phase21() {
+        // x²y'' + xy' + (x² − 1/4)y = 0  — Bessel ν=1/2.
+        // Phase 21 (named) recognises it before Frobenius runs.
+        let x_sq = pow(x(), int(2));
+        let expr = add(
+            mul(x_sq.clone(), yd()),
+            add(mul(x(), yp()), mul(sub(x_sq, rat(1, 4)), y())),
+        );
+        let result = solve_ode(expr, y(), x()).unwrap();
+        let s = format!("{result}");
+        assert!(s.contains("BesselJ"), "expected BesselJ in: {s}");
+        assert!(s.contains("BesselY"), "expected BesselY in: {s}");
+    }
+
+    #[test]
+    fn c2_frobenius_acceptance_produces_x_half_series() {
+        // 2x²y'' + 3xy' − (1+x)y = 0:
+        //   tildeP = 3/2, tildeQ = -(1+x)/2  →  p0 = 3/2, q0 = -1/2.
+        //   F(r) = r² + (3/2 - 1)r - 1/2 = r² + r/2 - 1/2 = (2r-1)(r+1)/2.
+        //   Roots r1 = 1/2, r2 = -1.  Differ by 3/2 — non-integer.
+        //   Recurrence: a_0 = 1, a_1 = 1/5, ...
+        let x_sq = pow(x(), int(2));
+        let expr = add(
+            mul(mul(int(2), x_sq), yd()),
+            add(
+                mul(mul(int(3), x()), yp()),
+                neg(mul(add(int(1), x()), y())),
+            ),
+        );
+        let result = solve_ode(expr, y(), x()).unwrap();
+        let s = format!("{result}");
+        // Result shape: Equal(y, Mul(Pow(x, 1/2), polynomial)).
+        assert!(s.contains("Pow(x, 1/2)"), "expected x^(1/2) in: {s}");
+        // a_1 = 1/5 appears as the literal 1/5 inside Mul(1/5, x).
+        assert!(s.contains("Mul(1/5, x)"), "expected a_1 = 1/5 in: {s}");
+        // a_2 = 1/70 appears as the literal 1/70 inside Mul(1/70, x^2).
+        assert!(s.contains("Mul(1/70, Pow(x, 2))"), "expected a_2 = 1/70 in: {s}");
+        // Must NOT match any named family.
+        assert!(!s.contains("BesselJ") && !s.contains("LegendreP"));
+    }
+
+    #[test]
+    fn c2_frobenius_direct_helper_produces_expected_first_coefficients() {
+        // Same ODE as above; call the helper directly and walk the IR.
+        let x_sq = pow(x(), int(2));
+        let expr = add(
+            mul(mul(int(2), x_sq), yd()),
+            add(
+                mul(mul(int(3), x()), yp()),
+                neg(mul(add(int(1), x()), y())),
+            ),
+        );
+        let result = try_frobenius_series_n(&expr, &y(), &x(), 4).unwrap();
+        // Equal(y, Mul(Pow(x, 1/2), Add(...)))
+        let IRNode::Apply(eq) = result else { panic!("expected Equal apply"); };
+        assert_eq!(eq.head, sym(EQUAL));
+        let series = eq.args[1].clone();
+        let IRNode::Apply(mul_node) = series else { panic!("expected Mul"); };
+        assert_eq!(mul_node.head, sym(MUL));
+        // First arg: Pow(x, 1/2).
+        let IRNode::Apply(pow_node) = mul_node.args[0].clone() else { panic!("expected Pow"); };
+        assert_eq!(pow_node.head, sym(POW));
+        assert_eq!(pow_node.args[0], x());
+        assert_eq!(pow_node.args[1], rat(1, 2));
+    }
+
+    #[test]
+    fn c2_frobenius_bails_on_integer_difference_roots() {
+        // x²y'' − xy' = 0:  F(r) = r² − 2r  →  roots r=2, r=0; differ by 2.
+        // Direct helper must return None (logarithmic case).
+        let x_sq = pow(x(), int(2));
+        let expr = sub(mul(x_sq, yd()), mul(x(), yp()));
+        assert!(try_frobenius_series(&expr, &y(), &x()).is_none());
+    }
+
+    #[test]
+    fn c2_frobenius_bails_on_equal_indicial_roots() {
+        // x²y'' + xy' = 0:  F(r) = r²  →  repeated root r=0.
+        let x_sq = pow(x(), int(2));
+        let expr = add(mul(x_sq, yd()), mul(x(), yp()));
+        assert!(try_frobenius_series(&expr, &y(), &x()).is_none());
+    }
+
+    #[test]
+    fn c2_frobenius_bails_on_irregular_singular_point() {
+        // x³y'' + y = 0:  order of vanishing of P at 0 is 3 > 2 — irregular.
+        let x_cubed = pow(x(), int(3));
+        let expr = add(mul(x_cubed, yd()), y());
+        assert!(try_frobenius_series(&expr, &y(), &x()).is_none());
+    }
+
+    #[test]
+    fn c2_frobenius_bails_on_regular_point() {
+        // y'' + y = 0 — constant-coefficient; x=0 is a regular (non-singular) point.
+        let expr = add(yd(), y());
+        assert!(try_frobenius_series(&expr, &y(), &x()).is_none());
     }
 }

--- a/code/packages/typescript/cas-ode/CHANGELOG.md
+++ b/code/packages/typescript/cas-ode/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## 0.3.0 — 2026-05-28
+
+### Added
+
+- **Track C2 — Frobenius / power-series ODE solver** (`tryFrobeniusSeries`):
+  - Solves second-order linear ODEs `P(x)·y'' + Q(x)·y' + R(x)·y = 0` with a
+    regular singular point at `x = 0` by substituting `y = x^r · Σ a_n x^n`.
+  - `polyCoeffsExtract` — extract rational polynomial coefficients of `expr`
+    in `x` up to arbitrary `maxDeg` (generalises the named-ODE `polynomialCoeffs`
+    which is capped at degree 2).
+  - `degreeOfMonomial` — recursive `[coeff, degree]` decomposition for a
+    monomial `c·x^k`; handles n-ary `Mul`, `Neg`, `Pow(x, k≥0)`, rational
+    literals.
+  - `fracPolyMul` — truncated polynomial multiplication over `Frac`.
+  - `isRegularSingular` — verify x=0 is a regular singular point and return
+    the analytic Taylor series `tildeP = x·p(x)` and `tildeQ = x²·q(x)`.
+    Computes `1 / P_eff(x)` (where `P_eff = P/x^m`) via the standard
+    series-inverse recurrence; returns `null` for irregular singular points
+    (order `m > 2`) or when the leading-zero analyticity condition fails.
+  - `solveIndicial` — solve `r² + (p_0-1)r + q_0 = 0` for rational roots
+    using `exactSqrt`; returns `null` on complex / irrational roots.
+  - `rootsDifferByInteger` — guard for the logarithmic Frobenius case (bails).
+  - `buildSeriesIr` — assemble `Mul(Pow(x, r), Add(a_0, a_1·x, …, a_N·x^N))`
+    IR; signed `Frac` exponents encoded with `Neg(Rational(…))` for `r < 0`.
+  - Dispatch order: inserted in `solveOde` after `tryVarCoeffNamedOde` and
+    before `tryBernoulli`.  Mirrors the Python ordering: the named families
+    (Bessel, Legendre, Hermite, Chebyshev) get first shot, and only un-named
+    regular-singular-point ODEs reach the Frobenius helper.
+  - Default truncation `N = 10`; recurrence is exact over `Frac` so the
+    series matches the Python reference coefficient-for-coefficient.
+- Scope (deliberate parity with Track C1):
+  - Singular point at `x = 0` only.
+  - Indicial roots must be rational and differ by a non-integer (the
+    logarithmic / merged-root cases produce log terms and bail to `null`).
+  - Irregular singular points (order of vanishing of `P` > 2) bail.
+
 ## 0.2.0 — 2026-05-16
 
 ### Added

--- a/code/packages/typescript/cas-ode/package.json
+++ b/code/packages/typescript/cas-ode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-ode",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pure TypeScript symbolic ODE solver over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-ode/src/index.ts
+++ b/code/packages/typescript/cas-ode/src/index.ts
@@ -160,6 +160,13 @@ export function solveOde(equation: IRNode, y: IRNode, x: IRNode, options: SolveO
   const named = tryVarCoeffNamedOde(expr, y, x);
   if (named !== null) return named;
 
+  // Track C2: Frobenius / power-series fallback for un-named regular singular
+  // point ODEs.  Returns null for: non-2nd-order, non-polynomial coefficients,
+  // regular points, irregular singular points, and integer-difference /
+  // equal indicial roots (logarithmic case — out of scope).
+  const frob = tryFrobeniusSeries(expr, y, x);
+  if (frob !== null) return frob;
+
   const bernoulli = tryBernoulli(expr, y, x, ops);
   if (bernoulli !== null) return bernoulli;
 
@@ -1514,4 +1521,317 @@ function tryVarCoeffNamedOde(expr: IRNode, y: IRNode, x: IRNode): IRNode | null 
     ?? tryLegendreOde(expr, y, x)
     ?? tryBesselOde(expr, y, x)
     ?? tryHermiteOde(expr, y, x);
+}
+
+// ============================================================================
+// Track C2 — Frobenius / power-series method (port from cas_ode.frobenius)
+//
+// Solves second-order linear ODEs P(x)·y'' + Q(x)·y' + R(x)·y = 0 with a
+// regular singular point at x = 0 by substituting the Frobenius series
+//
+//   y(x) = x^r · Σ_{n≥0} a_n x^n
+//
+// and producing a truncated power-series IR.  Scope (matches Python C1):
+//   1. Singular point at x = 0 only.
+//   2. Indicial roots must be rational and differ by a non-integer.
+//      Equal or integer-difference roots produce logarithmic terms in the
+//      second solution and bail (return null).
+//
+// Pipeline:
+//   collectVar2Coeffs    — already exists (reused for named-ODE recogniser).
+//   polyCoeffsExtract    — turn IR polynomial expr into [a_0, a_1, ...] Frac[].
+//   isRegularSingular    — verify x=0 regular-singular; return (tildeP, tildeQ)
+//                           where tildeP = x·p(x), tildeQ = x²·q(x).
+//   solveIndicial        — solve r² + (p_0-1) r + q_0 = 0 for rational roots.
+//   rootsDifferByInteger — bail flag for logarithmic case.
+//   buildSeriesIr        — assemble Equal(y, x^r · poly(x)) IR.
+//   tryFrobeniusSeries   — top-level entry point.
+//
+// Default truncation N=10 matches the Python reference.
+// ============================================================================
+
+const FROBENIUS_DEFAULT_N = 10;
+
+/**
+ * Extract rational polynomial coefficients of `expr` in `x` of degree ≤ maxDeg.
+ *
+ * Returns an array `[c_0, c_1, ..., c_maxDeg]` (length maxDeg+1) of Frac, or
+ * `null` if `expr` is not a polynomial in `x` (rational coefficients only).
+ *
+ * This is a Frobenius-specific helper: it allows arbitrary integer degrees
+ * (unlike `polynomialCoeffs` which caps at 2 for Hermite/Chebyshev forcing).
+ */
+function polyCoeffsExtract(expr: IRNode, x: IRNode, maxDeg: number): Frac[] | null {
+  const out: Frac[] = Array.from({ length: maxDeg + 1 }, () => Frac.zero());
+  for (const term of flattenAdd(expr)) {
+    const pair = degreeOfMonomial(term, x);
+    if (pair === null) return null;
+    const [coeff, deg] = pair;
+    if (deg > maxDeg) return null;
+    out[deg] = out[deg].add(coeff);
+  }
+  return out;
+}
+
+/**
+ * Return `[coeff, degree]` for a monomial `c·x^k`, or `null` for non-monomial.
+ *
+ * Handles: rational literals (degree 0), bare x (degree 1), Pow(x, k≥0),
+ * Mul(c, x^k), Neg-wrapped variants.  Recursive over nested Mul/Neg trees.
+ */
+function degreeOfMonomial(term: IRNode, x: IRNode): readonly [Frac, number] | null {
+  // Neg unwrap.
+  if (term.kind === "apply" && headName(term.head) === NEG.name && term.args.length === 1) {
+    const inner = degreeOfMonomial(term.args[0], x);
+    if (inner === null) return null;
+    return [inner[0].neg(), inner[1]] as const;
+  }
+  // Rational literal.
+  const lit = Frac.fromNode(term);
+  if (lit !== null) return [lit, 0] as const;
+  // Bare symbol — must be x.
+  if (term.kind === "symbol") {
+    return equals(term, x) ? ([Frac.one(), 1] as const) : null;
+  }
+  if (term.kind !== "apply") return null;
+  // Pow(x, k) with k ≥ 0.
+  if (headName(term.head) === POW.name && term.args.length === 2) {
+    const [base, exp] = term.args;
+    if (equals(base, x) && exp.kind === "integer" && exp.value >= 0n) {
+      return [Frac.one(), Number(exp.value)] as const;
+    }
+    return null;
+  }
+  // Mul(a, b) — degree adds, coefficients multiply.  n-ary Mul handled by
+  // recursing on each factor.
+  if (headName(term.head) === MUL.name) {
+    let coeff = Frac.one();
+    let degree = 0;
+    for (const arg of term.args) {
+      const part = degreeOfMonomial(arg, x);
+      if (part === null) return null;
+      coeff = coeff.mul(part[0]);
+      degree += part[1];
+    }
+    return [coeff, degree] as const;
+  }
+  return null;
+}
+
+/**
+ * Multiply two truncated polynomials (lists of Frac), result truncated at `maxDeg`.
+ */
+function fracPolyMul(a: readonly Frac[], b: readonly Frac[], maxDeg: number): Frac[] {
+  const out: Frac[] = Array.from({ length: maxDeg + 1 }, () => Frac.zero());
+  for (let i = 0; i < a.length && i <= maxDeg; i += 1) {
+    if (a[i].isZero()) continue;
+    for (let j = 0; j < b.length && i + j <= maxDeg; j += 1) {
+      if (b[j].isZero()) continue;
+      out[i + j] = out[i + j].add(a[i].mul(b[j]));
+    }
+  }
+  return out;
+}
+
+/**
+ * Verify x=0 is a regular singular point of P(x)y'' + Q(x)y' + R(x)y = 0 and
+ * return the analytic Taylor series (tildeP, tildeQ) where tildeP = x·p(x)
+ * and tildeQ = x²·q(x), with p = Q/P and q = R/P.
+ *
+ * Returns null if:
+ *   - P(0) ≠ 0 (regular point, not singular — caller falls through).
+ *   - Order of vanishing of P at 0 exceeds 2 (irregular or out of scope).
+ *   - The analyticity condition on the analyticity of x·p or x²·q fails.
+ *
+ * Strategy: compute `inv_P_eff(x) = 1 / (P(x)/x^m)` as a Taylor series via
+ * the standard 1/series recurrence, then form tildeP, tildeQ by shifting.
+ */
+function isRegularSingular(P: readonly Frac[], Q: readonly Frac[], R: readonly Frac[]):
+  readonly [Frac[], Frac[]] | null {
+  const n = P.length;
+  // Order of vanishing of P at 0.
+  let m = 0;
+  while (m < n && P[m].isZero()) m += 1;
+  if (m === 0) return null;  // x=0 regular (non-singular)
+  if (m > 2) return null;    // beyond Frobenius scope
+
+  // P_eff(x) = P(x) / x^m.
+  const Peff: Frac[] = Array.from({ length: n }, () => Frac.zero());
+  for (let i = m; i < n; i += 1) Peff[i - m] = P[i];
+  if (Peff[0].isZero()) return null;
+
+  // Invert P_eff as Taylor series: inv[0] = 1/P_eff[0],
+  // inv[k] = -(1/P_eff[0]) · Σ_{j=1..k} P_eff[j] · inv[k-j].
+  const inv: Frac[] = Array.from({ length: n }, () => Frac.zero());
+  inv[0] = Frac.one().div(Peff[0]);
+  for (let k = 1; k < n; k += 1) {
+    let s = Frac.zero();
+    for (let j = 1; j <= k; j += 1) {
+      if (j >= n) break;
+      s = s.add(Peff[j].mul(inv[k - j]));
+    }
+    inv[k] = inv[0].neg().mul(s);
+  }
+
+  // tildeP = x^{1-m} · Q · inv  (left-shift by m-1; positive shift drops
+  // leading terms — must be zero for analyticity).
+  const Qinv = fracPolyMul(Q, inv, n - 1);
+  const shiftP = m - 1;
+  for (let i = 0; i < shiftP; i += 1) {
+    if (!Qinv[i].isZero()) return null;
+  }
+  const tildeP: Frac[] = Array.from({ length: n }, () => Frac.zero());
+  for (let k = 0; k < n; k += 1) {
+    const idx = k + shiftP;
+    if (idx < n) tildeP[k] = Qinv[idx];
+  }
+
+  // tildeQ = x^{2-m} · R · inv  (m=2 → no shift; m=1 → right-shift by 1).
+  const Rinv = fracPolyMul(R, inv, n - 1);
+  const shiftQ = m - 2;
+  const tildeQ: Frac[] = Array.from({ length: n }, () => Frac.zero());
+  if (shiftQ >= 0) {
+    for (let i = 0; i < shiftQ; i += 1) {
+      if (!Rinv[i].isZero()) return null;
+    }
+    for (let k = 0; k < n; k += 1) {
+      const idx = k + shiftQ;
+      if (idx < n) tildeQ[k] = Rinv[idx];
+    }
+  } else {
+    // shiftQ === -1: tildeQ = x · Rinv  (right shift by 1).
+    for (let k = 1; k < n; k += 1) tildeQ[k] = Rinv[k - 1];
+  }
+
+  return [tildeP, tildeQ] as const;
+}
+
+/**
+ * Solve r(r-1) + p_0 r + q_0 = 0 for rational roots.  Returns `[r1, r2]`
+ * with r1 ≥ r2, or `null` if the roots are irrational, complex, or repeated.
+ */
+function solveIndicial(p0: Frac, q0: Frac): readonly [Frac, Frac] | null {
+  // r² + (p0 − 1) r + q0 = 0.
+  const B = p0.sub(Frac.one());
+  const C = q0;
+  const disc = B.mul(B).sub(new Frac(4).mul(C));
+  if (disc.ltZero()) return null;  // complex roots
+  const sqrtDisc = exactSqrt(disc);
+  if (sqrtDisc === null) return null;  // irrational roots
+  const half = new Frac(1, 2);
+  let r1 = B.neg().add(sqrtDisc).mul(half);
+  let r2 = B.neg().sub(sqrtDisc).mul(half);
+  // Compare: r1 ≥ r2 by Frac comparison via sub sign.
+  if (r1.sub(r2).ltZero()) { const t = r1; r1 = r2; r2 = t; }
+  return [r1, r2] as const;
+}
+
+/**
+ * Return true iff r1 − r2 is an integer (denominator 1).  Equal roots and
+ * positive-integer differences both trigger logarithmic Frobenius — out of scope.
+ */
+function rootsDifferByInteger(r1: Frac, r2: Frac): boolean {
+  return r1.sub(r2).denom === 1n;
+}
+
+/**
+ * Build the IR for `x^r · (a_0 + a_1 x + … + a_N x^N)`.
+ *
+ * Conventions:
+ *   - Zero coefficients past a_0 are omitted.
+ *   - r = 0 collapses to the bare polynomial.
+ *   - r = 1 emits `Mul(x, poly)`.
+ *   - Otherwise emits `Mul(Pow(x, r), poly)` with r encoded as an integer
+ *     or rational literal (signed via Neg wrapper for negative r).
+ */
+function buildSeriesIr(r: Frac, a: readonly Frac[], x: IRNode): IRNode {
+  // Build the polynomial Σ a_k x^k (a_0 always emitted, others only if nonzero).
+  const polyTerms: IRNode[] = [];
+  for (let k = 0; k < a.length; k += 1) {
+    const ak = a[k];
+    if (ak.isZero() && k > 0) continue;
+    const coeffIr: IRNode = ak.isNeg() ? app(NEG, [ak.neg().toIr()]) : ak.toIr();
+    let termNode: IRNode;
+    if (k === 0) {
+      termNode = coeffIr;
+    } else if (k === 1) {
+      if (ak.eq(Frac.one())) termNode = x;
+      else if (ak.eq(Frac.one().neg())) termNode = app(NEG, [x]);
+      else termNode = app(MUL, [coeffIr, x]);
+    } else {
+      const xk = app(POW, [x, int(k)]);
+      if (ak.eq(Frac.one())) termNode = xk;
+      else if (ak.eq(Frac.one().neg())) termNode = app(NEG, [xk]);
+      else termNode = app(MUL, [coeffIr, xk]);
+    }
+    polyTerms.push(termNode);
+  }
+  if (polyTerms.length === 0) polyTerms.push(int(0));
+
+  let polyIr: IRNode = polyTerms[0];
+  for (let i = 1; i < polyTerms.length; i += 1) {
+    polyIr = app(ADD, [polyIr, polyTerms[i]]);
+  }
+
+  if (r.isZero()) return polyIr;
+  if (r.eq(Frac.one())) return app(MUL, [x, polyIr]);
+
+  const rIr: IRNode = r.isNeg() ? app(NEG, [r.neg().toIr()]) : r.toIr();
+  const xPowR = app(POW, [x, rIr]);
+  return app(MUL, [xPowR, polyIr]);
+}
+
+/**
+ * Attempt to solve `expr = 0` as a Frobenius power series at `x = 0`.
+ *
+ * Returns `Equal(y, x^r · Σ_{k=0..N} a_k x^k)` on success, or `null` on any
+ * of the out-of-scope conditions: non-2nd-order, non-polynomial coefficients,
+ * regular point at 0, irregular singular point, complex/irrational/integer-
+ * difference indicial roots.
+ *
+ * Default truncation N = 10 matches the Python reference's
+ * `_DEFAULT_TRUNCATION_N`.  Caller can override via the optional `N` arg.
+ */
+function tryFrobeniusSeries(expr: IRNode, y: IRNode, x: IRNode, N: number = FROBENIUS_DEFAULT_N): IRNode | null {
+  const coeffs = collectVar2Coeffs(expr, y, x);
+  if (coeffs === null) return null;
+  const { p: pNode, q: qNode, r: rNode } = coeffs;
+
+  const Ppoly = polyCoeffsExtract(pNode, x, N);
+  if (Ppoly === null) return null;
+  const Qpoly = polyCoeffsExtract(qNode, x, N);
+  if (Qpoly === null) return null;
+  const Rpoly = polyCoeffsExtract(rNode, x, N);
+  if (Rpoly === null) return null;
+
+  const pq = isRegularSingular(Ppoly, Qpoly, Rpoly);
+  if (pq === null) return null;
+  const [tildeP, tildeQ] = pq;
+
+  const p0 = tildeP[0];
+  const q0 = tildeQ[0];
+
+  const roots = solveIndicial(p0, q0);
+  if (roots === null) return null;
+  const [r1, r2] = roots;
+  if (rootsDifferByInteger(r1, r2)) return null;
+
+  // F(s) = s(s-1) + p0·s + q0.
+  const F = (s: Frac): Frac => s.mul(s.sub(Frac.one())).add(p0.mul(s)).add(q0);
+
+  const a: Frac[] = [Frac.one()];
+  for (let n = 1; n <= N; n += 1) {
+    const denom = F(new Frac(n).add(r1));
+    if (denom.isZero()) return null;  // defensive — shouldn't happen post-guard
+    let rhs = Frac.zero();
+    for (let k = 1; k <= n; k += 1) {
+      const pk = k < tildeP.length ? tildeP[k] : Frac.zero();
+      const qk = k < tildeQ.length ? tildeQ[k] : Frac.zero();
+      rhs = rhs.add(a[n - k].mul(pk.mul(new Frac(n - k).add(r1)).add(qk)));
+    }
+    a.push(rhs.neg().div(denom));
+  }
+
+  const seriesIr = buildSeriesIr(r1, a, x);
+  return app(EQUAL, [y, seriesIr]);
 }

--- a/code/packages/typescript/cas-ode/tests/cas-ode.test.ts
+++ b/code/packages/typescript/cas-ode/tests/cas-ode.test.ts
@@ -17,6 +17,7 @@ import {
   LEGENDRE_Q,
   LOG,
   MUL,
+  NEG,
   POW,
   SIN,
   SUB,
@@ -384,5 +385,118 @@ describe("Phase 21 — named variable-coefficient ODEs", () => {
     expect(display(result!)).toContain("Pow");
     expect(display(result!)).not.toContain("LegendreP");
     expect(display(result!)).not.toContain("BesselJ");
+  });
+});
+
+// ============================================================================
+// Track C2 — Frobenius / power-series ODE
+//
+// These mirror the Python `test_frobenius.py` end-to-end behaviour:
+//   1. Acceptance: Bessel ν=1/2 — Phase 21 catches it; Frobenius would bail.
+//   2. Acceptance: 2x²y'' + 3xy' − (1+x)y = 0 produces x^(1/2)·(1 + x/5 + …).
+//   3. Bail on integer-difference indicial roots (x²y'' − xy' = 0).
+//   4. Bail on equal indicial roots (x²y'' + xy' = 0).
+//   5. Bail on irregular singular point (x³y'' + y = 0).
+//   6. Regular point falls through (y'' + y = 0 — caught by const-coeff).
+// ============================================================================
+
+describe("Track C2 — Frobenius power-series", () => {
+  function findPowOfX(node: IRNode, target: IRNode): boolean {
+    if (node.kind !== "apply") return false;
+    if (headName(node.head) === POW.name && node.args.length === 2 &&
+        equals(node.args[0], x) && equals(node.args[1], target)) return true;
+    return node.args.some((arg) => findPowOfX(arg, target));
+  }
+
+  it("acceptance: Bessel ν=1/2 — Phase 21 catches BesselJ/Y before Frobenius", () => {
+    // x²y'' + xy' + (x² − 1/4)y = 0
+    const xSq = app(POW, [x, int(2)]);
+    const expr = app(ADD, [
+      app(ADD, [
+        app(MUL, [xSq, ypp]),
+        app(MUL, [x, yp]),
+      ]),
+      app(MUL, [app(SUB, [xSq, rational(1, 4)]), y]),
+    ]);
+    const result = solveOde(expr, y, x);
+    expect(result).not.toBeNull();
+    // Dispatcher's Phase 21 (Bessel) wins — Frobenius would have bailed
+    // because the indicial roots ±1/2 differ by an integer (1).
+    expect(display(result!)).toContain("BesselJ");
+    expect(display(result!)).toContain("BesselY");
+  });
+
+  it("acceptance: produces x^(1/2)·polynomial for 2x²y'' + 3xy' − (1+x)y = 0", () => {
+    // 2x²y'' + 3xy' − (1+x)y = 0:
+    //   p₀ = 3/2, q₀ = −1/2.  Indicial roots r₁=1/2, r₂=−1 (differ by 3/2).
+    //   a₀ = 1, a₁ = 1/5, a₂ = 1/70, ...  (matches Python reference).
+    const xSq = app(POW, [x, int(2)]);
+    const expr = app(ADD, [
+      app(ADD, [
+        app(MUL, [app(MUL, [int(2), xSq]), ypp]),
+        app(MUL, [app(MUL, [int(3), x]), yp]),
+      ]),
+      app(NEG, [app(MUL, [app(ADD, [int(1), x]), y])]),
+    ]);
+    const result = solveOde(expr, y, x);
+    expect(result).not.toBeNull();
+    // Solution shape: Equal(y, Mul(Pow(x, 1/2), polynomial))
+    expect(result!.kind).toBe("apply");
+    if (result!.kind === "apply") {
+      expect(headName(result!.head)).toBe(EQUAL.name);
+      const rhs = result!.args[1];
+      expect(findPowOfX(rhs, rational(1, 2))).toBe(true);
+    }
+    // Must NOT match any named family.
+    expect(display(result!)).not.toContain("BesselJ");
+    expect(display(result!)).not.toContain("LegendreP");
+    expect(display(result!)).not.toContain("HermiteH");
+    expect(display(result!)).not.toContain("ChebyshevT");
+    // a₁ = 1/5 should appear as Rational(1, 5).
+    expect(display(result!)).toContain('"numer":"1"');
+    expect(display(result!)).toContain('"denom":"5"');
+  });
+
+  it("bails on integer-difference indicial roots → falls through", () => {
+    // x²y'' − x·y' = 0 has F(r) = r² − 2r → roots r=2, r=0; differ by 2 (integer).
+    // Frobenius bails; Euler-Cauchy catches it.
+    const xSq = app(POW, [x, int(2)]);
+    const expr = app(SUB, [app(MUL, [xSq, ypp]), app(MUL, [x, yp])]);
+    const result = solveOde(expr, y, x);
+    // Euler-Cauchy should solve it; result should NOT be a Frobenius series
+    // (no x^(1/2) or other fractional exponent).
+    expect(result).not.toBeNull();
+    // No Bessel/Legendre named families either.
+    expect(display(result!)).not.toContain("BesselJ");
+  });
+
+  it("bails on equal indicial roots → falls through", () => {
+    // x²y'' + x·y' = 0 has F(r) = r² → repeated root r=0.
+    const xSq = app(POW, [x, int(2)]);
+    const expr = app(ADD, [app(MUL, [xSq, ypp]), app(MUL, [x, yp])]);
+    const result = solveOde(expr, y, x);
+    // Euler-Cauchy catches this with repeated root → %c1 + %c2·Log(x).
+    expect(result).not.toBeNull();
+    expect(display(result!)).toContain("Log");
+  });
+
+  it("bails on irregular singular point (order m > 2)", () => {
+    // x³y'' + y = 0: order of vanishing of P is 3 > 2 — irregular.
+    // No solver catches it; solveOde returns null.
+    const xCubed = app(POW, [x, int(3)]);
+    const expr = app(ADD, [app(MUL, [xCubed, ypp]), y]);
+    const result = solveOde(expr, y, x);
+    // Frobenius bails; named ODEs and others also bail.  Result is null.
+    expect(result).toBeNull();
+  });
+
+  it("regular point at x=0 falls through to constant-coefficient solver", () => {
+    // y'' + y = 0 — constant-coefficient ODE; x=0 is a regular (non-singular) point.
+    // Frobenius bails (P(0) ≠ 0), and the const-coeff solver catches it first.
+    const expr = app(ADD, [ypp, y]);
+    const result = solveOde(expr, y, x);
+    expect(result).not.toBeNull();
+    // sin and cos — no Frobenius series shape.
+    expect(display(result!)).toMatch(/Sin|Cos/);
   });
 });


### PR DESCRIPTION
## Summary

Ports the **Frobenius / power-series ODE solver** from the Python `cas-ode` 0.7.0 reference (Track C1 / PR #4561) to **TypeScript** and **Rust** `cas-ode`.

- Solves 2nd-order linear ODEs `P(x)y'' + Q(x)y' + R(x)y = 0` with a regular singular point at `x = 0` by substituting `y(x) = x^r · Σ aₙ xⁿ` and producing a truncated power-series IR (default `N = 10`).
- Dispatch order mirrors the Python `solve_ode`: inserted **after** the named-ODE recognisers (Bessel, Legendre, Hermite, Chebyshev) and **before** Bernoulli.  So Bessel ν=1/2 still routes to `BesselJ/Y`; Frobenius only catches un-named regular-singular-point ODEs.
- Recurrence is exact over `BigInt`-`Frac` (TS) / `i64`-`Frac` (Rust); coefficients match the Python reference exactly (`a₁ = 1/5`, `a₂ = 1/70`, `a₃ = 1/1890`, …).

## Pipeline (per language)

| TS / Rust | Purpose |
| --- | --- |
| `polyCoeffsExtract` / `poly_coeffs_extract` | Arbitrary-degree polynomial coefficient extraction (generalises the named-ODE degree-2 cap). |
| `degreeOfMonomial` / `degree_of_monomial` | Recursive `(coeff, degree)` for `c·x^k` monomials. |
| `fracPolyMul` / `frac_poly_mul` | Truncated `Frac` polynomial multiplication. |
| `isRegularSingular` / `is_regular_singular` | Verify x=0 regular-singular; compute `tildeP = x·p(x)`, `tildeQ = x²·q(x)` via series-inversion of `P_eff = P/x^m`.  Bails when `m > 2`. |
| `solveIndicial` / `solve_indicial` | Exact rational roots of `r² + (p₀-1)r + q₀ = 0`. |
| `rootsDifferByInteger` / `roots_differ_by_integer` | Logarithmic-case bail flag. |
| `buildSeriesIr` / `build_series_ir` | Assemble `Mul(Pow(x, r), Add(a₀, a₁·x, …, a_N·x^N))`. |
| `tryFrobeniusSeries` / `try_frobenius_series` | Top-level entry point. |

## Scope (matches Track C1)

- Singular point at `x = 0` only.
- Indicial roots must be **rational** and differ by a **non-integer**.
- Equal / integer-difference roots (logarithmic case) and irregular singular points (`m > 2`) bail to `null` / `None`.

## Acceptance criteria

1. **Bessel ν=1/2** (`x²y'' + xy' + (x²−1/4)y = 0`) — Phase 21 catches it as `BesselJ/Y(1/2, x)` **before** Frobenius runs (the indicial roots ±1/2 differ by 1, so Frobenius would have bailed).
2. **`2x²y'' + 3xy' − (1+x)y = 0`** — non-named regular-singular-point ODE; Frobenius produces `x^(1/2) · (1 + x/5 + x²/70 + x³/1890 + …)`, matching the Python coefficients exactly.
3. **Integer-difference / equal / irregular / regular** cases all bail.

## Test plan

- [x] `cd code/packages/typescript/cas-ode && npm test` → **34/34 passing** (6 new Frobenius tests).
- [x] `cd code/packages/rust/cas-ode && cargo test` → **37/37 passing** (7 new Frobenius tests).
- [x] Inline security review: exact rational arithmetic, no unsafe code, all divisions guarded against zero denominators, no file/network access.
- [x] Version bumps: TS `0.2.0 → 0.3.0`, Rust `0.2.0 → 0.3.0`.  CHANGELOGs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)