### PR TITLE
feat(closurec): CV records for post-combine stages (CLOC11.62)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.25.0] - 2026-05-27
+
+### Added — CLOC11.62: CV records for post-combine stages
+
+Extends CLOC11.61's per-stage instrumentation to the four post-concatenation pipeline stages: `emit_use_strict`, `output_wrapper`, `isolation_mode` (IIFE), and `charset`. After the per-file loop, the CV log derives a new "combined" entry whose parents are every per-file CV ID — so a downstream output byte's provenance walks `combined → all source files` automatically.
+
+The combined entry is the substrate every post-concat contribution lands on:
+
+| Stage             | `source`           | `tag`           | `meta`                                                        |
+|-------------------|--------------------|-----------------|---------------------------------------------------------------|
+| emit_use_strict   | `emit_use_strict`  | `prepended`     | `{input_byte_len, output_byte_len}` (only when flag set)      |
+| output_wrapper    | `output_wrapper`   | `substituted`   | `{input_byte_len, output_byte_len}` (only when wrapper changed bytes) |
+| isolation_mode    | `isolation_mode`   | `iife_wrapped`  | `{input_byte_len, output_byte_len}` (only when IIFE set)      |
+| charset           | `charset`          | `normalized`    | `{mode: "US_ASCII"\|"UTF-8", input_byte_len, output_byte_len}` (always) |
+
+Contribution-or-not policy: the `charset` stage always contributes (it always runs); the other three skip the contribution when they're pass-throughs (no flag set / no bytes changed). This keeps the trace focused on actual byte movement while still recording the structural step.
+
+### New CV entity: `concatenated_combined_source`
+
+After the per-file loop, when CV is on, `run_compiler` calls `CVLog::merge(per_file_ids, Some(combined_origin))` to create a new entry whose `parent_ids` are every per-file root. Meta carries `file_count` and `byte_len`. Origin: `source = "concatenated_combined_source"`, no location (it's not a file on disk). All four post-combine contributions attach here.
+
+### Implementation
+
+- **`per_file_cv_ids: Vec<String>`** accumulated through the per-file loop.
+- **`combined_cv_id`** computed after the loop via `cv_log.merge(...)`.
+- **Each post-combine stage** wrapped with `if let Some(id) = &combined_cv_id { ... cv_log.contribute(id, ...) }`.
+- **`isolation_mode = None` branch** had to switch from move-of-`wrapped` to `.clone()` so we can record the input byte length in the CV branch above the move.
+- **6 new unit tests** in `run::tests` (combined entry exists with parents, emit_use_strict on, emit_use_strict off → no contribution, output_wrapper changing bytes, IIFE on, charset always with mode).
+- **Existing CLOC11.61 `pass_order` test** updated to assert prefix `[compilation_level, defines, ...]` rather than exact `[compilation_level, defines]`, since CLOC11.62 + later slices grow the pass_order.
+
+### Pipeline matrix (unchanged structurally)
+
+Same 15 steps; CLOC11.62 adds per-stage CV records inside steps 8–11 (and a new derived "combined" CV entity between steps 6 and 7).
+
+### Still queued
+
+- CLOC11.63: source-map / manifest writes recorded as derived CV entries.
+- CLOC11.64–66: per-token granularity, tombstones for removals, custom `--correlation_vector_output` path flag.
+
 ## [0.24.0] - 2026-05-27
 
 ### Changed — CLOC11.61: per-stage `--correlation_vector` contributions

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.24.0"
+version = "0.25.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/run.rs
+++ b/code/programs/rust/closurec/src/run.rs
@@ -493,6 +493,13 @@ pub fn run_compiler(config: &CompilerConfig) -> Result<CompilerOutput, CompilerE
     let mut cv_log = coding_adventures_correlation_vector::CVLog::new(
         config.special_modes.correlation_vector,
     );
+    // CLOC11.62: per-file CV IDs accumulate so the post-loop
+    // stages (wrapper / IIFE / charset / etc.) can derive a
+    // single "combined" CV entry with all of them as parents.
+    // That combined entry is the substrate the rest of the
+    // pipeline contributes against — every byte from any input
+    // gets its post-combine provenance recorded there.
+    let mut per_file_cv_ids: Vec<String> = Vec::new();
     for path in &inputs {
         let contents = fs::read_to_string(path).map_err(|e| CompilerError::InputReadError {
             path: path.clone(),
@@ -537,6 +544,10 @@ pub fn run_compiler(config: &CompilerConfig) -> Result<CompilerOutput, CompilerE
             None => transform_source(&contents, config)?,
         };
 
+        if let Some(id) = cv_id {
+            per_file_cv_ids.push(id);
+        }
+
         combined.push_str(&transformed);
         // Closure separates concatenated inputs with a newline so
         // back-to-back files don't end up syntactically merged.
@@ -544,6 +555,47 @@ pub fn run_compiler(config: &CompilerConfig) -> Result<CompilerOutput, CompilerE
             combined.push('\n');
         }
     }
+
+    // CLOC11.62: derive the post-concat "combined" CV entry.
+    //
+    // After the per-file loop, every subsequent stage operates on
+    // the concatenated `combined` string, not on individual
+    // files. The CV trace needs an entity that represents that
+    // post-concat substrate — otherwise contributions from
+    // `--emit_use_strict`, `--output_wrapper`, IIFE, `--charset`
+    // would have nowhere to attach.
+    //
+    // We use `CVLog::merge()` with the per-file CV IDs as parents,
+    // so a downstream consumer following an output-byte's
+    // provenance walks: combined-entry → all source files. The
+    // origin is synthetic ("concatenated_combined_source"); no
+    // location since it's not a file on disk.
+    let combined_cv_id = if config.special_modes.correlation_vector
+        && !per_file_cv_ids.is_empty()
+    {
+        let parent_refs: Vec<&str> =
+            per_file_cv_ids.iter().map(|s| s.as_str()).collect();
+        let mut meta = std::collections::HashMap::new();
+        meta.insert(
+            "file_count".to_string(),
+            serde_json::Value::Number((per_file_cv_ids.len() as u64).into()),
+        );
+        meta.insert(
+            "byte_len".to_string(),
+            serde_json::Value::Number((combined.len() as u64).into()),
+        );
+        Some(cv_log.merge(
+            &parent_refs,
+            Some(coding_adventures_correlation_vector::Origin {
+                source: "concatenated_combined_source".to_string(),
+                location: String::new(),
+                timestamp: None,
+                meta,
+            }),
+        ))
+    } else {
+        None
+    };
 
     // Step 2.25 (CLOC11.51): --checks_only short-circuits emission.
     //
@@ -576,6 +628,29 @@ pub fn run_compiler(config: &CompilerConfig) -> Result<CompilerOutput, CompilerE
     // it sits at the very top of the function body it's meant to
     // govern. CC has the same ordering.
     if config.language.emit_use_strict {
+        // CLOC11.62 — record the emit_use_strict contribution
+        // on the combined entry. The directive is a fixed-size
+        // 16-byte prepend (`"use strict";\n`), so meta carries
+        // the input/output byte lengths.
+        if let Some(id) = &combined_cv_id {
+            let mut meta = std::collections::HashMap::new();
+            meta.insert(
+                "input_byte_len".to_string(),
+                serde_json::Value::Number((combined.len() as u64).into()),
+            );
+            meta.insert(
+                "output_byte_len".to_string(),
+                serde_json::Value::Number(
+                    ((combined.len() + 16) as u64).into(),
+                ),
+            );
+            let _ = cv_log.contribute(
+                id,
+                "emit_use_strict",
+                "prepended",
+                meta,
+            );
+        }
         // Use double quotes to match CC's emission. A trailing
         // newline keeps the directive on its own line, which is
         // visually clearer in --output_wrapper templates that
@@ -598,6 +673,34 @@ pub fn run_compiler(config: &CompilerConfig) -> Result<CompilerOutput, CompilerE
     )
     .map_err(CompilerError::Wrapper)?;
 
+    // CLOC11.62 — record the output_wrapper contribution.
+    //
+    // We only emit a contribution when the wrapper actually
+    // changed the bytes (`wrapped != combined`). Skipping the
+    // contribution for the no-wrapper passthrough avoids
+    // spurious entries that say "this pass ran and did
+    // nothing" — the CV trace stays focused on bytes that
+    // moved.
+    if let Some(id) = &combined_cv_id {
+        if wrapped != combined {
+            let mut meta = std::collections::HashMap::new();
+            meta.insert(
+                "input_byte_len".to_string(),
+                serde_json::Value::Number((combined.len() as u64).into()),
+            );
+            meta.insert(
+                "output_byte_len".to_string(),
+                serde_json::Value::Number((wrapped.len() as u64).into()),
+            );
+            let _ = cv_log.contribute(
+                id,
+                "output_wrapper",
+                "substituted",
+                meta,
+            );
+        }
+    }
+
     // Step 3.5 (CLOC11.31): apply --isolation_mode IIFE if set.
     // Layered after the user wrapper, matching CC's pipeline:
     // user wrapper runs first, IIFE wraps the result. So the
@@ -605,8 +708,31 @@ pub fn run_compiler(config: &CompilerConfig) -> Result<CompilerOutput, CompilerE
     // CC, and the behavior users requesting IIFE expect.
     let isolated = match config.formatting.isolation_mode {
         IsolationMode::Iife => wrapper::apply_iife_wrap(&wrapped),
-        IsolationMode::None => wrapped,
+        IsolationMode::None => wrapped.clone(),
     };
+
+    // CLOC11.62 — record the isolation_mode contribution.
+    // Only fires when IIFE is on; the None case is a pass-through
+    // that doesn't change bytes.
+    if let Some(id) = &combined_cv_id {
+        if config.formatting.isolation_mode == IsolationMode::Iife {
+            let mut meta = std::collections::HashMap::new();
+            meta.insert(
+                "input_byte_len".to_string(),
+                serde_json::Value::Number((wrapped.len() as u64).into()),
+            );
+            meta.insert(
+                "output_byte_len".to_string(),
+                serde_json::Value::Number((isolated.len() as u64).into()),
+            );
+            let _ = cv_log.contribute(
+                id,
+                "isolation_mode",
+                "iife_wrapped",
+                meta,
+            );
+        }
+    }
 
     // Step 3.75 (CLOC11.16): apply --charset normalization.
     //
@@ -620,10 +746,38 @@ pub fn run_compiler(config: &CompilerConfig) -> Result<CompilerOutput, CompilerE
     // user injected via `--output_wrapper` (e.g. a `©` in a
     // banner) gets escaped alongside the body. See
     // `crate::charset` for the table of accepted values.
-    let encoded = crate::charset::apply_charset(
-        &isolated,
-        crate::charset::OutputCharset::from_raw(&config.io.charset),
-    );
+    let charset_mode = crate::charset::OutputCharset::from_raw(&config.io.charset);
+    let encoded = crate::charset::apply_charset(&isolated, charset_mode);
+
+    // CLOC11.62 — record the charset contribution.
+    //
+    // The contribution lands even when the mode is UTF-8 (pass-
+    // through) because the stage RAN — same symmetry argument as
+    // CLOC11.61's defines.applied. Meta carries the resolved
+    // mode name and byte deltas so a viewer can show whether
+    // escapes were emitted.
+    if let Some(id) = &combined_cv_id {
+        let mut meta = std::collections::HashMap::new();
+        meta.insert(
+            "mode".to_string(),
+            serde_json::Value::String(
+                match charset_mode {
+                    crate::charset::OutputCharset::UsAscii => "US_ASCII",
+                    crate::charset::OutputCharset::Utf8 => "UTF-8",
+                }
+                .to_string(),
+            ),
+        );
+        meta.insert(
+            "input_byte_len".to_string(),
+            serde_json::Value::Number((isolated.len() as u64).into()),
+        );
+        meta.insert(
+            "output_byte_len".to_string(),
+            serde_json::Value::Number((encoded.len() as u64).into()),
+        );
+        let _ = cv_log.contribute(id, "charset", "normalized", meta);
+    }
 
     // Step 4: write the output. Two cases:
     //   a) --js_output_file set → write to disk via write_output_file.
@@ -2159,10 +2313,13 @@ mod tests {
         assert!(body.contains("\"source\":\"compilation_level\""));
         assert!(body.contains("\"source\":\"defines\""));
         // pass_order in the CVLog dump should show
-        // compilation_level FIRST. We pin the substring `["compilation_level"` to catch the leading element.
+        // compilation_level FIRST, then defines. Other passes
+        // may follow (CLOC11.62 adds charset; later slices add
+        // more). Pin the prefix to keep the per-file ordering
+        // invariant while staying tolerant of new passes.
         assert!(
-            body.contains("\"pass_order\":[\"compilation_level\",\"defines\"]"),
-            "expected pass_order [compilation_level, defines], got: {body}"
+            body.contains("\"pass_order\":[\"compilation_level\",\"defines\""),
+            "expected pass_order to start with [compilation_level, defines, ...], got: {body}"
         );
         let _ = fs::remove_dir_all(&dir);
     }
@@ -2178,5 +2335,205 @@ mod tests {
         let a = transform_source(source, &cfg).expect("a");
         let b = transform_source_with_cv(source, &cfg, None).expect("b");
         assert_eq!(a, b);
+    }
+
+    // ------------------------------------------------------------------
+    // CLOC11.62 — CV records for post-combine stages (emit_use_strict,
+    // output_wrapper, isolation_mode, charset)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn correlation_vector_creates_combined_entry_after_per_file_loop() {
+        // The "concatenated_combined_source" CV entry should
+        // appear in the sidecar, with the per-file entries as
+        // parents. Lets us walk a downstream byte's provenance
+        // back to its source file(s).
+        let dir = temp_path("cv-combined-dir");
+        fs::create_dir_all(&dir).expect("setup");
+        let in_path = dir.join("in.js");
+        let out_path = dir.join("out.js");
+        let sidecar_path = dir.join("out.js.cv.json");
+        fs::write(&in_path, "var x = 1;").expect("setup");
+        let cfg = CompilerConfig {
+            io: IoConfig {
+                js_patterns: vec![in_path.to_string_lossy().to_string()],
+                js_output_file: Some(out_path.clone()),
+                ..Default::default()
+            },
+            special_modes: crate::config::SpecialModesConfig {
+                correlation_vector: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let _ = run_compiler(&cfg).expect("ok");
+        let body = fs::read_to_string(&sidecar_path).expect("read sidecar");
+        assert!(
+            body.contains("\"source\":\"concatenated_combined_source\""),
+            "missing combined entry: {body}"
+        );
+        // file_count meta should show 1.
+        assert!(body.contains("\"file_count\":1"), "got: {body}");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn correlation_vector_records_emit_use_strict_contribution() {
+        let dir = temp_path("cv-strict-dir");
+        fs::create_dir_all(&dir).expect("setup");
+        let in_path = dir.join("in.js");
+        let out_path = dir.join("out.js");
+        let sidecar_path = dir.join("out.js.cv.json");
+        fs::write(&in_path, "var x = 1;").expect("setup");
+        let cfg = CompilerConfig {
+            io: IoConfig {
+                js_patterns: vec![in_path.to_string_lossy().to_string()],
+                js_output_file: Some(out_path.clone()),
+                ..Default::default()
+            },
+            language: crate::config::LanguageConfig {
+                emit_use_strict: true,
+                ..Default::default()
+            },
+            special_modes: crate::config::SpecialModesConfig {
+                correlation_vector: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let _ = run_compiler(&cfg).expect("ok");
+        let body = fs::read_to_string(&sidecar_path).expect("read sidecar");
+        assert!(
+            body.contains("\"source\":\"emit_use_strict\""),
+            "missing emit_use_strict source: {body}"
+        );
+        assert!(
+            body.contains("\"tag\":\"prepended\""),
+            "missing prepended tag: {body}"
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn correlation_vector_does_not_record_emit_use_strict_when_unset() {
+        let dir = temp_path("cv-no-strict-dir");
+        fs::create_dir_all(&dir).expect("setup");
+        let in_path = dir.join("in.js");
+        let out_path = dir.join("out.js");
+        let sidecar_path = dir.join("out.js.cv.json");
+        fs::write(&in_path, "var x = 1;").expect("setup");
+        let cfg = CompilerConfig {
+            io: IoConfig {
+                js_patterns: vec![in_path.to_string_lossy().to_string()],
+                js_output_file: Some(out_path.clone()),
+                ..Default::default()
+            },
+            // emit_use_strict NOT set → no contribution.
+            special_modes: crate::config::SpecialModesConfig {
+                correlation_vector: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let _ = run_compiler(&cfg).expect("ok");
+        let body = fs::read_to_string(&sidecar_path).expect("read sidecar");
+        assert!(
+            !body.contains("emit_use_strict"),
+            "should NOT contain emit_use_strict when flag is off: {body}"
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn correlation_vector_records_output_wrapper_when_bytes_changed() {
+        let dir = temp_path("cv-wrapper-dir");
+        fs::create_dir_all(&dir).expect("setup");
+        let in_path = dir.join("in.js");
+        let out_path = dir.join("out.js");
+        let sidecar_path = dir.join("out.js.cv.json");
+        fs::write(&in_path, "var x;").expect("setup");
+        let cfg = CompilerConfig {
+            io: IoConfig {
+                js_patterns: vec![in_path.to_string_lossy().to_string()],
+                js_output_file: Some(out_path.clone()),
+                ..Default::default()
+            },
+            formatting: crate::config::FormattingConfig {
+                output_wrapper: "PRE %output% POST".to_string(),
+                ..Default::default()
+            },
+            special_modes: crate::config::SpecialModesConfig {
+                correlation_vector: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let _ = run_compiler(&cfg).expect("ok");
+        let body = fs::read_to_string(&sidecar_path).expect("read sidecar");
+        assert!(body.contains("\"source\":\"output_wrapper\""), "got: {body}");
+        assert!(body.contains("\"tag\":\"substituted\""), "got: {body}");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn correlation_vector_records_iife_when_isolation_mode_set() {
+        let dir = temp_path("cv-iife-dir");
+        fs::create_dir_all(&dir).expect("setup");
+        let in_path = dir.join("in.js");
+        let out_path = dir.join("out.js");
+        let sidecar_path = dir.join("out.js.cv.json");
+        fs::write(&in_path, "var x;").expect("setup");
+        let cfg = CompilerConfig {
+            io: IoConfig {
+                js_patterns: vec![in_path.to_string_lossy().to_string()],
+                js_output_file: Some(out_path.clone()),
+                ..Default::default()
+            },
+            formatting: crate::config::FormattingConfig {
+                isolation_mode: IsolationMode::Iife,
+                ..Default::default()
+            },
+            special_modes: crate::config::SpecialModesConfig {
+                correlation_vector: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let _ = run_compiler(&cfg).expect("ok");
+        let body = fs::read_to_string(&sidecar_path).expect("read sidecar");
+        assert!(body.contains("\"source\":\"isolation_mode\""), "got: {body}");
+        assert!(body.contains("\"tag\":\"iife_wrapped\""), "got: {body}");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn correlation_vector_always_records_charset_with_resolved_mode() {
+        // The charset contribution lands even at the default
+        // (US_ASCII out, no flag passed) because the stage RAN.
+        let dir = temp_path("cv-charset-dir");
+        fs::create_dir_all(&dir).expect("setup");
+        let in_path = dir.join("in.js");
+        let out_path = dir.join("out.js");
+        let sidecar_path = dir.join("out.js.cv.json");
+        fs::write(&in_path, "var x;").expect("setup");
+        let cfg = CompilerConfig {
+            io: IoConfig {
+                js_patterns: vec![in_path.to_string_lossy().to_string()],
+                js_output_file: Some(out_path.clone()),
+                ..Default::default()
+            },
+            special_modes: crate::config::SpecialModesConfig {
+                correlation_vector: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let _ = run_compiler(&cfg).expect("ok");
+        let body = fs::read_to_string(&sidecar_path).expect("read sidecar");
+        assert!(body.contains("\"source\":\"charset\""), "got: {body}");
+        assert!(body.contains("\"tag\":\"normalized\""), "got: {body}");
+        // The default mode is US_ASCII; should appear in meta.
+        assert!(body.contains("\"mode\":\"US_ASCII\""), "got: {body}");
+        let _ = fs::remove_dir_all(&dir);
     }
 }

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.24.0
+Version: 0.25.0
 
 ## Flags
 


### PR DESCRIPTION
## Summary
- Extends CLOC11.61's per-stage CV instrumentation to four post-concatenation pipeline stages: \`emit_use_strict\`, \`output_wrapper\`, \`isolation_mode\` (IIFE), \`charset\`.
- New CV entity: \`concatenated_combined_source\` — derived via \`CVLog::merge\` after the per-file loop, with every per-file CV ID as a parent. So a downstream byte's provenance walks **combined → all source files** automatically.
- **Stacked PR.** Base = \`feat/cloc11-61-cv-stage-split\` (PR #4571), which is on top of \`feat/cloc11-60-cv-plumbing\` (PR #4568). Merges sequentially: #4568 → #4571 → this PR.

## Contribution shape

| Stage             | \`source\`           | \`tag\`           | Records when                                  |
|-------------------|---------------------|-----------------|-----------------------------------------------|
| emit_use_strict   | \`emit_use_strict\`  | \`prepended\`    | flag is set                                   |
| output_wrapper    | \`output_wrapper\`   | \`substituted\`  | wrapper changed bytes                         |
| isolation_mode    | \`isolation_mode\`   | \`iife_wrapped\` | IIFE is set                                   |
| charset           | \`charset\`          | \`normalized\`   | always (it always runs); meta has \`mode\`    |

Pass-through stages skip the contribution to keep the trace focused on bytes that moved.

## Tests
- 6 new unit tests (combined entry exists, emit_use_strict on / off, output_wrapper bytes changed, IIFE on, charset always with mode)
- CLOC11.61 \`pass_order\` test updated to prefix match (grows with new slices)
- 229 unit tests + integration tests pass; clippy clean

## Versions
- \`Cargo.toml\`: 0.24.0 → 0.25.0
- \`cli.spec.json\`: 0.24.0 → 0.25.0
- Help-markdown fixture regenerated
- CHANGELOG \`[0.25.0]\` entry

## Security review (inline)
\`CVLog::merge()\` uses in-memory cv_ids as parents — no user-controlled paths reach \`parent_ids\`. Stage contributions use fixed source/tag strings + integer/string meta. No new FS/net I/O. No \`unsafe\`.

## Test plan
- [x] \`cargo build\` clean
- [x] \`cargo test\` — 229 unit + integration tests pass
- [x] \`cargo clippy --no-deps -p coding-adventures-closurec\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)