### PR TITLE
feat(symbolic-vm): Track E2 — generic IBP port + macsyma-finish-plan closed

### DIFF
--- a/code/packages/rust/symbolic-vm/CHANGELOG.md
+++ b/code/packages/rust/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,59 @@
 # Changelog — symbolic-vm (Rust)
 
+## [0.16.0] — 2026-05-28
+
+**Track E2 — generic tabular integration-by-parts fallback (Rust port).**
+Mirrors the Python `ibp_tabular.py` reference (Track E1) and the
+TypeScript port at `0.16.0`.  Closes the cross-language gap for the
+`Integrate` handler.
+
+When every shape-specific handler in `integrate` returned the original
+unevaluated `Integrate(...)` form for a `Mul`-shaped integrand, the new
+`try_ibp_tabular` fallback makes a last-ditch attempt by **generic
+tabular IBP**:
+
+```
+For f = u(x) · w(x) with u polynomial in x:
+  ∫ u·w dx = Σ_{k=0}^{N-1} (-1)^k · u^(k)(x) · I^(k+1)(w)
+```
+
+where N = deg(u) + 1.  The I-column entries `∫w, ∫∫w, ..., ∫^N w` come
+from a recursive call to `integrate` (not the outer handler — this
+avoids re-entering the IBP fallback during column construction); any
+step that fails to close abandons the partition.  Bounded by
+`IBP_MAX_FACTORS = 5` and `IBP_MAX_POLY_DEGREE = 8`.
+
+### Added
+
+- `try_ibp_tabular(f, x, vm)` — top-level fallback.  Returns the
+  closed-form antiderivative or `None`.
+- `ibp_flatten_mul(node)` — flattens nested-binary `Mul(a, Mul(b, c))`
+  trees so the IBP search isn't fooled by parse-tree grouping.
+- `ibp_multiply_ir(factors)` — rebuilds a left-associative `Mul` chain.
+- `ibp_polynomial_degree(node, x)` — returns the polynomial degree in x
+  (`Some(-1)` for zero, `None` for non-polynomial).
+- `ibp_contains_integrate(node)`, `ibp_is_zero(node)`,
+  `ibp_try_split(...)`, `ibp_combinations(n, k)` — implementation
+  helpers.
+
+### Changed
+
+- `integrate_handler` now invokes `try_ibp_tabular` as the **last**
+  fallback before returning the unevaluated `Integrate(...)` form.
+  Closed-form results are passed through `vm.eval` for simplification.
+
+### Test plan
+
+Six tests in `tests/ibp_tabular.rs`:
+
+1. `∫ x·sin(x) dx` closes via tabular IBP.
+2. `∫ x²·eˣ dx` closes via tabular IBP.
+3. `∫ x³·cos(x) dx` closes (verified against trapezoidal rule).
+4. Fallthrough: `∫ 1/x dx → log(x)` (IBP short-circuits — head is DIV).
+5. Fallthrough: `∫ sin(x²) dx` stays unevaluated or returns Fresnel —
+   IBP fabricates no bogus elementary form.
+6. Regression: `∫ cos(x²) dx` (Fresnel family) still stays unevaluated.
+
 ## [0.15.0] — 2026-05-28
 
 **Track D2 — bivariate Hensel lifting in `Factor` (Rust port).**

--- a/code/packages/rust/symbolic-vm/Cargo.toml
+++ b/code/packages/rust/symbolic-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symbolic-vm"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 description = "Generic symbolic expression evaluator over the symbolic-ir tree representation"
 license = "MIT"

--- a/code/packages/rust/symbolic-vm/src/handlers.rs
+++ b/code/packages/rust/symbolic-vm/src/handlers.rs
@@ -1996,8 +1996,15 @@ fn integrate_handler() -> Handler {
         }
 
         let result = integrate(&f, &x);
-        let original = apply_node(INTEGRATE, vec![f, IRNode::Symbol(x)]);
+        let original = apply_node(INTEGRATE, vec![f.clone(), IRNode::Symbol(x.clone())]);
         if result == original {
+            // Track E2: generic tabular IBP fallback.  Fires after every
+            // shape-specific handler in `integrate` returned the original
+            // unevaluated `Integrate(...)` form.  Mirrors the Python
+            // ``try_ibp_tabular`` hook in ``integrate.py``.
+            if let Some(ibp_result) = try_ibp_tabular(&f, &x, vm) {
+                return vm.eval(ibp_result);
+            }
             result
         } else {
             vm.eval(result)
@@ -2127,6 +2134,233 @@ fn integrate(f: &IRNode, x: &str) -> IRNode {
         }
         _ => apply_node(INTEGRATE, vec![f.clone(), IRNode::Symbol(x.to_string())]),
     }
+}
+
+// ---------------------------------------------------------------------------
+// Track E2 — Generic tabular integration-by-parts fallback.
+//
+// Mirrors `ibp_tabular.py` from the Python reference (Track E1).  When
+// every shape-specific handler in `integrate` returned the original
+// unevaluated `Integrate(...)` form, this fallback makes a last-ditch
+// attempt by **generic tabular IBP**:
+//
+//   For ``f = u(x) · w(x)`` where ``u`` is polynomial in ``x``:
+//     ∫ u·w dx = Σ_{k=0}^{N-1} (-1)^k · u^(k)(x) · I^(k+1)(w)
+//
+// where N = deg(u) + 1.  The I-column entries ``∫w, ∫∫w, ..., ∫^N w``
+// come from recursive ``integrate``; if any step fails to close, the
+// partition is abandoned.  Bounded by `IBP_MAX_FACTORS` (5) and
+// `IBP_MAX_POLY_DEGREE` (8).
+// ---------------------------------------------------------------------------
+
+const IBP_MAX_FACTORS: usize = 5;
+const IBP_MAX_POLY_DEGREE: usize = 8;
+
+/// Flatten a (possibly nested-binary) `Mul` tree into a list of leaves.
+/// `Mul(a, Mul(b, Mul(c, d)))` → `[a, b, c, d]`.  Without flattening the
+/// IBP search would miss splits like `u = a·c, w = b·d` purely because
+/// the parse tree happened to group differently.
+fn ibp_flatten_mul(node: &IRNode) -> Vec<IRNode> {
+    if let IRNode::Apply(apply) = node {
+        if apply.head == IRNode::Symbol(MUL.to_string()) {
+            let mut out = Vec::new();
+            for arg in &apply.args {
+                out.extend(ibp_flatten_mul(arg));
+            }
+            return out;
+        }
+    }
+    vec![node.clone()]
+}
+
+/// Rebuild a left-associative `Mul` chain from a list of factors.  Empty
+/// list → `1`; single factor returns itself.
+fn ibp_multiply_ir(factors: &[IRNode]) -> IRNode {
+    if factors.is_empty() {
+        return IRNode::Integer(1);
+    }
+    if factors.len() == 1 {
+        return factors[0].clone();
+    }
+    let mut acc = factors[0].clone();
+    for f in &factors[1..] {
+        acc = apply_node(MUL, vec![acc, f.clone()]);
+    }
+    acc
+}
+
+/// Polynomial degree of `node` in `x`.  Returns `Some(-1)` for the zero
+/// polynomial, `Some(d)` for degree-d polynomials, `None` for anything
+/// outside Q[x].  Mirrors Python `_polynomial_degree`.
+fn ibp_polynomial_degree(node: &IRNode, x: &str) -> Option<i64> {
+    let (num, den) = to_rational_ir(node, x)?;
+    if rp_normalize(&den).len() > 1 {
+        return None; // rational, not polynomial in x
+    }
+    let n = rp_normalize(&num);
+    if n.is_empty() {
+        Some(-1) // zero
+    } else {
+        Some((n.len() - 1) as i64)
+    }
+}
+
+/// True if `node` contains any unevaluated `Integrate(...)` sub-tree.
+fn ibp_contains_integrate(node: &IRNode) -> bool {
+    if let IRNode::Apply(apply) = node {
+        if apply.head == IRNode::Symbol(INTEGRATE.to_string()) {
+            return true;
+        }
+        return apply.args.iter().any(ibp_contains_integrate);
+    }
+    false
+}
+
+/// True iff `node` canonicalises to the integer literal `0`.  Also
+/// recognises `Neg(0)`.
+fn ibp_is_zero(node: &IRNode) -> bool {
+    match node {
+        IRNode::Integer(0) => true,
+        IRNode::Apply(apply) => {
+            apply.head == IRNode::Symbol(NEG.to_string())
+                && apply.args.len() == 1
+                && ibp_is_zero(&apply.args[0])
+        }
+        _ => false,
+    }
+}
+
+/// Enumerate k-element subsets of `[0, n)`.
+fn ibp_combinations(n: usize, k: usize) -> Vec<Vec<usize>> {
+    let mut out = Vec::new();
+    let mut pick = Vec::new();
+    fn walk(start: usize, n: usize, k: usize, pick: &mut Vec<usize>, out: &mut Vec<Vec<usize>>) {
+        if pick.len() == k {
+            out.push(pick.clone());
+            return;
+        }
+        for i in start..n {
+            pick.push(i);
+            walk(i + 1, n, k, pick, out);
+            pick.pop();
+        }
+    }
+    walk(0, n, k, &mut pick, &mut out);
+    out
+}
+
+/// Attempt generic tabular IBP on a `Mul`-shaped integrand.  Returns the
+/// closed-form antiderivative as IR, or `None` when no viable `(u, w)`
+/// split was found.
+fn try_ibp_tabular(f: &IRNode, x: &str, vm: &mut VM) -> Option<IRNode> {
+    // Only fires on Mul — every other shape has dedicated handlers.
+    let IRNode::Apply(apply) = f else {
+        return None;
+    };
+    if apply.head != IRNode::Symbol(MUL.to_string()) {
+        return None;
+    }
+    let factors = ibp_flatten_mul(f);
+    if factors.len() < 2 || factors.len() > IBP_MAX_FACTORS {
+        return None;
+    }
+    let n = factors.len();
+    // Prefer smaller `u` first — tabular IBP is most efficient when `u`
+    // is low-degree.
+    for u_size in 1..n {
+        for u_idx in ibp_combinations(n, u_size) {
+            let u_set: HashSet<usize> = u_idx.into_iter().collect();
+            let mut u_factors: Vec<IRNode> = Vec::new();
+            let mut w_factors: Vec<IRNode> = Vec::new();
+            for (i, factor) in factors.iter().enumerate() {
+                if u_set.contains(&i) {
+                    u_factors.push(factor.clone());
+                } else {
+                    w_factors.push(factor.clone());
+                }
+            }
+            if let Some(result) = ibp_try_split(&u_factors, &w_factors, x, vm) {
+                return Some(result);
+            }
+        }
+    }
+    None
+}
+
+/// Try `u = ∏ u_factors`, `w = ∏ w_factors` as the tabular split.
+fn ibp_try_split(
+    u_factors: &[IRNode],
+    w_factors: &[IRNode],
+    x: &str,
+    vm: &mut VM,
+) -> Option<IRNode> {
+    let u_ir = vm.eval(ibp_multiply_ir(u_factors));
+    let deg = ibp_polynomial_degree(&u_ir, x)?;
+    if deg < 0 {
+        // u is the zero polynomial — ∫ 0·w dx = 0.
+        return Some(IRNode::Integer(0));
+    }
+    let deg = deg as usize;
+    if deg > IBP_MAX_POLY_DEGREE {
+        return None;
+    }
+
+    // D-column: u, u', u'', ..., 0.
+    let mut d_col: Vec<IRNode> = vec![u_ir.clone()];
+    let mut cur = u_ir;
+    for _ in 0..=deg {
+        let next = vm.eval(diff(&cur, x));
+        d_col.push(next.clone());
+        cur = next;
+        if ibp_is_zero(&cur) {
+            break;
+        }
+    }
+    if !ibp_is_zero(d_col.last().unwrap()) {
+        return None;
+    }
+    let big_n = d_col.len() - 1; // u^(N) = 0
+
+    // I-column: w, ∫w, ∫∫w, ..., ∫^N w.
+    let w_ir = vm.eval(ibp_multiply_ir(w_factors));
+    let mut i_col: Vec<IRNode> = vec![w_ir.clone()];
+    let mut cur = w_ir;
+    let x_sym = IRNode::Symbol(x.to_string());
+    for _ in 0..big_n {
+        // Call integrate directly to avoid re-entering the IBP fallback
+        // inside the recursive integrator (mirrors Python's
+        // `integrate_fn=lambda g: _integrate(g, x)` rather than the
+        // outer handler).
+        let integrated = integrate(&cur, x);
+        let unevaluated = apply_node(INTEGRATE, vec![cur.clone(), x_sym.clone()]);
+        if integrated == unevaluated {
+            return None;
+        }
+        let simplified = vm.eval(integrated);
+        if ibp_contains_integrate(&simplified) {
+            return None;
+        }
+        i_col.push(simplified.clone());
+        cur = simplified;
+    }
+
+    // Assemble: Σ_{k=0}^{N-1} (-1)^k · D[k] · I[k+1].
+    let mut pieces: Vec<IRNode> = Vec::new();
+    for k in 0..big_n {
+        let mut term = apply_node(MUL, vec![d_col[k].clone(), i_col[k + 1].clone()]);
+        if k % 2 == 1 {
+            term = apply_node(NEG, vec![term]);
+        }
+        pieces.push(term);
+    }
+    if pieces.is_empty() {
+        return Some(IRNode::Integer(0));
+    }
+    let mut result = pieces[0].clone();
+    for piece in &pieces[1..] {
+        result = apply_node(ADD, vec![result, piece.clone()]);
+    }
+    Some(result)
 }
 
 fn complete_elliptic_first_kind(

--- a/code/packages/rust/symbolic-vm/tests/ibp_tabular.rs
+++ b/code/packages/rust/symbolic-vm/tests/ibp_tabular.rs
@@ -1,0 +1,173 @@
+//! Track E2 — Generic tabular integration-by-parts fallback (Rust port).
+//!
+//! Mirrors `tests/test_ibp.py` from the Python reference (Track E1) and
+//! the TypeScript port at `tests/ibp-tabular.test.ts`.  All correctness
+//! checks use **numeric differentiation of the returned antiderivative**
+//! against the original integrand.  This avoids hard-coding the exact
+//! algebraic form of the answer — any equivalent shape is accepted as
+//! long as the symbolic antiderivative evaluates to the correct numeric
+//! value.
+
+use symbolic_ir::{apply, flt, int, sym, IRNode, COS, DIV, EXP, INTEGRATE, LOG, MUL, POW, SIN};
+use symbolic_vm::{SymbolicBackend, VM};
+
+fn make_vm() -> VM {
+    VM::new(Box::new(SymbolicBackend::new()))
+}
+
+fn integrate(f: IRNode) -> IRNode {
+    apply(sym(INTEGRATE), vec![f, sym("x")])
+}
+
+/// Substitute `x` ← `value` everywhere in `node`.
+fn subst(node: &IRNode, var: &str, value: &IRNode) -> IRNode {
+    match node {
+        IRNode::Symbol(name) if name == var => value.clone(),
+        IRNode::Apply(apply_node) => {
+            let head = subst(&apply_node.head, var, value);
+            let args: Vec<IRNode> = apply_node.args.iter().map(|a| subst(a, var, value)).collect();
+            apply(head, args)
+        }
+        other => other.clone(),
+    }
+}
+
+/// Evaluate `expr` with x ← x_val and return the resulting float.
+fn eval_at(vm: &mut VM, expr: &IRNode, x_val: f64) -> f64 {
+    let substituted = subst(expr, "x", &flt(x_val));
+    let folded = vm.eval(substituted);
+    match folded {
+        IRNode::Float(f) => f,
+        IRNode::Integer(n) => n as f64,
+        IRNode::Rational(n, d) => n as f64 / d as f64,
+        _ => f64::NAN,
+    }
+}
+
+/// Recursively check whether `node` contains an `IRApply` with `head`.
+fn contains_head(node: &IRNode, head_name: &str) -> bool {
+    if let IRNode::Apply(a) = node {
+        if let IRNode::Symbol(s) = &a.head {
+            if s == head_name {
+                return true;
+            }
+        }
+        return a.args.iter().any(|arg| contains_head(arg, head_name));
+    }
+    false
+}
+
+/// Plain trapezoidal rule for ground-truth numeric integration.
+fn trapezoidal<F: Fn(f64) -> f64>(f: F, a: f64, b: f64, n: usize) -> f64 {
+    let h = (b - a) / n as f64;
+    let mut total = 0.5 * (f(a) + f(b));
+    for i in 1..n {
+        total += f(a + i as f64 * h);
+    }
+    total * h
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance #1 — ∫ x·sin(x) dx = sin(x) − x·cos(x).
+// ---------------------------------------------------------------------------
+#[test]
+fn ibp_x_times_sin_x_closes() {
+    let mut vm = make_vm();
+    let integrand = apply(sym(MUL), vec![sym("x"), apply(sym(SIN), vec![sym("x")])]);
+    let out = vm.eval(integrate(integrand));
+    assert!(!contains_head(&out, INTEGRATE), "not closed: {:?}", out);
+    let diff = eval_at(&mut vm, &out, 1.0) - eval_at(&mut vm, &out, 0.0);
+    let expected = 1.0_f64.sin() - 1.0_f64.cos();
+    assert!((diff - expected).abs() < 1e-9, "diff={}, expected={}", diff, expected);
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance #2 — ∫ x²·eˣ dx = (x² − 2x + 2)·eˣ.
+// ---------------------------------------------------------------------------
+#[test]
+fn ibp_xsquared_times_exp_x_closes() {
+    let mut vm = make_vm();
+    let integrand = apply(
+        sym(MUL),
+        vec![
+            apply(sym(POW), vec![sym("x"), int(2)]),
+            apply(sym(EXP), vec![sym("x")]),
+        ],
+    );
+    let out = vm.eval(integrate(integrand));
+    assert!(!contains_head(&out, INTEGRATE), "not closed: {:?}", out);
+    let diff = eval_at(&mut vm, &out, 2.0) - eval_at(&mut vm, &out, 0.0);
+    let expected = 2.0 * 2.0_f64.exp() - 2.0;
+    assert!((diff - expected).abs() < 1e-9, "diff={}, expected={}", diff, expected);
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance #3 — higher-degree polynomial × trig: ∫ x³·cos(x) dx.
+// ---------------------------------------------------------------------------
+#[test]
+fn ibp_xcubed_times_cos_x_closes() {
+    let mut vm = make_vm();
+    let integrand = apply(
+        sym(MUL),
+        vec![
+            apply(sym(POW), vec![sym("x"), int(3)]),
+            apply(sym(COS), vec![sym("x")]),
+        ],
+    );
+    let out = vm.eval(integrate(integrand));
+    assert!(!contains_head(&out, INTEGRATE), "not closed: {:?}", out);
+    let diff = eval_at(&mut vm, &out, 1.0) - eval_at(&mut vm, &out, 0.0);
+    let numeric = trapezoidal(|x| x * x * x * x.cos(), 0.0, 1.0, 50_000);
+    assert!(
+        (diff - numeric).abs() < 1e-5,
+        "diff={}, numeric={}",
+        diff,
+        numeric
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance #4 — fallthrough: ∫ 1/x dx returns log(x).  The integrand is
+// not a Mul (its head is DIV), so tabular IBP short-circuits to None.
+// ---------------------------------------------------------------------------
+#[test]
+fn ibp_fallthrough_one_over_x_returns_log() {
+    let mut vm = make_vm();
+    let integrand = apply(sym(DIV), vec![int(1), sym("x")]);
+    let out = vm.eval(integrate(integrand));
+    assert!(!contains_head(&out, INTEGRATE), "expected closed form: {:?}", out);
+    assert!(contains_head(&out, LOG));
+    let diff = eval_at(&mut vm, &out, 2.0) - eval_at(&mut vm, &out, 1.0);
+    assert!((diff - 2.0_f64.ln()).abs() < 1e-12, "diff={}", diff);
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance #5 — fallthrough: ∫ sin(x²) dx stays unevaluated (Fresnel).
+// The integrand isn't a Mul, so tabular IBP would also short-circuit to
+// None.  The engine must not fabricate a bogus elementary closed form.
+// ---------------------------------------------------------------------------
+#[test]
+fn ibp_fallthrough_fresnel_sin_xsq_unevaluated() {
+    let mut vm = make_vm();
+    let integrand = apply(sym(SIN), vec![apply(sym(POW), vec![sym("x"), int(2)])]);
+    let out = vm.eval(integrate(integrand));
+    let has_unevaluated = contains_head(&out, INTEGRATE);
+    let has_fresnel = contains_head(&out, "FresnelS");
+    assert!(has_unevaluated || has_fresnel, "unexpected closed form: {:?}", out);
+}
+
+// ---------------------------------------------------------------------------
+// Regression #6 — previously-Fresnel-family integral ∫ cos(x²) dx still
+// stays unevaluated after the IBP fallback ships.  The integrand is not
+// a Mul, so tabular IBP short-circuits to None and the engine must not
+// fabricate a bogus elementary antiderivative.
+// ---------------------------------------------------------------------------
+#[test]
+fn ibp_regression_cos_xsq_stays_unevaluated() {
+    let mut vm = make_vm();
+    let integrand = apply(sym(COS), vec![apply(sym(POW), vec![sym("x"), int(2)])]);
+    let out = vm.eval(integrate(integrand));
+    let has_unevaluated = contains_head(&out, INTEGRATE);
+    let has_fresnel = contains_head(&out, "FresnelC");
+    assert!(has_unevaluated || has_fresnel, "unexpected closed form: {:?}", out);
+}

--- a/code/packages/typescript/symbolic-vm/CHANGELOG.md
+++ b/code/packages/typescript/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,58 @@
 # Changelog
 
+## [0.16.0] — 2026-05-28
+
+**Track E2 — generic tabular integration-by-parts fallback (TypeScript
+port).**  Mirrors the Python `ibp_tabular.py` reference (Track E1) and
+closes the cross-language gap for the `Integrate` handler.
+
+When every shape-specific handler in `integrateIndefinite` has returned
+`undefined` for a `Mul`-shaped integrand, the new `tryIbpTabular`
+fallback makes a last-ditch attempt by **generic tabular IBP**:
+
+```
+For f = u(x) · w(x) with u polynomial in x:
+  ∫ u·w dx = Σ_{k=0}^{N-1} (-1)^k · u^(k)(x) · I^(k+1)(w)
+```
+
+where N = deg(u) + 1.  The I-column entries `∫w, ∫∫w, ..., ∫^N w` come
+from the recursive `integrateIndefinite` callback; any step that fails
+to close abandons the partition.  Bounded by `IBP_MAX_FACTORS = 5`
+(number of flattened Mul factors) and `IBP_MAX_POLY_DEGREE = 8` (degree
+of the polynomial column).
+
+### Added
+
+- `tryIbpTabular(f, x, integrateFn, diffFn, simplifyFn)` — top-level
+  fallback.  Returns the closed-form antiderivative or `undefined`.
+- `ibpFlattenMul(node)` — flattens nested-binary `Mul(a, Mul(b, c))`
+  trees so the IBP search isn't fooled by parse-tree grouping.
+- `ibpMultiplyIr(factors)` — rebuilds a left-associative `Mul` chain.
+- `ibpPolynomialDegree(node, x)` — returns the polynomial degree in x
+  (`-1` for zero, `undefined` for non-polynomial).
+- `ibpContainsIntegrate(node)`, `ibpIsZero(node)`, `ibpTrySplit(...)`,
+  `ibpCombinations(n, k)` — implementation helpers.
+
+### Changed
+
+- `integrate()` handler now invokes `tryIbpTabular` as the **last**
+  fallback before returning the unevaluated `Integrate(...)` form.
+  Closed-form results are passed through `vm.eval` for simplification.
+
+### Test plan
+
+Six tests in `tests/ibp-tabular.test.ts`:
+
+1. `∫ x·sin(x) dx` closes via tabular IBP — verified numerically
+   against `sin(1) − cos(1)`.
+2. `∫ x²·eˣ dx` closes via tabular IBP — verified against `2e² − 2`.
+3. `∫ x³·cos(x) dx` closes — verified against trapezoidal rule.
+4. Fallthrough: `∫ 1/x dx → log(x)` (IBP short-circuits — head is DIV).
+5. Fallthrough: `∫ sin(x²) dx` stays unevaluated or returns Fresnel —
+   IBP fabricates no bogus elementary form.
+6. Regression: `∫ cos(x²) dx` (Fresnel family) still stays unevaluated
+   after the IBP port lands.
+
 ## [0.15.0] — 2026-05-28
 
 **Track D2 — bivariate Hensel lifting in `Factor` (TypeScript port).**

--- a/code/packages/typescript/symbolic-vm/package.json
+++ b/code/packages/typescript/symbolic-vm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/symbolic-vm",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Pure TypeScript symbolic expression evaluator with strict and symbolic backends",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/symbolic-vm/src/index.ts
+++ b/code/packages/typescript/symbolic-vm/src/index.ts
@@ -2514,6 +2514,19 @@ function integrate(): Handler {
     }
     const result = integrateIndefinite(f, x);
     if (result === undefined) {
+      // Track E2: generic tabular IBP fallback.  Fires after every
+      // shape-specific handler in integrateIndefinite returned undefined.
+      // Mirrors the Python ``try_ibp_tabular`` hook in ``integrate.py``.
+      const ibpResult = tryIbpTabular(
+        f,
+        x,
+        (g) => integrateIndefinite(g, x),
+        (g) => diff(g, x),
+        (n) => vm.eval(n),
+      );
+      if (ibpResult !== undefined) {
+        return vm.eval(ibpResult);
+      }
       return expr;
     }
     return isDeferredIntegral(result, f, x) ? result : vm.eval(result);
@@ -3132,6 +3145,198 @@ function integrateIndefinite(f: IRNode, x: IRNode): IRNode | undefined {
   }
 
   return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Track E2 — Generic tabular integration-by-parts fallback.
+//
+// Mirrors ``ibp_tabular.py`` from the Python reference port (Track E1).
+// When the pipeline's shape-specific handlers in ``integrateIndefinite``
+// have all returned ``undefined`` for a ``Mul``-shaped integrand, this
+// fallback makes a last-ditch attempt by **generic tabular IBP**:
+//
+//   For ``f = u(x) · w(x)`` where ``u`` is polynomial in ``x``:
+//     ∫ u·w dx = Σ_{k=0}^{N-1} (-1)^k · u^(k)(x) · I^(k+1)(w)
+//
+// where N = deg(u) + 1 (so u^(N) = 0 and the trailing remainder
+// vanishes).  The I-column entries ``∫w, ∫∫w, ..., ∫^N w`` come from
+// the recursive ``integrateIndefinite`` callback; if any step fails
+// to close, the partition is abandoned.
+//
+// Bounded by ``IBP_MAX_FACTORS = 5`` (number of flattened Mul factors)
+// and ``IBP_MAX_POLY_DEGREE = 8`` (degree of the polynomial column).
+// ---------------------------------------------------------------------------
+
+const IBP_MAX_FACTORS = 5;
+const IBP_MAX_POLY_DEGREE = 8;
+
+/** Flatten a (possibly nested-binary) ``Mul`` tree into a list of leaves.
+ *  ``Mul(a, Mul(b, Mul(c, d)))`` → ``[a, b, c, d]``.  Without flattening
+ *  the IBP search would miss splits like ``u = a·c, w = b·d`` purely
+ *  because the parse tree happened to group differently. */
+function ibpFlattenMul(node: IRNode): IRNode[] {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) {
+    return [node];
+  }
+  const out: IRNode[] = [];
+  for (const arg of node.args) {
+    out.push(...ibpFlattenMul(arg));
+  }
+  return out;
+}
+
+/** Rebuild a left-associative ``Mul`` chain from a list of factors.
+ *  Empty list → ``1``; single factor returns itself. */
+function ibpMultiplyIr(factors: readonly IRNode[]): IRNode {
+  if (factors.length === 0) return int(1);
+  if (factors.length === 1) return factors[0];
+  let acc: IRNode = factors[0];
+  for (let i = 1; i < factors.length; i += 1) {
+    acc = app(MUL, [acc, factors[i]]);
+  }
+  return acc;
+}
+
+/** Return the polynomial degree of ``node`` in ``x``, or ``undefined``
+ *  if it is not in Q[x].  ``-1`` denotes the zero polynomial.  Mirrors
+ *  the Python ``_polynomial_degree`` helper. */
+function ibpPolynomialDegree(node: IRNode, x: IRSymbol): number | undefined {
+  const r = toRational(node, x);
+  if (r === undefined) return undefined;
+  if (polyQDegree(r.den) > 0) return undefined; // rational, not polynomial
+  const n = polyQNormalize(r.num);
+  if (n.length === 0) return -1; // zero polynomial
+  return n.length - 1;
+}
+
+/** True if ``node`` contains any unevaluated ``Integrate(...)`` sub-tree.
+ *  Used to reject I-column entries the recursive integrator could not
+ *  close to a true antiderivative. */
+function ibpContainsIntegrate(node: IRNode): boolean {
+  if (node.kind === "apply") {
+    if (equals(node.head, INTEGRATE)) return true;
+    return node.args.some((a) => ibpContainsIntegrate(a));
+  }
+  return false;
+}
+
+/** True iff ``node`` canonicalises to the integer literal ``0``.
+ *  Also recognises ``Neg(0)``. */
+function ibpIsZero(node: IRNode): boolean {
+  if (node.kind === "integer" && node.value === 0n) return true;
+  if (node.kind === "apply" && equals(node.head, NEG) && node.args.length === 1) {
+    return ibpIsZero(node.args[0]);
+  }
+  return false;
+}
+
+/** Enumerate ``k``-element subsets of ``[0, n)`` as index arrays. */
+function ibpCombinations(n: number, k: number): number[][] {
+  const out: number[][] = [];
+  const pick: number[] = [];
+  const walk = (start: number): void => {
+    if (pick.length === k) {
+      out.push(pick.slice());
+      return;
+    }
+    for (let i = start; i < n; i += 1) {
+      pick.push(i);
+      walk(i + 1);
+      pick.pop();
+    }
+  };
+  walk(0);
+  return out;
+}
+
+/** Attempt generic tabular IBP on a ``Mul``-shaped integrand.
+ *  Returns the closed-form antiderivative as IR, or ``undefined`` when
+ *  no viable ``(u, w)`` split was found. */
+function tryIbpTabular(
+  f: IRNode,
+  x: IRSymbol,
+  integrateFn: (g: IRNode) => IRNode | undefined,
+  diffFn: (g: IRNode) => IRNode,
+  simplifyFn: (n: IRNode) => IRNode,
+): IRNode | undefined {
+  // Only fires on Mul — every other shape has dedicated handlers.
+  if (f.kind !== "apply" || !equals(f.head, MUL)) return undefined;
+  const factors = ibpFlattenMul(f);
+  if (factors.length < 2 || factors.length > IBP_MAX_FACTORS) return undefined;
+  const n = factors.length;
+  // Prefer smaller ``u`` first — tabular IBP is most efficient when ``u``
+  // is low-degree.  Enumerate subset partitions of size 1 .. n-1.
+  for (let uSize = 1; uSize < n; uSize += 1) {
+    for (const uIdx of ibpCombinations(n, uSize)) {
+      const uSet = new Set(uIdx);
+      const uFactors: IRNode[] = [];
+      const wFactors: IRNode[] = [];
+      for (let i = 0; i < n; i += 1) {
+        if (uSet.has(i)) uFactors.push(factors[i]);
+        else wFactors.push(factors[i]);
+      }
+      const result = ibpTrySplit(uFactors, wFactors, x, integrateFn, diffFn, simplifyFn);
+      if (result !== undefined) return result;
+    }
+  }
+  return undefined;
+}
+
+/** Try ``u = ∏ uFactors``, ``w = ∏ wFactors`` as the tabular split. */
+function ibpTrySplit(
+  uFactors: readonly IRNode[],
+  wFactors: readonly IRNode[],
+  x: IRSymbol,
+  integrateFn: (g: IRNode) => IRNode | undefined,
+  diffFn: (g: IRNode) => IRNode,
+  simplifyFn: (n: IRNode) => IRNode,
+): IRNode | undefined {
+  const uIr = simplifyFn(ibpMultiplyIr(uFactors));
+  const deg = ibpPolynomialDegree(uIr, x);
+  if (deg === undefined) return undefined;
+  if (deg < 0) {
+    // u is the zero polynomial — ∫ 0·w dx = 0.
+    return int(0);
+  }
+  if (deg > IBP_MAX_POLY_DEGREE) return undefined;
+
+  // D-column: u, u', u'', ..., 0.
+  const dCol: IRNode[] = [uIr];
+  let cur: IRNode = uIr;
+  for (let i = 0; i <= deg; i += 1) {
+    cur = simplifyFn(diffFn(cur));
+    dCol.push(cur);
+    if (ibpIsZero(cur)) break;
+  }
+  if (!ibpIsZero(dCol[dCol.length - 1])) return undefined;
+  const N = dCol.length - 1; // u^(N) = 0
+
+  // I-column: w, ∫w, ∫∫w, ..., ∫^N w.
+  const wIr = simplifyFn(ibpMultiplyIr(wFactors));
+  const iCol: IRNode[] = [wIr];
+  cur = wIr;
+  for (let k = 0; k < N; k += 1) {
+    const integrated = integrateFn(cur);
+    if (integrated === undefined) return undefined;
+    const simplified = simplifyFn(integrated);
+    if (ibpContainsIntegrate(simplified)) return undefined;
+    iCol.push(simplified);
+    cur = simplified;
+  }
+
+  // Assemble: Σ_{k=0}^{N-1} (-1)^k · D[k] · I[k+1].
+  const pieces: IRNode[] = [];
+  for (let k = 0; k < N; k += 1) {
+    let term: IRNode = app(MUL, [dCol[k], iCol[k + 1]]);
+    if (k % 2 === 1) term = app(NEG, [term]);
+    pieces.push(term);
+  }
+  if (pieces.length === 0) return int(0);
+  let result: IRNode = pieces[0];
+  for (let i = 1; i < pieces.length; i += 1) {
+    result = app(ADD, [result, pieces[i]]);
+  }
+  return result;
 }
 
 function completeEllipticFirstKind(f: IRNode, x: IRNode, lower: IRNode, upper: IRNode): IRNode | undefined {

--- a/code/packages/typescript/symbolic-vm/tests/ibp-tabular.test.ts
+++ b/code/packages/typescript/symbolic-vm/tests/ibp-tabular.test.ts
@@ -1,0 +1,159 @@
+// Track E2 — Generic tabular integration-by-parts fallback (TypeScript port).
+//
+// Mirrors `tests/test_ibp.py` from the Python reference (Track E1).  All
+// correctness checks use **numeric differentiation of the returned
+// antiderivative** against the original integrand.  This avoids
+// hard-coding the exact algebraic form of the answer — any equivalent
+// shape (Sub(Sin(x), Mul(x, Cos(x))) vs. Add(Sin(x), Neg(Mul(x, Cos(x))))
+// vs. anything the simplifier picks tomorrow) is accepted as long as the
+// symbolic antiderivative evaluates to the correct numeric value.
+
+import { describe, expect, it } from "vitest";
+import {
+  COS,
+  DIV,
+  EXP,
+  INTEGRATE,
+  IRNode,
+  LOG,
+  MUL,
+  POW,
+  SIN,
+  app,
+  equals,
+  int,
+  numberNode,
+  sym,
+} from "@coding-adventures/symbolic-ir";
+import { SymbolicBackend, VM } from "../src/index.js";
+
+const X = sym("x");
+
+function integrate(f: IRNode): IRNode {
+  return app(INTEGRATE, [f, X]);
+}
+
+function makeVM(): VM {
+  return new VM(new SymbolicBackend());
+}
+
+function subst(node: IRNode, varNode: IRNode, value: IRNode): IRNode {
+  if (equals(node, varNode)) return value;
+  if (node.kind === "apply") {
+    return app(node.head, node.args.map((a) => subst(a, varNode, value)));
+  }
+  return node;
+}
+
+function evalAt(vm: VM, expr: IRNode, xVal: number): number {
+  const substituted = subst(expr, X, numberNode(xVal));
+  const folded = vm.eval(substituted);
+  if (folded.kind === "float") return folded.value;
+  if (folded.kind === "integer") return Number(folded.value);
+  if (folded.kind === "rational") return Number(folded.numer) / Number(folded.denom);
+  return Number.NaN;
+}
+
+function containsHead(node: IRNode, head: IRNode): boolean {
+  if (node.kind === "apply") {
+    if (equals(node.head, head)) return true;
+    return node.args.some((a) => containsHead(a, head));
+  }
+  return false;
+}
+
+function trapezoidal(fn: (x: number) => number, a: number, b: number, n = 50_000): number {
+  const h = (b - a) / n;
+  let total = 0.5 * (fn(a) + fn(b));
+  for (let i = 1; i < n; i += 1) total += fn(a + i * h);
+  return total * h;
+}
+
+describe("Track E2 — generic tabular IBP fallback", () => {
+  // -------------------------------------------------------------------------
+  // Acceptance #1 — ∫ x·sin(x) dx = sin(x) − x·cos(x).
+  // -------------------------------------------------------------------------
+  it("closes ∫ x·sin(x) dx via tabular IBP", () => {
+    const vm = makeVM();
+    const integrand = app(MUL, [X, app(SIN, [X])]);
+    const out = vm.eval(integrate(integrand));
+    expect(containsHead(out, INTEGRATE)).toBe(false);
+    // F(1) − F(0) should equal sin(1) − cos(1).
+    const diff = evalAt(vm, out, 1.0) - evalAt(vm, out, 0.0);
+    expect(diff).toBeCloseTo(Math.sin(1.0) - Math.cos(1.0), 9);
+  });
+
+  // -------------------------------------------------------------------------
+  // Acceptance #2 — ∫ x²·eˣ dx = (x² − 2x + 2)·eˣ.
+  // -------------------------------------------------------------------------
+  it("closes ∫ x²·eˣ dx via tabular IBP", () => {
+    const vm = makeVM();
+    const integrand = app(MUL, [app(POW, [X, int(2)]), app(EXP, [X])]);
+    const out = vm.eval(integrate(integrand));
+    expect(containsHead(out, INTEGRATE)).toBe(false);
+    // F(2) − F(0) = (4 − 4 + 2)·e² − (0 − 0 + 2)·e⁰ = 2e² − 2.
+    const diff = evalAt(vm, out, 2.0) - evalAt(vm, out, 0.0);
+    expect(diff).toBeCloseTo(2.0 * Math.exp(2.0) - 2.0, 9);
+  });
+
+  // -------------------------------------------------------------------------
+  // Acceptance #3 — higher-degree polynomial × trig: ∫ x³·cos(x) dx.
+  // -------------------------------------------------------------------------
+  it("closes ∫ x³·cos(x) dx via tabular IBP", () => {
+    const vm = makeVM();
+    const integrand = app(MUL, [app(POW, [X, int(3)]), app(COS, [X])]);
+    const out = vm.eval(integrate(integrand));
+    expect(containsHead(out, INTEGRATE)).toBe(false);
+    const diff = evalAt(vm, out, 1.0) - evalAt(vm, out, 0.0);
+    const numeric = trapezoidal((xv) => xv * xv * xv * Math.cos(xv), 0.0, 1.0);
+    expect(diff).toBeCloseTo(numeric, 5);
+  });
+
+  // -------------------------------------------------------------------------
+  // Acceptance #4 — fallthrough: ∫ 1/x dx returns log(x); IBP does not fire
+  // (integrand isn't a Mul — head is DIV).
+  // -------------------------------------------------------------------------
+  it("falls through to the log handler for ∫ 1/x dx (IBP returns undefined)", () => {
+    const vm = makeVM();
+    const integrand = app(DIV, [int(1), X]);
+    const out = vm.eval(integrate(integrand));
+    expect(containsHead(out, INTEGRATE)).toBe(false);
+    expect(containsHead(out, LOG)).toBe(true);
+    // F(2) − F(1) = log 2.
+    const diff = evalAt(vm, out, 2.0) - evalAt(vm, out, 1.0);
+    expect(diff).toBeCloseTo(Math.log(2.0), 12);
+  });
+
+  // -------------------------------------------------------------------------
+  // Acceptance #5 — fallthrough: ∫ sin(x²) dx stays unevaluated (Fresnel).
+  // IBP can't help — the integrand isn't a Mul.  The engine must not
+  // fabricate a bogus elementary closed form.
+  // -------------------------------------------------------------------------
+  it("leaves ∫ sin(x²) dx unevaluated — IBP fabricates nothing", () => {
+    const vm = makeVM();
+    const integrand = app(SIN, [app(POW, [X, int(2)])]);
+    const out = vm.eval(integrate(integrand));
+    // Either the unevaluated Integrate form or a Fresnel-S head.  The
+    // critical correctness property is that tabular IBP doesn't sneak
+    // in a fake elementary antiderivative.
+    const hasUnevaluated = containsHead(out, INTEGRATE);
+    const hasFresnel = containsHead(out, sym("FresnelS"));
+    expect(hasUnevaluated || hasFresnel).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // Regression #6 — previously-Fresnel-family integral ∫ cos(x²) dx still
+  // stays unevaluated after the IBP fallback ships.  The integrand is not
+  // a Mul (its head is COS), so tabular IBP short-circuits to undefined
+  // and the engine must not fabricate a bogus elementary antiderivative.
+  // -------------------------------------------------------------------------
+  it("leaves ∫ cos(x²) dx unevaluated after E2 ports (Fresnel regression)", () => {
+    const vm = makeVM();
+    const integrand = app(COS, [app(POW, [X, int(2)])]);
+    const out = vm.eval(integrate(integrand));
+    const hasUnevaluated = containsHead(out, INTEGRATE);
+    const hasFresnel = containsHead(out, sym("FresnelC"));
+    expect(hasUnevaluated || hasFresnel).toBe(true);
+  });
+});
+

--- a/code/specs/macsyma-completion.md
+++ b/code/specs/macsyma-completion.md
@@ -1,5 +1,24 @@
 # MACSYMA Completion Roadmap
 
+> **🎉 macsyma-finish-plan spec complete (2026-05-28).**  All five
+> tracks of `code/specs/macsyma-finish-plan.md` (ten sub-tracks total)
+> have shipped across Python, TypeScript, and Rust:
+>
+> - **Track A** — Phase 86 generic recogniser port (#4552) + delete
+>   42 redundant grid helpers (#4557).
+> - **Track B** — Apart simple-roots (#4558), Apart-retry telescope
+>   (#4559), Apart repeated-linear-factors (#4560) ports to TS+Rust.
+> - **Track C** — Frobenius / power-series ODE in Python (#4561)
+>   and the TS+Rust port (#4562).
+> - **Track D** — Bivariate Hensel lifting in Python `cas-factor`
+>   (#4563) and the TS+Rust port (#4564).
+> - **Track E** — Generic tabular IBP integration fallback in Python
+>   (#4569) and the TS+Rust port (this PR).
+>
+> The MACSYMA pipeline is now considered done for the purposes of this
+> repo — new work is feature-driven (e.g. Maple frontend), not
+> gap-driven.
+
 > **Status**: Living document. Tracks what is implemented, what is
 > specified but not built, and what needs a new spec. Updated as
 > work lands.

--- a/code/specs/macsyma-finish-plan.md
+++ b/code/specs/macsyma-finish-plan.md
@@ -1,5 +1,26 @@
 # MACSYMA Completion — Finish Plan
 
+> **🎉 Closed** — 2026-05-28 with the merge of the Track E2 PR
+> (generic IBP fallback ported to TypeScript and Rust).  All ten
+> sub-tracks across the five tracks landed:
+>
+> | Track | Sub-track | PR |
+> |---|---|---|
+> | A1 | Phase 86 generic recogniser port (TS + Rust) | #4552 |
+> | A2 | Delete 42 redundant grid helpers (all 3 langs) | #4557 |
+> | B1 | Apart simple-roots port (TS + Rust) | #4558 |
+> | B2 | Apart-retry telescope chain port (TS + Rust) | #4559 |
+> | B3 | Apart repeated-linear-factors port (TS + Rust) | #4560 |
+> | C1 | Frobenius / power-series ODE (Python) | #4561 |
+> | C2 | Frobenius port (TS + Rust) | #4562 |
+> | D1 | Bivariate Hensel lifting (Python) | #4563 |
+> | D2 | Bivariate Hensel port (TS + Rust) | #4564 |
+> | E1 | Generic IBP fallback (Python) | #4569 |
+> | E2 | Generic IBP port (TS + Rust) | this PR |
+>
+> Spec history below is preserved as the planning context.  New work
+> is feature-driven; no further phases against this plan.
+
 > **Status**: Planning document, drafted 2026-05-28 after the
 > cas-summation overboard incident (74 PRs closed + cleanup PR
 > #4545). Sets the boundary of "what does done look like" for the
@@ -77,10 +98,10 @@ is one or more PRs, and tracks can execute in parallel.
 
 ### Track A — Generic-cleanup follow-through (lowest risk first)
 
-| # | Description | Languages | Acceptance |
-|---|---|---|---|
-| A1 | Phase 86 generic recogniser port | TS + Rust | `npm test` / `cargo test` green; matches Python behavior on the 6 new Phase 86 test cases. |
-| A2 | Delete the 42 redundant N-Sqrt × M-Log × polynomial helpers (Phases 59–85) | All 3 | Sweep: pre/post test counts equal; no behavior change. |
+| # | Description | Languages | Acceptance | Status |
+|---|---|---|---|---|
+| A1 | Phase 86 generic recogniser port | TS + Rust | `npm test` / `cargo test` green; matches Python behavior on the 6 new Phase 86 test cases. | ✅ #4552 |
+| A2 | Delete the 42 redundant N-Sqrt × M-Log × polynomial helpers (Phases 59–85) | All 3 | Sweep: pre/post test counts equal; no behavior change. | ✅ #4557 |
 
 **Lesson check**: A1 and A2 are intentionally separated. Bundling
 delete-with-port is tempting but risks port hiding a regression. Land
@@ -92,11 +113,11 @@ Porting `Apart` to TypeScript and Rust unlocks the deferred Phase 40
 (Apart-retry telescope), Phase 46 (Apart-retry constant numerator
 widening), and Phase 48 (Apart for repeated linear factors) ports.
 
-| # | Description | Languages | Acceptance |
-|---|---|---|---|
-| B1 | `Apart` simple-roots (Phase 1 algorithm) port | TS + Rust | `Apart(1/(x²-1), x)` returns `1/(2(x-1)) - 1/(2(x+1))` in both. |
-| B2 | Apart-retry telescope chain port (Phase 40 + Phase 46) | TS + Rust | `∑_{k=1}^∞ 1/(k(k+1)) = 1` closes via Apart + telescope. |
-| B3 | Apart for repeated linear factors (Phase 48 algorithm) port | TS + Rust | `Apart(1/(k²(k+1)²), k)` decomposes correctly. |
+| # | Description | Languages | Acceptance | Status |
+|---|---|---|---|---|
+| B1 | `Apart` simple-roots (Phase 1 algorithm) port | TS + Rust | `Apart(1/(x²-1), x)` returns `1/(2(x-1)) - 1/(2(x+1))` in both. | ✅ #4558 |
+| B2 | Apart-retry telescope chain port (Phase 40 + Phase 46) | TS + Rust | `∑_{k=1}^∞ 1/(k(k+1)) = 1` closes via Apart + telescope. | ✅ #4559 |
+| B3 | Apart for repeated linear factors (Phase 48 algorithm) port | TS + Rust | `Apart(1/(k²(k+1)²), k)` decomposes correctly. | ✅ #4560 |
 
 **Lesson check**: B1, B2, B3 are sequential dependencies — do not parallel
 them. Each PR ports one algorithm; tests in the target language
@@ -107,10 +128,10 @@ validate against the Python reference output.
 Power-series / Frobenius method for variable-coefficient 2nd-order
 linear ODEs around regular singular points.
 
-| # | Description | Languages | Acceptance |
-|---|---|---|---|
-| C1 | Frobenius algorithm in Python `cas-ode` | Python | `ode2(x²y'' + xy' + (x²-1/4)y = 0, y, x)` → series solution recognised as `BesselJ(1/2, x)` family. |
-| C2 | Frobenius port | TS + Rust | Output matches Python on 3 standard ODE test cases (Bessel, Legendre, hypergeometric). |
+| # | Description | Languages | Acceptance | Status |
+|---|---|---|---|---|
+| C1 | Frobenius algorithm in Python `cas-ode` | Python | `ode2(x²y'' + xy' + (x²-1/4)y = 0, y, x)` → series solution recognised as `BesselJ(1/2, x)` family. | ✅ #4561 |
+| C2 | Frobenius port | TS + Rust | Output matches Python on 3 standard ODE test cases (Bessel, Legendre, hypergeometric). | ✅ #4562 |
 
 **Lesson check**: Frobenius is a real algorithm, not a grid. One helper
 per language, not one per equation type. Named ODE recognition
@@ -119,10 +140,10 @@ fallback for un-named regular-singular-point ODEs.
 
 ### Track D — Generic multivariate Hensel lifting
 
-| # | Description | Languages | Acceptance |
-|---|---|---|---|
-| D1 | Bivariate Hensel lifting in Python `cas-factor` | Python | `factor(x²+xy-2y²) → (x+2y)(x-y)` and similar. |
-| D2 | Hensel lifting port | TS + Rust | Same outputs as Python on 5 standard cases. |
+| # | Description | Languages | Acceptance | Status |
+|---|---|---|---|---|
+| D1 | Bivariate Hensel lifting in Python `cas-factor` | Python | `factor(x²+xy-2y²) → (x+2y)(x-y)` and similar. | ✅ #4563 |
+| D2 | Hensel lifting port | TS + Rust | Same outputs as Python on 5 standard cases. | ✅ #4564 |
 
 **Lesson check**: Hensel lifting is one algorithm; do not write one helper
 per polynomial shape. Pattern shapes can route through the algorithm
@@ -130,10 +151,10 @@ but should not bypass it.
 
 ### Track E — General IBP integration fallback
 
-| # | Description | Languages | Acceptance |
-|---|---|---|---|
-| E1 | Generic IBP table-driven fallback in Python `symbolic-vm` integration handler | Python | `∫ x·sin(x²) dx` and similar reach a closed form via IBP recursion. |
-| E2 | Generic IBP fallback port | TS + Rust | Same outputs on 5 standard cases. |
+| # | Description | Languages | Acceptance | Status |
+|---|---|---|---|---|
+| E1 | Generic IBP table-driven fallback in Python `symbolic-vm` integration handler | Python | `∫ x·sin(x²) dx` and similar reach a closed form via IBP recursion. | ✅ #4569 |
+| E2 | Generic IBP fallback port | TS + Rust | Same outputs on 5 standard cases. | ✅ this PR |
 
 ---
 

--- a/code/specs/spice-macsyma-pending-work.md
+++ b/code/specs/spice-macsyma-pending-work.md
@@ -1,5 +1,27 @@
 # SPICE Engine & MACSYMA Pipeline — Status and Pending Work
 
+> **🎉 MACSYMA finish-plan closed (2026-05-28).** All five tracks of
+> `code/specs/macsyma-finish-plan.md` (ten sub-tracks total) have
+> shipped across all three languages.  Sub-track PR map:
+>
+> | Sub-track | PR | Description |
+> |---|---|---|
+> | A1 | ✅ #4552 | Phase 86 generic recogniser port (TS + Rust) |
+> | A2 | ✅ #4557 | Delete 42 redundant grid helpers (all 3 langs) |
+> | B1 | ✅ #4558 | Apart simple-roots port (TS + Rust) |
+> | B2 | ✅ #4559 | Apart-retry telescope chain port (TS + Rust) |
+> | B3 | ✅ #4560 | Apart repeated-linear-factors port (TS + Rust) |
+> | C1 | ✅ #4561 | Frobenius / power-series ODE (Python) |
+> | C2 | ✅ #4562 | Frobenius port (TS + Rust) |
+> | D1 | ✅ #4563 | Bivariate Hensel lifting (Python `cas-factor`) |
+> | D2 | ✅ #4564 | Bivariate Hensel port (TS + Rust) |
+> | E1 | ✅ #4569 | Generic tabular IBP fallback (Python `symbolic-vm`) |
+> | E2 | ✅ this PR | Generic IBP port (TS + Rust `symbolic-vm` 0.16.0) |
+>
+> The MACSYMA pipeline is now considered done for the purposes of this
+> repo.  New work is feature-driven (e.g. Maple frontend) rather than
+> gap-driven.
+
 > **Living document.** Updated each time a PR lands or new work is planned.
 > Last updated: 2026-05-22 (after Phase 48 Apart-for-repeated-linear-
 > factors landed in Python — all three Phase 45-documented summation
@@ -545,7 +567,7 @@ The Risch integration suite is ~90% complete. Known remaining gaps:
 | `∫ sin(log(x)) dx`, `∫ cos(log(x)) dx`, `∫ xᵏ·sin/cos(log(x)) dx` (Phase 27 trig-of-log) | u=log(x) substitution converts to exp×trig form; closed form `x^(k+1)·((k+1)trig(log x)∓cotrig(log x))/((k+1)²+1)` | ✅ Python PR #3373 `symbolic-vm` 0.57.0; TS + Rust `symbolic-vm` 0.4.0 |
 | `∫ P(x)·log(Q(x)) dx`, `∫ P(x)·atan(Q(x)) dx` for non-linear Q (Phase 28 general IBP) | IBP with residual integrated via polynomial long division + Case A (prop to D′) / Case B (const/quadratic) | ✅ Python PR #3380 `symbolic-vm` 0.58.0; TS + Rust `symbolic-vm` 0.5.0 (PR #3381) |
 | `∫ c / (a + b·sin/cos(α·x + β)) dx` for rational `a, b, α, β` with `α ≠ 0` (Phases 34–38 Weierstrass family) | `u = tan((α·x+β)/2)` substitution: arctan form (`a² > b²`), degenerate `a² = b²`, log form (`a² < b²`), and linear-argument lifting all wired. | ✅ All discriminant regimes and both `b > |a|` / `b < −|a|` cos branches closed across all three languages. Phase 34 (PRs #3472/#3473/#3475 — arctan), Phase 35 (degenerate), Phase 36 (log form, `b > |a|`), Phase 37 (cos `b < −|a|` — PRs #3683/#3685/#3689), Phase 38 (non-bare linear arguments — PRs #3690/#3691/#3692). Symbolic `a, b, α, β` still need an assumption context. |
-| `∫ f(x)·g(x)` where neither integrates alone | General IBP fallback missing; only specific matched patterns work | Open |
+| `∫ f(x)·g(x)` where neither integrates alone | Generic tabular IBP fallback — Python (#4569 `symbolic-vm` 0.73.0), TS + Rust (this PR `symbolic-vm` 0.16.0).  Bounded by 5 factors / poly degree 8. | ✅ Track E1 + E2 |
 
 #### Completed REPL and session features
 


### PR DESCRIPTION
## Summary

- Ports the **generic tabular IBP integration fallback** from Python (`ibp_tabular.py`, Track E1, PR #4569) to the TypeScript and Rust `symbolic-vm` packages.  Wires `tryIbpTabular` / `try_ibp_tabular` as the LAST fallback in the `Integrate` handler — fires only after every shape-specific handler has returned undefined.
- Bumps `symbolic-vm` 0.15.0 → 0.16.0 in both TS and Rust with matching CHANGELOG entries.
- **Closes the `code/specs/macsyma-finish-plan.md` spec.**  All five tracks (A through E, ten sub-tracks) are now ✅ across Python, TypeScript, and Rust.

## Algorithm (identical across all three languages)

For `f = u(x) · w(x)` with `u` polynomial in `x`:

```
∫ u·w dx = Σ_{k=0}^{N-1} (-1)^k · u^(k)(x) · I^(k+1)(w)
```

where `N = deg(u) + 1`.  Bounded by `IBP_MAX_FACTORS = 5` (flattened Mul factors) and `IBP_MAX_POLY_DEGREE = 8` (polynomial column).  The recursive integrate callback uses the bare `integrateIndefinite` / `integrate` (not the outer handler), so IBP never re-enters itself.

## Acceptance criterion

Matches Python reference on the 5 spec'd cases plus a regression — 6 cases per language:

1. `∫ x·sin(x) dx` → closed form, numerically verified vs `sin(1) − cos(1)`.
2. `∫ x²·eˣ dx` → closed form, numerically verified vs `2e² − 2`.
3. `∫ x³·cos(x) dx` → closed form vs trapezoidal rule.
4. Fallthrough: `∫ 1/x dx → log(x)` (IBP short-circuits — head is DIV, not MUL).
5. Fallthrough: `∫ sin(x²) dx` stays unevaluated or returns Fresnel — IBP fabricates no bogus elementary form.
6. Regression: `∫ cos(x²) dx` (Fresnel family) still stays unevaluated after the IBP port.

## Test plan

- [x] `cd code/packages/typescript/symbolic-vm && npm test` — **177 tests pass** (171 pre-existing + 6 new).
- [x] `cd code/packages/rust/symbolic-vm && cargo test` — **194 tests pass + 2 doc tests** (188 pre-existing + 6 new).
- [x] No regressions in existing integration tests.
- [x] Inline security review — pure CAS algorithmic code, bounded recursion, no I/O / no eval / no untrusted input.  Rust port uses `checked_mul` / `checked_add` via existing `RatC` helpers for overflow safety.

## 🎉 macsyma-finish-plan spec complete

This PR closes the spec.  All ten sub-tracks across the five tracks landed:

| Track | Sub-track | PR |
|---|---|---|
| **A** — Generic-cleanup follow-through | A1: Phase 86 generic recogniser port (TS + Rust) | #4552 |
|   | A2: Delete 42 redundant N-Sqrt × M-Log × poly grid helpers (all 3 langs) | #4557 |
| **B** — Apart port | B1: Apart simple-roots port (TS + Rust) | #4558 |
|   | B2: Apart-retry telescope chain port (TS + Rust) | #4559 |
|   | B3: Apart repeated-linear-factors port (TS + Rust) | #4560 |
| **C** — Frobenius ODE | C1: Frobenius / power-series ODE in Python `cas-ode` | #4561 |
|   | C2: Frobenius port (TS + Rust) | #4562 |
| **D** — Bivariate Hensel lifting | D1: Bivariate Hensel lifting in Python `cas-factor` | #4563 |
|   | D2: Bivariate Hensel port (TS + Rust) | #4564 |
| **E** — General IBP integration fallback | E1: Generic IBP table-driven fallback in Python `symbolic-vm` | #4569 |
|   | E2: Generic IBP fallback port (TS + Rust) | **this PR** |

Spec doc updates included in this PR:

- `code/specs/macsyma-finish-plan.md` — added 🎉 closed marker at the top with the full ten-PR sub-track table; status column added to each per-track table marking every sub-track ✅.
- `code/specs/macsyma-completion.md` — added top-level completion banner.
- `code/specs/spice-macsyma-pending-work.md` — added completion banner with PR map; updated the integration-gaps table to mark the general IBP fallback ✅ Track E1 + E2.

The MACSYMA pipeline is now considered done for the purposes of this repo — new work is feature-driven (e.g. Maple frontend), not gap-driven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)