### PR TITLE
feat(symbolic-vm): Track E1 — generic IBP integration fallback (Python, 0.73.0)

### DIFF
--- a/code/packages/python/symbolic-vm/CHANGELOG.md
+++ b/code/packages/python/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,73 @@
 # Changelog
 
+## 0.73.0 — 2026-05-28
+
+**Track E1 — generic tabular integration-by-parts fallback.**
+
+Adds a last-ditch generic IBP handler that fires only after every
+shape-specific elementary / Phase 23 special-function / Elliptic
+handler has returned ``None``.  Closes the integration gap for
+``Mul``-shaped integrands that no per-shape recogniser matches but
+that admit the textbook tabular IBP factorisation
+``f = u(x) · w(x)`` with ``u`` polynomial and ``w`` integrable.
+
+### Algorithm
+
+For ``∫ u·w dx`` with ``u`` polynomial of degree ``N − 1`` and ``w``
+integrable, the antiderivative is the alternating sum
+
+```
+∫ u·w dx  =  Σ_{k=0}^{N-1}  (-1)^k · u^(k)(x) · I^(k+1)(w)
+```
+
+derived from N successive applications of IBP; the trailing remainder
+``(-1)^N · ∫ u^(N)·I^N(w) dx`` vanishes because ``u^(N) = 0``.  The
+implementation enumerates ``Mul`` factor partitions, picks the
+polynomial-on-one-side / integrable-on-the-other split, and assembles
+the table.  Bounded by ``_MAX_FACTORS = 5`` and ``_MAX_POLY_DEGREE =
+8`` so the search never explodes.
+
+### Added
+
+- ``ibp_tabular`` module with ``try_ibp_tabular(f, x, integrate_fn,
+  diff_fn, simplify_fn)`` — pure function, no VM dependency.
+- New test file ``tests/test_ibp.py`` exercising the three named
+  acceptance cases (``∫ x·sin(x) dx``, ``∫ x²·eˣ dx``,
+  ``∫ x³·cos(x) dx``), the new gap case
+  ``∫ x·sin(x)·cos(x) dx`` (three-factor Mul that per-shape
+  handlers don't recognise), and the two fallthroughs (``∫ 1/x dx``
+  via the elementary log rule; ``∫ sin(x²) dx`` via Phase 23
+  Fresnel — neither lets the generic IBP fabricate a closed form).
+
+### Changed
+
+- ``integrate.py`` — wires ``try_ibp_tabular`` into the
+  indefinite-integration outer handler **after** Phase 23
+  special-function and Elliptic fallbacks, as the final attempt
+  before returning unevaluated.
+- ``tests/test_phase16.py::test_poly_times_sech_squared_unevaluated``
+  → ``test_poly_times_sech_squared_via_ibp`` — Track E1 closes
+  ``∫ x·sech²(x) dx`` to ``x·tanh(x) − log(cosh(x))``, which the
+  earlier test asserted unevaluated.  Updated to check the new
+  closed form via numerical ``F'(x) ≈ f(x)``.
+- ``tests/test_phase17.py::test_poly_times_tanh_squared_unevaluated``
+  → ``test_poly_times_tanh_squared_via_ibp`` — same pattern; the
+  identity ``tanh²(x) = 1 − sech²(x)`` makes the integrand
+  elementary (the earlier docstring's "polylogarithm" label was
+  incorrect).  Track E1 produces ``x²/2 − x·tanh(x) + log(cosh(x))``.
+
+### Notes
+
+- Anti-pattern guard: this is ONE generic algorithm, not a
+  helper-per-shape.  The lesson check in
+  ``code/specs/macsyma-finish-plan.md`` forbids
+  ``_int_x_times_sin``-style additions; the new module's only
+  public entry is the single ``try_ibp_tabular`` function.
+- Termination: the D-column terminates at ``u^(N) = 0`` (guaranteed
+  for polynomial ``u``); the I-column terminates at ``N`` steps
+  (matched to D); the partition search is ``2^n − 2`` where
+  ``n ≤ 5`` factors.  No unbounded recursion.
+
 ## 0.72.0 — 2026-05-22
 
 **Phase 48 — Apart for repeated linear factors.**

--- a/code/packages/python/symbolic-vm/pyproject.toml
+++ b/code/packages/python/symbolic-vm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-symbolic-vm"
-version = "0.72.0"
+version = "0.73.0"
 description = "Pluggable symbolic VM — evaluates symbolic-ir trees through swappable backends (strict numeric vs. Mathematica-style symbolic rewriting)."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/symbolic-vm/src/symbolic_vm/ibp_tabular.py
+++ b/code/packages/python/symbolic-vm/src/symbolic_vm/ibp_tabular.py
@@ -1,0 +1,414 @@
+"""Generic tabular integration-by-parts fallback — Track E1.
+
+When the pipeline's specific shape-aware handlers (Phase 1, Phase 3–28,
+Phase 33–38, Phase 23 special-function fallbacks, Elliptic) have all
+returned ``None`` for a ``Mul``-shaped integrand, this module makes a
+last-ditch attempt to close the integral by **generic tabular IBP**.
+
+The algorithm
+=============
+
+For an integrand of the form ``f = u(x) · w(x)``:
+
+1. Identify a factorisation where ``u`` is **polynomial** in *x* (so its
+   derivative chain ``u, u', u'', …`` terminates at zero in a finite
+   number of steps ``N = deg(u) + 1``) and ``w`` is **integrable** (its
+   antiderivative ``∫w dx`` has a closed form via the existing
+   ``_integrate`` pipeline).
+2. Build the two columns:
+
+   ===========  ===============================
+   k            D-column (differentiate)   I-column (integrate)
+   ===========  ===============================
+   0            ``u``                      ``w``
+   1            ``u'``                     ``∫w dx``
+   2            ``u''``                    ``∫∫w dx``
+   …            …                          …
+   N            ``0``  (terminates)        ``I^N(w)``
+   ===========  ===============================
+
+3. The result is the alternating sum
+
+   ``∫ u·w dx  =  Σ_{k=0}^{N-1}  (-1)^k · u^(k)(x) · I^(k+1)(w)``
+
+   The trailing remainder ``(-1)^N · ∫ u^(N) · I^N(w) dx`` vanishes
+   because ``u^(N) = 0``.
+
+Why "tabular"?
+==============
+
+This is the textbook table that lecturers draw for ``∫ x³ cos x dx``:
+
+::
+
+    D     |    I
+    ------+-----------
+    x³    |    cos x
+    3x²   |    sin x
+    6x    |   −cos x
+    6     |   −sin x
+    0     |    cos x
+
+Multiplying down diagonals with alternating signs gives
+``x³ sin x + 3x² cos x − 6x sin x − 6 cos x``.
+
+When this fires (and when it doesn't)
+=====================================
+
+This is a **fallback** — it runs only after every other handler has
+returned ``None``.  The point is to close integrals that the per-shape
+helpers don't cover, *not* to replace them.  Common patterns it handles
+that fall through earlier:
+
+- Nested ``Mul`` trees where ``a · b · c`` is parsed as
+  ``Mul(a, Mul(b, c))`` and the per-shape helpers only look at the
+  outer two arguments.
+- Three-or-more-factor products where two factors group into a
+  polynomial and the rest forms an integrable kernel.
+
+It deliberately does **not**:
+
+- Recurse into itself.  Tabular has a natural termination on the D side
+  (``u^(N) = 0``), but if the I-column hits an integrand whose
+  antiderivative also needs tabular IBP we'd risk infinite descent.
+  Bounded one-level recursion via the standard ``_integrate`` pipeline
+  is enough for the realistic gap cases; we stop there.
+- Split into more than two pieces.  The split is always
+  ``factors  →  (polynomial-part, integrable-part)`` with a single
+  ``w``.  Multi-way decompositions can be expressed as repeated
+  applications of the same rule.
+
+Termination
+===========
+
+The D-column terminates at the first ``0`` derivative — guaranteed for a
+true polynomial.  We bound the loop at ``MAX_DEGREE + 2`` as a defensive
+sanity check; any polynomial with degree above that is unlikely to
+benefit from tabular IBP (the result blows up combinatorially).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from itertools import combinations
+
+from polynomial import normalize
+from symbolic_ir import (
+    ADD,
+    INTEGRATE,
+    MUL,
+    NEG,
+    IRApply,
+    IRInteger,
+    IRNode,
+    IRSymbol,
+)
+
+from symbolic_vm.polynomial_bridge import to_rational
+
+# ---------------------------------------------------------------------------
+# Tunables — keep tabular bounded so we never explore a combinatorial blow-up.
+# ---------------------------------------------------------------------------
+
+#: Maximum polynomial degree we'll differentiate.  Pure polynomials with
+#: very high degree produce huge tabular outputs (each level grows the
+#: assembled IR by O(deg)); the elementary-functions chain isn't the
+#: right tool for those.  Eight is a comfortable upper bound — covers
+#: every textbook IBP example without exploring quadratic-in-deg expansion.
+_MAX_POLY_DEGREE = 8
+
+#: Maximum number of ``Mul`` factors we consider after flattening.  With n
+#: factors we try ``2^n − 2`` non-trivial subset splits — five factors is
+#: 30 splits, plenty for realistic engineering integrands.
+_MAX_FACTORS = 5
+
+ZERO = IRInteger(0)
+ONE = IRInteger(1)
+NEG_ONE = IRInteger(-1)
+
+
+# ---------------------------------------------------------------------------
+# Mul flattening — keep the search across factor-orderings explicit
+# ---------------------------------------------------------------------------
+
+
+def _flatten_mul(node: IRNode) -> list[IRNode]:
+    """Return the leaves of a (possibly nested-binary) ``Mul`` tree.
+
+    ``Mul(a, Mul(b, Mul(c, d)))`` flattens to ``[a, b, c, d]``.  The VM
+    emits binary ``Mul`` nodes throughout but users wrote (and expect) a
+    flat associative product — without flattening, the IBP search would
+    miss splits like ``u = a·c, w = b·d`` purely because the parse tree
+    happened to group differently.
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return [node]
+    result: list[IRNode] = []
+    for arg in node.args:
+        result.extend(_flatten_mul(arg))
+    return result
+
+
+def _multiply_ir(factors: list[IRNode]) -> IRNode:
+    """Rebuild a left-associative ``Mul`` chain from a list of factors.
+
+    Empty list → ``1`` (the empty product).  Single factor returns
+    itself so downstream rewriters see the simplest shape.
+    """
+    if not factors:
+        return ONE
+    if len(factors) == 1:
+        return factors[0]
+    acc = factors[0]
+    for f in factors[1:]:
+        acc = IRApply(MUL, (acc, f))
+    return acc
+
+
+# ---------------------------------------------------------------------------
+# Polynomial-degree helpers — used to bound the differentiation chain
+# ---------------------------------------------------------------------------
+
+
+def _polynomial_degree(node: IRNode, x: IRSymbol) -> int | None:
+    """Return the degree of *node* as a polynomial in *x*, or ``None``.
+
+    Anything outside ``Q[x]`` (rationals, transcendentals, free symbols
+    other than *x*) returns ``None``.  A non-zero constant returns ``0``;
+    the zero polynomial returns ``-1`` so the caller can treat the
+    "drop-the-factor" partition consistently.
+    """
+    r = to_rational(node, x)
+    if r is None:
+        return None
+    num, den = r
+    if len(normalize(den)) > 1:
+        return None  # rational, not polynomial in x
+    num_n = normalize(num)
+    if not num_n:
+        return -1  # zero
+    # Strip trailing zeros — polynomial normalize already does this but
+    # we double-check so the public contract (length-1 ⇒ constant) holds
+    # for callers that mix-and-match coefficient providers.
+    return len(num_n) - 1
+
+
+# ---------------------------------------------------------------------------
+# "Did the recursive integrate close?" — single source of truth
+# ---------------------------------------------------------------------------
+
+
+def _contains_integrate(node: IRNode) -> bool:
+    """True if *node* contains any unevaluated ``Integrate(...)`` sub-tree.
+
+    Used to reject I-column entries that the ``_integrate`` callback
+    couldn't close to a true antiderivative.  Tabular IBP only emits a
+    result when **every** ``∫w, ∫∫w, …, ∫^N w`` is fully closed —
+    otherwise the assembled sum would still contain an unevaluated
+    integral and the caller's "did we make progress?" check would fail.
+    """
+    if isinstance(node, IRApply):
+        if node.head == INTEGRATE:
+            return True
+        return any(_contains_integrate(a) for a in node.args)
+    return False
+
+
+# ---------------------------------------------------------------------------
+# The fallback itself
+# ---------------------------------------------------------------------------
+
+
+def try_ibp_tabular(
+    f: IRNode,
+    x: IRSymbol,
+    integrate_fn: Callable[[IRNode], IRNode | None],
+    diff_fn: Callable[[IRNode], IRNode],
+    simplify_fn: Callable[[IRNode], IRNode] | None = None,
+) -> IRNode | None:
+    """Attempt generic tabular IBP on a ``Mul``-shaped integrand.
+
+    Parameters
+    ----------
+    f
+        The integrand.  Must be ``IRApply`` headed by ``MUL`` for IBP to
+        fire; anything else short-circuits to ``None``.
+    x
+        Integration variable.
+    integrate_fn
+        Recursive integrator for the I-column.  Conventionally the
+        caller passes the same ``_integrate`` Phase-1 pattern table that
+        the outer handler runs first — this keeps the recursion bounded
+        (no re-entry into tabular IBP) and ensures the I-column entries
+        use the existing closed-form library.
+    diff_fn
+        Differentiator for the D-column.  Conventionally ``_diff``.
+    simplify_fn
+        Optional callable applied to each D/I column entry after raw
+        differentiation / integration — usually ``vm.eval``.  The
+        polynomial-degree-bound check and zero-detection both depend on
+        the entries being in canonical form; without simplification a
+        ``D[k]`` of ``0`` might show up as ``Add(-2, 2)`` and the loop
+        wouldn't terminate.  If ``None``, raw outputs are used (the
+        algorithm still works, just less aggressively).
+
+    Returns
+    -------
+    IRNode | None
+        Closed-form antiderivative as IR, or ``None`` when no viable
+        ``(u, w)`` split was found.  ``None`` is the signal to the
+        caller "this fallback can't help; leave the integral
+        unevaluated."
+    """
+    # Only fires on Mul — everything else has dedicated handlers.
+    if not isinstance(f, IRApply) or f.head != MUL:
+        return None
+
+    factors = _flatten_mul(f)
+    if len(factors) < 2 or len(factors) > _MAX_FACTORS:
+        return None
+
+    # Enumerate non-trivial subset partitions: U has at least one factor
+    # and at most n-1 factors (leaving w non-empty).  Prefer smaller U
+    # first — tabular IBP is most efficient when ``u`` is low-degree.
+    n = len(factors)
+    indices = list(range(n))
+    for u_size in range(1, n):
+        for u_idx in combinations(indices, u_size):
+            u_set = set(u_idx)
+            u_factors = [factors[i] for i in indices if i in u_set]
+            w_factors = [factors[i] for i in indices if i not in u_set]
+            result = _try_split(
+                u_factors,
+                w_factors,
+                x,
+                integrate_fn,
+                diff_fn,
+                simplify_fn,
+            )
+            if result is not None:
+                return result
+    return None
+
+
+def _try_split(
+    u_factors: list[IRNode],
+    w_factors: list[IRNode],
+    x: IRSymbol,
+    integrate_fn: Callable[[IRNode], IRNode | None],
+    diff_fn: Callable[[IRNode], IRNode],
+    simplify_fn: Callable[[IRNode], IRNode] | None,
+) -> IRNode | None:
+    """Try ``u = ∏ u_factors``, ``w = ∏ w_factors`` as the tabular split.
+
+    Returns the assembled antiderivative, or ``None`` if any of the
+    well-defined preconditions fail:
+
+    1. ``u`` is a polynomial in *x* of bounded degree.
+    2. Each iterated integral ``∫^k w dx`` for k = 1..N closes via
+       ``integrate_fn`` (no residual unevaluated ``Integrate``).
+
+    The ``u`` polynomial-check rejects splits where any ``u`` factor
+    isn't polynomial — e.g. ``u_factors = [sin(x)]`` immediately fails
+    because ``sin(x)`` isn't in Q[x].
+    """
+    u_ir = _multiply_ir(u_factors)
+    if simplify_fn is not None:
+        u_ir = simplify_fn(u_ir)
+
+    deg = _polynomial_degree(u_ir, x)
+    if deg is None:
+        return None
+    if deg < 0:
+        # u is the zero polynomial — ∫ 0·w dx = 0.  Edge case, but
+        # consistent with the algorithm.
+        return ZERO
+    if deg > _MAX_POLY_DEGREE:
+        return None
+
+    # The D-column: u, u', u'', ..., 0 (the +1 buys us the terminating
+    # row at index = deg+1; in practice the loop exits earlier when the
+    # derivative simplifies to literal zero).
+    d_col: list[IRNode] = [u_ir]
+    cur: IRNode = u_ir
+    for _ in range(deg + 1):
+        cur = diff_fn(cur)
+        if simplify_fn is not None:
+            cur = simplify_fn(cur)
+        d_col.append(cur)
+        if _is_zero(cur):
+            break
+    # After this loop the last entry is either literal zero or "we
+    # exceeded deg+1 differentiations, polynomial assumption is wrong".
+    if not _is_zero(d_col[-1]):
+        return None
+    N = len(d_col) - 1  # u^(N) = 0; the trailing sum vanishes
+
+    # The I-column: w, ∫w, ∫∫w, ..., ∫^N w.  Each step uses the recursive
+    # integrate_fn; if any step fails to close, abort the partition.
+    w_ir = _multiply_ir(w_factors)
+    if simplify_fn is not None:
+        w_ir = simplify_fn(w_ir)
+    # An integrable ``w`` that *happens* to itself simplify to a
+    # polynomial in x would also be handled here, but the polynomial
+    # path through the outer handler is faster.  We don't bail on it
+    # explicitly — the algorithm still produces a correct result.
+    i_col: list[IRNode] = [w_ir]
+    cur = w_ir
+    for _ in range(N):
+        integrated = integrate_fn(cur)
+        if integrated is None:
+            return None
+        if simplify_fn is not None:
+            integrated = simplify_fn(integrated)
+        if _contains_integrate(integrated):
+            return None  # didn't close — abandon this split
+        i_col.append(integrated)
+        cur = integrated
+
+    # Assemble: Σ_{k=0}^{N-1} (-1)^k · D[k] · I[k+1].
+    pieces: list[IRNode] = []
+    for k in range(N):
+        term = IRApply(MUL, (d_col[k], i_col[k + 1]))
+        if k % 2 == 1:
+            term = IRApply(NEG, (term,))
+        pieces.append(term)
+
+    if not pieces:
+        return ZERO
+    result: IRNode = pieces[0]
+    for term in pieces[1:]:
+        result = IRApply(ADD, (result, term))
+    return result
+
+
+def _is_zero(node: IRNode) -> bool:
+    """True iff *node* canonicalises to the integer literal ``0``.
+
+    We only check the post-simplification form because the loop calls
+    ``simplify_fn`` before this predicate.  A non-canonical zero like
+    ``Sub(2, 2)`` would slip through, which is why ``simplify_fn`` is
+    strongly recommended at the call site.
+    """
+    if isinstance(node, IRInteger) and node.value == 0:
+        return True
+    if (
+        isinstance(node, IRApply)
+        and node.head == NEG
+        and len(node.args) == 1
+    ):
+        return _is_zero(node.args[0])
+    return False
+
+
+__all__ = ["try_ibp_tabular"]
+# Re-export the small helpers for unit-testing visibility.  External
+# callers should only use ``try_ibp_tabular`` — the rest are
+# implementation details we expose for white-box tests.
+__all__.extend(
+    [
+        "_flatten_mul",
+        "_polynomial_degree",
+        "_contains_integrate",
+    ]
+)

--- a/code/packages/python/symbolic-vm/src/symbolic_vm/integrate.py
+++ b/code/packages/python/symbolic-vm/src/symbolic_vm/integrate.py
@@ -125,12 +125,14 @@ from symbolic_vm.exp_hyp_integral import (
 )
 from symbolic_vm.exp_integral import exp_integral
 from symbolic_vm.exp_trig_integral import exp_cos_integral, exp_sin_integral
+from symbolic_vm.derivative import _diff as _vm_diff  # noqa: F401 — used in handler
 from symbolic_vm.hermite import hermite_reduce
 from symbolic_vm.hyp_power_integral import (
     cosh_power_integral,
     sinh_power_integral,
     sinh_times_cosh_power,
 )
+from symbolic_vm.ibp_tabular import try_ibp_tabular
 from symbolic_vm.log_integral import log_poly_integral
 from symbolic_vm.mixed_integral import mixed_integral
 from symbolic_vm.polynomial_bridge import (
@@ -254,6 +256,18 @@ def integrate() -> Handler:
             _elliptic_e_result = _try_incomplete_elliptic_e(f, x)
             if _elliptic_e_result is not None:
                 return _elliptic_e_result
+            # Track E1: generic tabular IBP fallback.  Fires after every
+            # shape-specific handler has returned None.  See
+            # ``ibp_tabular.py`` for the algorithm.
+            ibp_result = try_ibp_tabular(
+                f,
+                x,
+                integrate_fn=lambda g: _integrate(g, x),
+                diff_fn=lambda g: vm.eval(_vm_diff(g, x)),
+                simplify_fn=vm.eval,
+            )
+            if ibp_result is not None:
+                return vm.eval(ibp_result)
             return IRApply(INTEGRATE, (f, x))
         return vm.eval(result)
 

--- a/code/packages/python/symbolic-vm/tests/test_ibp.py
+++ b/code/packages/python/symbolic-vm/tests/test_ibp.py
@@ -1,0 +1,277 @@
+"""Track E1 — generic tabular integration-by-parts fallback tests.
+
+These exercise the ``ibp_tabular`` module that runs **after** every
+shape-specific integration handler has returned ``None``.  The test
+plan:
+
+1. **Acceptance #1** — ``∫ x·sin(x) dx`` closes to ``sin(x) − x·cos(x)``.
+2. **Acceptance #2** — ``∫ x²·eˣ dx`` closes to ``(x² − 2x + 2)·eˣ``.
+3. **Higher-degree polynomial × trig** — ``∫ x³·cos(x) dx``.
+4. **Gap closed by the new fallback** — ``∫ x·sin(x)·cos(x) dx``, a
+   three-factor Mul that the per-shape handlers don't recognise but
+   tabular IBP closes via the partition ``u = x, w = sin(x)·cos(x)``.
+5. **Fallthrough on no viable split** — ``∫ 1/x dx`` returns ``log(x)``
+   via the existing handler; tabular IBP doesn't fire (no Mul).
+6. **Fallthrough on un-integrable factor** — ``∫ sin(x²) dx`` is a
+   Fresnel integral; tabular IBP can't help and the special-function
+   handler returns the Fresnel form; the engine does **not** emit a
+   bogus elementary closed form.
+
+All correctness checks use **numeric differentiation of the returned
+antiderivative** vs. the original integrand.  This avoids hard-coding
+the exact algebraic form of the answer — any equivalent expression
+(``Sub(Sin(x), Mul(x, Cos(x)))`` vs. ``Add(Sin(x), Neg(Mul(x, Cos(x))))``
+vs. anything the simplifier picks tomorrow) is accepted as long as
+the symbolic antiderivative evaluates to the correct numeric
+antiderivative.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+from symbolic_ir import (
+    ADD,
+    COS,
+    DIV,
+    EXP,
+    INTEGRATE,
+    LOG,
+    MUL,
+    NEG,
+    POW,
+    SIN,
+    SUB,
+    IRApply,
+    IRFloat,
+    IRInteger,
+    IRNode,
+    IRRational,
+    IRSymbol,
+)
+
+from symbolic_vm import VM, SymbolicBackend
+
+X = IRSymbol("x")
+
+
+@pytest.fixture
+def vm() -> VM:
+    return VM(SymbolicBackend())
+
+
+# ---------------------------------------------------------------------------
+# Helpers — numeric evaluation of a returned antiderivative.
+# ---------------------------------------------------------------------------
+
+
+def _integrate(f: IRNode) -> IRApply:
+    return IRApply(INTEGRATE, (f, X))
+
+
+def _eval_ir(node: IRNode, x_val: float) -> float:  # noqa: PLR0911, PLR0912
+    """Walk an IR antiderivative and evaluate it at ``x = x_val``.
+
+    Only the subset of heads the integration handler emits is covered;
+    anything else raises so test failures show up as a clear
+    ``ValueError`` instead of a wrong numeric answer.
+    """
+    if isinstance(node, IRInteger):
+        return float(node.value)
+    if isinstance(node, IRRational):
+        return node.numer / node.denom
+    if isinstance(node, IRFloat):
+        return node.value
+    if isinstance(node, IRSymbol):
+        if node == X:
+            return x_val
+        raise ValueError(f"unknown free symbol: {node}")
+    assert isinstance(node, IRApply), f"unexpected IR shape: {node!r}"
+    head = node.head
+    if head == ADD:
+        return sum(_eval_ir(a, x_val) for a in node.args)
+    if head == SUB:
+        return _eval_ir(node.args[0], x_val) - _eval_ir(node.args[1], x_val)
+    if head == MUL:
+        result = 1.0
+        for a in node.args:
+            result *= _eval_ir(a, x_val)
+        return result
+    if head == DIV:
+        return _eval_ir(node.args[0], x_val) / _eval_ir(node.args[1], x_val)
+    if head == NEG:
+        return -_eval_ir(node.args[0], x_val)
+    if head == POW:
+        return _eval_ir(node.args[0], x_val) ** _eval_ir(node.args[1], x_val)
+    if head == SIN:
+        return math.sin(_eval_ir(node.args[0], x_val))
+    if head == COS:
+        return math.cos(_eval_ir(node.args[0], x_val))
+    if head == EXP:
+        return math.exp(_eval_ir(node.args[0], x_val))
+    if head == LOG:
+        return math.log(_eval_ir(node.args[0], x_val))
+    raise ValueError(f"unsupported head in test eval: {head}")
+
+
+def _trapezoidal(integrand_fn, a: float, b: float, n: int = 50_000) -> float:
+    """Plain trapezoidal rule — used as ground truth for definite integrals."""
+    h = (b - a) / n
+    total = 0.5 * (integrand_fn(a) + integrand_fn(b))
+    for i in range(1, n):
+        total += integrand_fn(a + i * h)
+    return total * h
+
+
+def _contains_head(node: IRNode, head: IRSymbol) -> bool:
+    """Recursively check whether *node* contains an ``IRApply`` with *head*."""
+    if isinstance(node, IRApply):
+        if node.head == head:
+            return True
+        return any(_contains_head(a, head) for a in node.args)
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — Acceptance: ∫ x·sin(x) dx
+# ---------------------------------------------------------------------------
+
+
+def test_acceptance_x_times_sin_x(vm: VM) -> None:
+    """``∫ x·sin(x) dx`` closes and the antiderivative is numerically correct."""
+    integrand = IRApply(MUL, (X, IRApply(SIN, (X,))))
+    out = vm.eval(_integrate(integrand))
+    assert not _contains_head(out, INTEGRATE), f"not closed: {out}"
+    # F(1) − F(0) should equal ∫₀¹ x·sin(x) dx = sin(1) − cos(1) ≈ 0.30116867.
+    diff = _eval_ir(out, 1.0) - _eval_ir(out, 0.0)
+    expected = math.sin(1.0) - math.cos(1.0) * 1.0 - (0.0 - math.cos(0.0) * 0.0)
+    # The classical antiderivative is sin(x) − x·cos(x); evaluate at 1 and 0:
+    # = (sin 1 − cos 1) − 0 = sin 1 − cos 1 ≈ 0.30116867.
+    expected_alt = math.sin(1.0) - math.cos(1.0)
+    assert math.isclose(diff, expected, abs_tol=1e-9)
+    assert math.isclose(diff, expected_alt, abs_tol=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — Acceptance: ∫ x²·eˣ dx
+# ---------------------------------------------------------------------------
+
+
+def test_acceptance_xsquared_times_exp_x(vm: VM) -> None:
+    """``∫ x²·eˣ dx = (x² − 2x + 2)·eˣ`` (classic IBP result)."""
+    integrand = IRApply(MUL, (IRApply(POW, (X, IRInteger(2))), IRApply(EXP, (X,))))
+    out = vm.eval(_integrate(integrand))
+    assert not _contains_head(out, INTEGRATE), f"not closed: {out}"
+    # Evaluate the symbolic antiderivative at x = 2 and x = 0.  Known
+    # value: F(2) − F(0) = (4 − 4 + 2)·e² − (0 − 0 + 2)·e⁰ = 2e² − 2.
+    diff = _eval_ir(out, 2.0) - _eval_ir(out, 0.0)
+    expected = 2.0 * math.exp(2.0) - 2.0
+    assert math.isclose(diff, expected, abs_tol=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — Higher-degree polynomial × trig: ∫ x³·cos(x) dx
+# ---------------------------------------------------------------------------
+
+
+def test_higher_degree_xcubed_times_cos_x(vm: VM) -> None:
+    """``∫ x³·cos(x) dx`` closes.
+
+    Closed form: ``x³·sin(x) + 3x²·cos(x) − 6x·sin(x) − 6·cos(x) + C``.
+    We check numerically at x = 1 vs. x = 0 against the trapezoidal rule.
+    """
+    integrand = IRApply(MUL, (IRApply(POW, (X, IRInteger(3))), IRApply(COS, (X,))))
+    out = vm.eval(_integrate(integrand))
+    assert not _contains_head(out, INTEGRATE), f"not closed: {out}"
+    diff = _eval_ir(out, 1.0) - _eval_ir(out, 0.0)
+    numeric = _trapezoidal(lambda xv: xv**3 * math.cos(xv), 0.0, 1.0)
+    assert math.isclose(diff, numeric, abs_tol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — Three-factor Mul gap closed by the new fallback.
+# ---------------------------------------------------------------------------
+
+
+def test_three_factor_x_sin_cos_via_ibp(vm: VM) -> None:
+    """``∫ x·sin(x)·cos(x) dx`` — the IBP fallback closes this case.
+
+    Before Track E1, the per-shape handlers ``_try_trig_product``
+    matched only two-factor ``MUL(poly, sin/cos(linear))`` patterns and
+    bailed on the three-factor shape.  Tabular IBP closes it via
+    ``u = x, w = sin(x)·cos(x)`` (recursive integrate gives
+    ``−cos(2x)/4`` for ``∫w``).
+
+    Numeric ground truth at x = 0..1:
+    ``∫₀¹ x·sin(x)·cos(x) dx = ∫₀¹ x·sin(2x)/2 dx ≈ 0.21770``.
+    """
+    integrand = IRApply(
+        MUL,
+        (X, IRApply(MUL, (IRApply(SIN, (X,)), IRApply(COS, (X,))))),
+    )
+    out = vm.eval(_integrate(integrand))
+    assert not _contains_head(out, INTEGRATE), (
+        f"expected closed form via tabular IBP, got: {out}"
+    )
+    diff = _eval_ir(out, 1.0) - _eval_ir(out, 0.0)
+    numeric = _trapezoidal(lambda xv: xv * math.sin(xv) * math.cos(xv), 0.0, 1.0)
+    assert math.isclose(diff, numeric, abs_tol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — Fallthrough: ``∫ 1/x dx`` uses the existing log handler, IBP not
+# fired (the integrand isn't a Mul, so tabular short-circuits to None).
+# ---------------------------------------------------------------------------
+
+
+def test_fallthrough_one_over_x_returns_log(vm: VM) -> None:
+    """``∫ 1/x dx = log(x)`` is closed by the existing handler.
+
+    The new IBP fallback short-circuits on non-``Mul`` integrands —
+    ``Div(1, x)`` has head ``DIV``, so ``try_ibp_tabular`` returns
+    ``None`` immediately and the elementary log rule provides the
+    closed form unchanged from before Track E1.
+    """
+    integrand = IRApply(DIV, (IRInteger(1), X))
+    out = vm.eval(_integrate(integrand))
+    assert not _contains_head(out, INTEGRATE), f"expected closed form: {out}"
+    assert _contains_head(out, LOG)
+    # F(2) − F(1) = log 2 ≈ 0.693147.
+    diff = _eval_ir(out, 2.0) - _eval_ir(out, 1.0)
+    assert math.isclose(diff, math.log(2.0), abs_tol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Test 6 — Fallthrough on un-integrable factor: ∫ sin(x²) dx (Fresnel).
+# ---------------------------------------------------------------------------
+
+
+def test_fallthrough_fresnel_sin_xsq(vm: VM) -> None:
+    """``∫ sin(x²) dx`` — Fresnel; IBP can't help.
+
+    The special-function handler (Phase 23) returns the Fresnel form
+    *before* tabular IBP runs, so the result mentions ``FresnelS``.
+    The critical correctness property is that tabular IBP doesn't
+    invent a bogus elementary closed form behind its back — the
+    Fresnel form must survive.  Even if Phase 23 were absent, the
+    integrand is **not a Mul**, so ``try_ibp_tabular`` would also
+    return ``None`` and the result would remain ``Integrate(...)``.
+    """
+    integrand = IRApply(SIN, (IRApply(POW, (X, IRInteger(2))),))
+    out = vm.eval(_integrate(integrand))
+    # Either the Fresnel special-function form (if Phase 23 fires) or
+    # the unevaluated ``Integrate`` form must come back — but NOT a
+    # bogus elementary closed form.
+    fresnel = IRSymbol("FresnelS")
+    has_fresnel = _contains_head(out, fresnel)
+    has_unevaluated = _contains_head(out, INTEGRATE)
+    assert has_fresnel or has_unevaluated, (
+        f"expected Fresnel or unevaluated, got: {out}"
+    )
+    # Crucially: no SIN/COS antiderivative-shape fabrication.  The
+    # Fresnel function may appear inside the result but it's wrapped
+    # as ``FresnelS(...)`` — the tell is the FresnelS head, not loose
+    # ``Sin`` over a bare ``x``.  We just check the engine did not lie.
+    if not has_fresnel:
+        assert has_unevaluated

--- a/code/packages/python/symbolic-vm/tests/test_phase16.py
+++ b/code/packages/python/symbolic-vm/tests/test_phase16.py
@@ -460,12 +460,22 @@ class TestPhase16_CothPowers:
 class TestPhase16_Fallthrough:
     """Inputs that must return unevaluated Integrate — deferred cases."""
 
-    def test_poly_times_sech_squared_unevaluated(self) -> None:
-        """∫ x·sech²(x) dx — poly×power not yet implemented."""
+    def test_poly_times_sech_squared_via_ibp(self) -> None:
+        """``∫ x·sech²(x) dx`` — closes via Track E1 generic tabular IBP.
+
+        The integrand has no shape-specific handler in Phase 16 (the
+        per-shape sech-power code requires a bare ``Pow(Sech(...), n)``
+        without a polynomial multiplier).  Track E1's tabular IBP
+        partitions ``u = x, w = sech²(x)`` and integrates to
+        ``x·tanh(x) − log(cosh(x))``.  Previously this case was
+        deferred and asserted unevaluated; the generic fallback now
+        closes it.  The numeric F' = f check guards correctness.
+        """
         vm = _make_vm()
         f = IRApply(MUL, (X, _pow(_sech(X), _INT(2))))
         F = _integrate_ir(vm, f)
-        _is_unevaluated(f, F)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
 
     def test_sech_nonlinear_arg_squared_unevaluated(self) -> None:
         """∫ sech²(x²) dx — non-linear argument returns unevaluated."""

--- a/code/packages/python/symbolic-vm/tests/test_phase17.py
+++ b/code/packages/python/symbolic-vm/tests/test_phase17.py
@@ -296,14 +296,28 @@ class TestPhase17_TanhPowers:
 class TestPhase17_Fallthrough:
     """Cases that must stay unevaluated — fallthrough to the user."""
 
-    def test_poly_times_tanh_squared_unevaluated(self) -> None:
-        """∫ x·tanh²(x) dx — poly×tanh^n is non-elementary (polylogarithm)."""
+    def test_poly_times_tanh_squared_via_ibp(self) -> None:
+        """``∫ x·tanh²(x) dx`` — closes via Track E1 generic tabular IBP.
+
+        The earlier docstring labelled this "non-elementary
+        (polylogarithm)" but that's incorrect: the identity
+        ``tanh²(x) = 1 − sech²(x)`` makes the integrand elementary
+        (``x − x·sech²(x)``), so the antiderivative
+        ``x²/2 − x·tanh(x) + log(cosh(x))`` is fully elementary.
+
+        Before Track E1, no shape-specific handler matched
+        ``polynomial × tanh²`` and the integrand stayed unevaluated.
+        The generic tabular IBP fallback now closes it via
+        ``u = x, w = tanh²(x)``.  ``F'(x) = f(x)`` is verified
+        numerically.
+        """
         from symbolic_ir import MUL  # noqa: PLC0415
 
         vm = _make_vm()
         f = IRApply(MUL, (X, _pow(_tanh(X), _INT(2))))
         F = _integrate_ir(vm, f)
-        _is_unevaluated(f, F)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
 
     def test_tanh_nonlinear_arg_unevaluated(self) -> None:
         """∫ tanh²(x²) dx — non-linear argument, unevaluated."""


### PR DESCRIPTION
## Summary

- Adds a **generic tabular integration-by-parts** fallback in Python `symbolic-vm` (new module `ibp_tabular.py`).  Fires LAST in the integration handler, after every shape-specific elementary, Phase 23 special-function, and Elliptic recogniser has returned `None`.
- Closes ∫ u·w dx where u is polynomial and w is integrable, including three-factor `Mul` shapes that per-shape recognisers don't match.
- **One generic algorithm, no per-shape helpers** — per the `macsyma-finish-plan.md` anti-pattern guard.

## Algorithm

For ∫ u·w dx with u polynomial of degree N-1 and w integrable:

```
∫ u·w dx  =  Σ_{k=0}^{N-1}  (-1)^k · u^(k)(x) · I^(k+1)(w)
```

Derived from N successive IBP applications; the trailing remainder vanishes since `u^(N) = 0`.  Implementation enumerates `Mul` factor partitions (bounded at `_MAX_FACTORS = 5` and `_MAX_POLY_DEGREE = 8`) and picks the polynomial-on-one-side / integrable-on-the-other split.

## Acceptance check

The spec named ∫ x·sin(x²) dx but acknowledged it's actually a u-substitution case (current main already closes via Phase 7 → `-cos(x²)/2`).  Used the spec's three named alternatives plus a new genuine gap closure as tests:

1. ∫ x·sin(x) dx → `sin(x) − x·cos(x)` ✓
2. ∫ x²·eˣ dx → `(x² − 2x + 2)·eˣ` ✓
3. ∫ x³·cos(x) dx ✓ (higher degree)
4. **New gap closure**: ∫ x·sin(x)·cos(x) dx — three-factor `Mul` that the per-shape `_try_trig_product` didn't match; tabular IBP partitions u = x, w = sin(x)·cos(x), recursive integrate gives `−cos(2x)/4`, antiderivative is `−x·cos(2x)/4 + sin(2x)/8`.
5. ∫ 1/x dx → existing `log(x)` handler (IBP correctly short-circuits on non-`Mul`).
6. ∫ sin(x²) dx → Fresnel form via Phase 23 (IBP correctly declines).

## Two test updates

- `tests/test_phase16.py::test_poly_times_sech_squared_unevaluated` → `..._via_ibp`
- `tests/test_phase17.py::test_poly_times_tanh_squared_unevaluated` → `..._via_ibp`

Both previously asserted these integrals stay unevaluated.  Track E1 now closes them via tabular IBP to elementary closed forms, verified numerically via `F'(x) ≈ f(x)`.  The Phase 17 test's "polylogarithm" docstring label was incorrect — the identity `tanh² = 1 − sech²` makes the integrand elementary.

## Scope

Python only.  Track E2 ports to TS + Rust.

## Test plan

- [ ] CI: `pytest` in `code/packages/python/symbolic-vm` (6 new + all 1500+ existing pass)
- [ ] `ruff` clean on new files
- [ ] Inline security review (pure symbolic — no I/O, no eval, bounded recursion via `_MAX_FACTORS`/`_MAX_POLY_DEGREE` constants) — passed
- [ ] No regression in elementary-table tests (verified locally: 1509 non-macsyma tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)