### PR TITLE
feat(dartmouth-basic-iir-compiler): thread source positions through IIR (BASIC05)

### DIFF
--- a/code/packages/rust/dartmouth-basic-iir-compiler/CHANGELOG.md
+++ b/code/packages/rust/dartmouth-basic-iir-compiler/CHANGELOG.md
@@ -1,5 +1,60 @@
 # Changelog — `dartmouth-basic-iir-compiler`
 
+## 0.4.0 — 2026-05-30 (BASIC05 — source-location threading for debugger)
+
+### Added — Real source positions in `IIRFunction.source_map`
+
+BASIC's emitted IIR now carries real `(line, column)` per instruction
+in `IIRFunction.source_map`, in lockstep with `instructions`.
+Previously the field was either empty or all `SourceLoc::SYNTHETIC`.
+
+This is the prerequisite for line-based breakpoints in the future
+`basic-dap` debugger crate.  Without real positions, the debug
+sidecar built by the DAP layer cannot resolve `setBreakpoints
+{ file, lines: [N] }` requests to IIR instructions.
+
+This mirrors the pattern landed for `oct-iir-compiler` 0.4.0
+(OCT05 / PR #4583).  Same `node_loc()` + `Cell<SourceLoc>` +
+statement-level `set_loc()` shape — the next step in the
+horizontally-sequenced "every language gets every Twig-grade
+tool" roadmap.
+
+### Implementation
+
+- New `node_loc(&GrammarASTNode) -> SourceLoc` helper extracts
+  `(start_line, start_column)` from an AST node, falling back to
+  `SYNTHETIC` when the parser couldn't attach positions.
+- `Compiler` gained two fields: `source_map: Vec<SourceLoc>` (the
+  per-function accumulator) and `current_loc: Cell<SourceLoc>`
+  (the "currently compiling" position).  Manual `impl Default`
+  replaces the `#[derive(Default)]` since `Cell<SourceLoc>` doesn't
+  have a usable default (well, it does — but being explicit makes
+  the SYNTHETIC start state obvious to readers).
+- `Compiler::emit` now pushes `current_loc.get()` onto `source_map`
+  for every instruction it appends, maintaining the lockstep
+  invariant.
+- `emit_line` calls `set_loc(node_loc(line))` on entry — all
+  instructions emitted for that line (label + body) inherit the
+  line's source position.
+- `emit_statement` re-tags with the wrapped statement node's own
+  position, which may be a tighter range than `emit_line` set.
+- `emit_program` sets the initial loc to the program root so the
+  synthesised end-of-program epilogue (`const 0; ret`) gets a
+  sensible source line rather than `SYNTHETIC`.
+- `compile_program` ends with the move-with-defensive-padding shape:
+  `main.source_map = std::mem::take(&mut comp.source_map)` after
+  ensuring `source_map.len() == instructions.len()`.
+
+### Tests
+
+- 2 new unit tests:
+  - `source_map_lockstep_with_instructions`: every function's
+    `source_map.len() == instructions.len()`.
+  - `source_map_carries_real_line_numbers`: a 4-line BASIC program
+    produces entries for every line — proving the per-line source
+    positions get threaded through, not just SYNTHETIC.
+- All existing lib tests still pass.
+
 ## 0.3.0 — 2026-05-29 (PL05-C — AOT backend acceptance proofs)
 
 ### Added — `tests/backend_compat.rs` exercises every IIR-to-* backend

--- a/code/packages/rust/dartmouth-basic-iir-compiler/Cargo.toml
+++ b/code/packages/rust/dartmouth-basic-iir-compiler/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "dartmouth-basic-iir-compiler"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
-description = "Dartmouth BASIC frontend for the LANG VM AOT chain — lowers parsed BASIC into interpreter_ir::IIRModule (i64 integer programs only in V1).  v0.2.0: ships BasicCirJit — a real bytecode JIT backend for jit-core.  v0.3.0: backend_compat e2e tests prove BASIC's IIR is accepted by every IIR-to-{wasm,jvm,clr,beam} validator."
+description = "Dartmouth BASIC frontend for the LANG VM AOT chain — lowers parsed BASIC into interpreter_ir::IIRModule (i64 integer programs only in V1).  v0.2.0: ships BasicCirJit — a real bytecode JIT backend for jit-core.  v0.3.0: backend_compat e2e tests prove BASIC's IIR is accepted by every IIR-to-{wasm,jvm,clr,beam} validator.  v0.4.0: threads real source positions through IIRFunction::source_map for line-based debugger breakpoints."
 
 [dependencies]
 coding-adventures-dartmouth-basic-parser = { path = "../dartmouth-basic-parser" }

--- a/code/packages/rust/dartmouth-basic-iir-compiler/src/lib.rs
+++ b/code/packages/rust/dartmouth-basic-iir-compiler/src/lib.rs
@@ -52,6 +52,7 @@ use coding_adventures_dartmouth_basic_parser::parse_dartmouth_basic;
 use interpreter_ir::function::{FunctionTypeStatus, IIRFunction};
 use interpreter_ir::instr::{IIRInstr, Operand};
 use interpreter_ir::module::IIRModule;
+use interpreter_ir::source_loc::SourceLoc;
 
 // Re-export the JIT backend so downstream consumers (tests, future
 // `dartmouth-basic-vm` wrappers) can use it without depending on the
@@ -59,6 +60,22 @@ use interpreter_ir::module::IIRModule;
 pub mod jit_backend;
 pub use jit_backend::{BasicCirJit, DEFAULT_OUTPUT_CAP, DEFAULT_STEP_CAP};
 use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
+
+/// Extract a [`SourceLoc`] from a `GrammarASTNode`, falling back to
+/// [`SourceLoc::SYNTHETIC`] when the parser couldn't attach position
+/// info (rare — mostly synthesised wrapper nodes).
+///
+/// Used by the BASIC compiler to tag every emitted IIR instruction
+/// with the source position of the AST node that produced it.  The
+/// resulting `IIRFunction.source_map` powers line-based breakpoints
+/// in the future `basic-dap` debugger crate and source-line reporting
+/// in stack traces.
+fn node_loc(node: &GrammarASTNode) -> SourceLoc {
+    match (node.start_line, node.start_column) {
+        (Some(line), Some(col)) => SourceLoc::new(line, col),
+        _ => SourceLoc::SYNTHETIC,
+    }
+}
 
 // ===========================================================================
 // Public surface
@@ -124,6 +141,7 @@ fn compile_program(ast: &GrammarASTNode, module_name: &str)
     // anywhere), so the function is genuinely fully typed for the
     // JIT's threshold-zero compile path.  This mirrors Brainfuck's
     // `IIRFunction { … type_status: FullyTyped, … }` construction.
+    let body_len = comp.instrs.len();
     let mut main = IIRFunction::new(
         "main",
         vec![],   // no parameters
@@ -131,13 +149,25 @@ fn compile_program(ast: &GrammarASTNode, module_name: &str)
         comp.instrs,
     );
     main.type_status = FunctionTypeStatus::FullyTyped;
+    // Move the accumulated source positions onto the function.  The
+    // lockstep invariant (one entry per instruction) is enforced by
+    // [`Compiler::emit`]: every push to `instrs` pairs with a push to
+    // `source_map`.  We defensively pad with `SYNTHETIC` in case any
+    // pre-source_map code path slipped through (this branch is dead
+    // today but cheap to keep).
+    while comp.source_map.len() < body_len {
+        comp.source_map.push(SourceLoc::SYNTHETIC);
+    }
+    if comp.source_map.len() > body_len {
+        comp.source_map.truncate(body_len);
+    }
+    main.source_map = std::mem::take(&mut comp.source_map);
     let mut module = IIRModule::new(module_name, "dartmouth-basic");
     module.functions.push(main);
     module.entry_point = Some("main".to_string());
     Ok(module)
 }
 
-#[derive(Default)]
 struct Compiler {
     instrs: Vec<IIRInstr>,
     /// Next synthetic register name (`_t0`, `_t1`, …) for temporaries.
@@ -149,6 +179,30 @@ struct Compiler {
     open_fors: Vec<ForState>,
     /// Counter for unique `for_<n>` label families.
     for_counter: usize,
+    /// Per-instruction source positions, built in lockstep with
+    /// `instrs`.  Moved onto `IIRFunction.source_map` at end of
+    /// [`compile_program`].
+    source_map: Vec<SourceLoc>,
+    /// "Currently compiling" source position.  Updated by every
+    /// statement-level entry point (`emit_line`, `emit_statement`)
+    /// and read by [`emit`] when it appends to the instruction
+    /// stream.  Using a [`Cell`](std::cell::Cell) so a future move to
+    /// `emit(&self, ...)` would not require a re-shuffle of mut
+    /// signatures.
+    current_loc: std::cell::Cell<SourceLoc>,
+}
+
+impl Default for Compiler {
+    fn default() -> Self {
+        Compiler {
+            instrs: Vec::new(),
+            temp_counter: 0,
+            open_fors: Vec::new(),
+            for_counter: 0,
+            source_map: Vec::new(),
+            current_loc: std::cell::Cell::new(SourceLoc::SYNTHETIC),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -173,6 +227,25 @@ impl Compiler {
     {
         self.instrs.push(IIRInstr::new(op,
             dest.map(|s| s.to_string()), srcs, type_hint));
+        // Tag this instruction with the "currently compiling" source
+        // position.  Statement-level entry points (`emit_line`,
+        // `emit_statement`) set `self.current_loc` so every
+        // instruction emitted while compiling that statement —
+        // including from sub-expressions — inherits the statement's
+        // source line.
+        //
+        // Line-based debuggers care about which line a breakpoint
+        // sits on, not the per-expression column.  Statement-level
+        // granularity is both sufficient and cheaper than per-
+        // expression threading.
+        self.source_map.push(self.current_loc.get());
+    }
+
+    /// Update the "currently compiling" source position.  Subsequent
+    /// [`emit`] calls tag their instructions with this position via
+    /// the `source_map` field.
+    fn set_loc(&self, loc: SourceLoc) {
+        self.current_loc.set(loc);
     }
 
     fn emit_program(&mut self, ast: &GrammarASTNode) -> Result<(), CompileError> {
@@ -180,6 +253,11 @@ impl Compiler {
             return Err(CompileError::Malformed(format!(
                 "expected root `program`, got `{}`", ast.rule_name)));
         }
+
+        // Default position for instructions emitted before any line
+        // (e.g. the synthesised end-of-program epilogue): the program
+        // root's own position.
+        self.set_loc(node_loc(ast));
 
         // Walk every `line` child, in order.
         for child in &ast.children {
@@ -200,6 +278,12 @@ impl Compiler {
     }
 
     fn emit_line(&mut self, line: &GrammarASTNode) -> Result<(), CompileError> {
+        // Tag every instruction emitted while compiling this line
+        // (including the synthetic `label line_N` and the statement
+        // body) with the line's source position.  The inner
+        // `emit_statement` may overwrite this with the wrapped
+        // statement node's own position — typically the same line.
+        self.set_loc(node_loc(line));
         let line_num = extract_line_num(line)
             .ok_or_else(|| CompileError::Malformed(
                 "line missing LINE_NUM token".into()))?;
@@ -227,6 +311,14 @@ impl Compiler {
     fn emit_statement(&mut self, stmt: &GrammarASTNode)
         -> Result<(), CompileError>
     {
+        // Re-tag the "currently compiling" loc with the inner
+        // statement node's own position.  In practice this is almost
+        // always the same line as `emit_line` already set, but the
+        // grammar permits multiple statements on one line (via `:`
+        // separators in some BASIC dialects) and the AST may have a
+        // tighter (line, col) range for the inner node — so the more
+        // specific one wins.
+        self.set_loc(node_loc(stmt));
         match stmt.rule_name.as_str() {
             "let_stmt"     => self.emit_let(stmt),
             "print_stmt"   => self.emit_print(stmt),
@@ -879,6 +971,54 @@ mod tests {
             CompileError::UnsupportedStatement(name) => assert_eq!(name, "GOSUB"),
             other => panic!("expected UnsupportedStatement(GOSUB), got {other:?}"),
         }
+    }
+
+    // ── Source-map invariants (BASIC05 — debugger prerequisite) ──────
+
+    /// Every function's `source_map` must have exactly one entry per
+    /// instruction.  Without this lockstep invariant the debugger's
+    /// sidecar cannot map a paused IIR PC back to a source line.
+    #[test]
+    fn source_map_lockstep_with_instructions() {
+        let m = compile("10 LET A = 42\n20 PRINT A\n30 END\n").expect("ok");
+        for f in &m.functions {
+            assert_eq!(
+                f.source_map.len(),
+                f.instructions.len(),
+                "fn {} source_map ({}) must be lockstep with instructions ({})",
+                f.name, f.source_map.len(), f.instructions.len(),
+            );
+        }
+    }
+
+    /// The compiler should thread real source positions through the
+    /// emitted IIR, not just `SYNTHETIC` (line=0, col=0).  Without
+    /// real positions, line-based breakpoints cannot resolve.
+    ///
+    /// We construct a small program with each statement on its own
+    /// line and assert that at least one instruction is tagged with
+    /// each non-empty source line.
+    #[test]
+    fn source_map_carries_real_line_numbers() {
+        let src = "10 LET A = 30\n\
+                   20 LET B = 12\n\
+                   30 PRINT A\n\
+                   40 END\n";
+        let m = compile(src).expect("ok");
+        let main = m.functions.iter().find(|f| f.name == "main").unwrap();
+        let lines_seen: std::collections::BTreeSet<u32> = main.source_map.iter()
+            .filter(|l| **l != SourceLoc::SYNTHETIC)
+            .map(|l| l.line)
+            .collect();
+        // Each BASIC source line should appear at least once in the
+        // source_map (since each emits at least the `label line_N`
+        // instruction plus a statement body).
+        assert!(lines_seen.contains(&1),
+            "expected line 1 (LET A) to appear in source_map; got: {lines_seen:?}");
+        assert!(lines_seen.contains(&2),
+            "expected line 2 (LET B) to appear in source_map; got: {lines_seen:?}");
+        assert!(lines_seen.contains(&3),
+            "expected line 3 (PRINT A) to appear in source_map; got: {lines_seen:?}");
     }
 
     /// A complete small program: LET, arithmetic, PRINT, END.


### PR DESCRIPTION
## Summary

- Threads real `(line, column)` source positions through BASIC's emitted IIR via `IIRFunction.source_map`, in lockstep with `instructions`.
- Mirrors the OCT05 pattern from PR #4583 — same `node_loc()` helper + `Cell<SourceLoc>` + statement-level `set_loc()` shape.
- Prerequisite for line-based breakpoints in the future `basic-dap` debugger crate (task #37).

## Implementation

- New `node_loc(&GrammarASTNode) -> SourceLoc` helper extracts `(start_line, start_column)`, falls back to `SYNTHETIC`.
- `Compiler` gained `source_map: Vec<SourceLoc>` + `current_loc: Cell<SourceLoc>` (manual `impl Default` replaces `#[derive(Default)]`).
- `Compiler::emit` pushes `current_loc.get()` onto `source_map` for every instruction.
- `emit_line` calls `set_loc(node_loc(line))` so all instructions for that BASIC line (label + body) get tagged.
- `emit_statement` re-tags with the wrapped statement node's tighter position.
- `compile_program` moves `source_map` onto `main` with defensive padding to maintain the lockstep invariant.

## Versions

- `dartmouth-basic-iir-compiler`: 0.3.0 → 0.4.0

## Test plan

- [x] 2 new unit tests: `source_map_lockstep_with_instructions`, `source_map_carries_real_line_numbers`
- [x] All 19 lib tests pass
- [x] All 8 backend_compat tests pass
- [x] All 6 jit_real_backend tests pass
- [x] All 4 jit_smoke tests pass
- [x] Downstream lang-aot 17 smoke tests pass
- [x] `/security-review` passed — no vulnerabilities found

Task #34 in the multi-language debugger-prerequisite track.  Next: task #35 (Nib source-loc threading).

🤖 Generated with [Claude Code](https://claude.com/claude-code)