### PR TITLE
feat(ruby-parser+sir): Phase 9c (FC) — single-RHS tuple destructure

### DIFF
--- a/code/packages/rust/ruby-parser/.pr-body-fc-9c.md
+++ b/code/packages/rust/ruby-parser/.pr-body-fc-9c.md
@@ -1,0 +1,101 @@
+## Summary
+
+Phase 9c lands **single-RHS tuple destructure** — the form Phase 9b
+flagged as deferred:
+
+```ruby
+a, b    = arr           # a == arr[0]; b == arr[1]
+a, b, c = arr           # a == arr[0]; b == arr[1]; c == arr[2]
+a, b    = make_pair()   # make_pair() evaluated once into a temp
+```
+
+Builds directly on Phase 9a's swap-safe temp pass and Phase 9b's
+LHS-walk refactor.
+
+## Grammar
+
+**No grammar changes.** The existing `multi_assignment` rule already
+accepts the 1-RHS shape because `expression { COMMA expression }`
+allows the trailing repetition group to be empty.  Phase 9c just turns
+on the lowering for that shape.
+
+## Lowering
+
+Routed through a new helper
+`lower_multi_assignment_single_rhs_destructure`:
+
+1. Bind the (already-lowered) single RHS to a fresh
+   `LetStarBinding(__multi_assign_t<N>_seq, rhs)`.  `LetStarBinding`
+   keeps the temp visible to the LHS-binding pass (the parallel-let
+   validator would hide names declared in the same `LetBinding`
+   group).  The single-temp evaluation also guarantees side effects
+   in the RHS fire exactly once — important for things like
+   `a, b = next_pair()` where the call has observable side effects.
+
+2. For each LHS at position `i`, emit
+   `Stmt::LetBinding` / `Stmt::Assign` reading
+   `Expr::SeqIndex { seq: VarRef(temp), index: IntLit(i) }`.
+
+| Source                | SIR shape (Phase 9c)                                                                                                                                                  |
+|-----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `a, b = arr`          | `LetStarBinding(t0_seq, arr); LetBinding(a, SeqIndex(t0_seq, 0)); LetBinding(b, SeqIndex(t0_seq, 1))`                                                                 |
+| `a, b, c = arr`       | `LetStarBinding(t0_seq, arr); LetBinding(a, SeqIndex(t0_seq, 0)); LetBinding(b, SeqIndex(t0_seq, 1)); LetBinding(c, SeqIndex(t0_seq, 2))`                             |
+| `a = 0; a, b = arr`   | re-bind path: `Assign(a, SeqIndex(t0_seq, 0))` + `LetBinding(b, SeqIndex(t0_seq, 1))` — requests `Feature::MutableBindings`                                          |
+
+### Arity check
+
+The no-splat arity check relaxes from "LHS == RHS strict" to
+"LHS == RHS *or* exactly 1 RHS with ≥2 LHS".  All other shapes still
+error.  The splat path is unchanged (`a, *b = arr` still uses the
+Phase 9b splat lowering and treats the single RHS as one of the
+absorbable values — single-RHS-with-splat auto-unpack remains a future
+phase).
+
+### Feature flags
+
+- `Feature::Sequences` — always requested (SeqIndex requires it).
+- `Feature::MutableBindings` — requested when any LHS re-binds a
+  pre-existing local.
+
+### Out-of-bounds semantics
+
+Target-language-defined per `Expr::SeqIndex`'s docs.  Ruby itself
+fills missing positions with `nil`; matching that exactly is left to
+the consuming backend (or a later phase if we want to make
+missing-index→nil explicit in the SIR).
+
+## Tests
+
+- `coding-adventures-ruby-lexer`: 173 → **173** (no change)
+- `coding-adventures-ruby-parser`: 152 → **155** (+3):
+  - `test_parse_multi_assignment_single_rhs_two_lhs`
+  - `test_parse_multi_assignment_single_rhs_three_lhs`
+  - `test_parse_multi_assignment_single_rhs_keeps_one_rhs_expression`
+- `ruby-to-semantic-ir`: 177 → **184** (+7):
+  - `single_rhs_destructure_two_lhs_reads_seq_index_zero_and_one`
+  - `single_rhs_destructure_three_lhs_emits_three_seq_indexes`
+  - `single_rhs_destructure_evaluates_rhs_exactly_once`
+  - `single_rhs_destructure_requests_sequences_feature`
+  - `single_rhs_destructure_module_passes_sir_validator` (E2E for
+    all three shapes incl. re-bind path)
+  - `single_rhs_destructure_rebind_uses_assign_not_letbinding`
+  - `single_rhs_destructure_lhs_4_rhs_2_no_splat_still_errors`
+
+All Phase 6r / 8b / 9a / 9b tests keep passing.
+
+## Test plan
+
+- [x] `cargo test -p coding-adventures-ruby-lexer` (173/173 pass)
+- [x] `cargo test -p coding-adventures-ruby-parser` (155/155 pass)
+- [x] `cargo test -p ruby-to-semantic-ir` (184/184 pass)
+- [x] Self-reviewed (no I/O, no unsafe — pure AST walk + SIR Stmt list
+      construction; SeqIndex indices are compile-time `i64` literals
+      with no user-controlled formatting)
+- [ ] CI green
+
+Follows PR #4567 (Phase 9b).  Next chunk: Phase 14a (empty
+`class Foo; end`).
+
+Closes the auto-unpack TODO Phase 9b's comments flagged.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.37.0] - 2026-05-28
+
+### Added (Phase 9c (FC) — single-RHS tuple destructure grammar coverage)
+
+No grammar changes — the existing `multi_assignment` rule already
+accepts the 1-RHS shape (`expression { COMMA expression }` allows the
+trailing repetition group to be empty).  Phase 9c enables the lowering
+for that shape; this version bump tracks the new parser-level tests
+that pin grammar behaviour:
+
+- `test_parse_multi_assignment_single_rhs_two_lhs` (`a, b = arr`)
+- `test_parse_multi_assignment_single_rhs_three_lhs` (`a, b, c = arr`)
+- `test_parse_multi_assignment_single_rhs_keeps_one_rhs_expression`
+  (asserts the RHS list has exactly one expression node)
+
+### Tests
+
+- `coding-adventures-ruby-parser`: 152 → **155** (+3)
+
 ## [0.36.0] - 2026-05-28
 
 ### Added (Phase 9b (FC) — splat target in multi-assignment LHS)

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -1550,6 +1550,85 @@ mod tests {
         assert!(tree_has_token_value(m, "*"));
     }
 
+    // -----------------------------------------------------------------------
+    // Phase 9c (FC) — single-RHS tuple destructure (`a, b = arr`).
+    //
+    // The grammar already accepts these shapes: `multi_assignment`
+    // requires ≥2 LHS targets and ≥1 RHS expression.  Phase 9c just
+    // turns on the lowering for the 1-RHS case.  These tests assert
+    // the grammar still recognises the construct correctly so the SIR
+    // lowerer's single-RHS dispatch has well-formed input.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_multi_assignment_single_rhs_two_lhs() {
+        // `a, b = arr` — 2 LHS, 1 RHS, no splat.
+        let ast = parse_ruby("a, b = arr");
+        let m = find_descendant(&ast, "multi_assignment")
+            .expect("expected multi_assignment node");
+        let lhs_target_count = m
+            .children
+            .iter()
+            .filter(|c| {
+                matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "mlhs_target")
+            })
+            .count();
+        assert_eq!(lhs_target_count, 2, "expected 2 mlhs_target nodes");
+        // No `*` token anywhere — this is the no-splat shape.
+        assert!(
+            !tree_has_token_value(m, "*"),
+            "single-RHS tuple destructure should have no splat"
+        );
+    }
+
+    #[test]
+    fn test_parse_multi_assignment_single_rhs_three_lhs() {
+        // `a, b, c = arr` — 3 LHS, 1 RHS.
+        let ast = parse_ruby("a, b, c = arr");
+        let m = find_descendant(&ast, "multi_assignment")
+            .expect("expected multi_assignment node");
+        let lhs_target_count = m
+            .children
+            .iter()
+            .filter(|c| {
+                matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "mlhs_target")
+            })
+            .count();
+        assert_eq!(lhs_target_count, 3, "expected 3 mlhs_target nodes");
+        assert!(!tree_has_token_value(m, "*"));
+    }
+
+    #[test]
+    fn test_parse_multi_assignment_single_rhs_keeps_one_rhs_expression() {
+        // The grammar should put exactly ONE expression on the RHS for
+        // the single-RHS case — `multi_assignment`'s RHS rule is
+        // `expression { COMMA expression }`, so the trailing repetition
+        // group must be empty here.
+        let ast = parse_ruby("a, b = arr");
+        let m = find_descendant(&ast, "multi_assignment")
+            .expect("expected multi_assignment node");
+        // Find the EQUALS token's index, then count expression nodes
+        // appearing after it.
+        let eq_idx = m
+            .children
+            .iter()
+            .position(|c| {
+                matches!(c, ASTNodeOrToken::Token(t) if t.value == "=")
+            })
+            .expect("expected EQUALS token in multi_assignment");
+        let rhs_expr_count = m.children[eq_idx + 1..]
+            .iter()
+            .filter(|c| {
+                matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "expression")
+            })
+            .count();
+        assert_eq!(
+            rhs_expr_count, 1,
+            "expected exactly 1 RHS expression, got {}",
+            rhs_expr_count
+        );
+    }
+
     #[test]
     fn test_parse_single_assignment_not_consumed_by_multi() {
         // Regression: `a = 1` (one LHS) must still parse as a plain

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,56 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.39.0] - 2026-05-28
+
+### Added (Phase 9c (FC) — single-RHS tuple destructure)
+
+`multi_assignment` now accepts the single-RHS shape that Phase 9b's
+comments still flagged as deferred:
+
+```ruby
+a, b    = arr           # a == arr[0]; b == arr[1]
+a, b, c = arr           # a == arr[0]; b == arr[1]; c == arr[2]
+a, b    = make_pair()   # make_pair() evaluated once into a temp
+```
+
+The lowerer routes 1-RHS / ≥2-LHS / no-splat through a new helper
+`lower_multi_assignment_single_rhs_destructure`.  The strategy:
+
+1. Bind the single (already-lowered) RHS to a fresh
+   `LetStarBinding(__multi_assign_t<N>_seq, rhs)` — `LetStarBinding`
+   keeps the temp visible to the LHS-binding pass and side effects
+   in the RHS fire exactly once.
+2. For each LHS position `i`, emit
+   `Stmt::LetBinding`/`Stmt::Assign` reading
+   `Expr::SeqIndex { seq: VarRef(temp), index: IntLit(i) }`.
+
+| Source                | SIR shape (Phase 9c)                                                                                              |
+|-----------------------|-------------------------------------------------------------------------------------------------------------------|
+| `a, b = arr`          | `LetStarBinding(t0_seq, arr); LetBinding(a, SeqIndex(t0_seq, 0)); LetBinding(b, SeqIndex(t0_seq, 1))`             |
+| `a, b, c = arr`       | `LetStarBinding(t0_seq, arr); LetBinding(a, SeqIndex(t0_seq, 0)); LetBinding(b, SeqIndex(t0_seq, 1)); LetBinding(c, SeqIndex(t0_seq, 2))` |
+| `a = 0; a, b = arr`   | re-bind path: stmt for `a` is `Assign`, requests `Feature::MutableBindings`                                       |
+
+Out-of-bounds semantics are target-language-defined per
+`Expr::SeqIndex`'s docs.  Ruby itself fills missing positions with
+`nil`; matching that exactly is left to the backend or a future
+phase.
+
+### Arity check (Phase 9c)
+
+The no-splat arity check relaxes from "LHS == RHS strict" to
+"LHS == RHS *or* exactly 1 RHS with ≥2 LHS".  All other shapes still
+error.  The splat path is unchanged (`a, *b = arr` still uses the
+Phase 9b splat lowering and treats the single RHS as one of the
+absorbable values — single-RHS-with-splat auto-unpack remains a
+future phase).
+
+### Tests
+
+- `ruby-to-semantic-ir`: 177 → **184** (+7)
+- `coding-adventures-ruby-parser`: 152 → **155** (+3 — grammar
+  coverage tests for `a, b = arr` shape).
+
 ## [0.38.0] - 2026-05-28
 
 ### Added (Phase 9b (FC) — splat target in multi-assignment LHS)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -2241,6 +2241,210 @@ mod tests {
         );
     }
 
+    // ───────────────────────────────────────────────────────────────
+    // Phase 9c (FC) — single-RHS tuple destructure (`a, b = arr`)
+    // ───────────────────────────────────────────────────────────────
+
+    #[test]
+    fn single_rhs_destructure_two_lhs_reads_seq_index_zero_and_one() {
+        // `a, b = arr` after `arr = [10, 20]`.  The lowering should
+        // bind `arr` to a temp once via LetStarBinding, then read
+        // `temp[0]` into `a` and `temp[1]` into `b`.
+        let m = lower("arr = [10, 20]\na, b = arr\n");
+        let body = main_body(&m);
+        // arr LetBinding + temp LetStarBinding + 2 LHS LetBindings = 4.
+        assert_eq!(
+            body.stmts.len(),
+            4,
+            "expected 4 stmts (arr + temp + 2 LHS), got {:?}",
+            body.stmts
+        );
+        // Stmt[1] is the temp LetStarBinding.
+        match &body.stmts[1] {
+            Stmt::LetStarBinding { name, .. } => {
+                assert!(
+                    name.starts_with("__multi_assign_t") && name.ends_with("_seq"),
+                    "expected single-RHS temp `__multi_assign_t<N>_seq`, got `{}`",
+                    name
+                );
+            }
+            other => panic!("expected LetStarBinding(temp, arr), got {:?}", other),
+        }
+        // Stmt[2] binds `a` to `temp[0]`.
+        match &body.stmts[2] {
+            Stmt::LetBinding { name, value, .. } => {
+                assert_eq!(name, "a");
+                match value {
+                    Expr::SeqIndex { seq, index, .. } => {
+                        assert!(
+                            matches!(seq.as_ref(),
+                                Expr::VarRef { name: n, .. }
+                                    if n.starts_with("__multi_assign_t")),
+                            "expected SeqIndex.seq to be VarRef(temp), got {:?}",
+                            seq
+                        );
+                        assert!(
+                            matches!(index.as_ref(), Expr::IntLit { value: 0, .. }),
+                            "expected SeqIndex.index = IntLit(0), got {:?}",
+                            index
+                        );
+                    }
+                    other => panic!("expected SeqIndex(temp, 0), got {:?}", other),
+                }
+            }
+            other => panic!("expected LetBinding(a, SeqIndex), got {:?}", other),
+        }
+        // Stmt[3] binds `b` to `temp[1]`.
+        match &body.stmts[3] {
+            Stmt::LetBinding { name, value, .. } => {
+                assert_eq!(name, "b");
+                match value {
+                    Expr::SeqIndex { index, .. } => assert!(
+                        matches!(index.as_ref(), Expr::IntLit { value: 1, .. }),
+                        "expected SeqIndex.index = IntLit(1), got {:?}",
+                        index
+                    ),
+                    other => panic!("expected SeqIndex(temp, 1), got {:?}", other),
+                }
+            }
+            other => panic!("expected LetBinding(b, SeqIndex), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn single_rhs_destructure_three_lhs_emits_three_seq_indexes() {
+        // `a, b, c = arr` — three SeqIndex reads, indices 0/1/2.
+        let m = lower("arr = [10, 20, 30]\na, b, c = arr\n");
+        let body = main_body(&m);
+        // arr + temp + 3 LHS = 5.
+        assert_eq!(body.stmts.len(), 5);
+        let expected_indices = [0i64, 1, 2];
+        for (i, expected) in expected_indices.iter().enumerate() {
+            // body.stmts[i + 2] is the i-th LHS binding.
+            match &body.stmts[i + 2] {
+                Stmt::LetBinding { value: Expr::SeqIndex { index, .. }, .. } => {
+                    match index.as_ref() {
+                        Expr::IntLit { value: v, .. } => assert_eq!(
+                            v, expected,
+                            "stmt[{}] expected index {} got {}",
+                            i + 2,
+                            expected,
+                            v
+                        ),
+                        other => panic!("expected IntLit, got {:?}", other),
+                    }
+                }
+                other => panic!("stmt[{}] expected LetBinding(SeqIndex), got {:?}", i + 2, other),
+            }
+        }
+    }
+
+    #[test]
+    fn single_rhs_destructure_evaluates_rhs_exactly_once() {
+        // The whole point of the temp is to evaluate the RHS once.
+        // Verify the lowered SIR has exactly ONE statement holding
+        // the lowered RHS (the LetStarBinding for the temp) — the
+        // LHS bindings should reference the temp by name, not re-
+        // evaluate the original RHS expression.
+        //
+        // We use a builtin-call shape (`String.new`) as a stand-in for
+        // "something with potential side effects".
+        let m = lower("a, b = make_pair\n");
+        let body = main_body(&m);
+        // temp + 2 LHS = 3 stmts.
+        assert_eq!(body.stmts.len(), 3);
+        // The first statement should be the LetStarBinding wrapping
+        // the entire RHS expression.  Either side of the SeqIndex
+        // reads is a *VarRef*, not a re-lowering of `make_pair`.
+        match &body.stmts[0] {
+            Stmt::LetStarBinding { name, .. } => assert!(
+                name.starts_with("__multi_assign_t") && name.ends_with("_seq")
+            ),
+            other => panic!("expected LetStarBinding(temp, rhs), got {:?}", other),
+        }
+        for i in 1..=2 {
+            if let Stmt::LetBinding { value: Expr::SeqIndex { seq, .. }, .. } =
+                &body.stmts[i]
+            {
+                assert!(
+                    matches!(seq.as_ref(), Expr::VarRef { .. }),
+                    "stmt[{}] SeqIndex.seq should be VarRef(temp), got {:?}",
+                    i,
+                    seq
+                );
+            } else {
+                panic!("stmt[{}] expected LetBinding(SeqIndex), got {:?}", i, body.stmts[i]);
+            }
+        }
+    }
+
+    #[test]
+    fn single_rhs_destructure_requests_sequences_feature() {
+        // SeqIndex requires `Feature::Sequences` in the manifest.
+        let m = lower("arr = [1, 2]\na, b = arr\n");
+        assert!(
+            m.manifest.contains(semantic_ir::Feature::Sequences),
+            "single-RHS multi-assignment should require Sequences"
+        );
+    }
+
+    #[test]
+    fn single_rhs_destructure_module_passes_sir_validator() {
+        // End-to-end: the SIR module produced by the lowerer should
+        // pass the validator without errors.
+        for src in [
+            "arr = [1, 2]\na, b = arr\n",
+            "arr = [10, 20, 30]\na, b, c = arr\n",
+            // Re-bind path: pre-existing locals should re-assign cleanly.
+            "a = 0\nb = 0\narr = [1, 2]\na, b = arr\n",
+        ] {
+            let m = lower(src);
+            let result = semantic_ir::validate(&m);
+            assert!(
+                result.is_ok(),
+                "validator rejected single-RHS destructure `{}`: {:?}",
+                src.trim().replace('\n', " | "),
+                result
+            );
+        }
+    }
+
+    #[test]
+    fn single_rhs_destructure_rebind_uses_assign_not_letbinding() {
+        // `a` was already declared as a local — the LHS binding for
+        // `a` after `a, b = arr` should be an Assign, not a new
+        // LetBinding (and `MutableBindings` should be requested).
+        let m = lower("a = 0\narr = [1, 2]\na, b = arr\n");
+        let body = main_body(&m);
+        // a-decl, arr-decl, temp, a-assign, b-let = 5 stmts.
+        assert_eq!(body.stmts.len(), 5);
+        match &body.stmts[3] {
+            Stmt::Assign { name, .. } => assert_eq!(name, "a"),
+            other => panic!("expected Assign(a, ...) for re-bind, got {:?}", other),
+        }
+        match &body.stmts[4] {
+            Stmt::LetBinding { name, .. } => assert_eq!(name, "b"),
+            other => panic!("expected LetBinding(b, ...) for first-sighting, got {:?}", other),
+        }
+        assert!(
+            m.manifest.contains(semantic_ir::Feature::MutableBindings),
+            "re-bind path should request MutableBindings"
+        );
+    }
+
+    #[test]
+    fn single_rhs_destructure_lhs_4_rhs_2_no_splat_still_errors() {
+        // The arity check should ONLY relax for the 1-RHS case.  A
+        // 2-RHS, 4-LHS form is still a hard error.
+        let result = compile_source("a, b, c, d = 1, 2\n", "test");
+        assert!(result.is_err(), "expected RubyLowerError for 4 LHS / 2 RHS");
+        let msg = result.unwrap_err().message;
+        assert!(
+            msg.contains("LHS count == RHS count") || msg.contains("tuple destructure"),
+            "expected arity error mentioning tuple destructure, got: {msg}"
+        );
+    }
+
     #[test]
     fn multi_assignment_two_swaps_use_distinct_temp_counters() {
         // Two consecutive swaps in the same scope must use DIFFERENT

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -2313,13 +2313,22 @@ impl Lowerer {
 
         // Arity check — different rule depending on whether a splat is
         // present.
+        //
+        // Phase 9c (FC) — single-RHS auto-unpack ("tuple destructure")
+        // adds one new acceptable shape for the no-splat path: exactly
+        // one RHS and ≥2 LHS.  We lower it by binding the single RHS to
+        // a temp and reading `temp[0]`, `temp[1]`, … into each LHS via
+        // `Expr::SeqIndex`.  The check below permits that shape; the
+        // dispatch a few lines down routes it to the dedicated helper.
         if splat_idx.is_none() {
-            if lhs_targets.len() != rhs_exprs.len() {
+            let is_single_rhs_unpack =
+                rhs_exprs.len() == 1 && lhs_targets.len() > 1;
+            if lhs_targets.len() != rhs_exprs.len() && !is_single_rhs_unpack {
                 return Err(RubyLowerError {
                     message: format!(
-                        "multi_assignment v0 requires LHS count == RHS count \
-                         (got {} LHS, {} RHS); single-RHS auto-unpack \
-                         not yet supported",
+                        "multi_assignment requires LHS count == RHS count \
+                         OR exactly 1 RHS (tuple destructure); \
+                         got {} LHS, {} RHS",
                         lhs_targets.len(),
                         rhs_exprs.len(),
                     ),
@@ -2360,6 +2369,27 @@ impl Lowerer {
                 &lhs_targets,
                 splat_idx_real,
                 lowered_rhs,
+            );
+        }
+
+        // ── Phase 9c dispatch ───────────────────────────────────────
+        //
+        // Single-RHS tuple destructure (`a, b = arr` and friends).
+        // The arity check above already guaranteed that this shape is
+        // 1 RHS + ≥2 LHS and no splat.  Route to a dedicated helper
+        // that binds the RHS to a temp once and reads `temp[i]` for
+        // each LHS via `Expr::SeqIndex`.
+        if lowered_rhs.len() == 1 && lhs_targets.len() > 1 {
+            // Move the lone RHS out of the Vec.  This `unwrap` is
+            // unreachable because `len() == 1` was just checked.
+            let rhs_value = lowered_rhs.into_iter().next().expect(
+                "lower_multi_assignment: single-RHS dispatch invariant \
+                 violated — lowered_rhs.len() == 1 was just checked",
+            );
+            return self.lower_multi_assignment_single_rhs_destructure(
+                node,
+                lhs_targets,
+                rhs_value,
             );
         }
         // For the (also re-mapped) compatibility with the Phase 9a
@@ -2492,6 +2522,116 @@ impl Lowerer {
                 out.push(stmt);
             }
         }
+        Ok(out)
+    }
+
+    // -------------------------------------------------------------------
+    // Phase 9c (FC) — multi-assignment single-RHS tuple destructure
+    // -------------------------------------------------------------------
+
+    /// Lower the single-RHS form of `multi_assignment`:
+    ///
+    /// ```text
+    /// a, b    = arr           → a == arr[0]; b == arr[1]
+    /// a, b, c = arr           → a == arr[0]; b == arr[1]; c == arr[2]
+    /// a, b    = make_pair()   → make_pair() evaluated once into a temp
+    /// ```
+    ///
+    /// Strategy:
+    ///
+    /// 1. Bind the (already-lowered) RHS to a fresh
+    ///    `LetStarBinding(__multi_assign_t<N>_seq, rhs)`.  We use
+    ///    `LetStarBinding` so the temp's name is visible to the
+    ///    subsequent LHS-binding pass (the parallel-let validator
+    ///    would otherwise hide names declared in the same LetBinding
+    ///    group).  The single-temp evaluation also guarantees side
+    ///    effects in the RHS fire exactly once — important for things
+    ///    like `a, b = next_pair()` where the call may have observable
+    ///    side effects.
+    ///
+    /// 2. For each LHS at position `i`, emit
+    ///    `Stmt::LetBinding`/`Stmt::Assign` reading from
+    ///    `Expr::SeqIndex { seq: VarRef(temp), index: IntLit(i) }`.
+    ///    The first-sighting vs. re-bind decision uses the same logic
+    ///    as the rest of the lowerer (`declared_locals`).
+    ///
+    /// Always requests `Feature::Sequences` (for `SeqIndex`).  The
+    /// re-bind path also requests `Feature::MutableBindings`.
+    ///
+    /// Out-of-bounds semantics: target-language-defined per
+    /// `Expr::SeqIndex`'s documentation.  Ruby itself would fill
+    /// missing positions with `nil`; matching that exactly is left to
+    /// the consuming backend (or a later phase if we want to make
+    /// missing-index→nil explicit in the SIR).
+    fn lower_multi_assignment_single_rhs_destructure(
+        &mut self,
+        _node: &GrammarASTNode,
+        lhs_targets: Vec<(String, bool, Span)>,
+        rhs_value: Expr,
+    ) -> Result<Vec<Stmt>, RubyLowerError> {
+        // Mint a unique temp name.
+        let counter = self.multi_assign_counter;
+        self.multi_assign_counter += 1;
+        let tmp_name = format!("__multi_assign_t{}_seq", counter);
+
+        // Span for the temp is the first LHS's span — close enough
+        // for diagnostics; the actual RHS expression already carries
+        // its own span in its sub-trees.
+        let tmp_span = lhs_targets
+            .first()
+            .map(|(_, _, s)| s.clone())
+            .expect("single-RHS destructure invariant: lhs_targets non-empty");
+
+        let mut out: Vec<Stmt> = Vec::with_capacity(lhs_targets.len() + 1);
+
+        // Pass 1: bind the RHS to the temp.
+        self.declared_locals.insert(tmp_name.clone());
+        out.push(Stmt::LetStarBinding {
+            name: tmp_name.clone(),
+            sir_type: None,
+            value: rhs_value,
+            span: tmp_span.clone(),
+        });
+
+        // Both SeqIndex and the temp's array shape rely on the
+        // Sequences feature flag.
+        self.features_used.insert(Feature::Sequences);
+
+        // Pass 2: bind each LHS from `temp[i]`.
+        for (i, (name, _is_splat, name_span)) in lhs_targets.into_iter().enumerate() {
+            let span = name_span.clone();
+            let index_expr = Expr::SeqIndex {
+                seq: Box::new(Expr::VarRef {
+                    name: tmp_name.clone(),
+                    scope: Scope::Local,
+                    span: span.clone(),
+                }),
+                index: Box::new(Expr::IntLit {
+                    value: i as i64,
+                    span: span.clone(),
+                }),
+                span: span.clone(),
+            };
+            let stmt = if self.declared_locals.contains(&name) {
+                self.features_used.insert(Feature::MutableBindings);
+                Stmt::Assign {
+                    name: name.clone(),
+                    scope: Scope::Local,
+                    value: index_expr,
+                    span,
+                }
+            } else {
+                self.declared_locals.insert(name.clone());
+                Stmt::LetBinding {
+                    name: name.clone(),
+                    sir_type: None,
+                    value: index_expr,
+                    span,
+                }
+            };
+            out.push(stmt);
+        }
+
         Ok(out)
     }
 


### PR DESCRIPTION
## Summary

Phase 9c lands **single-RHS tuple destructure** — the form Phase 9b
flagged as deferred:

```ruby
a, b    = arr           # a == arr[0]; b == arr[1]
a, b, c = arr           # a == arr[0]; b == arr[1]; c == arr[2]
a, b    = make_pair()   # make_pair() evaluated once into a temp
```

Builds directly on Phase 9a's swap-safe temp pass and Phase 9b's
LHS-walk refactor.

## Grammar

**No grammar changes.** The existing `multi_assignment` rule already
accepts the 1-RHS shape because `expression { COMMA expression }`
allows the trailing repetition group to be empty.  Phase 9c just turns
on the lowering for that shape.

## Lowering

Routed through a new helper
`lower_multi_assignment_single_rhs_destructure`:

1. Bind the (already-lowered) single RHS to a fresh
   `LetStarBinding(__multi_assign_t<N>_seq, rhs)`.  `LetStarBinding`
   keeps the temp visible to the LHS-binding pass (the parallel-let
   validator would hide names declared in the same `LetBinding`
   group).  The single-temp evaluation also guarantees side effects
   in the RHS fire exactly once — important for things like
   `a, b = next_pair()` where the call has observable side effects.

2. For each LHS at position `i`, emit
   `Stmt::LetBinding` / `Stmt::Assign` reading
   `Expr::SeqIndex { seq: VarRef(temp), index: IntLit(i) }`.

| Source                | SIR shape (Phase 9c)                                                                                                                                                  |
|-----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| `a, b = arr`          | `LetStarBinding(t0_seq, arr); LetBinding(a, SeqIndex(t0_seq, 0)); LetBinding(b, SeqIndex(t0_seq, 1))`                                                                 |
| `a, b, c = arr`       | `LetStarBinding(t0_seq, arr); LetBinding(a, SeqIndex(t0_seq, 0)); LetBinding(b, SeqIndex(t0_seq, 1)); LetBinding(c, SeqIndex(t0_seq, 2))`                             |
| `a = 0; a, b = arr`   | re-bind path: `Assign(a, SeqIndex(t0_seq, 0))` + `LetBinding(b, SeqIndex(t0_seq, 1))` — requests `Feature::MutableBindings`                                          |

### Arity check

The no-splat arity check relaxes from "LHS == RHS strict" to
"LHS == RHS *or* exactly 1 RHS with ≥2 LHS".  All other shapes still
error.  The splat path is unchanged (`a, *b = arr` still uses the
Phase 9b splat lowering and treats the single RHS as one of the
absorbable values — single-RHS-with-splat auto-unpack remains a future
phase).

### Feature flags

- `Feature::Sequences` — always requested (SeqIndex requires it).
- `Feature::MutableBindings` — requested when any LHS re-binds a
  pre-existing local.

### Out-of-bounds semantics

Target-language-defined per `Expr::SeqIndex`'s docs.  Ruby itself
fills missing positions with `nil`; matching that exactly is left to
the consuming backend (or a later phase if we want to make
missing-index→nil explicit in the SIR).

## Tests

- `coding-adventures-ruby-lexer`: 173 → **173** (no change)
- `coding-adventures-ruby-parser`: 152 → **155** (+3):
  - `test_parse_multi_assignment_single_rhs_two_lhs`
  - `test_parse_multi_assignment_single_rhs_three_lhs`
  - `test_parse_multi_assignment_single_rhs_keeps_one_rhs_expression`
- `ruby-to-semantic-ir`: 177 → **184** (+7):
  - `single_rhs_destructure_two_lhs_reads_seq_index_zero_and_one`
  - `single_rhs_destructure_three_lhs_emits_three_seq_indexes`
  - `single_rhs_destructure_evaluates_rhs_exactly_once`
  - `single_rhs_destructure_requests_sequences_feature`
  - `single_rhs_destructure_module_passes_sir_validator` (E2E for
    all three shapes incl. re-bind path)
  - `single_rhs_destructure_rebind_uses_assign_not_letbinding`
  - `single_rhs_destructure_lhs_4_rhs_2_no_splat_still_errors`

All Phase 6r / 8b / 9a / 9b tests keep passing.

## Test plan

- [x] `cargo test -p coding-adventures-ruby-lexer` (173/173 pass)
- [x] `cargo test -p coding-adventures-ruby-parser` (155/155 pass)
- [x] `cargo test -p ruby-to-semantic-ir` (184/184 pass)
- [x] Self-reviewed (no I/O, no unsafe — pure AST walk + SIR Stmt list
      construction; SeqIndex indices are compile-time `i64` literals
      with no user-controlled formatting)
- [ ] CI green

Follows PR #4567 (Phase 9b).  Next chunk: Phase 14a (empty
`class Foo; end`).

Closes the auto-unpack TODO Phase 9b's comments flagged.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
