### PR TITLE
feat(closurec): opt-in --correlation_vector plumbing (CLOC11.60)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,57 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.23.0] - 2026-05-27
+
+### Added — CLOC11.60: opt-in `--correlation_vector` plumbing through pipeline
+
+**Architectural milestone.** First slice of the correlation-vector traceability work specified in `feedback_closurec_correlation_vectors.md`. When `--correlation_vector` is set, the pipeline threads a [`coding_adventures_correlation_vector::CVLog`] through every input file and records per-file contributions for the transform stage. When the flag is unset (default), the `CVLog` is constructed in disabled mode — every `create`/`contribute` call is a no-op, so the existing zero-overhead pipeline behavior is preserved.
+
+The CV trace is written as a JSON sidecar file at the end of the run. Path policy:
+
+- When `--js_output_file` is set, the sidecar lives next to it as `<output>.cv.json`. Build pipelines consuming the compiled JS automatically pick up the trace without a separate flag.
+- When `--js_output_file` is absent (stdout output), the sidecar lands at `closurec-cv.json` in the current working directory.
+
+### What this slice covers (intentionally narrow)
+
+- **Per-file root CV entry**: assigns a CV ID at file ingestion with `Origin::source = "input_file"` and `location = <path>`.
+- **One summary contribution per file**: tags the entry with `source = "transform_source"`, `tag = "applied"`, and includes input + output byte lengths in `meta`. This is the placeholder for the deeper per-stage instrumentation queued in CLOC11.61..11.66.
+- **JSON sidecar emission** via `CVLog::to_json_string()`.
+
+### What's still queued
+
+- CLOC11.61: split the per-file summary contribution into one-per-stage (`whitespace_only`, `defines`).
+- CLOC11.62: wrapper / IIFE / charset stages.
+- CLOC11.63: source-map / manifest writes recorded as derived CV entries.
+- CLOC11.64–66: per-token granularity, tombstones for removals, custom `--correlation_vector_output` path flag.
+
+### Implementation
+
+- **`SpecialModesConfig.correlation_vector: bool`** field + cli.spec.json entry + wire.rs parsing.
+- **`run_compiler` instantiates `CVLog::new(config.special_modes.correlation_vector)`** once before the per-input loop. The boolean toggle threads down into every CV call; disabled-mode short-circuits at the crate level.
+- **`format_cv_log_json(&CVLog) -> String`** wraps `CVLog::to_json_string()` with a `{}` fallback so a serialization error doesn't break the otherwise-successful run.
+- **Step 7 (NEW) in `run_compiler`** — writes the sidecar after the manifest write so `wrote_files` ends up in pipeline order: JS, source map, manifest, CV sidecar.
+- **4 new unit tests** in `run::tests` (default → no sidecar, opt-in → sidecar next to output, opt-in stdout → default sidecar in CWD, multi-file → entry-per-file).
+
+### Pipeline matrix (cumulative across CLOC11)
+
+`run_compiler`:
+1. Resolve `--js` globs
+2. Resolve `--externs` globs
+3. `--print_tree` short-circuit
+4. `--print_tree_json` short-circuit
+5. Per-input `transform_source` (now records one CV contribution per file when `--correlation_vector` is set)
+6. Concatenate transformed inputs
+7. `--checks_only` short-circuit
+8. `--emit_use_strict` prepend
+9. `--output_wrapper` substitution
+10. `--isolation_mode IIFE` wrap
+11. `--charset` US_ASCII escape
+12. Write JS
+13. Write source map
+14. Write input manifest
+15. **Write CV sidecar (CLOC11.60, NEW) if `--correlation_vector` was set**
+
 ## [0.22.0] - 2026-05-26
 
 ### Added — CLOC11.04: `--define` numeric edge case test coverage

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.22.0"
+version = "0.23.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },
@@ -95,6 +95,7 @@
     { "id": "error_format", "long": "error_format", "type": "enum", "enum_values": ["STANDARD"], "default": "STANDARD", "description": "Format for error messages." },
     { "id": "renaming", "long": "renaming", "type": "boolean", "default": true, "description": "Disable variable renaming. Cannot be combined with ADVANCED compilation level." },
     { "id": "help_markdown", "long": "help_markdown", "type": "boolean", "default": false, "description": "Print markdown-formatted flag usage (hidden)." },
+    { "id": "correlation_vector", "long": "correlation_vector", "type": "boolean", "default": false, "description": "Thread a correlation-vector trace through every transform stage so output bytes are traceable back to input. Default off; opt in via this flag (CLOC11.60)." },
     { "id": "instrument_for_coverage_option", "long": "instrument_for_coverage_option", "type": "enum", "enum_values": ["NONE", "LINE", "BRANCH", "PRODUCTION"], "default": "NONE", "description": "Enable code instrumentation for coverage analysis." },
     { "id": "production_instrumentation_array_name", "long": "production_instrumentation_array_name", "type": "string", "default": "", "description": "Global array name used by production instrumentation." },
     { "id": "chunk_output_type", "long": "chunk_output_type", "type": "enum", "enum_values": ["GLOBAL_NAMESPACE", "ES_MODULES"], "default": "GLOBAL_NAMESPACE", "description": "Format for output chunks." },

--- a/code/programs/rust/closurec/src/config.rs
+++ b/code/programs/rust/closurec/src/config.rs
@@ -504,6 +504,14 @@ pub struct SpecialModesConfig {
     pub print_ast: bool,
     pub print_source_after_each_pass: bool,
     pub help_markdown: bool,
+    /// CLOC11.60: when true, the pipeline threads a
+    /// [`coding_adventures_correlation_vector::CVLog`] through
+    /// every transform stage so the user (or audit tooling) can
+    /// trace any output byte back to its input provenance. When
+    /// false (default), the CV log is constructed in disabled
+    /// mode (zero overhead — the crate short-circuits every
+    /// `create` / `contribute` call).
+    pub correlation_vector: bool,
 }
 
 // ---------------------------------------------------------------------------

--- a/code/programs/rust/closurec/src/run.rs
+++ b/code/programs/rust/closurec/src/run.rs
@@ -375,13 +375,68 @@ pub fn run_compiler(config: &CompilerConfig) -> Result<CompilerOutput, CompilerE
     // CLOC11.07+ replace the SIMPLE/ADVANCED arms with real
     // lex/parse/typecheck/passes/emit pipelines.
     let mut combined = String::new();
+    // CLOC11.60: opt-in correlation-vector log. Constructed in
+    // "enabled" mode iff `--correlation_vector` was passed; in
+    // disabled mode every CV call is a no-op. We accumulate
+    // contributions through the per-file loop and dump them at
+    // the end of `run_compiler` to a side-channel file
+    // (`closurec-cv.json` by default) when enabled.
+    let mut cv_log = coding_adventures_correlation_vector::CVLog::new(
+        config.special_modes.correlation_vector,
+    );
     for path in &inputs {
         let contents = fs::read_to_string(path).map_err(|e| CompilerError::InputReadError {
             path: path.clone(),
             kind: e.kind(),
             message: e.to_string(),
         })?;
+
+        // CLOC11.60 — assign a CV ID at ingestion (the per-file
+        // root), so every downstream contribution can attach to
+        // it. The `Origin` is the file path; granularity is
+        // per-file for now. CLOC11.61+ deepen this to per-token
+        // / per-byte as the transform stages get CV-aware.
+        let cv_id = if config.special_modes.correlation_vector {
+            let mut meta = std::collections::HashMap::new();
+            meta.insert(
+                "byte_len".to_string(),
+                serde_json::Value::Number((contents.len() as u64).into()),
+            );
+            Some(cv_log.create(Some(
+                coding_adventures_correlation_vector::Origin {
+                    source: "input_file".to_string(),
+                    location: path.to_string_lossy().into_owned(),
+                    timestamp: None,
+                    meta,
+                },
+            )))
+        } else {
+            None
+        };
+
         let transformed = transform_source(&contents, config)?;
+
+        // CLOC11.60 — record one summary contribution from
+        // `transform_source` per file. CLOC11.61+ split this into
+        // a contribution per stage (whitespace_only, defines).
+        if let Some(id) = &cv_id {
+            let mut meta = std::collections::HashMap::new();
+            meta.insert(
+                "input_byte_len".to_string(),
+                serde_json::Value::Number((contents.len() as u64).into()),
+            );
+            meta.insert(
+                "output_byte_len".to_string(),
+                serde_json::Value::Number((transformed.len() as u64).into()),
+            );
+            let _ = cv_log.contribute(
+                id,
+                "transform_source",
+                "applied",
+                meta,
+            );
+        }
+
         combined.push_str(&transformed);
         // Closure separates concatenated inputs with a newline so
         // back-to-back files don't end up syntactically merged.
@@ -530,10 +585,57 @@ pub fn run_compiler(config: &CompilerConfig) -> Result<CompilerOutput, CompilerE
         wrote_files.push(manifest_path.clone());
     }
 
+    // Step 7 (CLOC11.60): write the correlation-vector trace as
+    // a JSON sidecar file when `--correlation_vector` was set.
+    //
+    // Path policy:
+    //   - When `--js_output_file` is set, the sidecar sits
+    //     beside it as `<output>.cv.json`. Build pipelines
+    //     consuming the JS get the trace automatically without
+    //     a separate flag for the path.
+    //   - When `--js_output_file` is absent (stdout), the
+    //     sidecar lands at `closurec-cv.json` in the working
+    //     directory. Discoverable; user can rename / move.
+    //
+    // CLOC11.6N (a follow-up slice) will add an explicit
+    // `--correlation_vector_output <path>` flag so callers who
+    // want a custom location don't have to rely on the
+    // sidecar-of-output convention.
+    if config.special_modes.correlation_vector {
+        let sidecar_path = match &config.io.js_output_file {
+            Some(p) => {
+                let mut s = p.as_os_str().to_owned();
+                s.push(".cv.json");
+                PathBuf::from(s)
+            }
+            None => PathBuf::from("closurec-cv.json"),
+        };
+        let body = format_cv_log_json(&cv_log);
+        write_output_file(&sidecar_path, &body)?;
+        wrote_files.push(sidecar_path);
+    }
+
     Ok(CompilerOutput {
         stdout_text: result.stdout_text,
         wrote_files,
     })
+}
+
+/// Serialize a `CVLog` to a pretty-printed JSON string for the
+/// `--correlation_vector` sidecar. We use `serde_json::to_string_pretty`
+/// rather than hand-rolling the format because the CV crate's
+/// `CVEntry` / `Contribution` types are already `Serialize`, and
+/// the sidecar is consumed by tooling (not pinned in fixtures), so
+/// serde's formatting choices don't bite us.
+///
+/// On serialization failure (vanishingly rare for the CV crate's
+/// well-formed structs), we fall back to a minimal `{}` document so
+/// the write still succeeds — a missing sidecar would be worse than
+/// a stub one for the build-pipeline-consumes-the-file case.
+fn format_cv_log_json(cv_log: &coding_adventures_correlation_vector::CVLog) -> String {
+    cv_log
+        .to_json_string()
+        .unwrap_or_else(|_| "{}".to_string())
 }
 
 /// Format the contents of an `--output_manifest` file from a
@@ -1652,6 +1754,148 @@ mod tests {
             out.wrote_files,
             vec![out_path, map_path, manifest_path.clone()],
             "wrote_files in pipeline order: JS, source map, manifest"
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    // ------------------------------------------------------------------
+    // CLOC11.60 — opt-in correlation-vector plumbing
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn correlation_vector_off_writes_no_sidecar() {
+        // Default behavior: --correlation_vector unset → no CV
+        // sidecar file. Pin so a refactor doesn't accidentally
+        // always-on the CV trace (which would be visible
+        // user-perf regression and disk-usage surprise).
+        let in_path = temp_path("cv-off-in.js");
+        fs::write(&in_path, "var x=1;").expect("setup");
+        let cfg = CompilerConfig {
+            io: IoConfig {
+                js_patterns: vec![in_path.to_string_lossy().to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let out = run_compiler(&cfg).expect("ok");
+        // Stdout-only output, no sidecar.
+        assert!(out.wrote_files.is_empty(), "no files written; got {:?}", out.wrote_files);
+        let _ = fs::remove_file(&in_path);
+    }
+
+    #[test]
+    fn correlation_vector_on_writes_sidecar_next_to_output_file() {
+        // With --js_output_file set, the sidecar lands at
+        // `<output>.cv.json` next to the JS.
+        let dir = temp_path("cv-on-dir");
+        fs::create_dir_all(&dir).expect("setup");
+        let in_path = dir.join("in.js");
+        let out_path = dir.join("out.js");
+        let sidecar_path = dir.join("out.js.cv.json");
+        fs::write(&in_path, "var x=1;").expect("setup");
+        let cfg = CompilerConfig {
+            io: IoConfig {
+                js_patterns: vec![in_path.to_string_lossy().to_string()],
+                js_output_file: Some(out_path.clone()),
+                ..Default::default()
+            },
+            special_modes: crate::config::SpecialModesConfig {
+                correlation_vector: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let out = run_compiler(&cfg).expect("ok");
+        assert!(out.wrote_files.contains(&sidecar_path), "sidecar written");
+        let body = fs::read_to_string(&sidecar_path).expect("read sidecar");
+        // Body must be JSON. We don't pin the exact format
+        // (CVLog::to_json_string controls it) but assert the
+        // shape: starts with `{`, contains an entries section.
+        assert!(body.trim_start().starts_with('{'), "got: {body}");
+        // The Origin we recorded names "input_file" — pin that
+        // marker so the file→entry connection is verifiable
+        // without re-parsing the JSON.
+        assert!(body.contains("input_file"), "got: {body}");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn correlation_vector_on_writes_default_sidecar_when_stdout_output() {
+        // When --js_output_file is absent, the sidecar lands at
+        // `closurec-cv.json` in CWD. Test from a temp dir we
+        // chdir into so we don't litter the repo root.
+        let prev_cwd = std::env::current_dir().expect("cwd");
+        let dir = temp_path("cv-stdout-dir");
+        fs::create_dir_all(&dir).expect("setup");
+        std::env::set_current_dir(&dir).expect("chdir");
+
+        let in_path = dir.join("in.js");
+        fs::write(&in_path, "var x=1;").expect("setup");
+        let cfg = CompilerConfig {
+            io: IoConfig {
+                js_patterns: vec![in_path.to_string_lossy().to_string()],
+                ..Default::default()
+            },
+            special_modes: crate::config::SpecialModesConfig {
+                correlation_vector: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let out = run_compiler(&cfg).expect("ok");
+        let expected_sidecar = PathBuf::from("closurec-cv.json");
+        assert!(out.wrote_files.contains(&expected_sidecar), "got: {:?}", out.wrote_files);
+        assert!(dir.join("closurec-cv.json").exists());
+
+        // Restore cwd before the temp dir goes away.
+        std::env::set_current_dir(prev_cwd).expect("restore cwd");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn correlation_vector_records_one_entry_per_input_file() {
+        // Two --js inputs → CV log gains two entries (one per
+        // input). Verifies the per-file `create()` call lands.
+        let dir = temp_path("cv-multi-dir");
+        fs::create_dir_all(&dir).expect("setup");
+        let a = dir.join("a.js");
+        let b = dir.join("b.js");
+        let out_path = dir.join("combined.js");
+        let sidecar_path = dir.join("combined.js.cv.json");
+        fs::write(&a, "var a=1;").expect("a");
+        fs::write(&b, "var b=2;").expect("b");
+        let cfg = CompilerConfig {
+            io: IoConfig {
+                js_patterns: vec![
+                    a.to_string_lossy().to_string(),
+                    b.to_string_lossy().to_string(),
+                ],
+                js_output_file: Some(out_path.clone()),
+                ..Default::default()
+            },
+            special_modes: crate::config::SpecialModesConfig {
+                correlation_vector: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let _ = run_compiler(&cfg).expect("ok");
+        let body = fs::read_to_string(&sidecar_path).expect("read sidecar");
+        // Both file paths should appear as origins. Granular
+        // assertion via substring count: each `a.js` and `b.js`
+        // path appears at least once as the Origin.location.
+        assert!(body.contains("a.js"), "missing a.js: {body}");
+        assert!(body.contains("b.js"), "missing b.js: {body}");
+        // The `transform_source` contribution tag lands per file.
+        // Substring `"source":"transform_source"` is the
+        // per-contribution marker; the CVLog's `pass_order` also
+        // mentions it once, so the precise expectation is 2
+        // contribution occurrences for 2 input files.
+        let contribution_marker = "\"source\":\"transform_source\"";
+        assert_eq!(
+            body.matches(contribution_marker).count(),
+            2,
+            "expected 2 transform_source contributions, got: {body}"
         );
         let _ = fs::remove_dir_all(&dir);
     }

--- a/code/programs/rust/closurec/src/wire.rs
+++ b/code/programs/rust/closurec/src/wire.rs
@@ -487,6 +487,7 @@ fn read_special_modes(p: &ParseResult) -> Result<SpecialModesConfig, ConfigError
         print_ast: get_bool(p, "print_ast")?,
         print_source_after_each_pass: get_bool(p, "print_source_after_each_pass")?,
         help_markdown: get_bool(p, "help_markdown")?,
+        correlation_vector: get_bool(p, "correlation_vector")?,
     })
 }
 

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.22.0
+Version: 0.23.0
 
 ## Flags
 
@@ -365,6 +365,10 @@ Disable variable renaming. Cannot be combined with ADVANCED compilation level.
 ### `--help_markdown` (boolean, default: false)
 
 Print markdown-formatted flag usage (hidden).
+
+### `--correlation_vector` (boolean, default: false)
+
+Thread a correlation-vector trace through every transform stage so output bytes are traceable back to input. Default off; opt in via this flag (CLOC11.60).
 
 ### `--instrument_for_coverage_option` (enum, default: NONE)
 


### PR DESCRIPTION
## Summary
- **Architectural milestone.** First slice of correlation-vector traceability per \`feedback_closurec_correlation_vectors.md\`.
- When \`--correlation_vector\` is set, run_compiler threads a \`coding_adventures_correlation_vector::CVLog\` through every input and records per-file contributions. Default off = zero overhead (the crate short-circuits internally).
- CV trace written as a JSON sidecar at end of run:
  - \`--js_output_file\` set → \`<output>.cv.json\` next to compiled JS
  - \`--js_output_file\` absent → \`closurec-cv.json\` in CWD

## Intentionally narrow scope
This slice ships the **plumbing**, not full per-stage instrumentation:
- ✅ Per-file root CV entry (\`Origin::input_file\`, location = path)
- ✅ One summary \`transform_source.applied\` contribution per file with input/output byte lengths
- ✅ JSON sidecar via \`CVLog::to_json_string()\`

## Queued for follow-up slices
- **CLOC11.61** — split per-file summary into one contribution per stage (whitespace_only, defines)
- **CLOC11.62** — wrapper / IIFE / charset stages
- **CLOC11.63** — source-map / manifest writes recorded as derived CV entries
- **CLOC11.64–66** — per-token granularity, tombstones for removals, custom \`--correlation_vector_output\` path

## Cumulative pipeline matrix
1. Resolve \`--js\` globs
2. Resolve \`--externs\` globs
3. \`--print_tree\` short-circuit
4. \`--print_tree_json\` short-circuit
5. \`transform_source\` (now records 1 CV contribution per file when CV is on)
6. Concatenate
7. \`--checks_only\` short-circuit
8. \`--emit_use_strict\` prepend
9. \`--output_wrapper\` substitution
10. \`--isolation_mode IIFE\` wrap
11. \`--charset\` escape
12. Write JS
13. Write source map
14. Write input manifest
15. **Write CV sidecar (NEW)**

## Tests
- 4 new unit tests in \`run::tests\`:
  - default off → no sidecar
  - opt-in with \`--js_output_file\` → sidecar next to output
  - opt-in stdout-output → default sidecar in CWD
  - multi-file → 1 entry per file, 2 \`transform_source\` contributions
- 218 unit tests + integration tests pass

## Versions
- \`Cargo.toml\`: 0.22.0 → 0.23.0
- \`cli.spec.json\`: 0.22.0 → 0.23.0
- Help-markdown fixture regenerated
- CHANGELOG \`[0.23.0]\` entry

## Security review (inline)
\`CVLog::new\` disabled-mode is enforced inside the CV crate. Origin paths flow via \`to_string_lossy()\` (OS-string safe). Meta fields are integer-only \`Value::Number\` (no string-injection vector). Sidecar write reuses battle-tested \`write_output_file\`. \`format_cv_log_json\` has \`{}\` fallback so a serialization edge case won't break the JS write. No \`unsafe\`.

## Test plan
- [x] \`cargo build\` clean
- [x] \`cargo test\` — 218 unit + integration tests pass
- [x] \`cargo clippy --no-deps -p coding-adventures-closurec\` — clean
- [x] Inline security review

🤖 Generated with [Claude Code](https://claude.com/claude-code)