### PR TITLE
feat(jxl): IC09 JPEG XL Modular lossless codec (0.1.0)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -371,6 +371,7 @@ members = [
     "image-codec-bmp",
     "image-codec-ico",
     "image-codec-jpeg",
+    "image-codec-jxl",
     "image-codec-ppm",
     "image-codec-qoi",
     "image-codec-webp",

--- a/code/packages/rust/image-codec-jxl/BUILD
+++ b/code/packages/rust/image-codec-jxl/BUILD
@@ -1,0 +1,1 @@
+cargo test -p image-codec-jxl -- --nocapture

--- a/code/packages/rust/image-codec-jxl/CHANGELOG.md
+++ b/code/packages/rust/image-codec-jxl/CHANGELOG.md
@@ -1,0 +1,76 @@
+# Changelog — image-codec-jxl
+
+All notable changes to this crate are documented here.
+Versions follow [Semantic Versioning](https://semver.org/).
+
+---
+
+## [0.1.0] — 2026-05-28
+
+### Added
+
+- **`encode_jxl(pixels: &PixelContainer) -> Vec<u8>`** — encodes RGBA images
+  into a simplified JXL Modular naked codestream (`FF 0A` magic).
+
+- **`decode_jxl(data: &[u8]) -> Result<PixelContainer, String>`** — decodes
+  the same format back to a pixel buffer; also detects ISOBMFF containers and
+  extracts the `jxlc` codestream box.
+
+- **`JxlCodec`** — unit struct implementing the `pixel-container::ImageCodec`
+  trait (`mime_type = "image/jxl"`).
+
+- **`VERSION`** constant (`"0.1.0"`).
+
+- **`src/bitwriter.rs`** — MSB-first bit packing (`BitWriter`).
+
+- **`src/bitreader.rs`** — MSB-first bit extraction (`BitReader`) with
+  `align_to_byte()` and `remaining_bytes_from_boundary()`.
+
+- **`src/container.rs`** — container format detection: naked (`FF 0A`) and
+  ISOBMFF (`JXL ` signature + `jxlc` box scan).
+
+- **`src/modular.rs`** — gradient predictor with W/N/NW/NE edge handling,
+  `compute_residuals`, `reconstruct_values`.
+
+- **`src/entropy.rs`** — `encode_rans_block` / `decode_rans_block` (self-
+  describing wire format), `encode_channel_residuals` /
+  `decode_channel_residuals` (sign + magnitude two-pass split).
+
+- **`src/encoder.rs`** — SizeHeader bit encoding (div8 / direct paths, ratio
+  field), full encode pipeline.
+
+- **`src/decoder.rs`** — SizeHeader bit decoding (all ratio values), full
+  decode pipeline including dimension cross-check.
+
+- **`src/rct.rs`** — YCoCg reversible colour transform (forward + inverse,
+  RCT type 6) included for completeness; not used by the current encoder.
+
+- **66 unit tests + 3 doc tests** covering:
+  - BitWriter/BitReader correctness and edge cases
+  - Container detection (naked, ISOBMFF, error paths)
+  - Modular predictor round-trips and boundary conditions
+  - Entropy sign/magnitude split round-trips
+  - RCT lossless round-trip over the full 8bpp colour cube
+  - Full end-to-end `encode_jxl` → `decode_jxl` round-trips for 1×1, 2×2,
+    4×4, 8×8, 32×32, solid colour, gradient, RGBA, transparent, and mixed-
+    alpha images
+  - Error cases (bad magic, too short, empty input)
+  - `ImageCodec` trait and VERSION format
+
+### Architecture notes
+
+- Residuals for 8bpp channels lie in [−255, 255].  The `rans` crate uses a
+  `u8` symbol type (alphabet ≤ 256), so we split each residual into a
+  3-symbol sign stream and a 255-symbol magnitude stream.  This avoids any
+  multi-byte escape scheme and keeps both streams well within the alphabet
+  limit.
+
+- The SizeHeader follows the real JXL spec §4.1 (div8 path and direct path
+  with 2-bit selector), but the metadata after the SizeHeader uses our own
+  simplified binary layout rather than the full JXL ANS-coded metadata
+  sections.  This is intentional for teaching purposes.
+
+- ISOBMFF container detection is implemented (box scanning, `jxlc` lookup)
+  so the crate can strip the wrapper from files produced by libjxl tools,
+  even though decoding the non-simplified internal format would require the
+  full JXL specification.

--- a/code/packages/rust/image-codec-jxl/Cargo.toml
+++ b/code/packages/rust/image-codec-jxl/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "image-codec-jxl"
+version = "0.1.0"
+edition = "2021"
+description = "JPEG XL Modular lossless image encoder/decoder (IC09)"
+
+[dependencies]
+pixel-container = { path = "../pixel-container" }
+rans = { path = "../rans" }

--- a/code/packages/rust/image-codec-jxl/README.md
+++ b/code/packages/rust/image-codec-jxl/README.md
@@ -1,0 +1,118 @@
+# image-codec-jxl
+
+A JPEG XL Modular lossless encoder and decoder (IC09).
+
+## What it does
+
+Converts `PixelContainer` RGBA images to and from a simplified JXL Modular
+codestream.  The encoder emits a **naked codestream** (magic bytes `FF 0A`);
+the decoder accepts both naked codestreams and ISOBMFF-wrapped files.
+
+Compression is lossless: every pixel survives a round-trip unchanged.
+
+## Where it fits in the stack
+
+```
+PixelContainer (pixel-container)
+       │
+       ▼
+image-codec-jxl   ←  this crate
+       │
+       ▼
+Vec<u8> JXL bytes   (ready to write to disk or transmit over the network)
+```
+
+Dependencies: `pixel-container`, `rans`.
+
+## How JPEG XL Modular works (simplified)
+
+1. **SizeHeader** — width and height are encoded as raw MSB-first bits using a
+   compact variable-length scheme from the JXL spec (§4.1).
+
+2. **Gradient predictor** — for each channel (R, G, B, and optionally A) the
+   encoder visits pixels in raster order.  It predicts the current pixel from
+   its four available neighbours (W, N, NW, NE) using the formula:
+   ```
+   grad = W + N − NW
+   pred = clamp(grad, min(W,N,NW,NE), max(W,N,NW,NE))
+   ```
+   The *residual* (actual − predicted) is small and concentrated near zero.
+
+3. **Sign/magnitude split** — since residuals can be in [−255, 255] and the
+   rANS crate uses a `u8` (≤ 256-symbol) alphabet, each residual is split into:
+   - a **sign** symbol (0 = zero, 1 = positive, 2 = negative)
+   - a **magnitude** symbol `|r| − 1 ∈ [0, 254]` (for non-zero residuals)
+
+4. **rANS entropy coding** — both the sign and magnitude streams are compressed
+   with the `rans` crate (Range Asymmetric Numeral Systems), which achieves
+   near-Shannon compression in O(1) per symbol.
+
+## Usage
+
+```rust
+use image_codec_jxl::{encode_jxl, decode_jxl, JxlCodec};
+use pixel_container::{ImageCodec, PixelContainer};
+
+// ── Encode ──────────────────────────────────────────────────────────
+let mut src = PixelContainer::new(640, 480);
+src.fill(200, 100, 50, 255);
+
+let bytes = encode_jxl(&src);
+assert_eq!(&bytes[..2], &[0xFF, 0x0A]); // naked codestream magic
+
+// ── Decode ──────────────────────────────────────────────────────────
+let dst = decode_jxl(&bytes).expect("round-trip decode");
+assert_eq!(dst.pixel_at(0, 0), (200, 100, 50, 255));
+
+// ── Via the ImageCodec trait ─────────────────────────────────────────
+let bytes2 = JxlCodec.encode(&src);
+let dst2   = JxlCodec.decode(&bytes2).unwrap();
+assert_eq!(dst2.pixel_at(319, 239), (200, 100, 50, 255));
+```
+
+## Wire format
+
+```
+[FF 0A]                   naked codestream magic (2 bytes)
+[SizeHeader bits]         variable-length MSB-first bitfield (spec §4.1)
+[padding]                 zero-pad to next byte boundary
+[num_channels u8]         3 (RGB) or 4 (RGBA)
+[width  u32 LE]
+[height u32 LE]
+For each channel:
+  [sign rANS block]       signs: 0=zero, 1=pos, 2=neg
+  [magnitude rANS block]  |r|−1 for non-zero residuals
+```
+
+Each rANS block is self-describing:
+```
+[num_symbols u32 LE]
+[alphabet_size u32 LE]
+[counts: alphabet_size × u32 LE]
+[data_len u32 LE]
+[data_len bytes of rANS bitstream]
+```
+
+## Module map
+
+| Module | Purpose |
+|---|---|
+| `lib.rs` | Public API: `encode_jxl`, `decode_jxl`, `JxlCodec` |
+| `encoder.rs` | Top-level encode pipeline |
+| `decoder.rs` | Top-level decode pipeline |
+| `modular.rs` | Gradient predictor, residual compute/reconstruct |
+| `entropy.rs` | rANS block encode/decode, sign/magnitude split |
+| `container.rs` | Naked vs ISOBMFF detection, `jxlc` box search |
+| `bitwriter.rs` | MSB-first bit packing |
+| `bitreader.rs` | MSB-first bit extraction |
+| `rct.rs` | YCoCg reversible colour transform (for future use) |
+
+## Running tests
+
+```sh
+cargo test -p image-codec-jxl -- --nocapture
+```
+
+## Version
+
+0.1.0

--- a/code/packages/rust/image-codec-jxl/src/bitreader.rs
+++ b/code/packages/rust/image-codec-jxl/src/bitreader.rs
@@ -1,0 +1,168 @@
+//! # BitReader — MSB-first bit extraction
+//!
+//! The decoder counterpart to [`BitWriter`](super::bitwriter::BitWriter).
+//!
+//! Reads individual bits from a byte slice in MSB-first order.  Attempting
+//! to read past the end returns `Err` rather than silently producing garbage.
+//!
+//! ## Alignment helper
+//!
+//! After reading the variable-width SizeHeader, the remaining bytes start on
+//! an arbitrary bit boundary.  `align_to_byte()` advances the cursor to the
+//! next byte boundary so subsequent reads start cleanly.
+
+/// Extracts bits MSB-first from a borrowed byte slice.
+///
+/// # Example
+///
+/// ```rust
+/// use image_codec_jxl::bitreader::BitReader;
+///
+/// let data = &[0b1010_1010u8];
+/// let mut br = BitReader::new(data);
+/// assert_eq!(br.read_bit().unwrap(), true);   // MSB of 0xAA
+/// assert_eq!(br.read_bit().unwrap(), false);
+/// assert_eq!(br.read_bit().unwrap(), true);
+/// ```
+pub struct BitReader<'a> {
+    data: &'a [u8],
+    /// Index of the byte currently being read from.
+    byte_pos: usize,
+    /// Which bit within that byte to read next.  0 = MSB, 7 = LSB.
+    bit_pos: u8,
+}
+
+impl<'a> BitReader<'a> {
+    /// Create a reader over `data`, positioned at the very first bit.
+    pub fn new(data: &'a [u8]) -> Self {
+        BitReader { data, byte_pos: 0, bit_pos: 0 }
+    }
+
+    /// Read the next bit.
+    ///
+    /// Returns `Err` if the bitstream is exhausted.
+    pub fn read_bit(&mut self) -> Result<bool, String> {
+        if self.byte_pos >= self.data.len() {
+            return Err("JXL: unexpected end of bitstream".into());
+        }
+        // Extract the bit at position `bit_pos` counting from the MSB.
+        let bit = (self.data[self.byte_pos] >> (7 - self.bit_pos)) & 1 == 1;
+        self.bit_pos += 1;
+        if self.bit_pos == 8 {
+            self.bit_pos = 0;
+            self.byte_pos += 1;
+        }
+        Ok(bit)
+    }
+
+    /// Read `count` bits (≤ 64), assembling them MSB-first into a `u64`.
+    ///
+    /// The first bit read becomes the most significant of the returned value.
+    pub fn read_bits(&mut self, count: u8) -> Result<u64, String> {
+        let mut value = 0u64;
+        for _ in 0..count {
+            value = (value << 1) | (self.read_bit()? as u64);
+        }
+        Ok(value)
+    }
+
+    /// Advance the cursor to the next byte boundary.
+    ///
+    /// If we are already byte-aligned (`bit_pos == 0`) this is a no-op.
+    /// The skipped bits (padding) are discarded.
+    pub fn align_to_byte(&mut self) {
+        if self.bit_pos > 0 {
+            self.bit_pos = 0;
+            self.byte_pos += 1;
+        }
+    }
+
+    /// Number of *bytes* consumed so far (rounds up if partially into a byte).
+    ///
+    /// After `align_to_byte()` this equals the byte offset of the next clean
+    /// data byte.
+    pub fn bytes_consumed(&self) -> usize {
+        if self.bit_pos > 0 {
+            self.byte_pos + 1
+        } else {
+            self.byte_pos
+        }
+    }
+
+    /// The remaining bytes starting from the next byte boundary.
+    ///
+    /// If the reader is in the middle of a byte, that byte is skipped.
+    /// Useful for switching to a byte-oriented parser after reading the
+    /// bit-packed SizeHeader.
+    pub fn remaining_bytes_from_boundary(&self) -> &'a [u8] {
+        let pos = self.bytes_consumed();
+        let pos = pos.min(self.data.len());
+        &self.data[pos..]
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_single_bit_msb() {
+        let mut br = BitReader::new(&[0x80]); // 1000_0000
+        assert_eq!(br.read_bit().unwrap(), true);
+        assert_eq!(br.read_bit().unwrap(), false);
+    }
+
+    #[test]
+    fn read_eight_bits() {
+        let mut br = BitReader::new(&[0xAB]);
+        assert_eq!(br.read_bits(8).unwrap(), 0xAB);
+    }
+
+    #[test]
+    fn read_across_byte_boundary() {
+        let mut br = BitReader::new(&[0xFF, 0x00]);
+        assert_eq!(br.read_bits(4).unwrap(), 0x0F);  // top 4 bits of 0xFF
+        assert_eq!(br.read_bits(4).unwrap(), 0x0F);  // bottom 4 bits of 0xFF
+        assert_eq!(br.read_bits(8).unwrap(), 0x00);  // second byte
+    }
+
+    #[test]
+    fn exhausted_returns_err() {
+        let mut br = BitReader::new(&[]);
+        assert!(br.read_bit().is_err());
+    }
+
+    #[test]
+    fn align_to_byte_skips_partial() {
+        let mut br = BitReader::new(&[0xFF, 0xAB]);
+        let _ = br.read_bits(3).unwrap();
+        br.align_to_byte();
+        assert_eq!(br.read_bits(8).unwrap(), 0xAB);
+    }
+
+    #[test]
+    fn align_already_aligned_is_noop() {
+        let mut br = BitReader::new(&[0xDE, 0xAD]);
+        br.align_to_byte(); // already at bit 0 of byte 0
+        assert_eq!(br.read_bits(8).unwrap(), 0xDE);
+    }
+
+    #[test]
+    fn bytes_consumed_partial() {
+        let mut br = BitReader::new(&[0xFF]);
+        let _ = br.read_bits(3).unwrap();
+        assert_eq!(br.bytes_consumed(), 1); // partially into byte 0
+    }
+
+    #[test]
+    fn remaining_bytes_after_align() {
+        let mut br = BitReader::new(&[0xFF, 0xAA, 0xBB]);
+        let _ = br.read_bits(1).unwrap();
+        br.align_to_byte();
+        assert_eq!(br.remaining_bytes_from_boundary(), &[0xAA, 0xBB]);
+    }
+}

--- a/code/packages/rust/image-codec-jxl/src/bitwriter.rs
+++ b/code/packages/rust/image-codec-jxl/src/bitwriter.rs
@@ -1,0 +1,163 @@
+//! # BitWriter — MSB-first bit packing
+//!
+//! JPEG XL's SizeHeader and a handful of other early fields are packed as raw
+//! bits in MSB-first order before the rANS-coded sections begin.  This module
+//! provides a simple append-only writer that streams individual bits into a
+//! `Vec<u8>`.
+//!
+//! ## Bit order within a byte
+//!
+//! The most-significant bit of each output byte is written first.  So if you
+//! call `write_bit(1)` then `write_bit(0)` then `write_bit(0)` ... (8 calls)
+//! you get one byte whose top bit is 1 and whose lower seven bits are 0:
+//!
+//! ```text
+//! bit 7  bit 6  bit 5  bit 4  bit 3  bit 2  bit 1  bit 0
+//!  1      0      0      0      0      0      0      0
+//! ```
+//! which equals the byte 0x80.
+//!
+//! ## Flushing
+//!
+//! Call `finish()` to obtain all the bytes.  A partial final byte is
+//! zero-padded in the low bits before being appended.
+
+/// Appends bits MSB-first into a growing byte buffer.
+///
+/// # Example
+///
+/// ```rust
+/// use image_codec_jxl::bitwriter::BitWriter;
+///
+/// let mut bw = BitWriter::new();
+/// bw.write_bits(0b101, 3);  // writes bits 1, 0, 1 in that order
+/// let bytes = bw.finish();
+/// // three bits written → one partial byte: 0b101x_xxxx = 0xA0 (zero-padded)
+/// assert_eq!(bytes[0], 0xA0);
+/// ```
+pub struct BitWriter {
+    /// Completed bytes.
+    bytes: Vec<u8>,
+    /// Byte currently being assembled.
+    current: u8,
+    /// How many bits of `current` are already occupied (0 = none, 7 = all but LSB).
+    bits_used: u8,
+}
+
+impl BitWriter {
+    /// Create an empty writer.
+    pub fn new() -> Self {
+        BitWriter { bytes: Vec::new(), current: 0, bits_used: 0 }
+    }
+
+    /// Append one bit.  `bit = true` → 1, `bit = false` → 0.
+    ///
+    /// Bits are placed from the MSB side of each byte downward.
+    pub fn write_bit(&mut self, bit: bool) {
+        // The next free bit position within `current` is (7 - bits_used),
+        // counting from the MSB.
+        if bit {
+            self.current |= 1 << (7 - self.bits_used);
+        }
+        self.bits_used += 1;
+        if self.bits_used == 8 {
+            // The byte is complete — flush it and start a new one.
+            self.bytes.push(self.current);
+            self.current = 0;
+            self.bits_used = 0;
+        }
+    }
+
+    /// Append the `count` least-significant bits of `value`, MSB-first.
+    ///
+    /// For example `write_bits(0b101, 3)` writes the sequence 1 → 0 → 1.
+    ///
+    /// `count` must be ≤ 64.
+    pub fn write_bits(&mut self, value: u64, count: u8) {
+        // Emit from the most-significant bit of the requested range downward.
+        for shift in (0..count).rev() {
+            self.write_bit((value >> shift) & 1 == 1);
+        }
+    }
+
+    /// Flush any partial byte (zero-padded) and return the complete byte buffer.
+    ///
+    /// The writer is consumed by this call.
+    pub fn finish(mut self) -> Vec<u8> {
+        if self.bits_used > 0 {
+            // Zero-pad the remaining bits on the low side.
+            self.bytes.push(self.current);
+        }
+        self.bytes
+    }
+
+    /// Total bytes that `finish()` would produce right now, without consuming.
+    pub fn byte_count(&self) -> usize {
+        self.bytes.len() + if self.bits_used > 0 { 1 } else { 0 }
+    }
+}
+
+impl Default for BitWriter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_bit_high() {
+        let mut bw = BitWriter::new();
+        bw.write_bit(true);
+        let b = bw.finish();
+        // 1 bit at MSB → byte 0x80
+        assert_eq!(b, &[0x80]);
+    }
+
+    #[test]
+    fn eight_bits_exact_byte() {
+        let mut bw = BitWriter::new();
+        bw.write_bits(0xAB, 8);
+        let b = bw.finish();
+        assert_eq!(b, &[0xAB]);
+    }
+
+    #[test]
+    fn multiple_bytes() {
+        let mut bw = BitWriter::new();
+        bw.write_bits(0xDEAD, 16);
+        let b = bw.finish();
+        assert_eq!(b, &[0xDE, 0xAD]);
+    }
+
+    #[test]
+    fn partial_byte_zero_padded() {
+        let mut bw = BitWriter::new();
+        bw.write_bits(0b101, 3);
+        let b = bw.finish();
+        // bits: 1,0,1,0,0,0,0,0 → 0xA0
+        assert_eq!(b, &[0xA0]);
+    }
+
+    #[test]
+    fn zero_bits_no_output() {
+        let bw = BitWriter::new();
+        assert_eq!(bw.finish(), &[] as &[u8]);
+    }
+
+    #[test]
+    fn byte_count_matches_finish_len() {
+        let mut bw = BitWriter::new();
+        bw.write_bits(0xFF, 8);
+        bw.write_bit(true);
+        assert_eq!(bw.byte_count(), 2);
+        let b = bw.finish();
+        assert_eq!(b.len(), 2);
+    }
+}

--- a/code/packages/rust/image-codec-jxl/src/container.rs
+++ b/code/packages/rust/image-codec-jxl/src/container.rs
@@ -1,0 +1,198 @@
+//! # Container format detection
+//!
+//! A JPEG XL file arrives in one of two forms:
+//!
+//! 1. **Naked codestream** — the raw JXL codestream bytes, starting with the
+//!    two-byte magic `FF 0A`.
+//!
+//! 2. **ISOBMFF container** — the codestream is wrapped in an ISO Base Media
+//!    File Format (MP4-family) box structure.  The file starts with a 12-byte
+//!    `JXL ` signature box, followed by a sequence of typed boxes.  The
+//!    codestream itself lives in the `jxlc` box.
+//!
+//! This module's job is purely to locate the codestream bytes; all bit-level
+//! parsing happens in the encoder and decoder modules.
+//!
+//! ## ISOBMFF box layout
+//!
+//! ```text
+//! ┌──────────────────────────────────────────────────┐
+//! │ 4 bytes: box_size (big-endian u32, includes hdr) │
+//! │ 4 bytes: box_type (ASCII, e.g. "jxlc")           │
+//! │ N bytes: box payload (box_size − 8 bytes)         │
+//! └──────────────────────────────────────────────────┘
+//! ```
+//!
+//! The signature box is always exactly 12 bytes long and carries no payload
+//! beyond its own 12-byte structure (size=12, type=`JXL `, data=`\r\n\x87\n`).
+
+/// Two-byte magic that marks a naked JXL codestream.
+const NAKED_MAGIC: [u8; 2] = [0xFF, 0x0A];
+
+/// Twelve-byte signature that opens every ISOBMFF-wrapped JXL file.
+///
+/// Layout:
+/// - `\x00\x00\x00\x0C` — box_size = 12 (the box is only its header)
+/// - `JXL ` (four ASCII bytes, space is 0x20)
+/// - `\x0D\x0A\x87\x0A` — payload used as a corruption-detection canary
+const ISOBMFF_SIG: [u8; 12] = [
+    0x00, 0x00, 0x00, 0x0C,
+    b'J', b'X', b'L', b' ',
+    0x0D, 0x0A, 0x87, 0x0A,
+];
+
+/// Return the raw codestream bytes from a JXL file, stripping any container
+/// wrapper.
+///
+/// Accepts both naked codestreams (`FF 0A …`) and ISOBMFF containers.  On
+/// success the returned slice begins immediately after the two-byte naked magic
+/// (for naked files) or after the `jxlc` box header (for ISOBMFF files).
+///
+/// # Errors
+///
+/// Returns `Err` if:
+/// - The file is shorter than 2 bytes.
+/// - The first bytes match neither the naked magic nor the ISOBMFF signature.
+/// - An ISOBMFF container does not contain a `jxlc` box.
+/// - A box's size field is malformed (< 8 bytes or extends past EOF).
+pub fn extract_codestream(data: &[u8]) -> Result<&[u8], String> {
+    if data.len() < 2 {
+        return Err("JXL: file too short to be a valid JPEG XL image".into());
+    }
+
+    // ── Naked codestream ────────────────────────────────────────────────
+    if data[0] == NAKED_MAGIC[0] && data[1] == NAKED_MAGIC[1] {
+        // Skip the two-byte magic; the rest is the codestream.
+        return Ok(&data[2..]);
+    }
+
+    // ── ISOBMFF container ───────────────────────────────────────────────
+    if data.len() >= 12 && data[..12] == ISOBMFF_SIG {
+        return find_jxlc_box(data);
+    }
+
+    Err("JXL: unrecognized file signature — not a JPEG XL file".into())
+}
+
+/// Scan the ISOBMFF box chain for a `jxlc` box and return its payload.
+fn find_jxlc_box(data: &[u8]) -> Result<&[u8], String> {
+    let mut pos = 0usize;
+
+    while pos + 8 <= data.len() {
+        // The first 4 bytes are box_size (big-endian u32).
+        // box_size includes the 8-byte header (size + type fields).
+        let box_size = u32::from_be_bytes(
+            data[pos..pos + 4].try_into().unwrap()
+        ) as usize;
+
+        // box_size == 0 means "extends to end of file" (ISO 14496-12 §4.2).
+        // We don't need to handle that case to decode our own output, but we
+        // recognise it to avoid an infinite loop.
+        if box_size == 0 {
+            break;
+        }
+
+        if box_size < 8 {
+            return Err(format!(
+                "JXL: malformed ISOBMFF box at offset {} — size {} is less than 8",
+                pos, box_size
+            ));
+        }
+
+        let box_type = &data[pos + 4..pos + 8];
+
+        if box_type == b"jxlc" {
+            let payload_start = pos + 8;
+            let payload_end = pos + box_size;
+            if payload_end > data.len() {
+                return Err(format!(
+                    "JXL: `jxlc` box at offset {} claims size {} but file is only {} bytes",
+                    pos, box_size, data.len()
+                ));
+            }
+            return Ok(&data[payload_start..payload_end]);
+        }
+
+        pos += box_size;
+    }
+
+    Err("JXL: ISOBMFF container contains no `jxlc` (codestream) box".into())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn naked_codestream_strips_magic() {
+        let data = [0xFF, 0x0A, 0xDE, 0xAD, 0xBE, 0xEF];
+        let cs = extract_codestream(&data).unwrap();
+        assert_eq!(cs, &[0xDE, 0xAD, 0xBE, 0xEF]);
+    }
+
+    #[test]
+    fn naked_codestream_empty_after_magic() {
+        let data = [0xFF, 0x0A];
+        let cs = extract_codestream(&data).unwrap();
+        assert_eq!(cs, &[] as &[u8]);
+    }
+
+    #[test]
+    fn too_short_returns_err() {
+        assert!(extract_codestream(&[]).is_err());
+        assert!(extract_codestream(&[0xFF]).is_err());
+    }
+
+    #[test]
+    fn bad_magic_returns_err() {
+        assert!(extract_codestream(&[0x89, 0x50, 0x4E, 0x47]).is_err()); // PNG
+        assert!(extract_codestream(&[0xFF, 0xD8, 0xFF, 0xE0]).is_err()); // JPEG
+    }
+
+    #[test]
+    fn isobmff_finds_jxlc_box() {
+        // Minimal synthetic ISOBMFF file:
+        // [signature box 12 bytes] [jxlc box 12 bytes payload = [0x11, 0x22]]
+        let mut data = Vec::new();
+        // Signature box
+        data.extend_from_slice(&ISOBMFF_SIG);
+        // jxlc box: size=10 (8 hdr + 2 payload), type=jxlc, payload=[0x11,0x22]
+        data.extend_from_slice(&[0x00, 0x00, 0x00, 0x0A]); // box_size = 10
+        data.extend_from_slice(b"jxlc");
+        data.extend_from_slice(&[0x11, 0x22]);
+
+        let cs = extract_codestream(&data).unwrap();
+        assert_eq!(cs, &[0x11, 0x22]);
+    }
+
+    #[test]
+    fn isobmff_skips_non_jxlc_boxes() {
+        let mut data = Vec::new();
+        data.extend_from_slice(&ISOBMFF_SIG);
+        // ftyp box (not jxlc) — 8 bytes header only
+        data.extend_from_slice(&[0x00, 0x00, 0x00, 0x08]);
+        data.extend_from_slice(b"ftyp");
+        // jxlc box
+        data.extend_from_slice(&[0x00, 0x00, 0x00, 0x09]);
+        data.extend_from_slice(b"jxlc");
+        data.push(0xAB);
+
+        let cs = extract_codestream(&data).unwrap();
+        assert_eq!(cs, &[0xAB]);
+    }
+
+    #[test]
+    fn isobmff_no_jxlc_returns_err() {
+        let mut data = Vec::new();
+        data.extend_from_slice(&ISOBMFF_SIG);
+        // only an ftyp box
+        data.extend_from_slice(&[0x00, 0x00, 0x00, 0x08]);
+        data.extend_from_slice(b"ftyp");
+
+        assert!(extract_codestream(&data).is_err());
+    }
+}

--- a/code/packages/rust/image-codec-jxl/src/decoder.rs
+++ b/code/packages/rust/image-codec-jxl/src/decoder.rs
@@ -1,0 +1,221 @@
+//! # JXL decoder — top-level `decode_jxl` implementation
+//!
+//! Parses the simplified JXL Modular naked codestream produced by
+//! [`encoder::encode`] and reconstructs the original [`PixelContainer`].
+//!
+//! ## Parsing steps
+//!
+//! 1. Strip the container via [`container::extract_codestream`] — handles
+//!    both the naked (`FF 0A`) and ISOBMFF (`JXL ` signature) forms.
+//! 2. Parse the SizeHeader (raw bits, MSB-first).
+//! 3. Read the fixed simple header: `num_channels`, `width`, `height`.
+//! 4. For each channel decode the sign + magnitude rANS block pair.
+//! 5. Reconstruct pixel values from residuals using the gradient predictor.
+//! 6. Assemble the result into a [`PixelContainer`].
+
+use crate::bitreader::BitReader;
+use crate::container::extract_codestream;
+use crate::entropy::decode_channel_residuals;
+use crate::modular::reconstruct_values;
+use pixel_container::PixelContainer;
+
+// ── SizeHeader decoder ───────────────────────────────────────────────────────
+
+/// Decode one dimension (height or width) from the bit reader.
+///
+/// Mirrors the encoder's `encode_dim` exactly.
+fn decode_dim(br: &mut BitReader) -> Result<u32, String> {
+    let div8 = br.read_bit()?;
+    if div8 {
+        // Compact path: 5-bit field stores (dim/8 − 1).
+        let d = br.read_bits(5)? as u32;
+        Ok((d + 1) * 8)
+    } else {
+        // Direct path: 2-bit selector + variable-width dimension.
+        let sel = br.read_bits(2)?;
+        let bit_count = match sel {
+            0 => 9u8,
+            1 => 13,
+            2 => 18,
+            _ => 30,
+        };
+        let val = br.read_bits(bit_count)? as u32;
+        Ok(val + 1) // stored as (dim − 1)
+    }
+}
+
+/// Parse the SizeHeader from the codestream bytes (starting immediately after
+/// the two-byte naked magic has been stripped).
+///
+/// Returns `(width, height, bytes_consumed)`.
+///
+/// We handle the full ratio table from the JXL spec so the decoder can
+/// potentially accept ratio-encoded files even though our encoder always uses
+/// ratio = 0 (explicit width).
+fn decode_size_header(cs: &[u8]) -> Result<(u32, u32, usize), String> {
+    let mut br = BitReader::new(cs);
+
+    // Height is encoded first.
+    let height = decode_dim(&mut br)?;
+
+    // 3-bit ratio field.
+    let ratio = br.read_bits(3)?;
+
+    let width = if ratio == 0 {
+        // Explicit width.
+        decode_dim(&mut br)?
+    } else {
+        // Predefined aspect ratio — compute width from height.
+        // Ratios from JXL spec §4.1 (ratio 1–7).
+        match ratio {
+            1 => height,              // 1:1 (square)
+            2 => (height * 12) / 8,  // 12:8 = 3:2
+            3 => (height * 16) / 8,  // 16:8 = 2:1
+            4 => (height * 4) / 3,   // 4:3
+            5 => (height * 3) / 2,   // 3:2
+            6 => height * 2,         // 2:1
+            7 => (height * 5) / 4,   // 5:4
+            _ => return Err(format!("JXL: unexpected ratio value {}", ratio)),
+        }
+    };
+
+    // How many whole bytes did the SizeHeader occupy?
+    // `bytes_consumed()` rounds up to the next byte boundary.
+    let bytes = br.bytes_consumed();
+
+    Ok((width, height, bytes))
+}
+
+// ── Main decoder ─────────────────────────────────────────────────────────────
+
+/// Decode a simplified JXL Modular codestream back into a [`PixelContainer`].
+///
+/// Accepts both naked codestreams (`FF 0A …`) and ISOBMFF containers.
+///
+/// # Errors
+///
+/// Returns `Err` with a descriptive message if the data is not valid simplified
+/// JXL Modular output (as produced by [`encoder::encode`]), or if any internal
+/// buffer is truncated.
+pub fn decode(data: &[u8]) -> Result<PixelContainer, String> {
+    // ── 1. Strip container / find raw codestream ─────────────────────────
+    let cs = extract_codestream(data)?;
+
+    // ── 2. Parse SizeHeader ──────────────────────────────────────────────
+    let (width, height, size_bytes) = decode_size_header(cs)?;
+
+    // The rest of the stream starts right after the SizeHeader bytes.
+    let rest = &cs[size_bytes..];
+
+    // ── 3. Fixed simple header ───────────────────────────────────────────
+    // Layout: [1 byte num_channels] [4 bytes LE width] [4 bytes LE height]
+    if rest.len() < 9 {
+        return Err(format!(
+            "JXL: stream truncated after SizeHeader — need 9 bytes for simple header, got {}",
+            rest.len()
+        ));
+    }
+    let num_channels = rest[0] as usize;
+    let w = u32::from_le_bytes(rest[1..5].try_into().unwrap());
+    let h = u32::from_le_bytes(rest[5..9].try_into().unwrap());
+
+    // The width/height in the simple header must match the SizeHeader.
+    if w != width || h != height {
+        return Err(format!(
+            "JXL: simple header dimension mismatch — SizeHeader says {}×{}, simple header says {}×{}",
+            width, height, w, h
+        ));
+    }
+    if num_channels != 3 && num_channels != 4 {
+        return Err(format!(
+            "JXL: unsupported channel count {} (only 3 or 4 accepted)",
+            num_channels
+        ));
+    }
+
+    // ── 4. Decode residual blocks for each channel ───────────────────────
+    let mut pos = 9usize; // offset into `rest`
+    let mut channels: Vec<Vec<i32>> = Vec::with_capacity(num_channels);
+
+    for _ in 0..num_channels {
+        if pos > rest.len() {
+            return Err("JXL: stream truncated before channel residual data".into());
+        }
+        let (residuals, consumed) = decode_channel_residuals(&rest[pos..])?;
+        pos += consumed;
+
+        // ── 5. Reconstruct pixel values from residuals ───────────────────
+        if residuals.len() != (width * height) as usize {
+            return Err(format!(
+                "JXL: residual count {} does not match {}×{}={}",
+                residuals.len(),
+                width,
+                height,
+                width * height
+            ));
+        }
+        let values = reconstruct_values(&residuals, width, height);
+        channels.push(values);
+    }
+
+    // ── 6. Assemble PixelContainer ───────────────────────────────────────
+    let mut pc = PixelContainer::new(width, height);
+
+    for y in 0..height {
+        for x in 0..width {
+            let idx = (y * width + x) as usize;
+            let r = channels[0][idx].clamp(0, 255) as u8;
+            let g = channels[1][idx].clamp(0, 255) as u8;
+            let b = channels[2][idx].clamp(0, 255) as u8;
+            let a = if num_channels == 4 {
+                channels[3][idx].clamp(0, 255) as u8
+            } else {
+                255
+            };
+            pc.set_pixel(x, y, r, g, b, a);
+        }
+    }
+
+    Ok(pc)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::encoder;
+
+    fn roundtrip(p: &PixelContainer) -> PixelContainer {
+        let bytes = encoder::encode(p);
+        decode(&bytes).unwrap()
+    }
+
+    #[test]
+    fn decode_bad_magic_err() {
+        assert!(decode(b"\x89PNG\r\n\x1a\n").is_err());
+    }
+
+    #[test]
+    fn decode_too_short_err() {
+        assert!(decode(b"\xFF").is_err());
+    }
+
+    #[test]
+    fn decode_1x1_solid() {
+        let mut p = PixelContainer::new(1, 1);
+        p.set_pixel(0, 0, 10, 20, 30, 255);
+        let q = roundtrip(&p);
+        assert_eq!(q.pixel_at(0, 0), (10, 20, 30, 255));
+    }
+
+    #[test]
+    fn decode_preserves_dimensions() {
+        let p = PixelContainer::new(7, 11);
+        let q = roundtrip(&p);
+        assert_eq!(q.width, 7);
+        assert_eq!(q.height, 11);
+    }
+}

--- a/code/packages/rust/image-codec-jxl/src/encoder.rs
+++ b/code/packages/rust/image-codec-jxl/src/encoder.rs
@@ -1,0 +1,194 @@
+//! # JXL encoder — top-level `encode_jxl` implementation
+//!
+//! Converts a [`PixelContainer`] into a naked JXL codestream.
+//!
+//! ## Wire format (simplified JXL Modular)
+//!
+//! The encoder emits a *naked codestream* (not an ISOBMFF container).
+//! Everything after the two-byte magic is our simplified fixed format — we do
+//! not implement the full JXL metadata ANS sections; see the spec notes in the
+//! crate root for the teaching trade-off.
+//!
+//! ```text
+//! ┌──────────────────────────────────────────────────────────────────┐
+//! │ 2 bytes         │ naked codestream magic: 0xFF 0x0A              │
+//! │ variable bits   │ SizeHeader (MSB-first raw bits, spec §4.1)    │
+//! │ padding bits    │ zero-pad to next byte boundary                 │
+//! │ 1 byte          │ num_channels (3 = RGB, 4 = RGBA)               │
+//! │ 4 bytes LE      │ width  (u32)                                   │
+//! │ 4 bytes LE      │ height (u32)                                   │
+//! │ For each channel R, G, B, [A]:                                   │
+//! │   [sign rANS block]  — see entropy::encode_channel_residuals     │
+//! │   [mag  rANS block]                                              │
+//! └──────────────────────────────────────────────────────────────────┘
+//! ```
+//!
+//! ## SizeHeader encoding
+//!
+//! JXL spec §4.1 encodes image dimensions in raw MSB-first bits:
+//!
+//! ```text
+//! For each dimension (height first, then width if ratio=0):
+//!   div8: 1 bit
+//!   if div8:
+//!     dim_div8: 5 bits  →  dim = (dim_div8 + 1) * 8   (max 256 px)
+//!   else:
+//!     sel: 2 bits       →  bit_count = [9, 13, 18, 30][sel]
+//!     dim: bit_count    →  dim = stored_value + 1
+//!
+//! ratio: 3 bits   (0 = explicit width follows)
+//! ```
+
+use crate::bitwriter::BitWriter;
+use crate::entropy::encode_channel_residuals;
+use crate::modular::compute_residuals;
+use pixel_container::PixelContainer;
+
+// ── SizeHeader helpers ───────────────────────────────────────────────────────
+
+/// Encode a single dimension (height or width) into the BitWriter.
+///
+/// Strategy:
+/// - If dim is divisible by 8 and dim / 8 − 1 fits in 5 bits (dim ≤ 256)
+///   → use the compact div8 path.
+/// - Otherwise → use the direct path with the smallest bit-count that fits.
+fn encode_dim(bw: &mut BitWriter, dim: u32) {
+    // The compact div8 path: flag=1, then a 5-bit field holding (dim/8 − 1).
+    // Valid range: dim ∈ {8, 16, 24, …, 256}.
+    if dim > 0 && dim % 8 == 0 && (dim / 8) <= 32 {
+        bw.write_bit(true); // div8 = 1
+        bw.write_bits((dim / 8 - 1) as u64, 5);
+        return;
+    }
+
+    // Direct path: flag=0, then a 2-bit selector, then the value.
+    bw.write_bit(false); // div8 = 0
+    let val = dim - 1; // store (dim − 1) so dim = stored + 1
+    if val < (1 << 9) {
+        bw.write_bits(0, 2); // sel = 0 → 9 bits
+        bw.write_bits(val as u64, 9);
+    } else if val < (1 << 13) {
+        bw.write_bits(1, 2); // sel = 1 → 13 bits
+        bw.write_bits(val as u64, 13);
+    } else if val < (1 << 18) {
+        bw.write_bits(2, 2); // sel = 2 → 18 bits
+        bw.write_bits(val as u64, 18);
+    } else {
+        bw.write_bits(3, 2); // sel = 3 → 30 bits
+        bw.write_bits(val as u64, 30);
+    }
+}
+
+/// Encode the full SizeHeader (height + ratio + width) into raw bits and return
+/// the flushed bytes.
+fn encode_size_header(width: u32, height: u32) -> Vec<u8> {
+    let mut bw = BitWriter::new();
+    encode_dim(&mut bw, height);
+    bw.write_bits(0, 3); // ratio = 0 → explicit width follows
+    encode_dim(&mut bw, width);
+    bw.finish()
+}
+
+// ── Main encoder ─────────────────────────────────────────────────────────────
+
+/// Encode a [`PixelContainer`] into a simplified JXL Modular naked codestream.
+///
+/// The result is a complete, self-contained byte stream that `decode_jxl` can
+/// round-trip back to an identical `PixelContainer`.
+///
+/// # Panics
+///
+/// Panics if the pixel container has zero width or zero height (an empty image
+/// cannot be represented in JXL SizeHeader).
+pub fn encode(pixels: &PixelContainer) -> Vec<u8> {
+    let width = pixels.width;
+    let height = pixels.height;
+
+    assert!(width > 0 && height > 0, "JXL: cannot encode a zero-dimension image");
+
+    // Decide whether we need an alpha channel.
+    // We only write 4 channels when at least one pixel has A ≠ 255.
+    let has_alpha = (0..height).any(|y| (0..width).any(|x| pixels.pixel_at(x, y).3 != 255));
+    let num_channels: u8 = if has_alpha { 4 } else { 3 };
+
+    let mut out = Vec::new();
+
+    // ── Magic ──────────────────────────────────────────────────────────
+    out.extend_from_slice(&[0xFF, 0x0A]);
+
+    // ── SizeHeader (raw bits) ───────────────────────────────────────────
+    let size_bits = encode_size_header(width, height);
+    out.extend_from_slice(&size_bits);
+    // SizeHeader bits are already flushed/padded to whole bytes by BitWriter.
+
+    // ── Fixed simple header ─────────────────────────────────────────────
+    out.push(num_channels);
+    out.extend_from_slice(&width.to_le_bytes());
+    out.extend_from_slice(&height.to_le_bytes());
+
+    // ── Channel residual blocks ─────────────────────────────────────────
+    for ch in 0..num_channels as usize {
+        // Flatten the channel into a linear i32 buffer.
+        let values: Vec<i32> = (0..height)
+            .flat_map(|y| {
+                (0..width).map(move |x| {
+                    let (r, g, b, a) = pixels.pixel_at(x, y);
+                    match ch {
+                        0 => r as i32,
+                        1 => g as i32,
+                        2 => b as i32,
+                        _ => a as i32,
+                    }
+                })
+            })
+            .collect();
+
+        let residuals = compute_residuals(&values, width, height);
+        encode_channel_residuals(&residuals, &mut out);
+    }
+
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn magic_bytes_at_start() {
+        let p = PixelContainer::new(4, 4);
+        let bytes = encode(&p);
+        assert_eq!(&bytes[..2], &[0xFF, 0x0A]);
+    }
+
+    #[test]
+    fn rgb_only_when_fully_opaque() {
+        let mut p = PixelContainer::new(2, 2);
+        p.fill(100, 100, 100, 255);
+        let bytes = encode(&p);
+        // After magic (2) + SizeHeader + fixed-header, first byte of fixed hdr
+        // is num_channels — find it by scanning past SizeHeader.
+        // We'll just assert the output is non-empty and starts correctly.
+        assert!(bytes.len() > 10);
+    }
+
+    #[test]
+    fn rgba_when_has_transparent_pixel() {
+        let mut p = PixelContainer::new(2, 2);
+        p.fill(0, 0, 0, 0); // fully transparent
+        let bytes = encode(&p);
+        assert!(bytes.len() > 10);
+    }
+
+    #[test]
+    fn encode_1x1() {
+        let mut p = PixelContainer::new(1, 1);
+        p.set_pixel(0, 0, 128, 64, 32, 255);
+        let bytes = encode(&p);
+        assert!(bytes.len() > 2);
+    }
+}

--- a/code/packages/rust/image-codec-jxl/src/entropy.rs
+++ b/code/packages/rust/image-codec-jxl/src/entropy.rs
@@ -139,6 +139,18 @@ pub fn decode_rans_block(data: &[u8]) -> Result<(Vec<u8>, usize), String> {
         ));
     }
 
+    // DoS guard: a hostile input could claim num_symbols = u32::MAX (4 billion),
+    // causing a multi-gigabyte Vec allocation and OOM.  We cap at 256 M symbols,
+    // which covers a 16384×16384-pixel image — far beyond any realistic use case
+    // for this teaching codec.
+    const MAX_SYMBOLS: usize = 256 * 1024 * 1024; // 256 M
+    if num_symbols > MAX_SYMBOLS {
+        return Err(format!(
+            "JXL: rANS block claims {} symbols, exceeding the {} limit",
+            num_symbols, MAX_SYMBOLS
+        ));
+    }
+
     let counts_end = 8 + alphabet_size * 4;
     if data.len() < counts_end + 4 {
         return Err("JXL: rANS block truncated in frequency table".into());
@@ -149,13 +161,18 @@ pub fn decode_rans_block(data: &[u8]) -> Result<(Vec<u8>, usize), String> {
 
     let data_len = u32::from_le_bytes(data[counts_end..counts_end + 4].try_into().unwrap()) as usize;
     let data_start = counts_end + 4;
-    let data_end = data_start + data_len;
+    // Guard against usize overflow in data_start + data_len before we do the
+    // bounds check below.  data_start is at most 8 + 256*4 + 4 = 1036 bytes,
+    // so the checked_add is defensive but cheap.
+    let data_end = data_start.checked_add(data_len).ok_or_else(|| {
+        "JXL: rANS block data_len overflows address space".to_string()
+    })?;
 
     if data.len() < data_end {
         return Err(format!(
             "JXL: rANS block claims {} compressed bytes but only {} remain",
             data_len,
-            data.len() - data_start
+            data.len().saturating_sub(data_start)
         ));
     }
 

--- a/code/packages/rust/image-codec-jxl/src/entropy.rs
+++ b/code/packages/rust/image-codec-jxl/src/entropy.rs
@@ -1,0 +1,279 @@
+//! # Entropy coding helpers
+//!
+//! Bridges between the generic `rans` crate and the image-codec-specific
+//! wire format used by `image-codec-jxl`.
+//!
+//! ## Wire format for one rANS block
+//!
+//! Each rANS block is self-describing:
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────────┐
+//! │ 4 bytes LE │ num_symbols — count of coded items │
+//! │ 4 bytes LE │ alphabet_size — number of counts   │
+//! │ alphabet_size × 4 bytes LE │ frequency counts   │
+//! │ 4 bytes LE │ data_len — compressed byte count   │
+//! │ data_len bytes │ rANS bitstream                 │
+//! └─────────────────────────────────────────────────┘
+//! ```
+//!
+//! The frequency counts are the *raw* (non-normalised) histogram of the
+//! input symbols; `AnsTable::new` performs the normalisation internally.
+//! Every count is initialised to at least 1 so that all symbols in the
+//! declared alphabet are reachable.
+//!
+//! ## Per-channel residual encoding
+//!
+//! Gradient residuals for 8bpp images lie in [−255, 255].  The rANS crate
+//! uses a `u8` symbol type (alphabet ≤ 256).  To handle the full range we
+//! use a **two-pass split**:
+//!
+//! 1. **Sign pass** — encode a sign symbol for every pixel:
+//!    - 0 = residual is zero
+//!    - 1 = positive
+//!    - 2 = negative
+//!
+//! 2. **Magnitude pass** — encode `|residual| − 1` (in [0, 254]) for every
+//!    non-zero pixel.  Zero-residual pixels contribute nothing to this stream.
+//!
+//! This cleanly fits each sub-stream into u8 (alphabet sizes 3 and 255
+//! respectively) and keeps the two distributions separate for better
+//! compression.
+
+use rans::{AnsTable, RansDecoder, RansEncoder};
+
+// ── Encoding ────────────────────────────────────────────────────────────────
+
+/// Append a self-describing rANS block to `out`.
+///
+/// `symbols` is the sequence to encode.  `counts` is the raw frequency table
+/// (length = alphabet size); counts must be ≥ 1 for every symbol that appears.
+///
+/// Symbols are pushed to the encoder in **reverse** order (as required by rANS)
+/// then the block header + compressed data are appended to `out`.
+pub fn encode_rans_block(symbols: &[u8], counts: &[u32], out: &mut Vec<u8>) {
+    // Header: num_symbols
+    out.extend_from_slice(&(symbols.len() as u32).to_le_bytes());
+    // Header: alphabet_size
+    out.extend_from_slice(&(counts.len() as u32).to_le_bytes());
+    // Header: frequency counts
+    for &c in counts {
+        out.extend_from_slice(&c.to_le_bytes());
+    }
+
+    // Build table and encode.
+    let table = AnsTable::new(counts).expect("rANS table build failed — invalid counts");
+    let mut enc = RansEncoder::new(&table);
+    for &s in symbols.iter().rev() {
+        enc.put(s);
+    }
+    let data = enc.finish();
+
+    // Header: data_len + compressed bytes.
+    out.extend_from_slice(&(data.len() as u32).to_le_bytes());
+    out.extend_from_slice(&data);
+}
+
+/// Encode the residuals for one image channel (sign + magnitude blocks).
+///
+/// `residuals` must lie in [−255, 255] (guaranteed by gradient prediction on
+/// 8bpp input).  Two rANS blocks are appended to `out`:
+///
+/// 1. Sign block (alphabet size 3)
+/// 2. Magnitude block (alphabet size 255, for magnitudes 1–255 → indices 0–254)
+pub fn encode_channel_residuals(residuals: &[i32], out: &mut Vec<u8>) {
+    // ── Build sign and magnitude symbol sequences ────────────────────────
+    let mut sign_counts = [1u32; 3]; // start at 1 so no symbol has freq 0
+    let mut mag_counts = [1u32; 255];
+
+    let mut signs = Vec::with_capacity(residuals.len());
+    let mut mags: Vec<u8> = Vec::new();
+
+    for &r in residuals {
+        let (sign_sym, mag_sym) = if r == 0 {
+            (0u8, None)
+        } else if r > 0 {
+            let m = (r.unsigned_abs() - 1).min(254) as u8;
+            (1u8, Some(m))
+        } else {
+            let m = (r.unsigned_abs() - 1).min(254) as u8;
+            (2u8, Some(m))
+        };
+
+        signs.push(sign_sym);
+        sign_counts[sign_sym as usize] += 1;
+
+        if let Some(m) = mag_sym {
+            mags.push(m);
+            mag_counts[m as usize] += 1;
+        }
+    }
+
+    encode_rans_block(&signs, &sign_counts, out);
+    encode_rans_block(&mags, &mag_counts, out);
+}
+
+// ── Decoding ────────────────────────────────────────────────────────────────
+
+/// Decode a self-describing rANS block from `data`.
+///
+/// Returns `(symbols, bytes_consumed)`.
+///
+/// # Errors
+///
+/// Returns `Err` if the data is truncated, the header fields are inconsistent,
+/// or rANS decoding fails.
+pub fn decode_rans_block(data: &[u8]) -> Result<(Vec<u8>, usize), String> {
+    // ── Parse header ────────────────────────────────────────────────────
+    if data.len() < 8 {
+        return Err("JXL: rANS block header too short (need 8 bytes for num_symbols + alphabet_size)".into());
+    }
+    let num_symbols = u32::from_le_bytes(data[0..4].try_into().unwrap()) as usize;
+    let alphabet_size = u32::from_le_bytes(data[4..8].try_into().unwrap()) as usize;
+
+    // Sanity: alphabet_size must be ≤ 256 (rANS crate limit).
+    if alphabet_size == 0 || alphabet_size > 256 {
+        return Err(format!(
+            "JXL: invalid rANS alphabet_size {} (must be 1–256)",
+            alphabet_size
+        ));
+    }
+
+    let counts_end = 8 + alphabet_size * 4;
+    if data.len() < counts_end + 4 {
+        return Err("JXL: rANS block truncated in frequency table".into());
+    }
+    let counts: Vec<u32> = (0..alphabet_size)
+        .map(|i| u32::from_le_bytes(data[8 + i * 4..12 + i * 4].try_into().unwrap()))
+        .collect();
+
+    let data_len = u32::from_le_bytes(data[counts_end..counts_end + 4].try_into().unwrap()) as usize;
+    let data_start = counts_end + 4;
+    let data_end = data_start + data_len;
+
+    if data.len() < data_end {
+        return Err(format!(
+            "JXL: rANS block claims {} compressed bytes but only {} remain",
+            data_len,
+            data.len() - data_start
+        ));
+    }
+
+    // ── Decode symbols ───────────────────────────────────────────────────
+    let table = AnsTable::new(&counts).map_err(|e| format!("JXL: rANS table: {}", e))?;
+
+    let symbols = if num_symbols == 0 {
+        Vec::new()
+    } else {
+        let mut dec = RansDecoder::new(&table, &data[data_start..data_end])
+            .map_err(|e| format!("JXL: rANS decoder init: {}", e))?;
+        (0..num_symbols).map(|_| dec.get()).collect()
+    };
+
+    Ok((symbols, data_end))
+}
+
+/// Decode residuals for one channel from `data` (sign + magnitude blocks).
+///
+/// Returns `(residuals, bytes_consumed)`.
+pub fn decode_channel_residuals(data: &[u8]) -> Result<(Vec<i32>, usize), String> {
+    // Decode sign block.
+    let (signs, sign_len) = decode_rans_block(data)?;
+    // Decode magnitude block.
+    let (mags, mag_len) = decode_rans_block(&data[sign_len..])?;
+
+    // Reconstruct residuals.
+    let mut mag_iter = mags.into_iter();
+    let residuals: Result<Vec<i32>, String> = signs
+        .into_iter()
+        .map(|s| match s {
+            0 => Ok(0i32),
+            1 => {
+                let m = mag_iter.next().ok_or_else(|| {
+                    "JXL: magnitude stream exhausted before sign stream".to_string()
+                })?;
+                Ok(m as i32 + 1)
+            }
+            2 => {
+                let m = mag_iter.next().ok_or_else(|| {
+                    "JXL: magnitude stream exhausted before sign stream".to_string()
+                })?;
+                Ok(-(m as i32 + 1))
+            }
+            other => Err(format!("JXL: invalid sign symbol {}", other)),
+        })
+        .collect();
+
+    Ok((residuals?, sign_len + mag_len))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rt_rans(symbols: &[u8], alphabet: usize) {
+        let mut counts = vec![1u32; alphabet];
+        for &s in symbols {
+            counts[s as usize] += 1;
+        }
+        let mut buf = Vec::new();
+        encode_rans_block(symbols, &counts, &mut buf);
+        let (decoded, consumed) = decode_rans_block(&buf).unwrap();
+        assert_eq!(consumed, buf.len());
+        assert_eq!(&decoded, symbols);
+    }
+
+    #[test]
+    fn rans_block_round_trip_empty() {
+        rt_rans(&[], 3);
+    }
+
+    #[test]
+    fn rans_block_round_trip_single() {
+        rt_rans(&[0], 2);
+    }
+
+    #[test]
+    fn rans_block_round_trip_many() {
+        let syms: Vec<u8> = (0u8..20).map(|i| i % 3).collect();
+        rt_rans(&syms, 3);
+    }
+
+    fn rt_residuals(residuals: &[i32]) {
+        let mut buf = Vec::new();
+        encode_channel_residuals(residuals, &mut buf);
+        let (decoded, consumed) = decode_channel_residuals(&buf).unwrap();
+        assert_eq!(consumed, buf.len());
+        assert_eq!(&decoded, residuals);
+    }
+
+    #[test]
+    fn residuals_all_zero() {
+        rt_residuals(&[0; 16]);
+    }
+
+    #[test]
+    fn residuals_positive() {
+        rt_residuals(&[1, 5, 10, 100, 127]);
+    }
+
+    #[test]
+    fn residuals_negative() {
+        rt_residuals(&[-1, -5, -127, -100]);
+    }
+
+    #[test]
+    fn residuals_mixed() {
+        let r: Vec<i32> = (0..50).map(|i| i as i32 - 25).collect();
+        rt_residuals(&r);
+    }
+
+    #[test]
+    fn residuals_extremes() {
+        rt_residuals(&[255, -255, 0, 127, -128, 1, -1]);
+    }
+}

--- a/code/packages/rust/image-codec-jxl/src/lib.rs
+++ b/code/packages/rust/image-codec-jxl/src/lib.rs
@@ -1,0 +1,287 @@
+//! # image-codec-jxl — JPEG XL Modular lossless encoder/decoder (IC09)
+//!
+//! This crate implements a simplified but self-consistent JPEG XL Modular
+//! encoder and decoder for teaching purposes.
+//!
+//! ## JPEG XL overview
+//!
+//! JPEG XL (JXL) is an open image format standardised by ISO/IEC 18181 and
+//! designed as a successor to legacy JPEG.  It has two main coding modes:
+//!
+//! - **VarDCT** — a lossy path similar to JPEG, using DCT blocks and quantisation.
+//! - **Modular** — a lossless (or visually lossless) path based on gradient
+//!   prediction + entropy coding.  This is what we implement here.
+//!
+//! ## What we implement (Phase 1 scope)
+//!
+//! We emit a **naked codestream** (magic `FF 0A`) rather than an ISOBMFF
+//! container.  The internal structure after the SizeHeader is our own
+//! simplified binary format (not standard JXL metadata ANS coding), which
+//! keeps the implementation short and learnable.
+//!
+//! The decoder handles both naked codestreams and ISOBMFF-wrapped files
+//! (container detection only — the metadata inside would need the full JXL
+//! spec to decode).
+//!
+//! ## Codec pipeline
+//!
+//! ```text
+//! PixelContainer
+//!       │
+//!       ▼ encoder
+//! For each channel (R, G, B, [A]):
+//!   1. Flatten to i32 plane
+//!   2. Gradient predictor  →  residuals ∈ [−255, 255]
+//!   3. Sign/magnitude split →  two u8 symbol streams
+//!   4. rANS entropy coding  →  compressed bytes
+//!       │
+//!       ▼ wire format
+//! [FF 0A][SizeHeader bits][num_ch w h][sign rANS][mag rANS] × channels
+//!       │
+//!       ▼ decoder (reverse)
+//! PixelContainer
+//! ```
+//!
+//! ## Crate version
+//!
+//! The `VERSION` constant mirrors the `Cargo.toml` version string.
+
+pub mod bitreader;
+pub mod bitwriter;
+pub mod container;
+pub mod decoder;
+pub mod encoder;
+pub mod entropy;
+pub mod modular;
+pub mod rct;
+
+use pixel_container::{ImageCodec, PixelContainer};
+
+/// Crate version, matching `Cargo.toml`.
+pub const VERSION: &str = "0.1.0";
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/// Encode a [`PixelContainer`] into a simplified JXL Modular codestream.
+///
+/// The output starts with the two-byte naked codestream magic `FF 0A` and is
+/// a complete, self-contained file that `decode_jxl` can round-trip exactly.
+///
+/// # Panics
+///
+/// Panics if `pixels` has zero width or zero height.
+pub fn encode_jxl(pixels: &PixelContainer) -> Vec<u8> {
+    encoder::encode(pixels)
+}
+
+/// Decode a JXL codestream or ISOBMFF container back into a [`PixelContainer`].
+///
+/// Only our simplified format (as emitted by `encode_jxl`) is guaranteed to
+/// decode correctly.  Standard libjxl output would require the full JXL spec.
+///
+/// # Errors
+///
+/// Returns `Err` with a descriptive message if the data is not recognised as
+/// a valid simplified JXL Modular stream.
+pub fn decode_jxl(data: &[u8]) -> Result<PixelContainer, String> {
+    decoder::decode(data)
+}
+
+// ── ImageCodec trait implementation ──────────────────────────────────────────
+
+/// Unit struct that implements [`ImageCodec`] for JPEG XL Modular lossless.
+///
+/// # Example
+///
+/// ```
+/// use image_codec_jxl::JxlCodec;
+/// use pixel_container::{ImageCodec, PixelContainer};
+///
+/// let mut src = PixelContainer::new(4, 4);
+/// src.fill(200, 100, 50, 255);
+///
+/// let bytes  = JxlCodec.encode(&src);
+/// let dst    = JxlCodec.decode(&bytes).unwrap();
+///
+/// assert_eq!(dst.pixel_at(2, 2), (200, 100, 50, 255));
+/// ```
+pub struct JxlCodec;
+
+impl ImageCodec for JxlCodec {
+    fn mime_type(&self) -> &'static str {
+        "image/jxl"
+    }
+
+    fn encode(&self, container: &PixelContainer) -> Vec<u8> {
+        encode_jxl(container)
+    }
+
+    fn decode(&self, bytes: &[u8]) -> Result<PixelContainer, String> {
+        decode_jxl(bytes)
+    }
+}
+
+// ── Integration tests ─────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Round-trip helper ────────────────────────────────────────────────
+
+    /// Encode then decode and assert pixel-perfect identity.
+    fn round_trip(px: &PixelContainer) {
+        let bytes = encode_jxl(px);
+        let recovered = decode_jxl(&bytes)
+            .unwrap_or_else(|e| panic!("decode failed: {}", e));
+
+        assert_eq!(recovered.width, px.width, "width mismatch");
+        assert_eq!(recovered.height, px.height, "height mismatch");
+
+        for y in 0..px.height {
+            for x in 0..px.width {
+                assert_eq!(
+                    recovered.pixel_at(x, y),
+                    px.pixel_at(x, y),
+                    "pixel mismatch at ({}, {})",
+                    x,
+                    y
+                );
+            }
+        }
+    }
+
+    // ── Round-trip tests ─────────────────────────────────────────────────
+
+    #[test]
+    fn round_trip_solid_rgb() {
+        let mut p = PixelContainer::new(4, 4);
+        p.fill(200, 100, 50, 255);
+        round_trip(&p);
+    }
+
+    #[test]
+    fn round_trip_1x1() {
+        let mut p = PixelContainer::new(1, 1);
+        p.set_pixel(0, 0, 10, 20, 30, 200);
+        round_trip(&p);
+    }
+
+    #[test]
+    fn round_trip_transparent_solid() {
+        let mut p = PixelContainer::new(4, 4);
+        p.fill(0, 0, 0, 0);
+        round_trip(&p);
+    }
+
+    #[test]
+    fn round_trip_mixed_alpha() {
+        let mut p = PixelContainer::new(2, 2);
+        p.set_pixel(0, 0, 255, 0, 0, 255);
+        p.set_pixel(1, 0, 0, 255, 0, 128);
+        p.set_pixel(0, 1, 0, 0, 255, 0);
+        p.set_pixel(1, 1, 128, 128, 0, 64);
+        round_trip(&p);
+    }
+
+    #[test]
+    fn round_trip_gradient() {
+        let mut p = PixelContainer::new(8, 8);
+        for y in 0..8u32 {
+            for x in 0..8u32 {
+                p.set_pixel(x, y, (x * 32) as u8, (y * 32) as u8, 128, 255);
+            }
+        }
+        round_trip(&p);
+    }
+
+    #[test]
+    fn round_trip_large() {
+        let mut p = PixelContainer::new(32, 32);
+        for y in 0..32u32 {
+            for x in 0..32u32 {
+                p.set_pixel(x, y, x as u8, y as u8, 200, 255);
+            }
+        }
+        round_trip(&p);
+    }
+
+    #[test]
+    fn round_trip_max_channel_values() {
+        let mut p = PixelContainer::new(4, 4);
+        p.fill(255, 255, 255, 255);
+        round_trip(&p);
+    }
+
+    #[test]
+    fn round_trip_min_channel_values() {
+        // All zeros = transparent black; has_alpha detects A=0 → 4-channel encode.
+        let p = PixelContainer::new(4, 4);
+        round_trip(&p);
+    }
+
+    #[test]
+    fn round_trip_1x1_transparent() {
+        let mut p = PixelContainer::new(1, 1);
+        p.set_pixel(0, 0, 0, 0, 0, 0);
+        round_trip(&p);
+    }
+
+    // ── Format / magic tests ─────────────────────────────────────────────
+
+    #[test]
+    fn naked_codestream_magic() {
+        let p = PixelContainer::new(2, 2);
+        let bytes = encode_jxl(&p);
+        assert_eq!(&bytes[..2], &[0xFF, 0x0A], "first two bytes must be JXL naked magic");
+    }
+
+    // ── Error cases ──────────────────────────────────────────────────────
+
+    #[test]
+    fn decode_error_bad_magic() {
+        let err = decode_jxl(b"\x89PNG\r\n\x1a\n").unwrap_err();
+        assert!(!err.is_empty(), "error message must not be empty");
+    }
+
+    #[test]
+    fn decode_error_too_short() {
+        let err = decode_jxl(b"\xFF").unwrap_err();
+        assert!(!err.is_empty());
+    }
+
+    #[test]
+    fn decode_error_empty() {
+        let err = decode_jxl(b"").unwrap_err();
+        assert!(!err.is_empty());
+    }
+
+    // ── ImageCodec trait ─────────────────────────────────────────────────
+
+    #[test]
+    fn codec_mime_type() {
+        assert_eq!(JxlCodec.mime_type(), "image/jxl");
+    }
+
+    #[test]
+    fn codec_encode_decode_round_trip() {
+        let mut p = PixelContainer::new(4, 4);
+        p.fill(100, 150, 200, 255);
+        let bytes = JxlCodec.encode(&p);
+        let recovered = JxlCodec.decode(&bytes).unwrap();
+        assert_eq!(recovered.width, 4);
+        assert_eq!(recovered.height, 4);
+        assert_eq!(recovered.pixel_at(0, 0), (100, 150, 200, 255));
+        assert_eq!(recovered.pixel_at(3, 3), (100, 150, 200, 255));
+    }
+
+    #[test]
+    fn codec_version_is_semver() {
+        // Must be parseable as X.Y.Z
+        let parts: Vec<&str> = VERSION.split('.').collect();
+        assert_eq!(parts.len(), 3, "VERSION must be X.Y.Z");
+        for part in parts {
+            assert!(part.parse::<u32>().is_ok(), "each VERSION part must be numeric");
+        }
+    }
+}

--- a/code/packages/rust/image-codec-jxl/src/modular.rs
+++ b/code/packages/rust/image-codec-jxl/src/modular.rs
@@ -1,0 +1,207 @@
+//! # Modular image coding — gradient predictor and residual transform
+//!
+//! JXL Modular mode achieves lossless compression by decorrelating pixel
+//! values before entropy-coding them.  The key insight is that neighbouring
+//! pixels are highly correlated: knowing the values to the left, above, and
+//! diagonally adjacent gives a very good prediction of the current pixel.
+//! The *residual* (actual − predicted) is small and concentrated near zero,
+//! making it cheap to entropy-code.
+//!
+//! ## The gradient predictor
+//!
+//! Given a pixel at position (x, y) with neighbours:
+//!
+//! ```text
+//!   NW  N  NE
+//!    W  P
+//! ```
+//!
+//! We compute:
+//!
+//! ```text
+//! grad = W + N − NW               (gradient extrapolation)
+//! pred = clamp(grad, min(W,N,NW,NE), max(W,N,NW,NE))
+//! ```
+//!
+//! Clamping to the min/max of the four neighbours keeps the predictor from
+//! wildly over- or under-shooting at edges and ramps.
+//!
+//! ## Edge conditions
+//!
+//! At the edges of the image we fall back to:
+//!
+//! | position         | W   | N   | NW  | NE  |
+//! |------------------|-----|-----|-----|-----|
+//! | x=0, y=0        | 0   | 0   | 0   | 0   |
+//! | x=0, y>0        | N   | N   | N   | N¹  |
+//! | x>0, y=0        | W   | W   | W   | W¹  |
+//! | x>0, y>0, x=W-1 | ...  | ... | ... | N   |
+//!
+//! ¹ NE falls back to N if x = image_width − 1 *or* y = 0.
+//!
+//! ## Reconstruction
+//!
+//! Decoding is the exact inverse: scan in raster order, predict with the
+//! already-reconstructed neighbours, add the residual, and store.
+
+/// Predict the value of pixel (x, y) from already-decoded neighbours.
+///
+/// `channel` must be a flat row-major slice of length `width * height` where
+/// only pixels before (x, y) in raster order have been filled in.
+/// Pixels not yet decoded may be 0 — the predictor only reads earlier ones.
+pub fn gradient_predict(x: u32, y: u32, width: u32, channel: &[i32]) -> i32 {
+    // Helper closure: safely index into `channel`.
+    // We never call this with coordinates that are out of the allocated slice,
+    // but we *can* call it with x = width (conceptual NE for the last column),
+    // which we guard against below.
+    let get = |px: u32, py: u32| -> i32 { channel[(py * width + px) as usize] };
+
+    // ── Fetch the four relevant neighbours ───────────────────────────────
+    //
+    // W  = pixel to the left  (x−1, y).   Boundary: 0 when x = 0.
+    // N  = pixel above        (x, y−1).   Boundary: W when y = 0.
+    // NW = diagonal           (x−1, y−1). Boundary: W when x=0 or y=0,
+    //                                                N when x=0 and y>0.
+    // NE = above-right        (x+1, y−1). Boundary: N when y=0 or x=W−1.
+
+    let w = if x > 0 { get(x - 1, y) } else { 0 };
+
+    let n = if y > 0 { get(x, y - 1) } else { w };
+
+    let nw = if x > 0 && y > 0 {
+        get(x - 1, y - 1)
+    } else if y > 0 {
+        // x == 0: use N (nothing to the left)
+        n
+    } else {
+        // y == 0: use W (nothing above)
+        w
+    };
+
+    let ne = if y > 0 && x + 1 < width {
+        get(x + 1, y - 1)
+    } else {
+        // No pixel to the upper-right: use N
+        n
+    };
+
+    // ── Gradient + clamp ─────────────────────────────────────────────────
+    //
+    // The gradient formula extrapolates linearly from the three cardinal
+    // neighbours.  Clamping prevents overshooting at hard edges.
+    let grad = w + n - nw;
+    let lo = w.min(n).min(nw).min(ne);
+    let hi = w.max(n).max(nw).max(ne);
+    grad.clamp(lo, hi)
+}
+
+/// Compute residuals for a complete channel plane.
+///
+/// Scans in raster order (left-to-right, top-to-bottom).  `values` must have
+/// length `width * height`.  Returns a parallel slice of residuals.
+///
+/// Residuals can be negative: `residual = pixel − prediction`.
+pub fn compute_residuals(values: &[i32], width: u32, height: u32) -> Vec<i32> {
+    let n = (width * height) as usize;
+    debug_assert_eq!(values.len(), n, "channel length mismatch");
+
+    let mut residuals = Vec::with_capacity(n);
+
+    for y in 0..height {
+        for x in 0..width {
+            let pred = gradient_predict(x, y, width, values);
+            residuals.push(values[(y * width + x) as usize] - pred);
+        }
+    }
+
+    residuals
+}
+
+/// Reconstruct pixel values from residuals (the decode side).
+///
+/// Fills a buffer in raster order, using already-filled slots as neighbours for
+/// the predictor.  This is the exact inverse of `compute_residuals`.
+pub fn reconstruct_values(residuals: &[i32], width: u32, height: u32) -> Vec<i32> {
+    let n = (width * height) as usize;
+    debug_assert_eq!(residuals.len(), n, "residual slice length mismatch");
+
+    // The buffer is filled left-to-right, top-to-bottom.  At each step the
+    // predictor can already see all pixels decoded before (x, y) in raster
+    // order, which is exactly what `gradient_predict` requires.
+    let mut values = vec![0i32; n];
+
+    for y in 0..height {
+        for x in 0..width {
+            let pred = gradient_predict(x, y, width, &values);
+            values[(y * width + x) as usize] = pred + residuals[(y * width + x) as usize];
+        }
+    }
+
+    values
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Verify that encode → decode is lossless for a small channel plane.
+    fn round_trip_channel(values: Vec<i32>, w: u32, h: u32) {
+        let residuals = compute_residuals(&values, w, h);
+        let recovered = reconstruct_values(&residuals, w, h);
+        assert_eq!(values, recovered, "round-trip failed for {}×{}", w, h);
+    }
+
+    #[test]
+    fn single_pixel() {
+        round_trip_channel(vec![42], 1, 1);
+    }
+
+    #[test]
+    fn constant_value() {
+        // A flat image: predictor nails every pixel after the first → tiny residuals.
+        let values = vec![128i32; 16];
+        round_trip_channel(values, 4, 4);
+    }
+
+    #[test]
+    fn gradient_values() {
+        let values: Vec<i32> = (0..16).map(|i| i * 10).collect();
+        round_trip_channel(values, 4, 4);
+    }
+
+    #[test]
+    fn random_8bpp_values() {
+        let values: Vec<i32> = (0u8..=255).take(64).map(|v| v as i32).collect();
+        round_trip_channel(values, 8, 8);
+    }
+
+    #[test]
+    fn first_pixel_predicts_zero() {
+        // With no neighbours the predictor should return 0.
+        let mut dummy = vec![0i32; 4];
+        dummy[0] = 99; // pixel at (0,0) — not yet decoded by predictor
+        // For (0,0) we pass an empty-so-far buffer:
+        let pred = gradient_predict(0, 0, 2, &[0, 0, 0, 0]);
+        assert_eq!(pred, 0);
+    }
+
+    #[test]
+    fn residuals_sum_property() {
+        // For a ramp image the residuals should be almost all zero except (0,0).
+        // (A linear horizontal ramp is predicted perfectly by the gradient predictor.)
+        let values: Vec<i32> = (0..8).map(|x| x as i32 * 10).collect();
+        let residuals = compute_residuals(&values, 8, 1);
+        // First residual = pixel[0] - pred(0,0,w=8) = 0 - 0 = 0
+        assert_eq!(residuals[0], 0);
+        // For a perfect ramp, predictor = W for y=0, so residuals should all be 10.
+        // Actually for y=0 with uniform step: N=W=0 so pred = W = values[x-1].
+        // residual[x] = values[x] - values[x-1] = 10 for all x > 0.
+        for &r in &residuals[1..] {
+            assert_eq!(r, 10);
+        }
+    }
+}

--- a/code/packages/rust/image-codec-jxl/src/rct.rs
+++ b/code/packages/rust/image-codec-jxl/src/rct.rs
@@ -1,0 +1,131 @@
+//! # Reversible Colour Transform (RCT / YCoCg)
+//!
+//! JXL Modular can apply a lossless colour transform before the per-channel
+//! gradient predictor runs.  After transforming, the three colour channels
+//! become much less correlated with each other, which improves compression.
+//!
+//! ## YCoCg (RCT type 6 in the JXL specification)
+//!
+//! The transform is an integer variant of YCoCg derived from the Malvar-Sullivan
+//! "lossless" YCoCg transform:
+//!
+//! **Forward (RGB → YCoCg):**
+//!
+//! ```text
+//! Co  = R − B
+//! tmp = B + (Co >> 1)     (integer arithmetic, arithmetic right-shift)
+//! Cg  = G − tmp
+//! Y   = tmp + (Cg >> 1)
+//! ```
+//!
+//! Output channels: (Y, Co, Cg) replace (R, G, B).
+//!
+//! **Inverse (YCoCg → RGB):**
+//!
+//! ```text
+//! tmp = Y − (Cg >> 1)
+//! G   = Cg + tmp
+//! B   = tmp − (Co >> 1)
+//! R   = B + Co
+//! ```
+//!
+//! ## Usage note
+//!
+//! Our encoder does **not** apply RCT — it encodes channels directly in RGB
+//! order, which is simpler and already gives good results because the gradient
+//! predictor removes most spatial redundancy.
+//!
+//! These functions are included so that the decoder can, in principle, handle
+//! RCT-coded images produced by libjxl.  They are also tested directly as
+//! pure math functions regardless of whether the encoder uses them.
+
+/// Forward RCT (type 6): RGB → (Y, Co, Cg) using integer YCoCg.
+///
+/// All arithmetic is integer; right-shifts are *arithmetic* (sign-preserving).
+/// Input values need not be in [0, 255] — the transform is defined over ℤ.
+///
+/// Returns `(y, co, cg)`.
+pub fn rct_forward(r: i32, g: i32, b: i32) -> (i32, i32, i32) {
+    // Step 1: compute chroma-orange (difference of R and B).
+    let co = r - b;
+    // Step 2: shift the blue channel up by half of Co.
+    //         `>> 1` is arithmetic right-shift — rounds toward negative infinity.
+    let tmp = b + (co >> 1);
+    // Step 3: chroma-green (difference of G from adjusted luma).
+    let cg = g - tmp;
+    // Step 4: luma (adjust for Cg).
+    let y = tmp + (cg >> 1);
+    (y, co, cg)
+}
+
+/// Inverse RCT (type 6): (Y, Co, Cg) → RGB.
+///
+/// Exact inverse of `rct_forward`; applying both in succession leaves the
+/// original values unchanged.
+///
+/// Returns `(r, g, b)`.
+pub fn rct_inverse(y: i32, co: i32, cg: i32) -> (i32, i32, i32) {
+    // Undo step 4.
+    let tmp = y - (cg >> 1);
+    // Undo step 3.
+    let g = cg + tmp;
+    // Undo step 2.
+    let b = tmp - (co >> 1);
+    // Undo step 1.
+    let r = b + co;
+    (r, g, b)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn round_trip(r: i32, g: i32, b: i32) {
+        let (y, co, cg) = rct_forward(r, g, b);
+        let (rr, gg, bb) = rct_inverse(y, co, cg);
+        assert_eq!(
+            (r, g, b), (rr, gg, bb),
+            "RCT round-trip failed for ({}, {}, {})",
+            r, g, b
+        );
+    }
+
+    #[test]
+    fn round_trip_black() { round_trip(0, 0, 0); }
+
+    #[test]
+    fn round_trip_white() { round_trip(255, 255, 255); }
+
+    #[test]
+    fn round_trip_red() { round_trip(255, 0, 0); }
+
+    #[test]
+    fn round_trip_green() { round_trip(0, 255, 0); }
+
+    #[test]
+    fn round_trip_blue() { round_trip(0, 0, 255); }
+
+    #[test]
+    fn round_trip_arbitrary() {
+        for r in (0u8..=255).step_by(17) {
+            for g in (0u8..=255).step_by(23) {
+                for b in (0u8..=255).step_by(31) {
+                    round_trip(r as i32, g as i32, b as i32);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn luminance_of_grey_is_grey() {
+        // For (k, k, k): Co=0, Cg=0, Y=k.
+        let (y, co, cg) = rct_forward(100, 100, 100);
+        assert_eq!(co, 0);
+        assert_eq!(cg, 0);
+        assert_eq!(y, 100);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `image-codec-jxl` crate (IC09) implementing a simplified JXL Modular lossless encoder/decoder
- Naked codestream format (`FF 0A` magic); SizeHeader encoded as MSB-first bits per JXL spec §4.1
- Per-channel gradient predictor (W/N/NW/NE neighbours, clamped gradient formula)
- Sign + magnitude two-pass rANS entropy coding (avoids 9-bit alphabet issue with `rans` crate's u8 symbol type)
- Full `PixelContainer` round-trip for RGB (3-channel) and RGBA (4-channel) images
- ISOBMFF container detection (`jxlc` box scan) for decoder compatibility
- YCoCg reversible colour transform included in `rct.rs` (not used by encoder; ready for future use)

## Files created

- `code/packages/rust/image-codec-jxl/` — complete crate (8 source files, BUILD, README.md, CHANGELOG.md, Cargo.toml)
- `code/packages/rust/Cargo.toml` — added `"image-codec-jxl"` to workspace members

## Test plan

- [x] `cargo test -p image-codec-jxl -- --nocapture` → 66 unit tests + 3 doc tests, all pass, zero warnings
- [x] `cargo build -p image-codec-jxl` → clean build
- [x] `cargo build --workspace` → our crate compiles cleanly (pre-existing `uefi` `panic_impl` conflict is unrelated)
- [x] Round-trip tests: 1×1, 2×2, 4×4, 8×8, 32×32, solid colour, gradient, RGBA, transparent black, mixed alpha, max/min channel values
- [x] Error tests: bad magic (PNG header), too short, empty input
- [x] `ImageCodec` trait: mime_type = `"image/jxl"`, encode/decode via trait object

🤖 Generated with [Claude Code](https://claude.com/claude-code)