### PR TITLE
feat(rw2): IC16 Panasonic RW2 image codec (0.1.0)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -374,6 +374,7 @@ members = [
     "image-codec-jxl",
     "image-codec-ppm",
     "image-codec-qoi",
+    "image-codec-rw2",
     "image-codec-webp",
     "mosaic-analyzer",
     "mosaic-driver",

--- a/code/packages/rust/image-codec-rw2/BUILD
+++ b/code/packages/rust/image-codec-rw2/BUILD
@@ -1,0 +1,1 @@
+cargo test -p image-codec-rw2 -- --nocapture

--- a/code/packages/rust/image-codec-rw2/CHANGELOG.md
+++ b/code/packages/rust/image-codec-rw2/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog — image-codec-rw2
+
+## [0.1.0] — 2026-05-29
+
+### Added
+
+- Initial implementation of Panasonic RW2 image codec (IC16).
+- `decode_rw2`: full decode pipeline for 12-bit uncompressed RW2 files.
+  - RW2 magic validation (`"II"` + version byte 85).
+  - TIFF-like IFD parser for Panasonic private tags (sensor dimensions, borders,
+    white balance, raw data offset). Entry count capped at 512 for safety.
+  - 12-bit LE packed pixel unpacker (`unpack_12bit_le`): 2 pixels per 3 bytes.
+  - Active-area crop via `SensorTopBorder`/`SensorLeftBorder`/…`RightBorder` tags.
+  - RGGB bilinear Bayer demosaicing.
+  - White balance from tags 0x0011 (RedBalance) and 0x0012 (BlueBalance).
+  - Hardcoded Panasonic GH5 3×3 colour matrix (D65).
+  - sRGB gamma (IEC 61966-2-1 piecewise function).
+  - Output: `PixelContainer` (RGBA8, A=255).
+- `encode_rw2`: minimal test encoder that produces valid RW2 bytes decodeable
+  by `decode_rw2`. Not a production encoder — RW2 is a read-only format.
+- `Rw2Codec` struct implementing `paint_instructions::ImageCodec`.
+- `VERSION = "0.1.0"` public constant.
+- Security guards: max sensor 4096×4096, checked buffer arithmetic, IFD entry
+  count cap, all offset+length pairs bounds-checked before slicing.
+- Graceful `Err` for unsupported variants: 16-bit depth, Panasonic lossless.
+- 38 unit tests (14 in `lib.rs`, plus per-module tests in `header`, `unpack`,
+  `bayer`, `color`, `encoder`, `decoder`).
+
+### Limitations
+
+- Panasonic lossless compression (GH5/S1/S5 v5+) is detected but not decoded.
+- 16-bit ImageDepth is not supported.
+- Single hardcoded colour matrix; no per-model lookup.

--- a/code/packages/rust/image-codec-rw2/Cargo.toml
+++ b/code/packages/rust/image-codec-rw2/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "image-codec-rw2"
+version = "0.1.0"
+edition = "2021"
+description = "Panasonic RW2 RAW image decoder and minimal encoder using PixelContainer"
+
+[dependencies]
+pixel-container = { path = "../pixel-container" }
+paint-instructions = { path = "../paint-instructions" }

--- a/code/packages/rust/image-codec-rw2/README.md
+++ b/code/packages/rust/image-codec-rw2/README.md
@@ -1,0 +1,93 @@
+# image-codec-rw2
+
+Panasonic RW2 RAW image decoder for Rust.
+
+## What is RW2?
+
+RW2 (RAW version 2) is Panasonic's proprietary camera format used in every
+Lumix body since the GH1 (2009). It stores uncompressed 12-bit Bayer data
+from the camera sensor alongside white balance and crop metadata.
+
+## How it fits in the stack
+
+```
+RW2 bytes
+  → Rw2Codec::decode()
+  → PixelContainer (RGBA8)
+  → PngCodec::encode()
+  → PNG bytes
+```
+
+`image-codec-rw2` depends only on `pixel-container` (the shared RGBA buffer
+type) and `paint-instructions` (the `ImageCodec` trait). It has no dependency
+on `image-codec-tiff` — it parses its own TIFF-like IFD.
+
+## Usage
+
+```rust
+use image_codec_rw2::{decode_rw2, encode_rw2, Rw2Codec, VERSION};
+use paint_instructions::ImageCodec;
+
+// Decode
+let bytes = std::fs::read("DSCF0001.RW2").unwrap();
+let pixels = decode_rw2(&bytes).expect("not a valid RW2 file");
+println!("{}×{} image", pixels.width, pixels.height);
+
+// Via trait
+let pixels = Rw2Codec.decode(&bytes).unwrap();
+
+// Minimal test encoder (produces valid RW2 that decodes back)
+let rw2_bytes = encode_rw2(&pixels);
+
+println!("Version: {VERSION}");
+```
+
+## Decode pipeline
+
+1. Validate the 8-byte RW2 magic (`"II"` + version 85)
+2. Parse the TIFF-like IFD for Panasonic private tags
+3. Unpack 12-bit little-endian packed pixels (2 pixels per 3 bytes)
+4. Crop to the active sensor area using border tags
+5. Bilinear Bayer demosaicing (RGGB pattern)
+6. White balance from tags 0x0011/0x0012
+7. 3×3 Panasonic colour matrix (GH5 D65)
+8. sRGB gamma curve
+9. Build `PixelContainer` (RGBA8, A=255)
+
+## Limitations (v0.1)
+
+- Only **12-bit packed** (uncompressed) RW2 is supported.
+- **Panasonic lossless** compression (GH5/S1/S5 v5+) returns `Err`.
+- **16-bit depth** returns `Err`.
+- A single hardcoded colour matrix (GH5 D65) is used for all models.
+- Sensor dimensions above 4096×4096 are rejected.
+
+## File format reference
+
+```
+Offset  Size  Field
+0       2     "II" — always little-endian
+2       2     0x0055 (85) — RW2 version marker (NOT TIFF's 42)
+4       4     Offset of first IFD (u32 LE, usually 8)
+8+      —     TIFF-like IFD with Panasonic private tags
+?       —     12-bit LE packed raw Bayer data
+```
+
+## Module structure
+
+| File          | Responsibility                                    |
+|---------------|---------------------------------------------------|
+| `lib.rs`      | Public API, `Rw2Codec`, `VERSION`                 |
+| `header.rs`   | Magic validation, IFD parsing                     |
+| `unpack.rs`   | 12-bit LE packed pixel reader                     |
+| `bayer.rs`    | RGGB bilinear Bayer demosaicing                   |
+| `color.rs`    | White balance, colour matrix, sRGB gamma          |
+| `decoder.rs`  | Top-level `decode_rw2` pipeline                   |
+| `encoder.rs`  | Minimal test encoder                              |
+
+## References
+
+- dcraw.c `panasonic_load_raw()` — reference C implementation
+- LibRaw Panasonic decoders — https://github.com/LibRaw/LibRaw
+- Exiv2 Panasonic tag database — https://exiv2.org/tags-panasonic.html
+- rawspeed — https://github.com/darktable-org/rawspeed

--- a/code/packages/rust/image-codec-rw2/src/bayer.rs
+++ b/code/packages/rust/image-codec-rw2/src/bayer.rs
@@ -1,0 +1,210 @@
+// # bayer.rs — Standard 2×2 bilinear Bayer demosaicing (RGGB)
+//
+// ## What is a Bayer mosaic?
+//
+// A digital camera sensor typically has one photosite per pixel. To record
+// colour, each photosite is covered by a colour filter. Panasonic uses the
+// RGGB pattern — a 2×2 repeating tile:
+//
+//   ┌─────┬─────┐
+//   │  R  │  G  │  ← even row
+//   ├─────┼─────┤
+//   │  G  │  B  │  ← odd row
+//   └─────┴─────┘
+//    even   odd
+//    col    col
+//
+// Every pixel on the sensor records only one colour channel; the missing two
+// channels must be *interpolated* from neighbouring pixels of the same colour.
+// This process is called demosaicing (or debayering).
+//
+// ## Bilinear Interpolation
+//
+// We use the simplest correct algorithm: bilinear interpolation. For each
+// pixel, we average the nearest same-colour neighbours:
+//
+//   R pixel  → G from 4-connected (N, S, E, W) average
+//              B from 4-diagonal (NE, NW, SE, SW) average
+//
+//   G pixel (even-row, odd-col = Gr)
+//           → R from left/right average
+//              B from up/down average
+//
+//   G pixel (odd-row, even-col = Gb)
+//           → R from up/down average
+//              B from left/right average
+//
+//   B pixel  → G from 4-connected average
+//              R from 4-diagonal average
+//
+// Border pixels clamp their neighbour indices to the image bounds rather than
+// wrapping (replication padding). This is the standard choice for RAW decoders.
+//
+// ## Output
+//
+// Returns a Vec of `(r, g, b)` tuples in u16, row-major, same dimensions as
+// the input Bayer grid. The values stay in the 12-bit range [0, 4095] of the
+// unpacked raw pixels.
+
+/// Demosaic an RGGB Bayer grid using bilinear interpolation.
+///
+/// `raw`    — flat array of 12-bit pixel values, row-major, top-left origin.
+/// `width`  — image width in pixels.
+/// `height` — image height in pixels.
+///
+/// Returns a `Vec<(u16, u16, u16)>` of (R, G, B) triplets, one per pixel,
+/// in row-major order. Values are in the u16 range [0, 4095].
+pub fn demosaic_rggb(raw: &[u16], width: usize, height: usize) -> Vec<(u16, u16, u16)> {
+    // A helper that reads a raw pixel, clamping out-of-bounds coordinates to
+    // the nearest edge (replication padding). This avoids border special-casing
+    // at every call site and is numerically equivalent to mirror padding for
+    // the bilinear case.
+    let get = |row: i64, col: i64| -> u16 {
+        let r = row.max(0).min(height as i64 - 1) as usize;
+        let c = col.max(0).min(width as i64 - 1) as usize;
+        raw[r * width + c]
+    };
+
+    // Average up to four u16 values, discarding zero-weight slots (unused near
+    // borders where fewer neighbours exist). The divisor is always the actual
+    // number of terms, never zero.
+    let avg2 = |a: u16, b: u16| -> u16 { ((a as u32 + b as u32) / 2) as u16 };
+    let avg4 = |a: u16, b: u16, c: u16, d: u16| -> u16 {
+        ((a as u32 + b as u32 + c as u32 + d as u32) / 4) as u16
+    };
+
+    let mut out = Vec::with_capacity(width * height);
+
+    for row in 0..height {
+        for col in 0..width {
+            let r = row as i64;
+            let c = col as i64;
+
+            // Determine Bayer colour at this position.
+            // RGGB tile:
+            //   (even_row, even_col) → R
+            //   (even_row, odd_col)  → Gr  (green in red row)
+            //   (odd_row,  even_col) → Gb  (green in blue row)
+            //   (odd_row,  odd_col)  → B
+            let (red, green, blue) = match (row % 2, col % 2) {
+                // ── Red site ──────────────────────────────────────────────
+                (0, 0) => {
+                    let red = get(r, c);
+                    // Green: average of 4-connected same-row/same-col neighbours
+                    let green = avg4(
+                        get(r - 1, c), // north
+                        get(r + 1, c), // south
+                        get(r, c - 1), // west
+                        get(r, c + 1), // east
+                    );
+                    // Blue: average of 4 diagonal neighbours
+                    let blue = avg4(
+                        get(r - 1, c - 1),
+                        get(r - 1, c + 1),
+                        get(r + 1, c - 1),
+                        get(r + 1, c + 1),
+                    );
+                    (red, green, blue)
+                }
+                // ── Green-in-red-row (Gr) ─────────────────────────────────
+                (0, 1) => {
+                    let green = get(r, c);
+                    // Red: left and right neighbours (same even row)
+                    let red = avg2(get(r, c - 1), get(r, c + 1));
+                    // Blue: up and down neighbours (odd rows)
+                    let blue = avg2(get(r - 1, c), get(r + 1, c));
+                    (red, green, blue)
+                }
+                // ── Green-in-blue-row (Gb) ────────────────────────────────
+                (1, 0) => {
+                    let green = get(r, c);
+                    // Red: up and down (even rows)
+                    let red = avg2(get(r - 1, c), get(r + 1, c));
+                    // Blue: left and right (same odd row)
+                    let blue = avg2(get(r, c - 1), get(r, c + 1));
+                    (red, green, blue)
+                }
+                // ── Blue site ─────────────────────────────────────────────
+                _ => {
+                    let blue = get(r, c);
+                    // Green: 4-connected
+                    let green = avg4(
+                        get(r - 1, c),
+                        get(r + 1, c),
+                        get(r, c - 1),
+                        get(r, c + 1),
+                    );
+                    // Red: 4 diagonals
+                    let red = avg4(
+                        get(r - 1, c - 1),
+                        get(r - 1, c + 1),
+                        get(r + 1, c - 1),
+                        get(r + 1, c + 1),
+                    );
+                    (red, green, blue)
+                }
+            };
+
+            out.push((red, green, blue));
+        }
+    }
+
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn demosaic_2x2_all_zeros() {
+        // A 2×2 all-black Bayer grid should produce (0, 0, 0) for every pixel.
+        let raw = vec![0u16; 4];
+        let out = demosaic_rggb(&raw, 2, 2);
+        assert_eq!(out.len(), 4);
+        for (r, g, b) in &out {
+            assert_eq!((*r, *g, *b), (0, 0, 0));
+        }
+    }
+
+    #[test]
+    fn demosaic_2x2_red_only() {
+        // Only R site (0,0) is non-zero. Green and Blue sites are 0.
+        // After demosaicing, the R pixel should keep its value; others derive via
+        // interpolation from neighbours (all zero on a 2×2 grid at the boundary).
+        //
+        // Bayer grid (2×2):
+        //   R=1000  G=0
+        //   G=0     B=0
+        let raw = vec![1000u16, 0, 0, 0];
+        let out = demosaic_rggb(&raw, 2, 2);
+        // (0,0) is the R site — its R value must be 1000.
+        assert_eq!(out[0].0, 1000);
+    }
+
+    #[test]
+    fn demosaic_uniform_produces_uniform() {
+        // A uniform 4×4 Bayer grid (all pixels = 2048) should demosaic to
+        // approximately (2048, 2048, 2048) at every site because all neighbour
+        // averages of 2048 stay at 2048.
+        let raw = vec![2048u16; 16];
+        let out = demosaic_rggb(&raw, 4, 4);
+        assert_eq!(out.len(), 16);
+        for (r, g, b) in &out {
+            assert_eq!(*r, 2048);
+            assert_eq!(*g, 2048);
+            assert_eq!(*b, 2048);
+        }
+    }
+
+    #[test]
+    fn demosaic_output_length() {
+        let raw = vec![0u16; 6 * 4];
+        let out = demosaic_rggb(&raw, 6, 4);
+        assert_eq!(out.len(), 24);
+    }
+}

--- a/code/packages/rust/image-codec-rw2/src/color.rs
+++ b/code/packages/rust/image-codec-rw2/src/color.rs
@@ -1,0 +1,244 @@
+// # color.rs — White balance, camera colour matrix, and sRGB gamma
+//
+// ## The Colour Pipeline
+//
+// RAW sensor data measures photon counts — a device-dependent, linear-light
+// value. To produce a perceptually correct JPEG-like image, we need to:
+//
+//   1. Remove black level (sensor noise floor)
+//   2. Normalize to [0.0, 1.0]
+//   3. Multiply each channel by its white-balance gain
+//   4. Apply a 3×3 camera-to-sRGB colour matrix
+//   5. Apply the sRGB gamma curve (linearize then toe-compress)
+//   6. Clip to [0, 255] and cast to u8
+//
+// ## White Balance
+//
+// Digital cameras record raw Bayer values relative to the illuminant. A pixel
+// under a warm incandescent bulb has too much red and not enough blue. White
+// balance corrects this by multiplying R and B channels by reciprocal gains:
+//
+//   wb_r = red_balance / 256.0    (e.g. RedBalance=512 → wb_r=2.0)
+//   wb_g = 1.0                    (green channel is the reference)
+//   wb_b = blue_balance / 256.0
+//
+// ## Colour Matrix
+//
+// The camera's CFA spectral sensitivities are not the same as the CIE XYZ
+// colour matching functions. The 3×3 matrix maps from camera RGB to sRGB,
+// compensating for this difference. We use the Panasonic Lumix GH5 matrix as
+// a representative hardcode — it works reasonably well for all Micro 4/3 models:
+//
+//   [ 1.512  -0.518   0.006 ]
+//   [-0.202   1.590  -0.388 ]
+//   [ 0.055  -0.413   1.358 ]
+//
+// This matrix is from LibRaw / dcraw.c and targets D65 white point.
+//
+// ## sRGB Gamma
+//
+// The sRGB standard uses a piecewise transfer function:
+//
+//   if x ≤ 0.0031308:  srgb(x) = 12.92 × x
+//   else:              srgb(x) = 1.055 × x^(1/2.4) − 0.055
+//
+// This "lifts" the shadows (linear segment) and compresses the highlights
+// (power curve), matching the gamma of most displays.
+
+/// Panasonic Lumix GH5 camera-to-sRGB 3×3 colour matrix.
+///
+/// Rows: [R_out, G_out, B_out]. Columns: [R_in, G_in, B_in].
+/// Applied to white-balanced camera-linear values to get display-ready sRGB.
+pub const PANASONIC_COLOR_MATRIX: [[f64; 3]; 3] = [
+    [ 1.512, -0.518,  0.006],
+    [-0.202,  1.590, -0.388],
+    [ 0.055, -0.413,  1.358],
+];
+
+/// Apply the sRGB gamma (IEC 61966-2-1) transfer function to a linear [0,1]
+/// value, producing an output in [0,1].
+///
+/// Formula (pseudocode, not Rust):
+///
+/// ```text
+/// if v <= 0.0031308: out = 12.92 * v
+/// else:              out = 1.055 * v^(1/2.4) - 0.055
+/// ```
+#[inline]
+fn srgb_gamma(v: f64) -> f64 {
+    if v <= 0.0031308 {
+        12.92 * v
+    } else {
+        1.055 * v.powf(1.0 / 2.4) - 0.055
+    }
+}
+
+/// Clamp a floating-point value to [0.0, 1.0].
+#[inline]
+fn clamp01(v: f64) -> f64 {
+    v.max(0.0).min(1.0)
+}
+
+/// Apply the full camera-to-display colour pipeline.
+///
+/// ## Parameters
+///
+/// * `rgb`          — Demosaiced (R, G, B) tuples in camera-linear u16.
+/// * `black_level`  — Sensor black level (noise floor). Typically 240 for 12-bit RW2.
+/// * `white_level`  — Sensor saturation level. Typically 4095 (2^12 − 1).
+/// * `wb`           — White balance multipliers [wb_r, wb_g, wb_b]. Green is
+///                    usually 1.0; R and B are the correction factors.
+/// * `color_matrix` — 3×3 camera-to-sRGB matrix. Use [`PANASONIC_COLOR_MATRIX`]
+///                    for Panasonic bodies.
+///
+/// ## Returns
+///
+/// A `Vec<(u8, u8, u8)>` of sRGB display-ready (R, G, B) bytes, length equal
+/// to `rgb.len()`.
+pub fn apply_color_pipeline(
+    rgb: Vec<(u16, u16, u16)>,
+    black_level: u32,
+    white_level: u32,
+    wb: [f64; 3],
+    color_matrix: [[f64; 3]; 3],
+) -> Vec<(u8, u8, u8)> {
+    // Guard against divide-by-zero if white_level == black_level.
+    let range = (white_level as f64 - black_level as f64).max(1.0);
+
+    rgb.into_iter()
+        .map(|(r16, g16, b16)| {
+            // ── Step 1: subtract black level, floor at 0 ──────────────────
+            let r_blk = (r16 as i64 - black_level as i64).max(0) as f64;
+            let g_blk = (g16 as i64 - black_level as i64).max(0) as f64;
+            let b_blk = (b16 as i64 - black_level as i64).max(0) as f64;
+
+            // ── Step 2: normalise to [0.0, 1.0] ───────────────────────────
+            let r_norm = r_blk / range;
+            let g_norm = g_blk / range;
+            let b_norm = b_blk / range;
+
+            // ── Step 3: apply white balance gains ─────────────────────────
+            let r_wb = r_norm * wb[0];
+            let g_wb = g_norm * wb[1];
+            let b_wb = b_norm * wb[2];
+
+            // ── Step 4: apply 3×3 camera-to-sRGB matrix ───────────────────
+            // Each output channel is a weighted sum of all three input channels.
+            let r_mat = color_matrix[0][0] * r_wb
+                + color_matrix[0][1] * g_wb
+                + color_matrix[0][2] * b_wb;
+            let g_mat = color_matrix[1][0] * r_wb
+                + color_matrix[1][1] * g_wb
+                + color_matrix[1][2] * b_wb;
+            let b_mat = color_matrix[2][0] * r_wb
+                + color_matrix[2][1] * g_wb
+                + color_matrix[2][2] * b_wb;
+
+            // ── Step 5: apply sRGB gamma ───────────────────────────────────
+            // Clip to [0,1] first so gamma works correctly (powf on negative is NaN).
+            let r_gamma = srgb_gamma(clamp01(r_mat));
+            let g_gamma = srgb_gamma(clamp01(g_mat));
+            let b_gamma = srgb_gamma(clamp01(b_mat));
+
+            // ── Step 6: clip to [0,1] and scale to u8 ─────────────────────
+            let to_u8 = |v: f64| -> u8 { (clamp01(v) * 255.0).round() as u8 };
+            (to_u8(r_gamma), to_u8(g_gamma), to_u8(b_gamma))
+        })
+        .collect()
+}
+
+/// Compute the white balance multipliers from IFD RedBalance / BlueBalance tags.
+///
+/// Both tags store (channel / green) × 256 as a u16. Green is normalised to 1.0.
+///
+/// If either tag is missing (None), defaults to 1.0 for that channel (neutral).
+///
+/// # Examples
+///
+/// ```
+/// // RedBalance=512, BlueBalance=256 → [2.0, 1.0, 1.0]
+/// use image_codec_rw2::color::white_balance_from_tags;
+/// let wb = white_balance_from_tags(Some(512), Some(256));
+/// assert!((wb[0] - 2.0).abs() < 1e-9);
+/// assert!((wb[1] - 1.0).abs() < 1e-9);
+/// assert!((wb[2] - 1.0).abs() < 1e-9);
+/// ```
+pub fn white_balance_from_tags(red_balance: Option<u32>, blue_balance: Option<u32>) -> [f64; 3] {
+    let wb_r = red_balance
+        .map(|v| v as f64 / 256.0)
+        .unwrap_or(1.0);
+    let wb_b = blue_balance
+        .map(|v| v as f64 / 256.0)
+        .unwrap_or(1.0);
+    [wb_r, 1.0, wb_b]
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wb_from_tags_both_present() {
+        let wb = white_balance_from_tags(Some(512), Some(256));
+        assert!((wb[0] - 2.0).abs() < 1e-9, "R: expected 2.0, got {}", wb[0]);
+        assert!((wb[1] - 1.0).abs() < 1e-9, "G: expected 1.0, got {}", wb[1]);
+        assert!((wb[2] - 1.0).abs() < 1e-9, "B: expected 1.0, got {}", wb[2]);
+    }
+
+    #[test]
+    fn wb_from_tags_missing() {
+        // Both None → neutral [1,1,1]
+        let wb = white_balance_from_tags(None, None);
+        assert_eq!(wb, [1.0, 1.0, 1.0]);
+    }
+
+    #[test]
+    fn srgb_gamma_zero() {
+        // 0.0 → 0.0 (linear segment)
+        assert!((srgb_gamma(0.0)).abs() < 1e-12);
+    }
+
+    #[test]
+    fn srgb_gamma_one() {
+        // 1.0 → 1.0 (both segments agree at endpoints by construction)
+        assert!((srgb_gamma(1.0) - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn color_pipeline_neutral_identity() {
+        // With black_level=0, white_level=255 (pretend 8-bit), identity WB and
+        // identity colour matrix, the pipeline should be a near-pass-through
+        // (only sRGB gamma is applied).
+        let identity = [[1.0f64, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]];
+        let pixels: Vec<(u16, u16, u16)> = vec![(128, 128, 128)];
+        let out = apply_color_pipeline(pixels, 0, 255, [1.0, 1.0, 1.0], identity);
+        // After normalise (128/255) + gamma, expect a reasonable mid-grey.
+        let (r, g, b) = out[0];
+        assert_eq!(r, g);
+        assert_eq!(g, b);
+        // Should be somewhere around 128 (sRGB gamma ~55% at 0.5 linear).
+        assert!(r > 80 && r < 200, "Expected mid-grey, got {r}");
+    }
+
+    #[test]
+    fn color_pipeline_black_pixel() {
+        // A pixel exactly at black_level should produce (0, 0, 0).
+        let identity = [[1.0f64, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]];
+        let pixels: Vec<(u16, u16, u16)> = vec![(240, 240, 240)];
+        let out = apply_color_pipeline(pixels, 240, 4095, [1.0, 1.0, 1.0], identity);
+        assert_eq!(out[0], (0, 0, 0));
+    }
+
+    #[test]
+    fn color_pipeline_white_pixel() {
+        // A pixel at white_level should produce (255, 255, 255) with identity pipeline.
+        let identity = [[1.0f64, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]];
+        let pixels: Vec<(u16, u16, u16)> = vec![(4095, 4095, 4095)];
+        let out = apply_color_pipeline(pixels, 240, 4095, [1.0, 1.0, 1.0], identity);
+        assert_eq!(out[0], (255, 255, 255));
+    }
+}

--- a/code/packages/rust/image-codec-rw2/src/decoder.rs
+++ b/code/packages/rust/image-codec-rw2/src/decoder.rs
@@ -1,0 +1,202 @@
+// # decoder.rs — Top-level RW2 decode pipeline
+//
+// This module ties together all the sub-modules:
+//
+//   1. Validate magic bytes (`header::check_magic`)
+//   2. Parse IFD tags (`header::parse_ifd`)
+//   3. Validate ImageDepth (only 12-bit supported in v0.1)
+//   4. Detect Panasonic lossless compression and return a friendly Err
+//   5. Unpack 12-bit LE pixel data (`unpack::unpack_12bit_le`)
+//   6. Crop to the active sensor area (remove optical-black borders)
+//   7. Bayer demosaicing (`bayer::demosaic_rggb`)
+//   8. White balance + colour matrix + sRGB gamma (`color::apply_color_pipeline`)
+//   9. Build PixelContainer (RGBA8, A=255)
+//
+// ## Security
+//
+// * Sensor dimensions are capped at 4096×4096 (hard) to prevent huge allocs.
+// * The raw data offset and byte count are bounds-checked before slicing.
+// * All pixel buffer size calculations use checked arithmetic.
+
+use crate::bayer::demosaic_rggb;
+use crate::color::{apply_color_pipeline, white_balance_from_tags, PANASONIC_COLOR_MATRIX};
+use crate::header::{check_magic, parse_ifd};
+use crate::unpack::{row_stride_bytes, unpack_12bit_le};
+use pixel_container::PixelContainer;
+
+/// Maximum sensor dimension we accept (width or height).
+///
+/// A real Panasonic Lumix GH6 sensor is 5728×4296. Capping at 4096 is
+/// conservative but safe for a v0.1 decoder — it prevents gigabyte-scale allocs
+/// from malformed files.
+const MAX_SENSOR_DIM: u32 = 4096;
+
+/// Typical black level for 12-bit Panasonic RW2 files.
+const BLACK_LEVEL_12BIT: u32 = 240;
+
+/// Maximum 12-bit pixel value (2^12 − 1).
+const WHITE_LEVEL_12BIT: u32 = 4095;
+
+/// Decode a Panasonic RW2 file from a byte slice into a PixelContainer.
+///
+/// ## Errors
+///
+/// Returns `Err(String)` with a descriptive message for any of:
+/// - File too short or wrong magic.
+/// - IFD parsing failure.
+/// - Missing required tags (sensor width/height).
+/// - 16-bit ImageDepth (not supported in v0.1).
+/// - Panasonic lossless compression detected (not supported in v0.1).
+/// - Sensor dimensions exceeding `MAX_SENSOR_DIM`.
+/// - Raw data offset out of file bounds.
+pub fn decode_rw2(bytes: &[u8]) -> Result<PixelContainer, String> {
+    // ── Step 1: Check the 8-byte RW2 magic ───────────────────────────────────
+    let ifd_offset = check_magic(bytes)?;
+
+    // ── Step 2: Parse the IFD for Panasonic private tags ─────────────────────
+    let ifd = parse_ifd(bytes, ifd_offset)?;
+
+    // ── Step 3: Extract required dimensions ──────────────────────────────────
+    let sensor_width = ifd
+        .sensor_width
+        .ok_or("RW2: missing SensorWidth tag (0x0002)")?;
+    let sensor_height = ifd
+        .sensor_height
+        .ok_or("RW2: missing SensorHeight tag (0x0003)")?;
+
+    // Safety: reject absurdly large sensors that would exhaust RAM.
+    if sensor_width > MAX_SENSOR_DIM {
+        return Err(format!(
+            "RW2: SensorWidth {sensor_width} exceeds maximum {MAX_SENSOR_DIM}"
+        ));
+    }
+    if sensor_height > MAX_SENSOR_DIM {
+        return Err(format!(
+            "RW2: SensorHeight {sensor_height} exceeds maximum {MAX_SENSOR_DIM}"
+        ));
+    }
+
+    // ── Step 4: Check ImageDepth ──────────────────────────────────────────────
+    // We support 12-bit packed. 16-bit requires a different unpack scheme.
+    if let Some(depth) = ifd.image_depth {
+        if depth == 16 {
+            return Err("RW2: 16-bit ImageDepth not supported in v0.1".into());
+        }
+    }
+    // If ImageDepth is missing, assume 12-bit (most common case).
+
+    // ── Step 5: Locate the raw pixel strip ────────────────────────────────────
+    let raw_offset = ifd
+        .raw_data_offset
+        .ok_or("RW2: could not locate raw pixel data (tags 0x0097 / StripOffsets both missing)")?;
+    let raw_offset = raw_offset as usize;
+
+    // Compute the expected uncompressed byte count:
+    //   stride × sensor_height
+    let stride = row_stride_bytes(sensor_width);
+    let expected_bytes = stride
+        .checked_mul(sensor_height as usize)
+        .ok_or("RW2: sensor dimensions overflow usize")?;
+
+    // Validate that the raw offset is within the file.
+    if raw_offset >= bytes.len() {
+        return Err(format!(
+            "RW2: raw data offset {raw_offset} is beyond file end ({})",
+            bytes.len()
+        ));
+    }
+
+    let available = bytes.len() - raw_offset;
+
+    // ── Step 6: Detect Panasonic lossless ─────────────────────────────────────
+    // If the available byte count is less than 80% of the expected uncompressed
+    // size, we assume the file uses Panasonic lossless compression (row-by-row
+    // variable-length). v0.1 does not implement the decompressor.
+    if available < expected_bytes * 4 / 5 {
+        return Err(format!(
+            "RW2: Panasonic lossless compression detected \
+             (available bytes {available} < 80% of expected {expected_bytes}). \
+             Lossless RW2 is not supported in v0.1."
+        ));
+    }
+
+    let raw_bytes = &bytes[raw_offset..raw_offset + expected_bytes.min(available)];
+
+    // ── Step 7: Unpack 12-bit packed pixels ───────────────────────────────────
+    let total_pixels = sensor_width as usize * sensor_height as usize;
+    let raw_pixels = unpack_12bit_le(raw_bytes, total_pixels);
+
+    // ── Step 8: Crop to active area ───────────────────────────────────────────
+    //
+    // The sensor records some optical-black columns and rows used for black-level
+    // estimation. The border tags define which pixels are the "active image area":
+    //   rows:  [top_border .. bottom_border)
+    //   cols:  [left_border .. right_border)
+    //
+    // If any border tag is missing, we use the full sensor extent.
+    let top    = ifd.sensor_top_border  .unwrap_or(0)             as usize;
+    let left   = ifd.sensor_left_border .unwrap_or(0)             as usize;
+    let bottom = ifd.sensor_bottom_border.unwrap_or(sensor_height) as usize;
+    let right  = ifd.sensor_right_border .unwrap_or(sensor_width)  as usize;
+
+    // Clamp borders to sensor dimensions to handle malformed tags.
+    let top    = top   .min(sensor_height as usize);
+    let left   = left  .min(sensor_width  as usize);
+    let bottom = bottom.min(sensor_height as usize).max(top);
+    let right  = right .min(sensor_width  as usize).max(left);
+
+    let crop_w = right  - left;
+    let crop_h = bottom - top;
+
+    if crop_w == 0 || crop_h == 0 {
+        return Err("RW2: active area is empty after border crop".into());
+    }
+
+    // Extract the cropped Bayer grid.
+    let mut cropped = Vec::with_capacity(crop_w * crop_h);
+    for row in top..bottom {
+        for col in left..right {
+            let idx = row * sensor_width as usize + col;
+            cropped.push(raw_pixels.get(idx).copied().unwrap_or(0));
+        }
+    }
+
+    // ── Step 9: Bayer demosaicing ─────────────────────────────────────────────
+    let demosaiced = demosaic_rggb(&cropped, crop_w, crop_h);
+
+    // ── Step 10: Colour pipeline ──────────────────────────────────────────────
+    let wb = white_balance_from_tags(ifd.red_balance, ifd.blue_balance);
+    let srgb = apply_color_pipeline(
+        demosaiced,
+        BLACK_LEVEL_12BIT,
+        WHITE_LEVEL_12BIT,
+        wb,
+        PANASONIC_COLOR_MATRIX,
+    );
+
+    // ── Step 11: Build PixelContainer (RGBA8, A=255) ──────────────────────────
+    let mut container = PixelContainer::new(crop_w as u32, crop_h as u32);
+    for (i, (r, g, b)) in srgb.into_iter().enumerate() {
+        let x = (i % crop_w) as u32;
+        let y = (i / crop_w) as u32;
+        container.set_pixel(x, y, r, g, b, 255);
+    }
+
+    Ok(container)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decode_too_short() {
+        let result = decode_rw2(&[0x49, 0x49, 0x55]);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("too short"));
+    }
+}

--- a/code/packages/rust/image-codec-rw2/src/encoder.rs
+++ b/code/packages/rust/image-codec-rw2/src/encoder.rs
@@ -1,0 +1,252 @@
+// # encoder.rs — Minimal RW2 test encoder
+//
+// This encoder writes a synthetic but valid RW2 file. It is NOT a production
+// encoder — Panasonic RW2 is a read-only proprietary format. The purpose here
+// is to produce test fixtures that the decoder can exercise, verifying the full
+// round-trip.
+//
+// ## What We Emit
+//
+//   ┌─────────────────────────────────────────────────────┐
+//   │ 8-byte RW2 header                                   │
+//   ├─────────────────────────────────────────────────────┤
+//   │ IFD: 2-byte entry count (10 entries)                │
+//   │      10 × 12-byte IFD entries                       │
+//   │      4-byte next_ifd = 0                            │
+//   ├─────────────────────────────────────────────────────┤
+//   │ 12-bit LE packed raw pixel data                     │
+//   └─────────────────────────────────────────────────────┘
+//
+// ## IFD Tags Written
+//
+// We write these Panasonic private tags:
+//   0x0002 SensorWidth       = container.width
+//   0x0003 SensorHeight      = container.height
+//   0x0004 SensorTopBorder   = 0   (no border — active area = full sensor)
+//   0x0005 SensorLeftBorder  = 0
+//   0x0006 SensorBottomBorder= height
+//   0x0007 SensorRightBorder = width
+//   0x0011 RedBalance        = 256 (neutral, 1.0 × 256)
+//   0x0012 BlueBalance       = 256 (neutral)
+//   0x0024 ImageDepth        = 12  (bits per pixel)
+//   0x0097 RawDataOffset     = offset of raw data (computed below)
+//
+// ## Pixel Encoding
+//
+// We convert from the PixelContainer's u8 sRGB values back to an approximate
+// 12-bit linear value for testing. The goal is purely round-trip fidelity: any
+// pixel that goes through encode → decode should produce a similar colour.
+//
+// For simplicity we use a linear approximation:
+//
+//   raw_12bit = channel_u8 / 255.0 * (4095 - 240) + 240
+//            ≈ channel_u8 * 15 + 240
+//
+// This is intentionally simple — we just need sensible test data, not a perfect
+// inverse of the colour pipeline.
+
+use crate::unpack::row_stride_bytes;
+use pixel_container::PixelContainer;
+
+// ---------------------------------------------------------------------------
+// IFD entry writing helpers
+// ---------------------------------------------------------------------------
+
+/// Append a 12-byte SHORT IFD entry to `out`.
+///
+/// TIFF type code 3 = SHORT (u16). For a single SHORT value the 4-byte
+/// value_or_offset field holds the u16 inline in the first 2 bytes.
+fn push_short_entry(out: &mut Vec<u8>, tag: u16, value: u16) {
+    // tag (u16 LE)
+    out.extend_from_slice(&tag.to_le_bytes());
+    // type = 3 (SHORT) (u16 LE)
+    out.extend_from_slice(&3u16.to_le_bytes());
+    // count = 1 (u32 LE)
+    out.extend_from_slice(&1u32.to_le_bytes());
+    // value_or_offset: value in low 2 bytes, high 2 bytes = 0
+    let mut val_field = [0u8; 4];
+    val_field[0..2].copy_from_slice(&value.to_le_bytes());
+    out.extend_from_slice(&val_field);
+}
+
+/// Append a 12-byte LONG IFD entry to `out`.
+///
+/// TIFF type code 4 = LONG (u32). For a single LONG value the 4-byte
+/// value_or_offset field holds the u32 inline.
+fn push_long_entry(out: &mut Vec<u8>, tag: u16, value: u32) {
+    // tag (u16 LE)
+    out.extend_from_slice(&tag.to_le_bytes());
+    // type = 4 (LONG) (u16 LE)
+    out.extend_from_slice(&4u16.to_le_bytes());
+    // count = 1 (u32 LE)
+    out.extend_from_slice(&1u32.to_le_bytes());
+    // value inline
+    out.extend_from_slice(&value.to_le_bytes());
+}
+
+// ---------------------------------------------------------------------------
+// Pixel conversion
+// ---------------------------------------------------------------------------
+
+/// Convert an 8-bit sRGB channel value to an approximate 12-bit camera-linear
+/// value suitable for encoding in the synthetic RW2 raw data.
+///
+/// Formula: raw ≈ u8_val × 15 + 240   (maps [0, 255] → [240, 4065])
+///
+/// The exact inverse of our colour pipeline would require inverting sRGB gamma
+/// and the colour matrix. For test purposes, this linear approximation is
+/// sufficient to verify the encoder/decoder integration.
+#[inline]
+fn u8_to_raw12(v: u8) -> u16 {
+    // Scale into [240, 4095]
+    let raw = v as u32 * 15 + 240;
+    raw.min(4095) as u16
+}
+
+// ---------------------------------------------------------------------------
+// Public encoder
+// ---------------------------------------------------------------------------
+
+/// Encode a `PixelContainer` into a minimal synthetic RW2 file.
+///
+/// This is primarily intended for unit tests. The output is a structurally
+/// valid RW2 file that `decode_rw2` can parse back.
+///
+/// The encoding uses R→raw12(R) for R sites, G→raw12(G) for G sites,
+/// B→raw12(B) for B sites according to the RGGB Bayer pattern.
+pub fn encode_rw2(pixels: &PixelContainer) -> Vec<u8> {
+    let width  = pixels.width;
+    let height = pixels.height;
+
+    // We build the file in three passes so we know the raw data offset.
+    //
+    //   Header:   8 bytes
+    //   IFD:      2 (entry_count) + 10*12 (entries) + 4 (next_ifd) = 126 bytes
+    //   Total before raw data: 8 + 126 = 134 bytes
+
+    let header_ifd_size: u32 = 8 + 2 + 10 * 12 + 4;
+    let raw_data_offset = header_ifd_size;
+
+    let mut out = Vec::new();
+
+    // ── 8-byte RW2 header ────────────────────────────────────────────────────
+    //
+    //   "II"  — little-endian byte order marker
+    //   0x0055 LE — RW2 version (85)
+    //   offset_to_ifd — always 8 (IFD immediately follows header)
+    out.extend_from_slice(b"II");
+    out.extend_from_slice(&85u16.to_le_bytes());
+    out.extend_from_slice(&8u32.to_le_bytes()); // IFD at offset 8
+
+    // ── IFD: 10 entries ──────────────────────────────────────────────────────
+    //
+    // TIFF IFD starts with a 2-byte count. Each entry is 12 bytes. The
+    // directory ends with a 4-byte next_ifd = 0.
+    out.extend_from_slice(&10u16.to_le_bytes()); // entry_count
+
+    push_short_entry(&mut out, 0x0002, width  as u16); // SensorWidth
+    push_short_entry(&mut out, 0x0003, height as u16); // SensorHeight
+    push_short_entry(&mut out, 0x0004, 0);              // SensorTopBorder
+    push_short_entry(&mut out, 0x0005, 0);              // SensorLeftBorder
+    push_short_entry(&mut out, 0x0006, height as u16); // SensorBottomBorder
+    push_short_entry(&mut out, 0x0007, width  as u16); // SensorRightBorder
+    push_short_entry(&mut out, 0x0011, 256);            // RedBalance (neutral)
+    push_short_entry(&mut out, 0x0012, 256);            // BlueBalance (neutral)
+    push_short_entry(&mut out, 0x0024, 12);             // ImageDepth = 12 bpp
+    push_long_entry (&mut out, 0x0097, raw_data_offset);// RawDataOffset
+
+    out.extend_from_slice(&0u32.to_le_bytes()); // next_ifd = 0 (no more IFDs)
+
+    // ── 12-bit packed raw pixel data ─────────────────────────────────────────
+    //
+    // We emit one Bayer-patterned pixel per sensor position. The RGGB mosaic
+    // assigns each site a colour:
+    //   (even_row, even_col) → R channel
+    //   (even_row, odd_col)  → G channel
+    //   (odd_row,  even_col) → G channel
+    //   (odd_row,  odd_col)  → B channel
+    //
+    // We then pack pairs of adjacent raw values into 3-byte little-endian groups.
+
+    let stride = row_stride_bytes(width);
+    let mut raw_data = vec![0u8; stride * height as usize];
+
+    // Build a flat array of raw 12-bit values (width × height, row-major).
+    let mut raw_pixels = vec![0u16; width as usize * height as usize];
+    for y in 0..height {
+        for x in 0..width {
+            let (r, g, b, _) = pixels.pixel_at(x, y);
+            let raw_val = match (y % 2, x % 2) {
+                (0, 0) => u8_to_raw12(r), // R site
+                (0, 1) => u8_to_raw12(g), // Gr site
+                (1, 0) => u8_to_raw12(g), // Gb site
+                _      => u8_to_raw12(b), // B site
+            };
+            raw_pixels[(y as usize) * (width as usize) + (x as usize)] = raw_val;
+        }
+    }
+
+    // Pack pairs of raw_pixels into 3-byte groups row by row.
+    for row in 0..height as usize {
+        let row_start  = row * width as usize;
+        let byte_start = row * stride;
+        let mut col = 0usize;
+        let mut byte_idx = byte_start;
+
+        while col < width as usize {
+            let p0 = raw_pixels[row_start + col];
+            let p1 = if col + 1 < width as usize {
+                raw_pixels[row_start + col + 1]
+            } else {
+                0
+            };
+
+            // Pack p0 and p1 into 3 bytes:
+            //   byte0 = p0[7:0]
+            //   byte1 = p0[11:8] | (p1[3:0] << 4)
+            //   byte2 = p1[11:4]
+            let b0 = (p0 & 0xFF) as u8;
+            let b1 = ((p0 >> 8) & 0x0F) as u8 | (((p1 & 0x0F) << 4) as u8);
+            let b2 = ((p1 >> 4) & 0xFF) as u8;
+
+            if byte_idx + 2 < raw_data.len() {
+                raw_data[byte_idx]     = b0;
+                raw_data[byte_idx + 1] = b1;
+                raw_data[byte_idx + 2] = b2;
+            }
+
+            col += 2;
+            byte_idx += 3;
+        }
+    }
+
+    out.extend_from_slice(&raw_data);
+
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encoded_starts_with_rw2_magic() {
+        let pixels = PixelContainer::new(4, 4);
+        let rw2 = encode_rw2(&pixels);
+        assert_eq!(&rw2[0..2], b"II");
+        let version = u16::from_le_bytes([rw2[2], rw2[3]]);
+        assert_eq!(version, 85);
+    }
+
+    #[test]
+    fn encoded_ifd_offset_is_8() {
+        let pixels = PixelContainer::new(4, 4);
+        let rw2 = encode_rw2(&pixels);
+        let ifd_offset = u32::from_le_bytes([rw2[4], rw2[5], rw2[6], rw2[7]]);
+        assert_eq!(ifd_offset, 8);
+    }
+}

--- a/code/packages/rust/image-codec-rw2/src/header.rs
+++ b/code/packages/rust/image-codec-rw2/src/header.rs
@@ -204,8 +204,13 @@ pub fn parse_ifd(bytes: &[u8], ifd_offset: u32) -> Result<Rw2Ifd, String> {
     }
 
     // IFD body: entry_count × 12 bytes, starting at off+2.
-    let entries_start = off + 2;
-    let entries_end = entries_start + entry_count * 12;
+    // Use checked arithmetic to prevent usize overflow if ifd_offset is near
+    // usize::MAX (possible on a crafted file on a 32-bit host).
+    let entries_start = off.checked_add(2).ok_or("RW2: IFD offset arithmetic overflow")?;
+    let entries_end = entry_count
+        .checked_mul(12)
+        .and_then(|n| entries_start.checked_add(n))
+        .ok_or("RW2: IFD entry range arithmetic overflow")?;
     if entries_end > bytes.len() {
         return Err("RW2: IFD extends past end of file".into());
     }

--- a/code/packages/rust/image-codec-rw2/src/header.rs
+++ b/code/packages/rust/image-codec-rw2/src/header.rs
@@ -1,0 +1,334 @@
+// # header.rs — RW2 magic validation and IFD parsing
+//
+// ## RW2 File Header
+//
+// RW2 looks like TIFF but is distinguished by a different version byte:
+//
+//   Offset  Size  Field
+//   0       2     Byte order marker: "II" (0x49 0x49) — always little-endian
+//   2       2     Version: 0x0055 (85 decimal) — NOT 42 like standard TIFF
+//   4       4     Offset of first IFD (u32 LE, usually 8)
+//
+// This 4-byte structure ("IIU\0") is the discriminating magic.
+//
+// ## IFD (Image File Directory) Structure
+//
+// The TIFF IFD format is a compact directory used here for Panasonic private
+// tags. Each directory is:
+//
+//   u16 LE: entry_count
+//   [entry_count × 12-byte entries]
+//   u32 LE: next_ifd_offset (0 = no more IFDs)
+//
+// Each 12-byte entry:
+//
+//   Offset  Size  Field
+//   0       2     tag (u16 LE)
+//   2       2     type (u16 LE): 1=BYTE, 3=SHORT, 4=LONG, 5=RATIONAL, …
+//   4       4     count (u32 LE): how many values
+//   8       4     value_or_offset (u32 LE):
+//                   • if count × sizeof(type) ≤ 4 bytes: the value is stored inline
+//                   • otherwise: a file offset to the actual value bytes
+//
+// For this crate we only need SHORT (u16) and LONG (u32) inline values, which
+// is the case for all Panasonic private tags we parse.
+
+/// Parsed fields extracted from the RW2 IFD.
+///
+/// All fields that are absent from the IFD remain `None`. The decoder
+/// applies sensible defaults when tags are missing (e.g. border = full sensor,
+/// white balance = neutral 1.0).
+#[derive(Debug, Default)]
+pub struct Rw2Ifd {
+    /// Full sensor width in pixels (tag 0x0002).
+    pub sensor_width: Option<u32>,
+    /// Full sensor height in pixels (tag 0x0003).
+    pub sensor_height: Option<u32>,
+    /// Top row of active image area (tag 0x0004).
+    pub sensor_top_border: Option<u32>,
+    /// Left column of active image area (tag 0x0005).
+    pub sensor_left_border: Option<u32>,
+    /// Exclusive bottom row of active area (tag 0x0006).
+    pub sensor_bottom_border: Option<u32>,
+    /// Exclusive right column of active area (tag 0x0007).
+    pub sensor_right_border: Option<u32>,
+    /// White-balance red multiplier × 256 (tag 0x0011).
+    pub red_balance: Option<u32>,
+    /// White-balance blue multiplier × 256 (tag 0x0012).
+    pub blue_balance: Option<u32>,
+    /// Bits per raw pixel (tag 0x0024). Supported: 12.
+    pub image_depth: Option<u32>,
+    /// File offset of the raw pixel strip (tag 0x0097 or StripOffsets 273).
+    pub raw_data_offset: Option<u32>,
+}
+
+// ---------------------------------------------------------------------------
+// TIFF type sizes
+// ---------------------------------------------------------------------------
+
+/// Return the byte size of a single TIFF value of the given type code.
+///
+/// | Code | Name     | Bytes |
+/// |------|----------|-------|
+/// |  1   | BYTE     |   1   |
+/// |  2   | ASCII    |   1   |
+/// |  3   | SHORT    |   2   |
+/// |  4   | LONG     |   4   |
+/// |  5   | RATIONAL |   8   |
+/// |  6   | SBYTE    |   1   |
+/// |  7   | UNDEFINED|   1   |
+/// |  8   | SSHORT   |   2   |
+/// |  9   | SLONG    |   4   |
+/// | 10   | SRATIONAL|   8   |
+/// | 11   | FLOAT    |   4   |
+/// | 12   | DOUBLE   |   8   |
+fn tiff_type_size(type_code: u16) -> usize {
+    match type_code {
+        1 | 2 | 6 | 7 => 1,
+        3 | 8 => 2,
+        4 | 9 | 11 => 4,
+        5 | 10 | 12 => 8,
+        _ => 1, // unknown → treat as byte so we don't panic
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Little-endian read helpers
+// ---------------------------------------------------------------------------
+
+/// Read a u16 from `bytes[offset..]` in little-endian order.
+///
+/// # Panics
+///
+/// Panics if `offset + 2 > bytes.len()`. Callers must validate bounds first.
+pub(crate) fn read_u16_le(bytes: &[u8], offset: usize) -> u16 {
+    u16::from_le_bytes([bytes[offset], bytes[offset + 1]])
+}
+
+/// Read a u32 from `bytes[offset..]` in little-endian order.
+///
+/// # Panics
+///
+/// Panics if `offset + 4 > bytes.len()`. Callers must validate bounds first.
+pub(crate) fn read_u32_le(bytes: &[u8], offset: usize) -> u32 {
+    u32::from_le_bytes([
+        bytes[offset],
+        bytes[offset + 1],
+        bytes[offset + 2],
+        bytes[offset + 3],
+    ])
+}
+
+// ---------------------------------------------------------------------------
+// Magic check
+// ---------------------------------------------------------------------------
+
+/// Validate the 8-byte RW2 file header.
+///
+/// Returns `Ok(ifd_offset)` where `ifd_offset` is the file offset to the first
+/// IFD (always u32 LE at bytes 4–7).
+///
+/// # Errors
+///
+/// - `"RW2: file too short"` — fewer than 8 bytes.
+/// - `"RW2: not a little-endian file"` — bytes 0–1 are not "II".
+/// - `"RW2: not an RW2 file (TIFF version byte is N, expected 85)"` — bytes 2–3
+///   hold the TIFF version marker 42 (standard TIFF) or something else. The
+///   version 85 (0x0055) is the discriminator that makes a file RW2 vs TIFF.
+pub fn check_magic(bytes: &[u8]) -> Result<u32, String> {
+    // Need at least the 8-byte header.
+    if bytes.len() < 8 {
+        return Err("RW2: file too short".into());
+    }
+
+    // Bytes 0–1: byte-order marker. RW2 is always little-endian ("II").
+    // "MM" would indicate big-endian TIFF, which RW2 never uses.
+    if &bytes[0..2] != b"II" {
+        return Err(format!(
+            "RW2: not a little-endian file (got {:02X} {:02X}, expected 49 49)",
+            bytes[0], bytes[1]
+        ));
+    }
+
+    // Bytes 2–3: version. Standard TIFF = 42 (0x002A). RW2 = 85 (0x0055).
+    let version = read_u16_le(bytes, 2);
+    if version != 85 {
+        return Err(format!(
+            "RW2: not an RW2 file (version byte is {version}, expected 85)"
+        ));
+    }
+
+    // Bytes 4–7: offset of first IFD.
+    let ifd_offset = read_u32_le(bytes, 4);
+    Ok(ifd_offset)
+}
+
+// ---------------------------------------------------------------------------
+// IFD parser
+// ---------------------------------------------------------------------------
+
+/// Parse the Panasonic private IFD tags from the RW2 file.
+///
+/// `ifd_offset` is obtained from `check_magic`. All Panasonic tags we care
+/// about fit in a single IFD; the `next_ifd_offset` pointer at the end of
+/// the directory is ignored (sub-IFDs are not recursed into for now).
+///
+/// ## Security
+///
+/// - IFD entry count is capped at 512 to prevent huge loops on corrupted files.
+/// - Every byte range access is bounds-checked before indexing.
+///
+/// ## Tag extraction strategy
+///
+/// For SHORT tags: the 4-byte value_or_offset field holds the u16 value
+/// inline (little-endian in the first 2 bytes).
+///
+/// For LONG tags: the 4-byte value_or_offset field holds the u32 value inline
+/// (when count == 1 and type == LONG, the whole value fits in 4 bytes).
+pub fn parse_ifd(bytes: &[u8], ifd_offset: u32) -> Result<Rw2Ifd, String> {
+    let off = ifd_offset as usize;
+
+    // Need at least 2 bytes for the entry count.
+    if off + 2 > bytes.len() {
+        return Err("RW2: IFD offset out of bounds".into());
+    }
+
+    let entry_count = read_u16_le(bytes, off) as usize;
+
+    // Security cap: legitimate cameras have fewer than 100 IFD entries; cap at
+    // 512 to guard against malformed files that claim millions of entries.
+    if entry_count > 512 {
+        return Err(format!(
+            "RW2: IFD entry count {entry_count} exceeds maximum 512"
+        ));
+    }
+
+    // IFD body: entry_count × 12 bytes, starting at off+2.
+    let entries_start = off + 2;
+    let entries_end = entries_start + entry_count * 12;
+    if entries_end > bytes.len() {
+        return Err("RW2: IFD extends past end of file".into());
+    }
+
+    let mut ifd = Rw2Ifd::default();
+
+    for i in 0..entry_count {
+        let e = entries_start + i * 12;
+
+        // Each IFD entry is exactly 12 bytes:
+        //   [0..2]  tag       (u16 LE)
+        //   [2..4]  type      (u16 LE)
+        //   [4..8]  count     (u32 LE)
+        //   [8..12] value_or_offset (u32 LE)
+        let tag       = read_u16_le(bytes, e);
+        let type_code = read_u16_le(bytes, e + 2);
+        let count     = read_u32_le(bytes, e + 4);
+        let val_field = read_u32_le(bytes, e + 8); // raw 4-byte value field
+
+        // Determine whether the value is inline (stored in the value_or_offset
+        // field) or at a file offset. Value is inline if:
+        //   count × type_size ≤ 4 bytes
+        let type_size = tiff_type_size(type_code);
+        let is_inline = (count as usize).saturating_mul(type_size) <= 4;
+
+        // Extract scalar value (u32) for SHORT and LONG tags.
+        // For SHORT (2 bytes, inline): the first 2 bytes of the value field.
+        // For LONG (4 bytes, inline):  the whole 4-byte value field.
+        // If the value is at an offset, we read from there.
+        let scalar: u32 = match (type_code, is_inline) {
+            // SHORT (type 3) inline: low 16 bits of value_or_offset
+            (3, true) => (val_field & 0xFFFF) as u32,
+            // LONG (type 4) inline
+            (4, true) => val_field,
+            // BYTE (type 1) inline
+            (1, true) => val_field & 0xFF,
+            // Indirect: read from file offset (only for LONG, 4 bytes)
+            (4, false) => {
+                let offset = val_field as usize;
+                if offset + 4 > bytes.len() {
+                    continue; // bounds violation → skip this tag
+                }
+                read_u32_le(bytes, offset)
+            }
+            // Indirect SHORT: read u16 from file offset
+            (3, false) => {
+                let offset = val_field as usize;
+                if offset + 2 > bytes.len() {
+                    continue;
+                }
+                read_u16_le(bytes, offset) as u32
+            }
+            _ => continue, // unsupported type for our tags → skip
+        };
+
+        // Populate the relevant field based on the Panasonic private tag number.
+        match tag {
+            0x0002 => ifd.sensor_width        = Some(scalar),
+            0x0003 => ifd.sensor_height       = Some(scalar),
+            0x0004 => ifd.sensor_top_border   = Some(scalar),
+            0x0005 => ifd.sensor_left_border  = Some(scalar),
+            0x0006 => ifd.sensor_bottom_border= Some(scalar),
+            0x0007 => ifd.sensor_right_border = Some(scalar),
+            0x0011 => ifd.red_balance         = Some(scalar),
+            0x0012 => ifd.blue_balance        = Some(scalar),
+            0x0024 => ifd.image_depth         = Some(scalar),
+            // Tag 0x0097 — Panasonic raw data strip offset
+            0x0097 => ifd.raw_data_offset     = Some(scalar),
+            // Standard TIFF StripOffsets (273 = 0x0111) — fallback
+            0x0111 => {
+                if ifd.raw_data_offset.is_none() {
+                    ifd.raw_data_offset = Some(scalar);
+                }
+            }
+            _ => {} // unrecognised tag → ignore
+        }
+    }
+
+    Ok(ifd)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn magic_too_short() {
+        assert!(check_magic(&[0x49, 0x49]).is_err());
+    }
+
+    #[test]
+    fn magic_wrong_byte_order() {
+        // "MM" big-endian header
+        let mut b = vec![0u8; 8];
+        b[0] = 0x4D; b[1] = 0x4D; // "MM"
+        b[2] = 0x00; b[3] = 0x2A; // TIFF version 42
+        assert!(check_magic(&b).is_err());
+    }
+
+    #[test]
+    fn magic_tiff_version_rejected() {
+        // "II" + version 42 = standard TIFF → must be rejected as not RW2
+        let mut b = vec![0u8; 8];
+        b[0] = 0x49; b[1] = 0x49; // "II"
+        b[2] = 0x2A; b[3] = 0x00; // version 42 LE
+        let result = check_magic(&b);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("version byte is 42"));
+    }
+
+    #[test]
+    fn magic_rw2_accepted() {
+        // "II" + version 85 (0x55) = valid RW2
+        let mut b = vec![0u8; 8];
+        b[0] = 0x49; b[1] = 0x49;
+        b[2] = 0x55; b[3] = 0x00; // 85 LE
+        b[4] = 0x08; b[5] = 0x00; b[6] = 0x00; b[7] = 0x00; // IFD at offset 8
+        let result = check_magic(&b);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), 8);
+    }
+}

--- a/code/packages/rust/image-codec-rw2/src/lib.rs
+++ b/code/packages/rust/image-codec-rw2/src/lib.rs
@@ -1,0 +1,357 @@
+// # image-codec-rw2
+//
+// Panasonic RW2 RAW image decoder (and minimal test encoder) for Rust.
+//
+// ## What is RW2?
+//
+// RW2 (RAW version 2) is Panasonic's proprietary camera RAW format, used in
+// every Lumix body since the GH1 (2009). It replaced the older `.raw` format
+// and is now the dominant RAW format on all Micro 4/3 and full-frame S-series
+// bodies.
+//
+// ## Format at a Glance
+//
+//   ┌──────────────────────────────────────────────┐
+//   │  8-byte RW2 header                           │
+//   │    "II" (LE) + version 85 + IFD offset       │
+//   ├──────────────────────────────────────────────┤
+//   │  TIFF-like IFD (Panasonic private tags)       │
+//   │    SensorWidth / SensorHeight                 │
+//   │    Border crop tags (active area)             │
+//   │    RedBalance / BlueBalance (WB)              │
+//   │    RawDataOffset                              │
+//   ├──────────────────────────────────────────────┤
+//   │  12-bit LE packed raw Bayer data              │
+//   │    RGGB pattern, stride = ⌈W×12/8⌉ bytes     │
+//   └──────────────────────────────────────────────┘
+//
+// ## Decode Pipeline
+//
+// ```text
+// RW2 bytes
+//   → magic + IFD parse (header.rs)
+//   → 12-bit LE unpack (unpack.rs)
+//   → active-area crop
+//   → bilinear Bayer demosaic, RGGB (bayer.rs)
+//   → WB × colour matrix × sRGB gamma (color.rs)
+//   → PixelContainer (RGBA8, A=255)
+// ```
+//
+// ## Limitations (v0.1)
+//
+// - Only 12-bit packed (uncompressed) RW2 is decoded.
+// - Panasonic lossless compression (GH5/S1/S5 v5+) returns `Err`.
+// - 16-bit ImageDepth returns `Err`.
+// - A single hardcoded colour matrix (Panasonic GH5 D65) is used for all models.
+
+pub const VERSION: &str = "0.1.0";
+
+// Re-export pixel_container types so callers don't need a separate dep.
+pub use pixel_container::PixelContainer;
+
+// Sub-modules.
+pub mod bayer;
+pub mod color;
+mod decoder;
+mod encoder;
+mod header;
+mod unpack;
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/// Decode a Panasonic RW2 file from a byte slice into a [`PixelContainer`].
+///
+/// The returned container is RGBA8 with A=255 throughout.
+///
+/// # Errors
+///
+/// Returns `Err` with a descriptive message if:
+/// - The bytes are not valid RW2 (wrong magic, truncated file, etc.)
+/// - The file uses Panasonic lossless compression (not supported in v0.1)
+/// - The sensor uses 16-bit depth (not supported in v0.1)
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// let bytes = std::fs::read("sample.RW2").unwrap();
+/// match image_codec_rw2::decode_rw2(&bytes) {
+///     Ok(pixels) => println!("{}×{}", pixels.width, pixels.height),
+///     Err(e) => eprintln!("Error: {e}"),
+/// }
+/// ```
+pub fn decode_rw2(bytes: &[u8]) -> Result<PixelContainer, String> {
+    decoder::decode_rw2(bytes)
+}
+
+/// Encode a [`PixelContainer`] into a minimal synthetic RW2 file.
+///
+/// This is a test-only encoder — it produces structurally valid RW2 bytes that
+/// `decode_rw2` can round-trip. It is NOT suitable for writing files to a
+/// Panasonic camera; the format is proprietary and read-only in practice.
+pub fn encode_rw2(pixels: &PixelContainer) -> Vec<u8> {
+    encoder::encode_rw2(pixels)
+}
+
+// ── Codec trait implementation ────────────────────────────────────────────────
+
+use paint_instructions::ImageCodec;
+
+/// `ImageCodec` implementation for Panasonic RW2.
+///
+/// Plugs into the codec pipeline:
+///
+/// ```text
+/// rw2_bytes → Rw2Codec::decode() → PixelContainer → PngCodec::encode() → png_bytes
+/// ```
+pub struct Rw2Codec;
+
+impl ImageCodec for Rw2Codec {
+    fn mime_type(&self) -> &'static str {
+        "image/x-panasonic-rw2"
+    }
+
+    fn encode(&self, pixels: &PixelContainer) -> Vec<u8> {
+        encode_rw2(pixels)
+    }
+
+    fn decode(&self, bytes: &[u8]) -> Result<PixelContainer, String> {
+        decode_rw2(bytes)
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::unpack::unpack_12bit_le;
+
+    // ── Helper: create a solid-colour PixelContainer ─────────────────────────
+
+    fn solid(w: u32, h: u32, r: u8, g: u8, b: u8) -> PixelContainer {
+        let mut buf = PixelContainer::new(w, h);
+        buf.fill(r, g, b, 255);
+        buf
+    }
+
+    // ── Test 1: magic accepted ────────────────────────────────────────────────
+    //
+    // A 2×2 image encoded by our encoder must be successfully decoded back.
+
+    #[test]
+    fn magic_accepted() {
+        let original = solid(2, 2, 100, 150, 200);
+        let rw2 = encode_rw2(&original);
+        let result = decode_rw2(&rw2);
+        assert!(result.is_ok(), "Expected Ok, got: {:?}", result.err());
+        let decoded = result.unwrap();
+        assert_eq!(decoded.width,  2);
+        assert_eq!(decoded.height, 2);
+    }
+
+    // ── Test 2: wrong magic — standard TIFF (II + 42) ─────────────────────────
+    //
+    // Standard TIFF uses version byte 42 (0x002A). RW2 uses 85 (0x0055).
+    // We must reject standard TIFF files.
+
+    #[test]
+    fn wrong_magic_tiff() {
+        let mut tiff_header = vec![0u8; 8];
+        tiff_header[0] = 0x49; tiff_header[1] = 0x49; // "II"
+        tiff_header[2] = 0x2A; tiff_header[3] = 0x00; // version 42 LE = standard TIFF
+        tiff_header[4] = 0x08; // IFD at 8
+        let result = decode_rw2(&tiff_header);
+        assert!(result.is_err());
+        let msg = result.unwrap_err();
+        assert!(
+            msg.contains("version byte is 42") || msg.contains("not an RW2"),
+            "Unexpected error: {msg}"
+        );
+    }
+
+    // ── Test 3: wrong magic — random bytes ────────────────────────────────────
+
+    #[test]
+    fn wrong_magic_random() {
+        let data = vec![0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x00, 0x00, 0x00];
+        let result = decode_rw2(&data);
+        assert!(result.is_err());
+    }
+
+    // ── Test 4: header too short ───────────────────────────────────────────────
+
+    #[test]
+    fn header_too_short() {
+        let result = decode_rw2(&[0x49, 0x49, 0x55]);
+        assert!(result.is_err());
+        assert!(
+            result.unwrap_err().contains("too short"),
+            "Expected 'too short' error"
+        );
+    }
+
+    // ── Test 5: 12-bit LE unpack pair ─────────────────────────────────────────
+    //
+    // Verify the unpacking arithmetic against a hand-computed reference.
+    // p0 = 0x123, p1 = 0x456:
+    //   byte0 = 0x23
+    //   byte1 = 0x01 | (0x06 << 4) = 0x61
+    //   byte2 = 0x45
+
+    #[test]
+    fn unpack_12bit_le_pair() {
+        let data = [0x23u8, 0x61, 0x45];
+        let pixels = unpack_12bit_le(&data, 2);
+        assert_eq!(pixels[0], 0x123);
+        assert_eq!(pixels[1], 0x456);
+    }
+
+    // ── Test 6: sensor border crop ────────────────────────────────────────────
+    //
+    // We build a synthetic 4×4 sensor but with borders that crop it to 2×2.
+    // The decoder should produce a 2×2 output, not 4×4.
+
+    #[test]
+    fn sensor_border_crop() {
+        // Encode a 4×4 image and patch the IFD borders to crop to center 2×2.
+        // Our encoder sets borders = [0, 0, height, width] (full sensor). We
+        // need to manipulate the raw bytes to set borders [1, 1, 3, 3] instead.
+        //
+        // The IFD starts at offset 8. Entry count is 10 entries × 12 bytes = 120
+        // bytes of entries at offset 10. Entries are written in this order:
+        //
+        //   entry 0 (offset 10): tag 0x0002 SensorWidth
+        //   entry 1 (offset 22): tag 0x0003 SensorHeight
+        //   entry 2 (offset 34): tag 0x0004 SensorTopBorder   ← patch to 1
+        //   entry 3 (offset 46): tag 0x0005 SensorLeftBorder  ← patch to 1
+        //   entry 4 (offset 58): tag 0x0006 SensorBottomBorder← patch to 3
+        //   entry 5 (offset 70): tag 0x0007 SensorRightBorder ← patch to 3
+        //   ...
+        //
+        // value_or_offset is at bytes [8..12] within each 12-byte entry, i.e.
+        // at IFD_start + 2 + (entry_index * 12) + 8.
+
+        let base = solid(4, 4, 80, 120, 160);
+        let mut rw2 = encode_rw2(&base);
+
+        // Patch entries 2..5 to set borders [1, 1, 3, 3].
+        // Each entry's value field starts at: 8 (header) + 2 (count) + idx*12 + 8
+        let base_entry = 8 + 2; // 10
+        for (idx, border_val) in [(2usize, 1u16), (3, 1), (4, 3), (5, 3)] {
+            let val_offset = base_entry + idx * 12 + 8;
+            rw2[val_offset]     = (border_val & 0xFF) as u8;
+            rw2[val_offset + 1] = (border_val >> 8) as u8;
+        }
+
+        let decoded = decode_rw2(&rw2).expect("decode should succeed");
+        assert_eq!(decoded.width,  2, "Expected crop width 2, got {}", decoded.width);
+        assert_eq!(decoded.height, 2, "Expected crop height 2, got {}", decoded.height);
+    }
+
+    // ── Test 7: white balance extraction ─────────────────────────────────────
+    //
+    // Tag 0x0011 RedBalance = 512 → wb_r = 2.0
+    // Tag 0x0012 BlueBalance = 256 → wb_b = 1.0
+
+    #[test]
+    fn wb_extraction() {
+        use crate::color::white_balance_from_tags;
+        let wb = white_balance_from_tags(Some(512), Some(256));
+        assert!((wb[0] - 2.0).abs() < 1e-9, "wb_r expected 2.0, got {}", wb[0]);
+        assert!((wb[1] - 1.0).abs() < 1e-9, "wb_g expected 1.0, got {}", wb[1]);
+        assert!((wb[2] - 1.0).abs() < 1e-9, "wb_b expected 1.0, got {}", wb[2]);
+    }
+
+    // ── Test 8: colour pipeline neutral ───────────────────────────────────────
+    //
+    // With an identity 3×3 colour matrix, neutral WB, and a mid-grey input,
+    // all three output channels should be equal (same grey value).
+
+    #[test]
+    fn color_pipeline_neutral() {
+        use crate::color::apply_color_pipeline;
+        let identity = [[1.0f64, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]];
+        let pixels = vec![(2048u16, 2048, 2048)];
+        let out = apply_color_pipeline(pixels, 240, 4095, [1.0, 1.0, 1.0], identity);
+        let (r, g, b) = out[0];
+        assert_eq!(r, g, "R and G should be equal for mid-grey");
+        assert_eq!(g, b, "G and B should be equal for mid-grey");
+    }
+
+    // ── Test 9: round-trip solid colour ───────────────────────────────────────
+    //
+    // A 4×4 solid-green image should round-trip through encode→decode with
+    // the green channel dominant in the output. We can't expect exact values
+    // because the colour pipeline applies gamma and a colour matrix, but we
+    // can check that g > r and g > b for a solid-green input.
+
+    #[test]
+    fn round_trip_solid_color() {
+        let original = solid(4, 4, 0, 200, 0);
+        let rw2 = encode_rw2(&original);
+        let decoded = decode_rw2(&rw2).expect("decode should succeed");
+
+        // The output should be 4×4.
+        assert_eq!(decoded.width,  4);
+        assert_eq!(decoded.height, 4);
+
+        // Check a few pixels: green channel should dominate.
+        let (r, g, b, _a) = decoded.pixel_at(1, 1);
+        assert!(
+            g >= r && g >= b,
+            "Expected green to dominate: ({r},{g},{b})"
+        );
+    }
+
+    // ── Test 10: lossless returns Err ─────────────────────────────────────────
+    //
+    // If the file claims a sensor size but the available raw bytes are less than
+    // 80% of the expected uncompressed size, the decoder must return Err.
+
+    #[test]
+    fn lossless_returns_err() {
+        // Build a valid 8×8 RW2 file, then truncate the raw data section to
+        // force the "lossless compression detected" code path.
+        let base = solid(8, 8, 50, 100, 150);
+        let rw2 = encode_rw2(&base);
+
+        // The raw data starts at offset 134 (8 header + 126 IFD).
+        // For an 8×8 sensor at 12 bpp: stride = ceil(8*12/8) = 12 bytes,
+        // expected total = 12 * 8 = 96 bytes. Keep only 10 bytes of raw data
+        // (way under 80% of 96 = 76.8 bytes), which should trigger the error.
+        let truncated = rw2[..134 + 10].to_vec();
+        let result = decode_rw2(&truncated);
+        assert!(result.is_err());
+        let msg = result.unwrap_err();
+        assert!(
+            msg.contains("lossless") || msg.contains("compression"),
+            "Expected lossless error, got: {msg}"
+        );
+    }
+
+    // ── Test 11: MIME type ────────────────────────────────────────────────────
+
+    #[test]
+    fn mime_type() {
+        assert_eq!(Rw2Codec.mime_type(), "image/x-panasonic-rw2");
+    }
+
+    // ── Test 12: VERSION constant ─────────────────────────────────────────────
+
+    #[test]
+    fn version_constant() {
+        assert_eq!(VERSION, "0.1.0");
+    }
+
+    // ── Test 13: codec trait round-trip ───────────────────────────────────────
+
+    #[test]
+    fn codec_trait_round_trip() {
+        use paint_instructions::ImageCodec;
+        let original = solid(4, 4, 120, 80, 40);
+        let rw2 = Rw2Codec.encode(&original);
+        let decoded = Rw2Codec.decode(&rw2).expect("decode should succeed");
+        assert_eq!(decoded.width,  4);
+        assert_eq!(decoded.height, 4);
+    }
+}

--- a/code/packages/rust/image-codec-rw2/src/unpack.rs
+++ b/code/packages/rust/image-codec-rw2/src/unpack.rs
@@ -1,0 +1,164 @@
+// # unpack.rs — 12-bit little-endian packed pixel reader
+//
+// ## Bit Packing Scheme
+//
+// Panasonic packs two 12-bit pixel values into three bytes (24 bits total),
+// discarding zero waste bits. The scheme is little-endian:
+//
+//   Byte index:   |    byte0    |    byte1    |    byte2    |
+//   Bit indices:  | b7 .. b0    | b7 .. b0    | b7 .. b0    |
+//
+//   Pixel 0 (p0):  b0[7:0] | b1[3:0] << 8   (i.e. bits [7:0] then [11:8])
+//   Pixel 1 (p1):  b1[7:4] >> 4 | b2[7:0] << 4
+//
+// In other words:
+//   byte0         = p0[7:0]          (low 8 bits of p0)
+//   byte1 low  4  = p0[11:8]         (high nibble of p0)
+//   byte1 high 4  = p1[3:0]          (low nibble of p1)
+//   byte2         = p1[11:4]         (high 8 bits of p1)
+//
+// ## Row Stride
+//
+// A complete row of `width` pixels occupies:
+//
+//   stride = ⌈width × 12 / 8⌉ = (width × 12 + 7) / 8 bytes
+//
+// The last 3-byte group in a row may encode a partial pixel if `width` is odd.
+// We always emit exactly `num_pixels` values and ignore trailing bits.
+
+/// Unpack `num_pixels` 12-bit LE pixels from a packed byte slice.
+///
+/// Each pair of adjacent pixels occupies 3 consecutive bytes. Pixels beyond
+/// the available input are silently omitted (the returned `Vec` may be shorter
+/// than `num_pixels` if `data` is too short — callers should check).
+///
+/// # Examples
+///
+/// ```
+/// // The 3-byte sequence 0x34, 0x12, 0x56 encodes:
+/// //   p0 = 0x034 | (0x12 & 0x0F) << 8 = 0x234
+/// //   p1 = (0x12 >> 4) | (0x56 << 4) = 0x561
+/// // That is:
+/// //   byte0 = 0x34 → p0[7:0] = 0x34
+/// //   byte1 = 0x12 → p0[11:8] = 0x02, p1[3:0] = 0x01
+/// //   byte2 = 0x56 → p1[11:4] = 0x56
+/// // p0 = 0x34 | (0x02 << 8) = 0x234
+/// // p1 = 0x01 | (0x56 << 4) = 0x561
+/// ```
+pub fn unpack_12bit_le(data: &[u8], num_pixels: usize) -> Vec<u16> {
+    let mut out = Vec::with_capacity(num_pixels);
+    let mut i = 0usize;
+
+    while out.len() < num_pixels {
+        // Need at least 3 bytes to decode a pair.
+        if i + 2 >= data.len() {
+            break;
+        }
+
+        let b0 = data[i] as u16;
+        let b1 = data[i + 1] as u16;
+        let b2 = data[i + 2] as u16;
+
+        // Pixel 0: low 8 bits from b0, high 4 bits from low nibble of b1.
+        //   p0 = b0 | ((b1 & 0x0F) << 8)
+        let p0 = b0 | ((b1 & 0x0F) << 8);
+        out.push(p0);
+
+        if out.len() < num_pixels {
+            // Pixel 1: low 4 bits from high nibble of b1, high 8 bits from b2.
+            //   p1 = (b1 >> 4) | (b2 << 4)
+            let p1 = (b1 >> 4) | (b2 << 4);
+            out.push(p1);
+        }
+
+        i += 3;
+    }
+
+    out
+}
+
+/// Compute the row stride in bytes for a given sensor width packed at 12 bpp.
+///
+/// stride = ⌈width × 12 / 8⌉
+///
+/// For example:
+/// - width = 4000 → stride = 6000 bytes  (4000 × 12 / 8 = 6000 exactly)
+/// - width = 3    → stride = 5 bytes     ((3 × 12 + 7) / 8 = 5)
+pub fn row_stride_bytes(width: u32) -> usize {
+    // Use usize to avoid overflow on large sensors.
+    let bits = width as usize * 12;
+    (bits + 7) / 8
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unpack_known_pair() {
+        // Hand-computed test vector.
+        //
+        // Let p0 = 0x123 and p1 = 0x456.
+        //
+        // Encoding:
+        //   byte0 = p0[7:0]          = 0x23
+        //   byte1 = p0[11:8] | (p1[3:0] << 4) = 0x01 | (0x06 << 4) = 0x61
+        //   byte2 = p1[11:4]         = 0x45
+        let data = [0x23u8, 0x61, 0x45];
+        let pixels = unpack_12bit_le(&data, 2);
+        assert_eq!(pixels.len(), 2);
+        assert_eq!(pixels[0], 0x123, "p0 mismatch: got {:03X}", pixels[0]);
+        assert_eq!(pixels[1], 0x456, "p1 mismatch: got {:03X}", pixels[1]);
+    }
+
+    #[test]
+    fn unpack_all_zeros() {
+        let data = [0u8; 6];
+        let pixels = unpack_12bit_le(&data, 4);
+        assert_eq!(pixels, vec![0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn unpack_all_max_12bit() {
+        // Max 12-bit value = 0xFFF = 4095.
+        // Encoding two 0xFFF pixels:
+        //   byte0 = 0xFF  (p0[7:0] = 0xFF)
+        //   byte1 = 0xFF  (p0[11:8] = 0x0F << 0 = 0xF, p1[3:0] = 0xF << 4 = 0xF0)
+        //           → 0x0F | 0xF0 = 0xFF
+        //   byte2 = 0xFF  (p1[11:4] = 0xFF)
+        let data = [0xFFu8, 0xFF, 0xFF];
+        let pixels = unpack_12bit_le(&data, 2);
+        assert_eq!(pixels[0], 0xFFF);
+        assert_eq!(pixels[1], 0xFFF);
+    }
+
+    #[test]
+    fn unpack_respects_num_pixels() {
+        // 6 bytes could decode 4 pixels, but we only request 3.
+        let data = [0x23u8, 0x61, 0x45, 0x23, 0x61, 0x45];
+        let pixels = unpack_12bit_le(&data, 3);
+        assert_eq!(pixels.len(), 3);
+    }
+
+    #[test]
+    fn row_stride_even_width() {
+        // 4000 pixels × 12 bits / 8 = 6000 bytes exactly.
+        assert_eq!(row_stride_bytes(4000), 6000);
+    }
+
+    #[test]
+    fn row_stride_odd_width() {
+        // 3 pixels × 12 bits = 36 bits → ⌈36/8⌉ = 5 bytes.
+        assert_eq!(row_stride_bytes(3), 5);
+    }
+
+    #[test]
+    fn row_stride_single_pixel() {
+        // 1 pixel × 12 bits = 12 bits → ⌈12/8⌉ = 2 bytes.
+        assert_eq!(row_stride_bytes(1), 2);
+    }
+}


### PR DESCRIPTION
## Summary

- New crate `image-codec-rw2` implementing IC16 — Panasonic's proprietary RW2 RAW format used in all Lumix cameras since 2009
- Full decode pipeline: magic → IFD parse → 12-bit LE unpack → active-area crop → RGGB Bayer demosaic → WB + colour matrix + sRGB gamma → PixelContainer
- Minimal test encoder for round-trip testing
- `Rw2Codec` implementing the `ImageCodec` trait; no dependency on `image-codec-tiff`
- 38 unit tests across all modules (38/38 passing)

## What was built

| Module | Responsibility |
|--------|---------------|
| `header.rs` | Magic validation (`"II"` + version 85), TIFF-like IFD parser |
| `unpack.rs` | 12-bit LE packed pixel reader (2 pixels per 3 bytes) |
| `bayer.rs` | Standard 2×2 bilinear Bayer demosaicing, RGGB pattern |
| `color.rs` | WB from tags, Panasonic GH5 colour matrix, sRGB gamma |
| `decoder.rs` | Top-level pipeline, lossless detection, dimension guards |
| `encoder.rs` | Minimal synthetic encoder for test fixtures |

## Security measures

- Sensor dimensions capped at 4096×4096 (hard limit)
- IFD entry count capped at 512
- All file offsets bounds-checked before slicing
- Checked arithmetic throughout buffer size calculations (including IFD entry range computation added in security-fix commit)
- Graceful `Err` for lossless compression (detected by 80% byte-count heuristic) and 16-bit depth
- No unsafe code

## Test plan

- [ ] CI passes: `cargo test -p image-codec-rw2 -- --nocapture`
- [ ] All 38 unit tests green
- [ ] `cargo build -p image-codec-rw2` clean compile
- [ ] Workspace build shows no new errors (`cargo build --workspace` pre-existing `uefi` error is unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)