### PR TITLE
feat(ruby-parser+sir): Phase 9b (FC) — splat target in multi-assignment LHS

### DIFF
--- a/code/grammars/ruby.grammar
+++ b/code/grammars/ruby.grammar
@@ -45,14 +45,31 @@ statement    = endless_def_statement | def_statement | class_statement | module_
 #   returns a Vec<Stmt> from this one source statement.
 #
 # v0 restrictions (deferred to later phases):
-#   - LHS count must equal RHS count.  Mismatched arities (e.g.
-#     `a, b = 1, 2, 3` or `a, b, c = 1, 2`) → RubyLowerError.
+#   - LHS count must equal RHS count for the *non-splat* targets;
+#     mismatched arities still produce a RubyLowerError.  When a splat
+#     target IS present (Phase 9b — see below), the splat absorbs zero
+#     or more "extra" RHS values into a Sequence and the non-splat LHS
+#     count drives the arity check.
 #   - Single-RHS auto-unpack `a, b = arr` is NOT supported.
-#   - Splat targets `a, *b = 1, 2, 3` ride with Phase 6s.
 #   - Multi-assignment LHS inside a `modifier_statement`
 #     (`a, b = 1, 2 if cond`) is NOT supported — modifier_statement's
 #     LHS alternation lists single-LHS forms only.
-multi_assignment = NAME COMMA NAME { COMMA NAME } EQUALS expression { COMMA expression } ;
+#
+# Phase 9b (FC) — splat target on the LHS.
+#
+# `mlhs_target` allows an optional leading `*` so one (at most) of the
+# LHS positions can absorb the "rest" of the RHS values into a Sequence:
+#
+#   a, *b = 1, 2, 3      → a == 1; b == [2, 3]
+#   *a, b = 1, 2, 3      → a == [1, 2]; b == 3
+#   a, *b, c = 1, 2, 3, 4 → a == 1; b == [2, 3]; c == 4
+#
+# Same shape as `param` and `call_arg` (`[ "*" ] NAME`).  At most one
+# splat per LHS is allowed; the lowerer enforces the single-splat rule
+# (the grammar would allow multiple `*` tokens but the lowerer rejects
+# them with a clear error message).
+multi_assignment = mlhs_target COMMA mlhs_target { COMMA mlhs_target } EQUALS expression { COMMA expression } ;
+mlhs_target  = [ "*" ] NAME ;
 # Phase 6q — modifier conditionals/loops `x if y`, `x unless y`,
 # `x while y`, `x until y`.
 #

--- a/code/packages/rust/ruby-parser/.pr-body-fc-9b.md
+++ b/code/packages/rust/ruby-parser/.pr-body-fc-9b.md
@@ -1,0 +1,84 @@
+## Summary
+
+Phase 9b lands **splat targets on the LHS of multi-assignment** — the construct Phase 6r explicitly deferred:
+
+```ruby
+a, *b = 1, 2, 3       # a == 1; b == [2, 3]
+*a, b = 1, 2, 3       # a == [1, 2]; b == 3
+a, *b, c = 1, 2, 3, 4 # a == 1; b == [2, 3]; c == 4
+a, *b = 1             # a == 1; b == []  — splat may absorb 0 values
+```
+
+Builds directly on Phase 9a's swap-safe temp pass.
+
+## Grammar
+
+`multi_assignment` LHS now uses a sub-rule `mlhs_target` matching the established `param` / `call_arg` shape:
+
+```ebnf
+multi_assignment = mlhs_target COMMA mlhs_target { COMMA mlhs_target }
+                   EQUALS expression { COMMA expression } ;
+mlhs_target      = [ "*" ] NAME ;
+```
+
+Single-LHS forms (`a = 1`) still fall through to plain `assignment` unchanged because `multi_assignment` requires at least two `mlhs_target`s.  Multiple splats are syntactically possible at the grammar level but the lowerer rejects them with a clear error.
+
+`_grammar.rs` regenerated via `grammar-tools compile-grammar`.
+
+## Lowering
+
+The splat path always routes through the swap-safe temp pass (Phase 9a pattern):
+
+1. Bind every RHS to a fresh `LetStarBinding(__multi_assign_t<N>_<i>, rhs[i])` temp.
+2. Walk the LHS list:
+   - **Non-splat target before splat** (position `i < splat_idx`) → `VarRef(temps[i])`.
+   - **Non-splat target after splat**  (position `i > splat_idx`) → `VarRef(temps[rhs_len - lhs_len + i])`.
+   - **Splat target** → `Expr::SeqLit([VarRef(temps[splat_idx]), …, VarRef(temps[rhs_len - lhs_len + splat_idx])])`.  May be empty if RHS count equals non-splat count.
+
+The splat's `SeqLit` requires `Feature::Sequences`.  The LHS bindings use the existing first-sighting `LetBinding` / re-binding `Assign` decision (with `Feature::MutableBindings` for the re-bind path).
+
+| Source                  | SIR shape (Phase 9b)                                                                                                                                          |
+|-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `a, *b = 1, 2, 3`       | 3 temps + `LetBinding(a, t0); LetBinding(b, SeqLit([t1, t2]))`                                                                                                |
+| `*a, b = 1, 2, 3`       | 3 temps + `LetBinding(a, SeqLit([t0, t1])); LetBinding(b, t2)`                                                                                                |
+| `a, *b, c = 1, 2, 3, 4` | 4 temps + `LetBinding(a, t0); LetBinding(b, SeqLit([t1, t2])); LetBinding(c, t3)`                                                                             |
+| `a, *b = 1`             | 1 temp + `LetBinding(a, t0); LetBinding(b, SeqLit([]))` *(empty splat)*                                                                                       |
+
+### Arity check
+
+- **No splat present** → LHS count must equal RHS count (Phase 6r semantics — unchanged).
+- **Splat present** → RHS count must be `≥ non_splat_count`.  Otherwise the lowerer returns a `RubyLowerError`.
+
+### Single-RHS auto-unpack still deferred
+
+`a, *b = [1, 2, 3]` (one RHS that is itself an array) still isn't unpacked — that's Phase 9c.  The current path treats single-RHS forms with splat the same way as multi-RHS: the splat absorbs the remaining RHS values (in this case zero or one, depending on whether the array is the only RHS).
+
+## Tests
+
+- `coding-adventures-ruby-lexer`: 173 → **173** (no change)
+- `coding-adventures-ruby-parser`: 149 → **152** (+3):
+  - `test_parse_multi_assignment_splat_at_end`
+  - `test_parse_multi_assignment_splat_at_start`
+  - `test_parse_multi_assignment_splat_in_middle`
+- `ruby-to-semantic-ir`: 170 → **177** (+7):
+  - `splat_lhs_at_end_absorbs_trailing_rhs_into_seqlit`
+  - `splat_lhs_at_start_absorbs_leading_rhs_into_seqlit`
+  - `splat_lhs_in_middle_absorbs_middle_rhs_into_seqlit`
+  - `splat_lhs_with_minimum_rhs_count_gives_empty_seqlit`
+  - `splat_lhs_requests_sequences_feature`
+  - `splat_lhs_module_passes_sir_validator` (E2E for all three splat positions)
+  - `splat_lhs_too_few_rhs_is_a_lower_error`
+
+All 5 prior Phase 6r/9a tests keep passing — they exercise the non-splat path (which still routes through the existing logic) and were re-validated against the refactored AST walk.
+
+## Test plan
+
+- [x] `cargo test -p coding-adventures-ruby-lexer` (173/173 pass)
+- [x] `cargo test -p coding-adventures-ruby-parser` (152/152 pass)
+- [x] `cargo test -p ruby-to-semantic-ir` (177/177 pass)
+- [x] Self-reviewed (no I/O, no unsafe — pure AST walk + SIR Stmt list construction; splat marker detection is type-checked against `TokenType::Star`)
+- [ ] CI green
+
+Follows PR #4556 (Phase 9a).  Next chunk: Phase 9c (tuple destructure `a, b = arr` — single-RHS auto-unpack).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.36.0] - 2026-05-28
+
+### Added (Phase 9b (FC) — splat target in multi-assignment LHS)
+
+`multi_assignment` rule extended to allow an optional `*` prefix on
+each LHS target via a new `mlhs_target` rule:
+
+```ebnf
+multi_assignment = mlhs_target COMMA mlhs_target { COMMA mlhs_target }
+                   EQUALS expression { COMMA expression } ;
+mlhs_target      = [ "*" ] NAME ;
+```
+
+The grammar allows the splat at any LHS position; the lowerer
+enforces "at most one splat".  Single-LHS forms (`a = 1`) still fall
+through to the existing `assignment` rule unchanged because
+`multi_assignment` requires at least two `mlhs_target`s.
+
+`_grammar.rs` regenerated via `grammar-tools compile-grammar`.
+
+### Tests
+
+- `coding-adventures-ruby-parser`: 149 → **152** (+3):
+  - `test_parse_multi_assignment_splat_at_end`
+  - `test_parse_multi_assignment_splat_at_start`
+  - `test_parse_multi_assignment_splat_in_middle`
+
 ## [0.35.0] - 2026-05-26
 
 ### Added (Phase 8a-2 (FC) — `>>=` right-shift compound assign)

--- a/code/packages/rust/ruby-parser/src/_grammar.rs
+++ b/code/packages/rust/ruby-parser/src/_grammar.rs
@@ -46,12 +46,12 @@ pub fn parser_grammar() -> ParserGrammar {
         GrammarRule {
             name: r#"multi_assignment"#.to_string(),
             body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::RuleReference { name: r#"mlhs_target"#.to_string() },
                 GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
-                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::RuleReference { name: r#"mlhs_target"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
                         GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
-                        GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"mlhs_target"#.to_string() },
                     ] }) },
                 GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
@@ -60,7 +60,15 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 55,
+            line_number: 71,
+        },
+        GrammarRule {
+            name: r#"mlhs_target"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Optional { element: Box::new(GrammarElement::Literal { value: r#"*"#.to_string() }) },
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+            ] },
+            line_number: 72,
         },
         GrammarRule {
             name: r#"modifier_statement"#.to_string(),
@@ -79,7 +87,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 91,
+            line_number: 108,
         },
         GrammarRule {
             name: r#"def_statement"#.to_string(),
@@ -97,7 +105,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 92,
+            line_number: 109,
         },
         GrammarRule {
             name: r#"endless_def_statement"#.to_string(),
@@ -112,7 +120,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 98,
+            line_number: 115,
         },
         GrammarRule {
             name: r#"class_statement"#.to_string(),
@@ -125,7 +133,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 103,
+            line_number: 120,
         },
         GrammarRule {
             name: r#"module_statement"#.to_string(),
@@ -138,7 +146,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 104,
+            line_number: 121,
         },
         GrammarRule {
             name: r#"method_with_block"#.to_string(),
@@ -160,7 +168,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"block"#.to_string() },
             ] },
-            line_number: 106,
+            line_number: 123,
         },
         GrammarRule {
             name: r#"block"#.to_string(),
@@ -168,7 +176,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"do_block"#.to_string() },
                 GrammarElement::RuleReference { name: r#"brace_block"#.to_string() },
             ] },
-            line_number: 107,
+            line_number: 124,
         },
         GrammarRule {
             name: r#"do_block"#.to_string(),
@@ -181,7 +189,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 108,
+            line_number: 125,
         },
         GrammarRule {
             name: r#"brace_block"#.to_string(),
@@ -191,7 +199,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"statement"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 109,
+            line_number: 126,
         },
         GrammarRule {
             name: r#"block_params"#.to_string(),
@@ -204,7 +212,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"|"#.to_string() },
             ] },
-            line_number: 110,
+            line_number: 127,
         },
         GrammarRule {
             name: r#"return_statement"#.to_string(),
@@ -212,7 +220,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"return"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"expression"#.to_string() }) },
             ] },
-            line_number: 112,
+            line_number: 129,
         },
         GrammarRule {
             name: r#"break_statement"#.to_string(),
@@ -220,7 +228,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"break"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"expression"#.to_string() }) },
             ] },
-            line_number: 113,
+            line_number: 130,
         },
         GrammarRule {
             name: r#"next_statement"#.to_string(),
@@ -228,7 +236,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"next"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"expression"#.to_string() }) },
             ] },
-            line_number: 114,
+            line_number: 131,
         },
         GrammarRule {
             name: r#"yield_statement"#.to_string(),
@@ -236,7 +244,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"yield"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"yield_args"#.to_string() }) },
             ] },
-            line_number: 136,
+            line_number: 153,
         },
         GrammarRule {
             name: r#"yield_args"#.to_string(),
@@ -260,7 +268,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) },
                 ] },
             ] },
-            line_number: 137,
+            line_number: 154,
         },
         GrammarRule {
             name: r#"params"#.to_string(),
@@ -271,7 +279,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"param"#.to_string() },
                     ] }) },
             ] },
-            line_number: 152,
+            line_number: 169,
         },
         GrammarRule {
             name: r#"param"#.to_string(),
@@ -282,7 +290,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
             ] },
-            line_number: 153,
+            line_number: 170,
         },
         GrammarRule {
             name: r#"if_statement"#.to_string(),
@@ -299,7 +307,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 154,
+            line_number: 171,
         },
         GrammarRule {
             name: r#"elsif_clause"#.to_string(),
@@ -313,7 +321,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 155,
+            line_number: 172,
         },
         GrammarRule {
             name: r#"else_clause"#.to_string(),
@@ -324,7 +332,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 156,
+            line_number: 173,
         },
         GrammarRule {
             name: r#"unless_statement"#.to_string(),
@@ -339,7 +347,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 157,
+            line_number: 174,
         },
         GrammarRule {
             name: r#"while_statement"#.to_string(),
@@ -352,7 +360,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 158,
+            line_number: 175,
         },
         GrammarRule {
             name: r#"until_statement"#.to_string(),
@@ -365,7 +373,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 159,
+            line_number: 176,
         },
         GrammarRule {
             name: r#"case_statement"#.to_string(),
@@ -379,7 +387,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 182,
+            line_number: 199,
         },
         GrammarRule {
             name: r#"when_clause"#.to_string(),
@@ -398,7 +406,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 183,
+            line_number: 200,
         },
         GrammarRule {
             name: r#"in_clause"#.to_string(),
@@ -413,7 +421,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 205,
+            line_number: 222,
         },
         GrammarRule {
             name: r#"pattern"#.to_string(),
@@ -423,7 +431,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"literal_pattern"#.to_string() },
                 GrammarElement::RuleReference { name: r#"binding_pattern"#.to_string() },
             ] },
-            line_number: 206,
+            line_number: 223,
         },
         GrammarRule {
             name: r#"literal_pattern"#.to_string(),
@@ -433,12 +441,12 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"symbol_literal"#.to_string() },
                 GrammarElement::TokenReference { name: r#"KEYWORD"#.to_string() },
             ] },
-            line_number: 207,
+            line_number: 224,
         },
         GrammarRule {
             name: r#"binding_pattern"#.to_string(),
             body: GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
-            line_number: 208,
+            line_number: 225,
         },
         GrammarRule {
             name: r#"array_pattern"#.to_string(),
@@ -453,7 +461,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 209,
+            line_number: 226,
         },
         GrammarRule {
             name: r#"hash_pattern"#.to_string(),
@@ -468,7 +476,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 210,
+            line_number: 227,
         },
         GrammarRule {
             name: r#"hash_pattern_pair"#.to_string(),
@@ -477,7 +485,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"pattern"#.to_string() }) },
             ] },
-            line_number: 211,
+            line_number: 228,
         },
         GrammarRule {
             name: r#"begin_statement"#.to_string(),
@@ -493,7 +501,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"ensure_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 232,
+            line_number: 249,
         },
         GrammarRule {
             name: r#"rescue_clause"#.to_string(),
@@ -511,7 +519,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 241,
+            line_number: 258,
         },
         GrammarRule {
             name: r#"exception_list"#.to_string(),
@@ -522,7 +530,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
                     ] }) },
             ] },
-            line_number: 242,
+            line_number: 259,
         },
         GrammarRule {
             name: r#"ensure_clause"#.to_string(),
@@ -533,7 +541,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 243,
+            line_number: 260,
         },
         GrammarRule {
             name: r#"assignment"#.to_string(),
@@ -557,7 +565,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 263,
+            line_number: 280,
         },
         GrammarRule {
             name: r#"rightward_assignment"#.to_string(),
@@ -566,7 +574,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"=>"#.to_string() },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
             ] },
-            line_number: 282,
+            line_number: 299,
         },
         GrammarRule {
             name: r#"method_call"#.to_string(),
@@ -586,7 +594,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"dot_call"#.to_string() }) },
             ] },
-            line_number: 293,
+            line_number: 310,
         },
         GrammarRule {
             name: r#"dot_call"#.to_string(),
@@ -608,7 +616,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                     ] }) },
             ] },
-            line_number: 294,
+            line_number: 311,
         },
         GrammarRule {
             name: r#"call_arg"#.to_string(),
@@ -619,7 +627,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 301,
+            line_number: 318,
         },
         GrammarRule {
             name: r#"method_call_no_paren"#.to_string(),
@@ -634,17 +642,17 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 315,
+            line_number: 332,
         },
         GrammarRule {
             name: r#"expression_stmt"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"expression"#.to_string() },
-            line_number: 316,
+            line_number: 333,
         },
         GrammarRule {
             name: r#"expression"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"ternary"#.to_string() },
-            line_number: 402,
+            line_number: 419,
         },
         GrammarRule {
             name: r#"ternary"#.to_string(),
@@ -657,7 +665,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 403,
+            line_number: 420,
         },
         GrammarRule {
             name: r#"range"#.to_string(),
@@ -671,7 +679,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_or"#.to_string() },
                     ] }) },
             ] },
-            line_number: 404,
+            line_number: 421,
         },
         GrammarRule {
             name: r#"logical_or"#.to_string(),
@@ -685,7 +693,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_and"#.to_string() },
                     ] }) },
             ] },
-            line_number: 405,
+            line_number: 422,
         },
         GrammarRule {
             name: r#"logical_and"#.to_string(),
@@ -699,7 +707,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_not"#.to_string() },
                     ] }) },
             ] },
-            line_number: 406,
+            line_number: 423,
         },
         GrammarRule {
             name: r#"logical_not"#.to_string(),
@@ -710,7 +718,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) }) },
                 GrammarElement::RuleReference { name: r#"comparison"#.to_string() },
             ] },
-            line_number: 413,
+            line_number: 430,
         },
         GrammarRule {
             name: r#"comparison"#.to_string(),
@@ -728,7 +736,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"sum"#.to_string() },
                     ] }) },
             ] },
-            line_number: 414,
+            line_number: 431,
         },
         GrammarRule {
             name: r#"sum"#.to_string(),
@@ -742,7 +750,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term"#.to_string() },
                     ] }) },
             ] },
-            line_number: 415,
+            line_number: 432,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -756,7 +764,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"factor"#.to_string() },
                     ] }) },
             ] },
-            line_number: 416,
+            line_number: 433,
         },
         GrammarRule {
             name: r#"factor"#.to_string(),
@@ -780,7 +788,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"dot_call"#.to_string() }) },
             ] },
-            line_number: 426,
+            line_number: 443,
         },
         GrammarRule {
             name: r#"lambda_literal"#.to_string(),
@@ -793,7 +801,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"block"#.to_string() },
             ] },
-            line_number: 445,
+            line_number: 462,
         },
         GrammarRule {
             name: r#"unary_minus"#.to_string(),
@@ -801,7 +809,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"factor"#.to_string() },
             ] },
-            line_number: 446,
+            line_number: 463,
         },
         GrammarRule {
             name: r#"symbol_literal"#.to_string(),
@@ -813,7 +821,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 447,
+            line_number: 464,
         },
         GrammarRule {
             name: r#"array_literal"#.to_string(),
@@ -828,7 +836,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 448,
+            line_number: 465,
         },
         GrammarRule {
             name: r#"hash_literal"#.to_string(),
@@ -843,7 +851,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 449,
+            line_number: 466,
         },
         GrammarRule {
             name: r#"hash_entry"#.to_string(),
@@ -863,7 +871,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                 ] },
             ] },
-            line_number: 450,
+            line_number: 467,
         },
     ],
         version: 1,

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -1499,6 +1499,57 @@ mod tests {
         assert!(tree_has_token_value(m, "*"), "expected `*` in second RHS");
     }
 
+    // -----------------------------------------------------------------------
+    // Phase 9b (FC) — splat LHS in multi-assignment
+    //
+    // Grammar addition:
+    //   multi_assignment = mlhs_target COMMA mlhs_target { COMMA mlhs_target }
+    //                      EQUALS expression { COMMA expression } ;
+    //   mlhs_target      = [ "*" ] NAME ;
+    //
+    // We assert: (1) `*` appears as a leading token in the right
+    // `mlhs_target` slot, (2) the parser recognises the construct as
+    // `multi_assignment`, and (3) the LHS target count comes out
+    // right.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_multi_assignment_splat_at_end() {
+        let ast = parse_ruby("a, *b = 1, 2, 3");
+        let m = find_descendant(&ast, "multi_assignment")
+            .expect("expected multi_assignment node");
+        // Count mlhs_target children to confirm splat is its own slot.
+        let lhs_target_count = m.children.iter().filter(|c| matches!(c,
+            ASTNodeOrToken::Node(n) if n.rule_name == "mlhs_target"
+        )).count();
+        assert_eq!(lhs_target_count, 2, "expected 2 mlhs_target nodes");
+        assert!(tree_has_token_value(m, "*"), "expected `*` in tree");
+    }
+
+    #[test]
+    fn test_parse_multi_assignment_splat_at_start() {
+        let ast = parse_ruby("*a, b = 1, 2, 3");
+        let m = find_descendant(&ast, "multi_assignment")
+            .expect("expected multi_assignment node");
+        let lhs_target_count = m.children.iter().filter(|c| matches!(c,
+            ASTNodeOrToken::Node(n) if n.rule_name == "mlhs_target"
+        )).count();
+        assert_eq!(lhs_target_count, 2, "expected 2 mlhs_target nodes");
+        assert!(tree_has_token_value(m, "*"));
+    }
+
+    #[test]
+    fn test_parse_multi_assignment_splat_in_middle() {
+        let ast = parse_ruby("a, *b, c = 1, 2, 3, 4");
+        let m = find_descendant(&ast, "multi_assignment")
+            .expect("expected multi_assignment node");
+        let lhs_target_count = m.children.iter().filter(|c| matches!(c,
+            ASTNodeOrToken::Node(n) if n.rule_name == "mlhs_target"
+        )).count();
+        assert_eq!(lhs_target_count, 3, "expected 3 mlhs_target nodes");
+        assert!(tree_has_token_value(m, "*"));
+    }
+
     #[test]
     fn test_parse_single_assignment_not_consumed_by_multi() {
         // Regression: `a = 1` (one LHS) must still parse as a plain

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.38.0] - 2026-05-28
+
+### Added (Phase 9b (FC) — splat target in multi-assignment LHS)
+
+`multi_assignment` now accepts an optional `*` prefix on each LHS
+target via the new `mlhs_target` rule.  At most one splat per LHS is
+allowed; the splat absorbs zero or more "extra" RHS values into an
+`Expr::SeqLit` while non-splat targets bind to fixed-position RHS
+values (counted from the start, or from the end if a splat sits to
+the left).
+
+| Source                      | SIR shape (after Phase 9b)                                                                                                                                                                                  |
+|-----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `a, *b = 1, 2, 3`           | `LetStarBinding(t0,1); LetStarBinding(t1,2); LetStarBinding(t2,3); LetBinding(a, VarRef(t0)); LetBinding(b, SeqLit([VarRef(t1), VarRef(t2)]))`                                                              |
+| `*a, b = 1, 2, 3`           | `LetStarBinding(t0,1); LetStarBinding(t1,2); LetStarBinding(t2,3); LetBinding(a, SeqLit([VarRef(t0), VarRef(t1)])); LetBinding(b, VarRef(t2))`                                                              |
+| `a, *b, c = 1, 2, 3, 4`     | 4 temps + `LetBinding(a, t0); LetBinding(b, SeqLit([t1, t2])); LetBinding(c, t3)`                                                                                                                            |
+| `a, *b = 1`                 | 1 temp + `LetBinding(a, t0); LetBinding(b, SeqLit([]))` *(empty splat)*                                                                                                                                     |
+
+The splat path always routes through the swap-safe temp pass (Phase
+9a pattern) — every RHS value lands in a fresh
+`LetStarBinding(__multi_assign_t<N>_<i>, rhs[i])` first, so the
+splat's `SeqLit` and the surrounding non-splat bindings all read
+captured values.  `Feature::Sequences` is required.
+
+Arity check:
+
+- No splat → LHS count must equal RHS count (Phase 6r semantics).
+- Splat present → RHS count must be `≥ non_splat_count`.  Otherwise
+  the lowerer rejects with a clear error.
+
+### Tests
+
+- `ruby-to-semantic-ir`: 170 → **177** (+7):
+  - `splat_lhs_at_end_absorbs_trailing_rhs_into_seqlit`
+  - `splat_lhs_at_start_absorbs_leading_rhs_into_seqlit`
+  - `splat_lhs_in_middle_absorbs_middle_rhs_into_seqlit`
+  - `splat_lhs_with_minimum_rhs_count_gives_empty_seqlit`
+  - `splat_lhs_requests_sequences_feature`
+  - `splat_lhs_module_passes_sir_validator` (E2E for all three splat positions)
+  - `splat_lhs_too_few_rhs_is_a_lower_error`
+
 ## [0.37.0] - 2026-05-28
 
 ### Changed (Phase 9a (FC) — swap-safe parallel multi-assignment)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -2063,6 +2063,184 @@ mod tests {
         );
     }
 
+    // -----------------------------------------------------------------
+    // Phase 9b (FC) — splat LHS in multi-assignment
+    // -----------------------------------------------------------------
+    //
+    // Grammar now allows `[ "*" ] NAME` per LHS target.  At most one
+    // splat per LHS — the splat absorbs zero or more "extra" RHS
+    // values into an `Expr::SeqLit` while non-splat targets bind to
+    // fixed-position RHS values (counted from the start, or from the
+    // end if a splat sits to the left).
+    //
+    // The splat path always routes through the swap-safe temp pass
+    // (Phase 9a pattern): every RHS value is bound to a fresh
+    // `LetStarBinding(__multi_assign_t<N>_<i>, rhs[i])`, then each LHS
+    // is assigned from the corresponding temp(s).
+
+    #[test]
+    fn splat_lhs_at_end_absorbs_trailing_rhs_into_seqlit() {
+        // `a, *b = 1, 2, 3` → a=1; b=[2, 3]
+        let m = lower("a, *b = 1, 2, 3\n");
+        let body = main_body(&m);
+        // 3 temps + 2 LHS bindings = 5 stmts.
+        assert_eq!(
+            body.stmts.len(),
+            5,
+            "expected 5 stmts (3 temps + 2 LHS), got {:?}",
+            body.stmts
+        );
+        // Stmt[3] binds `a` to temp 0 (= IntLit 1).
+        match &body.stmts[3] {
+            Stmt::LetBinding { name, value, .. } => {
+                assert_eq!(name, "a");
+                assert!(
+                    matches!(value, Expr::VarRef { name: n, .. } if n.starts_with("__multi_assign_t")),
+                    "a should bind to a temp VarRef, got {:?}",
+                    value
+                );
+            }
+            other => panic!("expected LetBinding(a, temp), got {:?}", other),
+        }
+        // Stmt[4] binds `b` to SeqLit of temps 1..3.
+        match &body.stmts[4] {
+            Stmt::LetBinding { name, value, .. } => {
+                assert_eq!(name, "b");
+                match value {
+                    Expr::SeqLit { items, .. } => {
+                        assert_eq!(items.len(), 2, "splat should absorb 2 values");
+                        for item in items {
+                            assert!(
+                                matches!(item, Expr::VarRef { name: n, .. } if n.starts_with("__multi_assign_t")),
+                                "splat items should be VarRef to temps, got {:?}",
+                                item
+                            );
+                        }
+                    }
+                    other => panic!("expected SeqLit for splat, got {:?}", other),
+                }
+            }
+            other => panic!("expected LetBinding(b, SeqLit), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn splat_lhs_at_start_absorbs_leading_rhs_into_seqlit() {
+        // `*a, b = 1, 2, 3` → a=[1, 2]; b=3
+        let m = lower("*a, b = 1, 2, 3\n");
+        let body = main_body(&m);
+        assert_eq!(body.stmts.len(), 5);
+        // Stmt[3] binds `a` to SeqLit of temps 0..2.
+        match &body.stmts[3] {
+            Stmt::LetBinding { name, value, .. } => {
+                assert_eq!(name, "a");
+                match value {
+                    Expr::SeqLit { items, .. } => {
+                        assert_eq!(items.len(), 2, "splat at start should absorb 2 values");
+                    }
+                    other => panic!("expected SeqLit for splat, got {:?}", other),
+                }
+            }
+            other => panic!("expected LetBinding(a, SeqLit), got {:?}", other),
+        }
+        // Stmt[4] binds `b` to temp 2 (the last temp).
+        match &body.stmts[4] {
+            Stmt::LetBinding { name, value, .. } => {
+                assert_eq!(name, "b");
+                assert!(
+                    matches!(value, Expr::VarRef { name: n, .. } if n.starts_with("__multi_assign_t")),
+                );
+            }
+            other => panic!("expected LetBinding(b, temp), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn splat_lhs_in_middle_absorbs_middle_rhs_into_seqlit() {
+        // `a, *b, c = 1, 2, 3, 4` → a=1; b=[2, 3]; c=4
+        let m = lower("a, *b, c = 1, 2, 3, 4\n");
+        let body = main_body(&m);
+        // 4 temps + 3 LHS bindings = 7 stmts.
+        assert_eq!(body.stmts.len(), 7);
+        // Stmt[4] binds `a` to temp 0.
+        assert!(matches!(&body.stmts[4], Stmt::LetBinding { name, .. } if name == "a"));
+        // Stmt[5] binds `b` to SeqLit of 2 items (the middle 2 temps).
+        match &body.stmts[5] {
+            Stmt::LetBinding { name, value, .. } => {
+                assert_eq!(name, "b");
+                match value {
+                    Expr::SeqLit { items, .. } => assert_eq!(items.len(), 2),
+                    other => panic!("expected SeqLit, got {:?}", other),
+                }
+            }
+            other => panic!("expected LetBinding(b, SeqLit), got {:?}", other),
+        }
+        // Stmt[6] binds `c` to the last temp.
+        assert!(matches!(&body.stmts[6], Stmt::LetBinding { name, .. } if name == "c"));
+    }
+
+    #[test]
+    fn splat_lhs_with_minimum_rhs_count_gives_empty_seqlit() {
+        // `a, *b = 1` → a=1; b=[]
+        let m = lower("a, *b = 1\n");
+        let body = main_body(&m);
+        // 1 temp + 2 LHS bindings = 3 stmts.
+        assert_eq!(body.stmts.len(), 3);
+        match &body.stmts[2] {
+            Stmt::LetBinding { name, value, .. } => {
+                assert_eq!(name, "b");
+                match value {
+                    Expr::SeqLit { items, .. } => assert!(items.is_empty()),
+                    other => panic!("expected empty SeqLit, got {:?}", other),
+                }
+            }
+            other => panic!("expected LetBinding(b, SeqLit), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn splat_lhs_requests_sequences_feature() {
+        // The splat target binds a SeqLit which requires the
+        // `Sequences` feature in the module manifest.
+        let m = lower("a, *b = 1, 2, 3\n");
+        assert!(
+            m.manifest.contains(semantic_ir::Feature::Sequences),
+            "splat-target multi-assignment should require Sequences"
+        );
+    }
+
+    #[test]
+    fn splat_lhs_module_passes_sir_validator() {
+        // End-to-end smoke test for all three splat positions.
+        for src in [
+            "a, *b = 1, 2, 3\n",
+            "*a, b = 1, 2, 3\n",
+            "a, *b, c = 1, 2, 3, 4\n",
+        ] {
+            let m = lower(src);
+            let result = semantic_ir::validate(&m);
+            assert!(
+                result.is_ok(),
+                "validator rejected splat multi-assign `{}`: {:?}",
+                src.trim(),
+                result
+            );
+        }
+    }
+
+    #[test]
+    fn splat_lhs_too_few_rhs_is_a_lower_error() {
+        // `a, *b, c = 1` has 2 non-splat LHS but only 1 RHS — the
+        // arity check should reject this.
+        let result = compile_source("a, *b, c = 1\n", "test");
+        assert!(result.is_err(), "expected RubyLowerError for splat with too-few RHS");
+        let msg = result.unwrap_err().message;
+        assert!(
+            msg.contains("non-splat LHS") || msg.contains("RHS count"),
+            "expected splat-arity error, got: {msg}"
+        );
+    }
+
     #[test]
     fn multi_assignment_two_swaps_use_distinct_temp_counters() {
         // Two consecutive swaps in the same scope must use DIFFERENT

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -2179,78 +2179,105 @@ impl Lowerer {
     ///
     /// Grammar shape (per `ruby.grammar`):
     /// ```text
-    /// multi_assignment = NAME COMMA NAME { COMMA NAME }
+    /// multi_assignment = mlhs_target COMMA mlhs_target { COMMA mlhs_target }
     ///                    EQUALS
     ///                    expression { COMMA expression } ;
+    /// mlhs_target      = [ "*" ] NAME ;
     /// ```
     ///
-    /// AST layout: the leading `NAME` tokens and their separator
-    /// `COMMA`s sit before the `EQUALS` token; after `EQUALS` come
-    /// the `expression` rule nodes (also `COMMA`-separated, but the
-    /// `COMMA` between expressions is a Token child while the
-    /// `expression` itself is a Node child).  We walk the children
-    /// linearly: NAME tokens encountered *before* EQUALS form the LHS
-    /// list; `expression` nodes encountered *after* EQUALS form the
-    /// RHS list.
+    /// AST layout: each `mlhs_target` sub-node holds an optional `"*"`
+    /// token followed by a `NAME` token.  After the EQUALS token the
+    /// RHS `expression` nodes follow.  We walk the parent's children
+    /// linearly: `mlhs_target` sub-nodes encountered *before* EQUALS
+    /// form the LHS list (recording `(name, is_splat)` per target);
+    /// `expression` nodes encountered *after* EQUALS form the RHS list.
     ///
-    /// Lowering rule for each `(lhs[i], rhs[i])` pair: identical to a
-    /// plain `lhs[i] = rhs[i]` assignment —
-    /// - First sighting of `lhs[i]` in this scope → `Stmt::LetBinding`.
-    /// - Subsequent sighting → `Stmt::Assign` (and the lowerer marks
-    ///   `Feature::MutableBindings`, same as the assignment lowerer).
+    /// Lowering rules:
     ///
-    /// **v0 restrictions** (documented in `ruby.grammar` and the
-    /// changelog):
+    /// - **Non-splat target** at position `i` binds the `i`-th RHS
+    ///   value (from the start, or from the end if the splat sits to
+    ///   its left), exactly like Phase 6r's pair-wise lowering:
+    ///   `Stmt::LetBinding` on first sighting, `Stmt::Assign` on
+    ///   re-bind.
+    /// - **Splat target** (Phase 9b — at most one per LHS) binds an
+    ///   `Expr::SeqLit` of the "middle" RHS values — those that aren't
+    ///   claimed by the fixed-position non-splat targets to its left
+    ///   or right.  Always requests `Feature::Sequences`.
     ///
-    /// - LHS count must equal RHS count.  Mismatched arities are
-    ///   rejected with a `RubyLowerError` rather than silently
-    ///   padding with `nil` / discarding extras.  This keeps the v0
-    ///   semantics unambiguous; the more permissive Ruby semantics
-    ///   (excess LHS gets `nil`, excess RHS is dropped) ride with a
-    ///   future phase.
-    /// - Single-RHS auto-unpack `a, b = arr` is NOT supported (the
-    ///   grammar requires at least one RHS expression but the
-    ///   lowerer will reject the count mismatch).
-    /// - Splat targets `a, *b = 1, 2, 3` ride with Phase 6s.
+    /// **Arity check** (Phase 9b refinement):
+    ///
+    /// - No splat present → LHS count must equal RHS count (Phase 6r
+    ///   semantics).
+    /// - Splat present → RHS count must be ≥ `non_splat_count`.  The
+    ///   splat absorbs the difference (possibly zero) into a Sequence.
+    ///
+    /// **Still deferred to later phases**:
+    ///
+    /// - Single-RHS auto-unpack `a, b = arr` (Phase 9c).
+    /// - Multi-assignment LHS inside a `modifier_statement`.
     fn lower_multi_assignment(
         &mut self,
         node: &GrammarASTNode,
     ) -> Result<Vec<Stmt>, RubyLowerError> {
         // Walk children, partitioning at the EQUALS token.
+        // Each LHS sub-node is an `mlhs_target` — `[ "*" ] NAME`.
         let mut saw_equals = false;
-        let mut lhs_names: Vec<(String, Span)> = Vec::new();
+        let mut lhs_targets: Vec<(String, bool, Span)> = Vec::new();
         let mut rhs_exprs: Vec<&GrammarASTNode> = Vec::new();
         for child in &node.children {
             match child {
                 ASTNodeOrToken::Token(t) => {
                     if t.type_ == TokenType::Equals {
                         saw_equals = true;
-                    } else if !saw_equals && t.type_ == TokenType::Name {
-                        // LHS name.  (COMMAs are also Token children
-                        // but they're not Name-typed, so this branch
-                        // skips them naturally.)
-                        lhs_names.push((t.value.clone(), self.span_of_token(t)));
                     }
-                    // Tokens after EQUALS (COMMAs between RHS
-                    // expressions) are dropped — we only care about
-                    // the Node children for the RHS list.
+                    // COMMAs and any stray tokens are ignored at this
+                    // level — actual LHS NAMEs now live inside
+                    // `mlhs_target` sub-nodes.
                 }
                 ASTNodeOrToken::Node(n) => {
-                    if saw_equals && n.rule_name == "expression" {
+                    if !saw_equals && n.rule_name == "mlhs_target" {
+                        // Pick out optional "*" + NAME token from this
+                        // sub-node.  The lexer emits "*" as a
+                        // `TokenType::Star` token (not a Name-typed
+                        // token), so the splat detection is
+                        // type-based; the target's Name lands on a
+                        // `TokenType::Name`.  Defensive value-filter on
+                        // Name covers the edge case where a future
+                        // lexer change re-routes `*` through Name.
+                        let mut is_splat = false;
+                        let mut name_and_span: Option<(String, Span)> = None;
+                        for sub in &n.children {
+                            if let ASTNodeOrToken::Token(t) = sub {
+                                if t.type_ == TokenType::Star
+                                    || (t.type_ == TokenType::Name && t.value == "*")
+                                {
+                                    is_splat = true;
+                                } else if t.type_ == TokenType::Name {
+                                    name_and_span = Some((
+                                        t.value.clone(),
+                                        self.span_of_token(t),
+                                    ));
+                                }
+                            }
+                        }
+                        if let Some((nm, sp)) = name_and_span {
+                            lhs_targets.push((nm, is_splat, sp));
+                        }
+                    } else if saw_equals && n.rule_name == "expression" {
                         rhs_exprs.push(n);
                     }
                 }
             }
         }
 
-        // Sanity: the grammar guarantees at least two LHS names and
-        // at least one RHS, and an EQUALS token between them.  Defend
+        // Sanity: the grammar guarantees at least two LHS targets and
+        // at least one RHS, plus an EQUALS token between them.  Defend
         // against pathological inputs anyway.
-        if lhs_names.len() < 2 {
+        if lhs_targets.len() < 2 {
             return Err(RubyLowerError {
                 message: format!(
-                    "multi_assignment expected ≥2 LHS names, got {}",
-                    lhs_names.len()
+                    "multi_assignment expected ≥2 LHS targets, got {}",
+                    lhs_targets.len()
                 ),
                 line: node.start_line.unwrap_or(0),
                 column: node.start_column.unwrap_or(0),
@@ -2263,14 +2290,50 @@ impl Lowerer {
                 column: node.start_column.unwrap_or(0),
             });
         }
-        if lhs_names.len() != rhs_exprs.len() {
+
+        // Locate splat position(s).  At most one splat is allowed per
+        // LHS — Ruby's grammar enforces this and so does the lowerer.
+        let splat_positions: Vec<usize> = lhs_targets
+            .iter()
+            .enumerate()
+            .filter_map(|(i, (_, is_splat, _))| if *is_splat { Some(i) } else { None })
+            .collect();
+        if splat_positions.len() > 1 {
             return Err(RubyLowerError {
                 message: format!(
-                    "multi_assignment v0 requires LHS count == RHS count \
-                     (got {} LHS, {} RHS); splat / single-RHS auto-unpack \
-                     not yet supported",
-                    lhs_names.len(),
+                    "multi_assignment allows at most one splat (*) LHS, got {}",
+                    splat_positions.len()
+                ),
+                line: node.start_line.unwrap_or(0),
+                column: node.start_column.unwrap_or(0),
+            });
+        }
+        let splat_idx: Option<usize> = splat_positions.first().copied();
+        let non_splat_count = lhs_targets.len() - if splat_idx.is_some() { 1 } else { 0 };
+
+        // Arity check — different rule depending on whether a splat is
+        // present.
+        if splat_idx.is_none() {
+            if lhs_targets.len() != rhs_exprs.len() {
+                return Err(RubyLowerError {
+                    message: format!(
+                        "multi_assignment v0 requires LHS count == RHS count \
+                         (got {} LHS, {} RHS); single-RHS auto-unpack \
+                         not yet supported",
+                        lhs_targets.len(),
+                        rhs_exprs.len(),
+                    ),
+                    line: node.start_line.unwrap_or(0),
+                    column: node.start_column.unwrap_or(0),
+                });
+            }
+        } else if rhs_exprs.len() < non_splat_count {
+            return Err(RubyLowerError {
+                message: format!(
+                    "multi_assignment with splat needs RHS count ≥ \
+                     non-splat LHS count (got {} RHS, {} non-splat LHS)",
                     rhs_exprs.len(),
+                    non_splat_count,
                 ),
                 line: node.start_line.unwrap_or(0),
                 column: node.start_column.unwrap_or(0),
@@ -2283,6 +2346,29 @@ impl Lowerer {
             .iter()
             .map(|e| self.lower_expression(e))
             .collect::<Result<_, _>>()?;
+
+        // ── Phase 9b dispatch ───────────────────────────────────────
+        //
+        // When a splat is present, we route to a dedicated lowering
+        // path so the Phase 6r/9a non-splat code below stays simple.
+        // The splat path always uses the swap-safe temp pass (Phase 9a
+        // pattern) because routing one LHS to a SeqLit makes the
+        // bookkeeping easier when every RHS value sits in a named temp.
+        if let Some(splat_idx_real) = splat_idx {
+            return self.lower_multi_assignment_with_splat(
+                node,
+                &lhs_targets,
+                splat_idx_real,
+                lowered_rhs,
+            );
+        }
+        // For the (also re-mapped) compatibility with the Phase 9a
+        // code, project to the old `lhs_names: Vec<(String, Span)>`
+        // shape now that we know there are no splats.
+        let lhs_names: Vec<(String, Span)> = lhs_targets
+            .iter()
+            .map(|(n, _, s)| (n.clone(), s.clone()))
+            .collect();
 
         // ── Phase 9a (FC) — swap-safe parallel binding ───────────────
         //
@@ -2405,6 +2491,129 @@ impl Lowerer {
                 };
                 out.push(stmt);
             }
+        }
+        Ok(out)
+    }
+
+    // -------------------------------------------------------------------
+    // Phase 9b (FC) — multi-assignment WITH splat LHS
+    // -------------------------------------------------------------------
+
+    /// Lower the splat-LHS form of `multi_assignment`:
+    ///
+    /// ```text
+    /// a, *b = 1, 2, 3        → a == 1; b == [2, 3]
+    /// *a, b = 1, 2, 3        → a == [1, 2]; b == 3
+    /// a, *b, c = 1, 2, 3, 4  → a == 1; b == [2, 3]; c == 4
+    /// ```
+    ///
+    /// Strategy: always go through the temp pass (same shape as Phase
+    /// 9a's swap-safe path) — every RHS value is bound to a fresh
+    /// `LetStarBinding(__multi_assign_t<N>_<i>, rhs[i])`.  Then we walk
+    /// the LHS list:
+    ///
+    /// - Non-splat target at position `i` (before splat) → reads
+    ///   `__multi_assign_t<N>_<i>`.
+    /// - Non-splat target at position `i` (after splat)  → reads
+    ///   `__multi_assign_t<N>_<rhs_len - (lhs_len - 1 - i)>`.
+    /// - Splat target → binds `Expr::SeqLit` of the "middle" temps
+    ///   `__multi_assign_t<N>_<splat_idx>..__multi_assign_t<N>_<end>`
+    ///   where `end = rhs_len - (lhs_len - 1 - splat_idx)`.  May be
+    ///   empty (the splat gets an empty Sequence).  Always requests
+    ///   `Feature::Sequences`.
+    fn lower_multi_assignment_with_splat(
+        &mut self,
+        node: &GrammarASTNode,
+        lhs_targets: &[(String, bool, Span)],
+        splat_idx: usize,
+        lowered_rhs: Vec<Expr>,
+    ) -> Result<Vec<Stmt>, RubyLowerError> {
+        // Step 1: emit temp bindings for every RHS.  Reuses the same
+        // counter-based naming scheme as Phase 9a so temps from
+        // adjacent multi-assignments don't collide.
+        let counter = self.multi_assign_counter;
+        self.multi_assign_counter += 1;
+        let stmt_span = self.span_of(node);
+        let rhs_len = lowered_rhs.len();
+
+        let mut out: Vec<Stmt> = Vec::with_capacity(rhs_len + lhs_targets.len());
+        let mut temp_names: Vec<String> = Vec::with_capacity(rhs_len);
+        for (i, rhs_value) in lowered_rhs.into_iter().enumerate() {
+            let tmp_name = format!("__multi_assign_t{}_{}", counter, i);
+            // Record so subsequent VarRef lookups treat the temp as
+            // a local.  (It IS declared via LetStarBinding here.)
+            self.declared_locals.insert(tmp_name.clone());
+            out.push(Stmt::LetStarBinding {
+                name: tmp_name.clone(),
+                sir_type: None,
+                value: rhs_value,
+                span: stmt_span.clone(),
+            });
+            temp_names.push(tmp_name);
+        }
+
+        // Step 2: emit the LHS bindings.  The splat absorbs the
+        // middle of the temp list (possibly an empty middle).
+        let lhs_len = lhs_targets.len();
+        // Indices of the temps that go into the splat's SeqLit.
+        let splat_temps_start = splat_idx;
+        let splat_temps_end = rhs_len - (lhs_len - 1 - splat_idx);
+
+        for (i, (name, is_splat, name_span)) in lhs_targets.iter().enumerate() {
+            let span = name_span.clone();
+            let value = if *is_splat {
+                // Build a Sequence from the middle slice of temps.
+                self.features_used.insert(Feature::Sequences);
+                let items: Vec<Expr> = (splat_temps_start..splat_temps_end)
+                    .map(|j| Expr::VarRef {
+                        name: temp_names[j].clone(),
+                        scope: Scope::Local,
+                        span: span.clone(),
+                    })
+                    .collect();
+                Expr::SeqLit {
+                    items,
+                    span: span.clone(),
+                }
+            } else {
+                // Pick the temp at i-mapped position.  Before the
+                // splat, positions match directly (0..splat_idx).
+                // After the splat, count from the end:
+                //   The post-splat tail has `lhs_len - 1 - splat_idx`
+                //   non-splat targets; they map to the last
+                //   `lhs_len - 1 - splat_idx` temps.  Target at LHS
+                //   position `i` is at temp index `rhs_len - lhs_len + i`.
+                let temp_index = if i < splat_idx {
+                    i
+                } else {
+                    // i > splat_idx (since splat itself handled above)
+                    rhs_len - lhs_len + i
+                };
+                Expr::VarRef {
+                    name: temp_names[temp_index].clone(),
+                    scope: Scope::Local,
+                    span: span.clone(),
+                }
+            };
+
+            let stmt = if self.declared_locals.contains(name) {
+                self.features_used.insert(Feature::MutableBindings);
+                Stmt::Assign {
+                    name: name.clone(),
+                    scope: Scope::Local,
+                    value,
+                    span,
+                }
+            } else {
+                self.declared_locals.insert(name.clone());
+                Stmt::LetBinding {
+                    name: name.clone(),
+                    sir_type: None,
+                    value,
+                    span,
+                }
+            };
+            out.push(stmt);
         }
         Ok(out)
     }


### PR DESCRIPTION
## Summary

Phase 9b lands **splat targets on the LHS of multi-assignment** — the construct Phase 6r explicitly deferred:

```ruby
a, *b = 1, 2, 3       # a == 1; b == [2, 3]
*a, b = 1, 2, 3       # a == [1, 2]; b == 3
a, *b, c = 1, 2, 3, 4 # a == 1; b == [2, 3]; c == 4
a, *b = 1             # a == 1; b == []  — splat may absorb 0 values
```

Builds directly on Phase 9a's swap-safe temp pass.

## Grammar

`multi_assignment` LHS now uses a sub-rule `mlhs_target` matching the established `param` / `call_arg` shape:

```ebnf
multi_assignment = mlhs_target COMMA mlhs_target { COMMA mlhs_target }
                   EQUALS expression { COMMA expression } ;
mlhs_target      = [ "*" ] NAME ;
```

Single-LHS forms (`a = 1`) still fall through to plain `assignment` unchanged because `multi_assignment` requires at least two `mlhs_target`s.  Multiple splats are syntactically possible at the grammar level but the lowerer rejects them with a clear error.

`_grammar.rs` regenerated via `grammar-tools compile-grammar`.

## Lowering

The splat path always routes through the swap-safe temp pass (Phase 9a pattern):

1. Bind every RHS to a fresh `LetStarBinding(__multi_assign_t<N>_<i>, rhs[i])` temp.
2. Walk the LHS list:
   - **Non-splat target before splat** (position `i < splat_idx`) → `VarRef(temps[i])`.
   - **Non-splat target after splat**  (position `i > splat_idx`) → `VarRef(temps[rhs_len - lhs_len + i])`.
   - **Splat target** → `Expr::SeqLit([VarRef(temps[splat_idx]), …, VarRef(temps[rhs_len - lhs_len + splat_idx])])`.  May be empty if RHS count equals non-splat count.

The splat's `SeqLit` requires `Feature::Sequences`.  The LHS bindings use the existing first-sighting `LetBinding` / re-binding `Assign` decision (with `Feature::MutableBindings` for the re-bind path).

| Source                  | SIR shape (Phase 9b)                                                                                                                                          |
|-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
| `a, *b = 1, 2, 3`       | 3 temps + `LetBinding(a, t0); LetBinding(b, SeqLit([t1, t2]))`                                                                                                |
| `*a, b = 1, 2, 3`       | 3 temps + `LetBinding(a, SeqLit([t0, t1])); LetBinding(b, t2)`                                                                                                |
| `a, *b, c = 1, 2, 3, 4` | 4 temps + `LetBinding(a, t0); LetBinding(b, SeqLit([t1, t2])); LetBinding(c, t3)`                                                                             |
| `a, *b = 1`             | 1 temp + `LetBinding(a, t0); LetBinding(b, SeqLit([]))` *(empty splat)*                                                                                       |

### Arity check

- **No splat present** → LHS count must equal RHS count (Phase 6r semantics — unchanged).
- **Splat present** → RHS count must be `≥ non_splat_count`.  Otherwise the lowerer returns a `RubyLowerError`.

### Single-RHS auto-unpack still deferred

`a, *b = [1, 2, 3]` (one RHS that is itself an array) still isn't unpacked — that's Phase 9c.  The current path treats single-RHS forms with splat the same way as multi-RHS: the splat absorbs the remaining RHS values (in this case zero or one, depending on whether the array is the only RHS).

## Tests

- `coding-adventures-ruby-lexer`: 173 → **173** (no change)
- `coding-adventures-ruby-parser`: 149 → **152** (+3):
  - `test_parse_multi_assignment_splat_at_end`
  - `test_parse_multi_assignment_splat_at_start`
  - `test_parse_multi_assignment_splat_in_middle`
- `ruby-to-semantic-ir`: 170 → **177** (+7):
  - `splat_lhs_at_end_absorbs_trailing_rhs_into_seqlit`
  - `splat_lhs_at_start_absorbs_leading_rhs_into_seqlit`
  - `splat_lhs_in_middle_absorbs_middle_rhs_into_seqlit`
  - `splat_lhs_with_minimum_rhs_count_gives_empty_seqlit`
  - `splat_lhs_requests_sequences_feature`
  - `splat_lhs_module_passes_sir_validator` (E2E for all three splat positions)
  - `splat_lhs_too_few_rhs_is_a_lower_error`

All 5 prior Phase 6r/9a tests keep passing — they exercise the non-splat path (which still routes through the existing logic) and were re-validated against the refactored AST walk.

## Test plan

- [x] `cargo test -p coding-adventures-ruby-lexer` (173/173 pass)
- [x] `cargo test -p coding-adventures-ruby-parser` (152/152 pass)
- [x] `cargo test -p ruby-to-semantic-ir` (177/177 pass)
- [x] Self-reviewed (no I/O, no unsafe — pure AST walk + SIR Stmt list construction; splat marker detection is type-checked against `TokenType::Star`)
- [ ] CI green

Follows PR #4556 (Phase 9a).  Next chunk: Phase 9c (tuple destructure `a, b = arr` — single-RHS auto-unpack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
