### PR TITLE
feat(dartmouth-basic-iir-compiler): AOT backend acceptance tests (PL05-C)

### DIFF
--- a/code/packages/rust/dartmouth-basic-iir-compiler/CHANGELOG.md
+++ b/code/packages/rust/dartmouth-basic-iir-compiler/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog — `dartmouth-basic-iir-compiler`
 
+## 0.3.0 — 2026-05-29 (PL05-C — AOT backend acceptance proofs)
+
+### Added — `tests/backend_compat.rs` exercises every IIR-to-* backend
+
+BASIC's emitted IIR is now proven by automated tests to be accepted
+by the validators of every AOT backend (wasm, jvm, clr, beam).  This
+closes the "BASIC's IIR shape could regress without anyone noticing"
+gap — the same shape Twig (`twig-ir-compiler/tests/backend_compat.rs`),
+Nib (`nib-iir-compiler/tests/backend_compat.rs`), and Oct (PR #4580)
+already had.
+
+### Coverage (8 tests)
+
+| Group | Test | Asserts |
+|---|---|---|
+| Minimal | `basic_minimal_end_accepted_by_every_backend` | `10 END` |
+| Minimal | `basic_let_binding_accepted_by_every_backend` | `LET A = 42` |
+| Arithmetic | `basic_typed_add_accepted_by_every_backend` | `C = A + B` |
+| Arithmetic | `basic_typed_mul_accepted_by_every_backend` | `C = A * B` |
+| Control flow | `basic_if_then_goto_accepted_by_every_backend` | `IF A > 5 THEN 100` |
+| Control flow | `basic_for_next_loop_accepted_by_every_backend` | `FOR I = 1 TO 3 / NEXT I` |
+| Control flow | `basic_goto_accepted_by_every_backend` | `GOTO 100` |
+| Invariant | `basic_main_is_fully_typed` | main has `type_status == FullyTyped` |
+
+All 8 pass on first run — BASIC's IIR is shape-compatible with every
+backend with zero further changes.  This is the AOT counterpart to
+the existing tests/jit_smoke.rs + tests/jit_real_backend.rs (which
+prove the JIT path).
+
+### Dependencies
+
+Added `iir-to-wasm`, `iir-to-jvm-class-file`, `iir-to-cil-bytecode`,
+`iir-to-beam` as **dev-dependencies**.  None of them ship to runtime
+consumers of `dartmouth-basic-iir-compiler`.
+
+### Tests
+
+- 8 new backend_compat tests pass.
+- 17 lib + 8 + 6 + 4 existing tests still pass.
+
 ## 0.2.0 — 2026-05-26 (PL05-B — real BasicCirJit backend)
 
 ### Added — `BasicCirJit`: a real `jit_core::backend::Backend`

--- a/code/packages/rust/dartmouth-basic-iir-compiler/Cargo.toml
+++ b/code/packages/rust/dartmouth-basic-iir-compiler/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "dartmouth-basic-iir-compiler"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
-description = "Dartmouth BASIC frontend for the LANG VM AOT chain — lowers parsed BASIC into interpreter_ir::IIRModule (i64 integer programs only in V1).  v0.2.0: ships BasicCirJit — a real bytecode JIT backend for jit-core."
+description = "Dartmouth BASIC frontend for the LANG VM AOT chain — lowers parsed BASIC into interpreter_ir::IIRModule (i64 integer programs only in V1).  v0.2.0: ships BasicCirJit — a real bytecode JIT backend for jit-core.  v0.3.0: backend_compat e2e tests prove BASIC's IIR is accepted by every IIR-to-{wasm,jvm,clr,beam} validator."
 
 [dependencies]
 coding-adventures-dartmouth-basic-parser = { path = "../dartmouth-basic-parser" }
@@ -11,3 +11,12 @@ interpreter-ir   = { path = "../interpreter-ir" }
 # Promoted from dev-dep — BasicCirJit lives in this crate.
 jit-core         = { path = "../jit-core" }
 vm-core          = { path = "../vm-core" }
+
+[dev-dependencies]
+# Used by tests/backend_compat.rs to prove BASIC programs are
+# accepted by every IIR-to-* backend validator (wasm / jvm / clr /
+# beam).
+iir-to-wasm           = { path = "../iir-to-wasm" }
+iir-to-jvm-class-file = { path = "../iir-to-jvm-class-file" }
+iir-to-cil-bytecode   = { path = "../iir-to-cil-bytecode" }
+iir-to-beam           = { path = "../iir-to-beam" }

--- a/code/packages/rust/dartmouth-basic-iir-compiler/tests/backend_compat.rs
+++ b/code/packages/rust/dartmouth-basic-iir-compiler/tests/backend_compat.rs
@@ -1,0 +1,131 @@
+//! Dartmouth BASIC → IIR-to-* backend acceptance tests.
+//!
+//! Proves BASIC's emitted IIR is accepted by every AOT backend
+//! (wasm / jvm / clr / beam).  Without these tests we could regress
+//! BASIC's IIR shape (e.g. emit an op no backend knows) without anyone
+//! noticing until users try to AOT-compile.
+//!
+//! Pattern mirrors `twig-ir-compiler/tests/backend_compat.rs` and
+//! `oct-iir-compiler/tests/backend_compat.rs`.
+
+use dartmouth_basic_iir_compiler::compile_source;
+
+/// Helper: run every backend's validator on a module.  Panics on any
+/// rejection, attributing the failure to the named backend.
+fn assert_accepted_by_every_backend(m: &interpreter_ir::IIRModule, label: &str) {
+    for (name, errs) in [
+        ("wasm", iir_to_wasm::validate::validate_for_wasm(m)),
+        ("jvm",  iir_to_jvm_class_file::validate::validate_for_jvm(m)),
+        ("clr",  iir_to_cil_bytecode::validate::validate_iir_for_clr(m)),
+        ("beam", iir_to_beam::validate::validate_for_beam(m)),
+    ] {
+        assert!(errs.is_empty(),
+            "[{name}] validator rejected BASIC {label}; got {} error(s): {errs:?}",
+            errs.len());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Group 1: minimal shapes
+// ---------------------------------------------------------------------------
+
+/// The smallest possible BASIC program: `10 END`.
+#[test]
+fn basic_minimal_end_accepted_by_every_backend() {
+    let m = compile_source("10 END\n", "compat").expect("BASIC must compile");
+    assert_accepted_by_every_backend(&m, "`10 END`");
+}
+
+/// `LET` binding — exercises `const` + `mov` (typed i64).
+#[test]
+fn basic_let_binding_accepted_by_every_backend() {
+    let src = "10 LET A = 42\n\
+               20 END\n";
+    let m = compile_source(src, "compat").expect("BASIC must compile");
+    assert_accepted_by_every_backend(&m, "`LET A = 42`");
+}
+
+// ---------------------------------------------------------------------------
+// Group 2: arithmetic
+// ---------------------------------------------------------------------------
+
+/// Binary `+` — typed `add`.
+#[test]
+fn basic_typed_add_accepted_by_every_backend() {
+    let src = "10 LET A = 30\n\
+               20 LET B = 12\n\
+               30 LET C = A + B\n\
+               40 END\n";
+    let m = compile_source(src, "compat").expect("BASIC must compile");
+    assert_accepted_by_every_backend(&m, "`C = A + B`");
+}
+
+/// Binary `*` — typed `mul`.
+#[test]
+fn basic_typed_mul_accepted_by_every_backend() {
+    let src = "10 LET A = 6\n\
+               20 LET B = 7\n\
+               30 LET C = A * B\n\
+               40 END\n";
+    let m = compile_source(src, "compat").expect("BASIC must compile");
+    assert_accepted_by_every_backend(&m, "`C = A * B`");
+}
+
+// ---------------------------------------------------------------------------
+// Group 3: control flow
+// ---------------------------------------------------------------------------
+
+/// `IF … THEN <line>` — branches via `cmp_*` + `jmp_if_*` + line-label.
+#[test]
+fn basic_if_then_goto_accepted_by_every_backend() {
+    let src = "10 LET A = 7\n\
+               20 IF A > 5 THEN 100\n\
+               30 END\n\
+               100 END\n";
+    let m = compile_source(src, "compat").expect("BASIC must compile");
+    assert_accepted_by_every_backend(&m, "`IF A > 5 THEN 100`");
+}
+
+/// `FOR … NEXT` loop — exercises backward `jmp` + counter mutation.
+#[test]
+fn basic_for_next_loop_accepted_by_every_backend() {
+    let src = "10 FOR I = 1 TO 3\n\
+               20 NEXT I\n\
+               30 END\n";
+    let m = compile_source(src, "compat").expect("BASIC must compile");
+    assert_accepted_by_every_backend(&m, "`FOR I = 1 TO 3 / NEXT I`");
+}
+
+/// `GOTO` — unconditional jump to a labeled line.
+#[test]
+fn basic_goto_accepted_by_every_backend() {
+    let src = "10 LET A = 1\n\
+               20 GOTO 100\n\
+               30 LET A = 999\n\
+               100 END\n";
+    let m = compile_source(src, "compat").expect("BASIC must compile");
+    assert_accepted_by_every_backend(&m, "`GOTO 100`");
+}
+
+// ---------------------------------------------------------------------------
+// Group 4: function-status invariant
+// ---------------------------------------------------------------------------
+
+/// Every BASIC function in the module must be `FullyTyped` — without
+/// that, JITCore's threshold-zero compile path doesn't fire and the
+/// IIR-to-* backends emit untyped fallbacks (or reject).
+#[test]
+fn basic_main_is_fully_typed() {
+    let src = "10 LET A = 1\n\
+               20 LET B = A + 1\n\
+               30 END\n";
+    let m = compile_source(src, "compat").expect("BASIC must compile");
+    let main = m.functions.iter().find(|f| f.name == "main")
+        .expect("module must have main");
+    assert_eq!(
+        main.type_status,
+        interpreter_ir::function::FunctionTypeStatus::FullyTyped,
+        "BASIC main should be FullyTyped; got: {:?}",
+        main.type_status,
+    );
+}


### PR DESCRIPTION
## Summary

Proves BASIC's IIR is accepted by every AOT backend (wasm/jvm/clr/beam) via 8 new \`tests/backend_compat.rs\` tests.  Matches Twig (14 tests), Nib, and Oct (PR #4580, 9 tests).

## Test groups

| Group | Tests | What |
|---|---|---|
| Minimal | 2 | \`10 END\`, \`LET A = 42\` |
| Arithmetic | 2 | typed +, typed * |
| Control flow | 3 | IF/THEN/GOTO, FOR/NEXT, GOTO |
| Invariant | 1 | main is FullyTyped |

## Result

**All 8 tests pass on first run** — BASIC's IIR is shape-compatible with every backend with zero further changes.  This is the AOT counterpart to \`tests/jit_smoke.rs\` and \`tests/jit_real_backend.rs\` (which prove the JIT path).

## Test plan

- [x] 8 new backend_compat tests pass
- [x] 17 lib + 8 backend_compat + 6 jit_smoke + 4 jit_real_backend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)