### PR TITLE
fix(swiftui-demo): make VisiCalc SwiftUI demo runnable end-to-end

### DIFF
--- a/code/packages/rust/mosaic-emit-swiftui/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-swiftui/src/pipeline.rs
@@ -896,19 +896,31 @@ fn emit_host_input(node: &LayoutNode, indent: usize) -> Result<String, PipelineE
         }
     }
 
-    // `.onSubmit { dispatch(.e(value: value)) }`. SwiftUI fires onSubmit
-    // when the user presses Enter / Return in the TextField.
+    // `.onSubmit { dispatch(.e) }`. SwiftUI fires onSubmit when the
+    // user presses Enter / Return in the TextField.
+    //
+    // We deliberately emit the VOID form regardless of whether
+    // `value:` is bound on the HostInput. The previous shape
+    // `dispatch(.<case>(value: <value_expr>))` was an emitter bug:
+    // it tried to call a Swift enum case with an associated value
+    // that the .mil never declared (`emit onCommit ;` has no
+    // payload), producing "enum case has no associated values"
+    // compile errors. Matches the React backend, which dispatches
+    // `{ type: "commit" }` with no value field. Authors who need
+    // the live value subscribe to `onChange` (which IS the
+    // value-carrying path — see the `.onChange(of:)` handler
+    // above).
+    //
+    // If a future Mosaic component genuinely needs an onCommit
+    // that carries the value, the right move is to declare
+    // `emit onCommit ( value : text ) ;` in the .mil and have the
+    // emitter look up the emit's payload from the interface
+    // descriptor — not to guess from the HostInput's `value:` prop.
+    // That richer payload-aware handling is tracked as a follow-up.
     if let Some(emit_name) = find_emit_ref_prop(node, "onCommit") {
         let case_name = to_camel_case_first_lower(&strip_on_prefix(emit_name));
         validate_emit_name(&case_name)?;
-        if find_slot_ref_prop(node, "value").is_some() {
-            line.push_str(&format!(
-                ".onSubmit {{ dispatch(.{case_name}(value: {value_expr})) }}"
-            ));
-        } else {
-            // No value slot — emit the void form.
-            line.push_str(&format!(".onSubmit {{ dispatch(.{case_name}) }}"));
-        }
+        line.push_str(&format!(".onSubmit {{ dispatch(.{case_name}) }}"));
     }
 
     // `.onExitCommand { dispatch(.e) }` — macOS Escape-key handler.
@@ -2916,9 +2928,17 @@ mod tests {
         )
         .unwrap()
         .output;
+        // Always emit the void-form dispatch. The previous
+        // `dispatch(.commit(value: value))` shape was an emitter bug:
+        // when the Mosaic component declares `emit onCommit ;` (no
+        // payload — which is the common case), the Swift compiler
+        // rejected the value-carrying form as "enum case has no
+        // associated values". Authors that need the live value
+        // subscribe to `onChange` instead (which IS the value-
+        // carrying path; see `.onChange(of: ...)` test elsewhere).
         assert!(
-            out.contains(".onSubmit { dispatch(.commit(value: value)) }"),
-            "expected .onSubmit dispatch site, got:\n{out}"
+            out.contains(".onSubmit { dispatch(.commit) }"),
+            "expected void-form .onSubmit dispatch, got:\n{out}"
         );
     }
 

--- a/demo/visicalc-swiftui/Package.swift
+++ b/demo/visicalc-swiftui/Package.swift
@@ -13,10 +13,14 @@ let package = Package(
     name: "VisiCalc",
     platforms: [
         // SwiftUI's TextField + onSubmit + onExitCommand all need
-        // macOS 11+ / iOS 15+. We pick macOS 12 to also get
-        // ToolbarItem(placement:) parity with iOS 15.
-        .macOS(.v12),
-        .iOS(.v15),
+        // macOS 11+ / iOS 15+. mosaic-emit-swiftui emits the
+        // `.onChange(of: x) { handler }` form which Apple revised
+        // in macOS 14 / iOS 17 (the old single-closure signature
+        // is now deprecated, and the new two-or-three-arg form is
+        // required). Pick macOS 14 / iOS 17 to match the emitter's
+        // current output without an `if #available` workaround.
+        .macOS(.v14),
+        .iOS(.v17),
     ],
     products: [
         .executable(name: "visicalc", targets: ["VisiCalc"]),

--- a/demo/visicalc-swiftui/Sources/VisiCalc/VisiCalcApp.swift
+++ b/demo/visicalc-swiftui/Sources/VisiCalc/VisiCalcApp.swift
@@ -1,14 +1,37 @@
 // VisiCalcApp.swift — top-level SwiftUI app entry (VC2-swiftui).
 //
-// Standard @main App scaffold. The ContentView next door does the
-// real work; this file just wires the WindowGroup.
+// @main App scaffold. The ContentView next door does the real work;
+// this file wires the WindowGroup AND attaches an
+// NSApplicationDelegate that elevates the running process to a
+// regular foreground app.
+//
+// Why the AppDelegate? `swift run` launches the binary without an
+// .app bundle / Info.plist, so macOS treats the process as
+// BackgroundOnly by default. The SwiftUI WindowGroup still creates
+// a window but it never appears in the Dock and never activates,
+// which makes the demo hard to find when launched from a terminal.
+// The delegate's `applicationDidFinishLaunching` flips the
+// activation policy to `.regular` (Dock icon + menu bar + window
+// focus) and forces activation. Production .app bundles get the
+// same behaviour via their Info.plist's `LSUIElement = false` so
+// this is a no-op there.
 
 import SwiftUI
+import AppKit
+
+final class VisiCalcAppDelegate: NSObject, NSApplicationDelegate {
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        NSApplication.shared.setActivationPolicy(.regular)
+        NSApplication.shared.activate(ignoringOtherApps: true)
+    }
+}
 
 @main
 struct VisiCalcApp: App {
+    @NSApplicationDelegateAdaptor(VisiCalcAppDelegate.self) var appDelegate
+
     var body: some Scene {
-        WindowGroup {
+        WindowGroup("VisiCalc") {
             ContentView()
         }
     }


### PR DESCRIPTION
## Summary

Three small fixes that unblock running the SwiftUI VisiCalc demo from a terminal. Verified by screenshotting the running app on macOS 14+ — the window appears with title \"VisiCalc\", header strip \"VISICALC · MOSAIC SWIFTUI DEMO\", a FormulaBar showing the selected cell + formula, and a 5×5 grid with cell A1 highlighted.

## What's fixed

### 1. mosaic-emit-swiftui — `HostInput.onCommit` void-form dispatch

`emit_host_input_swift` was emitting `.onSubmit { dispatch(.<case>(value: <value_expr>)) }` unconditionally when `value:` was bound. But the emit declared in .mil is often payload-less (e.g., FormulaBar's `emit onCommit ;`), so the generated Swift enum case had no associated values:

```
error: enum case 'commit' has no associated values
```

**Fix:** always emit the void form `dispatch(.<case>)`. Matches the React backend (which dispatches `{ type: \"commit\" }` with no value field). Authors who need the live value subscribe to `onChange` (which IS the value-carrying path).

If a future Mosaic component genuinely needs an onCommit that carries a value, the right move is to declare `emit onCommit ( value : text ) ;` in the .mil and have the emitter look up the emit's payload from the interface descriptor. Tracked as a follow-up.

Updated the matching test to assert the void form. All 82 SwiftUI tests still green.

### 2. demo/visicalc-swiftui Package.swift — macOS 14 platform bump

mosaic-emit-swiftui emits `.onChange(of: x) { handler }` which Apple revised in macOS 14 / iOS 17. The Package.swift targeted macOS 12; the generated FormulaBar.swift hit:

```
error: 'onChange(of:initial:_:)' is only available in macOS 14.0 or newer
```

**Fix:** bump platforms to `.macOS(.v14)` / `.iOS(.v17)`. An `if #available`-wrapped fallback for older macOS would belong in the emitter, not the demo — tracked as a follow-up.

### 3. VisiCalcApp.swift — NSApplicationDelegateAdaptor for foreground

`swift run` launches the binary without an .app bundle, so macOS treats it as `BackgroundOnly` — the SwiftUI window is created but never appears in the Dock or activates.

**Fix:** install `NSApplicationDelegateAdaptor(VisiCalcAppDelegate)` that calls `setActivationPolicy(.regular)` and `activate(ignoringOtherApps: true)` in `applicationDidFinishLaunching`. Production .app bundles get this from Info.plist's `LSUIElement = false`, so this is a no-op when wrapped properly.

Also added a window title `WindowGroup(\"VisiCalc\")` so the title bar shows the name.

## Test plan

- [x] `cargo test -p mosaic-emit-swiftui` — 82/82 green
- [x] `cd demo/visicalc-swiftui && bash scripts/build.sh && swift build && swift run` — launches, window visible, FormulaBar + Grid rendered
- [ ] CI passes

## Safety

Security-clean. No new unsafe code. The AppDelegate is standard AppKit boilerplate. The `dispatch(.<case>)` change is strictly narrower than the previous behaviour (drops an argument).

🤖 Generated with [Claude Code](https://claude.com/claude-code)