### PR TITLE
feat(ruby-parser+sir): Phase 14b (FC) — class body carries executable statements

### DIFF
--- a/code/packages/rust/ruby-parser/.pr-body-fc-14b.md
+++ b/code/packages/rust/ruby-parser/.pr-body-fc-14b.md
@@ -1,0 +1,114 @@
+## Summary
+
+Phase 14b makes a Ruby `class` body **carry its executable statements**.
+`class Foo … end` now lowers to
+
+```
+Stmt::ClassDef { name: "Foo", body: <lowered class-body statements>, span }
+```
+
+replacing Phase 14a's always-empty `body: vec![]`.  Method definitions
+(`def` / endless `def`) inside the body continue to be hoisted to
+top-level `Function`s — SIR v0 has no method-as-statement node, so a
+method can't live inside `body` (a `Vec<Stmt>`) — but every **non-`def`**
+statement (constant/expression assignments, bare expressions, nested
+`class`/`module` declarations, loops, …) is now lowered in source order
+and preserved in the body instead of being silently dropped.
+
+No new `semantic_ir::nodes::*` variant; this builds on the SIR17
+`Stmt::ClassDef` introduced by Phase 14a (PR #4584).
+
+## ruby-to-semantic-ir (0.41.0)
+
+- New `lower_class_body_statements` helper walks the class body's
+  `statement` children once:
+  - `def_statement` / `endless_def_statement` → **hoisted** to
+    top-level `Function`s, contributing nothing to `body`.
+  - every other statement → lowered via the shared
+    `lower_statement_inner_multi` dispatch and pushed onto `body`.
+- The `class_statement` arm no longer calls the recursive whole-body
+  `collect_def_statements_from_body` pre-pass; hoisting is now
+  per-direct-child.  A nested `class`/`module` statement is lowered via
+  the normal dispatch (whose own arm hoists *its* direct `def`s), so
+  every method is hoisted **exactly once** — no double-registration
+  that would trip the validator's function-name-uniqueness check.
+- A method-*only* class still produces an empty `body` (the methods
+  hoist).  `module M; end` is unchanged (still NilLit no-op + def hoist,
+  pending Phase 14d's `ModuleDef`).
+
+## semantic-ir (0.2.1 — validator only, no node-shape change)
+
+The validator now actually walks a populated `ClassDef.body` (Phase 14a
+left the body loop a documented no-op).
+
+- Factored the statement-sequence walk out of `check_block` into a new
+  private `check_stmt_seq(&[Stmt], env, depth)` helper.  `check_block`
+  calls it for `block.stmts` (then checks the trailing `block.value`),
+  preserving the exact prior behaviour — parallel-`let` grouping,
+  sequential `let*`, mutable `Assign`, loop/scope handling.
+- `Stmt::ClassDef`'s arm calls `check_stmt_seq` on the body inside a
+  fresh `env.mark()`/`env.rewind()` scope, so class-body locals do not
+  leak into the surrounding statement stream, and a bad reference inside
+  a class body is now reported instead of silently accepted.  An
+  explicit `MAX_IR_DEPTH` guard bounds recursion for pathologically
+  nested `class … class …` bodies.
+
+## ruby-parser (0.39.0)
+
+No grammar changes — `class_statement`'s body (`{ !"end" statement }`)
+already accepts any statement.  Adds parser coverage pinning the body
+shape the 14b lowerer walks.
+
+## Backends (go / python / rust / typescript)
+
+Unchanged.  `Feature::Classes` is still absent from every backend's
+accepted-feature set, so a class-using module is rejected at the
+capability check *before* `emit` — the backends' `ClassDef` panic arms
+remain unreachable.  Emitting classes is deferred to a later phase.
+
+| SIR shape (Phase 14b)                                         | Source                              |
+|---------------------------------------------------------------|-------------------------------------|
+| `ClassDef { "Foo", body: [LetBinding "MAX" = 10] }` + hoisted `bar` | `class Foo; MAX = 10; def bar; end; end` |
+| `ClassDef { "Outer", body: [ClassDef { "Inner", body: [] }] }` + hoisted `o`,`i` | `class Outer; def o;end; class Inner; def i;end; end; end` |
+
+## Tests
+
+- `coding-adventures-ruby-lexer`: **173** (no change)
+- `coding-adventures-ruby-parser`: 158 → **161** (+3):
+  - `test_parse_class_body_mixes_def_and_assignment`
+  - `test_parse_class_body_multiple_assignments_preserved`
+  - `test_parse_nested_class_inside_class_body`
+- `ruby-to-semantic-ir`: 189 → **193** (+4):
+  - `class_body_preserves_executable_statement_and_hoists_method`
+  - `class_body_preserves_multiple_statements_in_source_order`
+  - `class_with_body_statements_passes_sir_validator` (E2E lower → validate)
+  - `nested_class_methods_hoisted_exactly_once`
+  - (`class_with_method_body_still_emits_class_def_and_hoists_method`
+    retained: method-only → empty body, comment updated)
+- `semantic-ir`: 81 → **84** (+3):
+  - `class_def_body_with_let_binding_validates`
+  - `class_def_body_undefined_varref_is_error` (proves the body is
+    walked, not no-op'd)
+  - `class_def_body_local_does_not_leak_to_sibling`
+- All four backend suites + `twig-to-semantic-ir` green (capability
+  check still rejects class-using modules pre-emit, so the panic arms
+  stay unreachable).
+
+## Test plan
+
+- [x] `cargo test -p coding-adventures-ruby-lexer` (173/173)
+- [x] `cargo test -p coding-adventures-ruby-parser` (161/161)
+- [x] `cargo test -p ruby-to-semantic-ir` (193/193)
+- [x] `cargo test -p semantic-ir` (84/84)
+- [x] `cargo test -p semantic-ir-to-{go,python,rust,typescript} -p twig-to-semantic-ir` (all green)
+- [x] Security review passed (1 round, no findings) — pure AST/IR logic:
+      no I/O, no unsafe; the new validator + lowerer recursion is
+      depth-bounded (validator via `MAX_IR_DEPTH`; lowerer shares the
+      pre-existing recursive-descent property bounded upstream by the
+      parser); per-child hoisting reaches each `def` exactly once.
+- [ ] CI green
+
+Follows PR #4584 (Phase 14a).  Next chunk: Phase 14c (inheritance
+`class Foo < Bar`).
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.39.0] - 2026-05-30
+
+### Added (Phase 14b (FC) — class body with method defs + statements)
+
+No grammar changes — the `class_statement` body
+(`{ !"end" statement }`) already accepts any statement, so a class
+mixing method definitions and executable statements parses without
+a grammar edit.  Phase 14b adds parser coverage pinning the body
+shape the 14b lowerer walks (one `statement` child per source line,
+each wrapping its own inner rule):
+
+- `test_parse_class_body_mixes_def_and_assignment` — `class Foo;
+  MAX = 10; def bar; end; end` parses to a body holding both an
+  `assignment` and a `def_statement`.
+- `test_parse_class_body_multiple_assignments_preserved` — two
+  consecutive constant assignments parse as two distinct body
+  `statement` children, in source order.
+- `test_parse_nested_class_inside_class_body` — a `class` declared
+  inside another class parses as a nested `class_statement` body
+  child (the shape the lowerer recurses through).
+
+A `body_inner_rule_names` test helper collects the inner-rule name
+of each direct body statement (one level deep).
+
+Test count: 158 → 161 (+3).
+
 ## [0.38.0] - 2026-05-29
 
 ### Added (Phase 14a (FC) — empty `class Foo; end` grammar coverage)

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -577,6 +577,88 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // Phase 14b (FC) — class body mixing method defs and executable
+    // statements.  The grammar is still unchanged (`class_statement`'s
+    // `{ !"end" statement }` body already accepts any statement); these
+    // tests pin the parse shape the 14b lowerer walks: the body holds
+    // one `statement` child per source line, each wrapping its own
+    // inner rule (`def_statement`, `assignment`, nested
+    // `class_statement`, …).
+    // -----------------------------------------------------------------------
+
+    /// Collect the inner-rule name of every `statement` child directly
+    /// under `node`'s body (one level deep — does not recurse).
+    fn body_inner_rule_names(node: &GrammarASTNode) -> Vec<String> {
+        node.children
+            .iter()
+            .filter_map(|c| match c {
+                ASTNodeOrToken::Node(n) if n.rule_name == "statement" => {
+                    n.children.iter().find_map(|inner| match inner {
+                        ASTNodeOrToken::Node(d) => Some(d.rule_name.clone()),
+                        _ => None,
+                    })
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_parse_class_body_mixes_def_and_assignment() {
+        // `class Foo\n  MAX = 10\n  def bar\n  end\nend` — the body has
+        // two statements: an `assignment` (MAX = 10) and a
+        // `def_statement` (bar).  The 14b lowerer hoists the def and
+        // keeps the assignment in ClassDef.body.
+        let ast = parse_ruby("class Foo\n  MAX = 10\n  def bar\n  end\nend");
+        let cls = find_statement_inner(&ast, "class_statement")
+            .expect("expected class_statement");
+        let names = body_inner_rule_names(cls);
+        assert!(
+            names.iter().any(|r| r == "assignment"),
+            "expected an assignment in the class body; got {:?}",
+            names
+        );
+        assert!(
+            names.iter().any(|r| r == "def_statement"),
+            "expected a def_statement in the class body; got {:?}",
+            names
+        );
+    }
+
+    #[test]
+    fn test_parse_class_body_multiple_assignments_preserved() {
+        // Two executable statements parse as two distinct body
+        // `statement` children, in source order.
+        let ast = parse_ruby("class Cfg\n  A = 1\n  B = 2\nend");
+        let cls = find_statement_inner(&ast, "class_statement")
+            .expect("expected class_statement");
+        let names = body_inner_rule_names(cls);
+        assert_eq!(
+            names,
+            vec!["assignment".to_string(), "assignment".to_string()],
+            "expected two assignment statements in order; got {:?}",
+            names
+        );
+    }
+
+    #[test]
+    fn test_parse_nested_class_inside_class_body() {
+        // A class declared inside another class parses as a nested
+        // `class_statement` body child — the shape the 14b lowerer
+        // recurses through (hoisting the inner class's defs exactly
+        // once).
+        let ast = parse_ruby("class Outer\n  class Inner\n  end\nend");
+        let outer = find_statement_inner(&ast, "class_statement")
+            .expect("expected outer class_statement");
+        let names = body_inner_rule_names(outer);
+        assert!(
+            names.iter().any(|r| r == "class_statement"),
+            "expected a nested class_statement in Outer's body; got {:?}",
+            names
+        );
+    }
+
+    // -----------------------------------------------------------------------
     // Phase 6g — blocks `do … end` and brace-blocks `method { … }`
     // -----------------------------------------------------------------------
 

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.41.0] - 2026-05-30
+
+### Changed (Phase 14b (FC) — class body with method defs + statements)
+
+`class Foo … end` now lowers to `Stmt::ClassDef` with a **populated**
+`body` (Phase 14a always emitted `body: vec![]`).  The class body's
+*executable* statements — constant/expression assignments, bare
+expressions, nested `class`/`module` declarations, loops, … — are
+lowered in source order and preserved in `ClassDef.body`, instead of
+being silently dropped.
+
+- New `lower_class_body_statements` helper walks the class body's
+  `statement` children once:
+  - `def_statement` / `endless_def_statement` are **hoisted** to
+    top-level `Function`s (unchanged — SIR v0 has no
+    method-as-statement node, so a method can't live inside a
+    `Vec<Stmt>`), contributing nothing to `body`.
+  - every other statement is lowered via the shared
+    `lower_statement_inner_multi` dispatch and pushed onto `body`.
+- The `class_statement` arm no longer calls the recursive
+  whole-body `collect_def_statements_from_body` pre-pass; hoisting is
+  now per-direct-child.  A nested `class`/`module` is lowered via the
+  normal dispatch (whose own arm hoists *its* direct `def`s), so every
+  method is hoisted **exactly once** — no double-registration that
+  would trip the validator's function-name-uniqueness check.
+- A method-*only* class still produces an empty `body` (the methods
+  hoist); the `module_statement` arm is unchanged (still a NilLit
+  no-op + def hoist, pending Phase 14d's `ModuleDef`).
+
+New tests (4): `class_body_preserves_executable_statement_and_hoists_method`,
+`class_body_preserves_multiple_statements_in_source_order`,
+`class_with_body_statements_passes_sir_validator` (E2E lower → validate),
+`nested_class_methods_hoisted_exactly_once`.  The existing
+`class_with_method_body_still_emits_class_def_and_hoists_method` is
+retained (method-only → empty body) with an updated comment.
+
+Test count: 189 → 193 (+4).
+
 ## [0.40.0] - 2026-05-29
 
 ### Added (Phase 14a (FC) — empty `class Foo; end`)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -664,11 +664,12 @@ mod tests {
 
     #[test]
     fn class_with_method_body_still_emits_class_def_and_hoists_method() {
-        // Phase 14a contract for non-empty classes: the new
-        // `Stmt::ClassDef` is emitted (body always empty in 14a)
-        // AND the pre-14a method-hoisting fallback continues to work
-        // so older fixtures don't regress.  Phase 14b will replace
-        // the hoist with nested body lowering.
+        // A method-*only* class keeps an empty `ClassDef.body` under
+        // both Phase 14a and 14b: method defs are hoisted to top-level
+        // `Function`s (SIR v0 has no method-as-statement node), so they
+        // are not represented inside the body `Vec<Stmt>`.  Phase 14b
+        // changes the *non-def* statements (see the tests below); the
+        // method-hoist contract is unchanged.
         let m = lower("class Foo\n  def bar\n  end\nend\n");
         // `bar` was hoisted to top-level Functions.
         assert!(
@@ -683,11 +684,122 @@ mod tests {
                 assert_eq!(name, "Foo");
                 assert!(
                     body.is_empty(),
-                    "Phase 14a body is always empty; populated body lands in 14b"
+                    "method-only class body stays empty (defs hoist); got {:?}",
+                    body
                 );
             }
             other => panic!("expected Stmt::ClassDef, got {:?}", other),
         }
+    }
+
+    // -----------------------------------------------------------------
+    // Phase 14b (FC) — class body with method defs + executable
+    // statements.  Method defs continue to hoist to top-level
+    // Functions; every *non-def* statement is now preserved in
+    // `Stmt::ClassDef.body` (Phase 14a discarded them).
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn class_body_preserves_executable_statement_and_hoists_method() {
+        // `MAX = 10` (an executable class-body statement) must survive
+        // into `ClassDef.body` as a `LetBinding`, while `def bar` is
+        // still hoisted to a top-level Function.
+        let m = lower("class Foo\n  MAX = 10\n  def bar\n  end\nend\n");
+        assert!(
+            m.functions.iter().any(|f| f.name == "bar"),
+            "expected hoisted `bar`; got {:?}",
+            m.functions.iter().map(|f| &f.name).collect::<Vec<_>>()
+        );
+        let main = main_body(&m);
+        match &main.stmts[0] {
+            Stmt::ClassDef { name, body, .. } => {
+                assert_eq!(name, "Foo");
+                assert_eq!(
+                    body.len(),
+                    1,
+                    "the def is hoisted (0 body stmts) and only `MAX = 10` stays; got {:?}",
+                    body
+                );
+                match &body[0] {
+                    Stmt::LetBinding { name, value, .. } => {
+                        assert_eq!(name, "MAX");
+                        assert!(matches!(value, Expr::IntLit { value: 10, .. }));
+                    }
+                    other => panic!("expected LetBinding MAX, got {:?}", other),
+                }
+            }
+            other => panic!("expected Stmt::ClassDef, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn class_body_preserves_multiple_statements_in_source_order() {
+        // Two constant assignments must appear in `body` in the same
+        // order they were written.
+        let m = lower("class Cfg\n  A = 1\n  B = 2\nend\n");
+        let main = main_body(&m);
+        match &main.stmts[0] {
+            Stmt::ClassDef { body, .. } => {
+                assert_eq!(body.len(), 2, "both assignments preserved; got {:?}", body);
+                let names: Vec<&str> = body
+                    .iter()
+                    .map(|s| match s {
+                        Stmt::LetBinding { name, .. } => name.as_str(),
+                        other => panic!("expected LetBinding, got {:?}", other),
+                    })
+                    .collect();
+                assert_eq!(names, vec!["A", "B"]);
+            }
+            other => panic!("expected Stmt::ClassDef, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn class_with_body_statements_passes_sir_validator() {
+        // E2E: a class mixing an executable statement and a method def
+        // must lower to a module the validator accepts.  Guards against
+        // drift between the lowerer's populated body and the
+        // validator's new `check_stmt_seq`-based ClassDef walk.
+        let m = lower("class Foo\n  MAX = 10\n  def bar\n  end\nend\n");
+        let result = semantic_ir::validate(&m);
+        assert!(
+            result.is_ok(),
+            "validator rejected class with populated body: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn nested_class_methods_hoisted_exactly_once() {
+        // A class nested inside another class lowers to a nested
+        // `ClassDef` in the outer class's body.  Both methods must be
+        // hoisted to top-level Functions *exactly once* — a regression
+        // here (double-hoist) would create duplicate function names and
+        // trip the validator's name-uniqueness check.
+        let m = lower(
+            "class Outer\n  def o\n  end\n  class Inner\n    def i\n    end\n  end\nend\n",
+        );
+        let count = |needle: &str| m.functions.iter().filter(|f| f.name == needle).count();
+        assert_eq!(count("o"), 1, "`o` hoisted exactly once");
+        assert_eq!(count("i"), 1, "`i` hoisted exactly once");
+        // Outer's body carries the nested Inner ClassDef.
+        let main = main_body(&m);
+        match &main.stmts[0] {
+            Stmt::ClassDef { name, body, .. } => {
+                assert_eq!(name, "Outer");
+                assert_eq!(body.len(), 1, "Inner class is the only body stmt; got {:?}", body);
+                match &body[0] {
+                    Stmt::ClassDef { name, body, .. } => {
+                        assert_eq!(name, "Inner");
+                        assert!(body.is_empty(), "Inner is method-only → empty body");
+                    }
+                    other => panic!("expected nested ClassDef Inner, got {:?}", other),
+                }
+            }
+            other => panic!("expected Stmt::ClassDef Outer, got {:?}", other),
+        }
+        // Whole module still validates (no duplicate names).
+        assert!(semantic_ir::validate(&m).is_ok());
     }
 
     #[test]

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -518,26 +518,28 @@ impl Lowerer {
                 })
             }
             "class_statement" => {
-                // Phase 14a (FC): `class Foo; end` now lowers to
-                // first-class `Stmt::ClassDef { name: "Foo", body:
-                // vec![], span }` — the SIR has a real class node.
+                // Phase 14b (FC): `class Foo … end` lowers to a
+                // first-class `Stmt::ClassDef { name, body, span }`
+                // whose `body` now carries the class's *executable*
+                // statements in source order (Phase 14a always
+                // emitted an empty body).
                 //
-                // For Phase 14a we land *only* the empty-body case
-                // semantically: the SIR's `body: vec![]` is always
-                // empty.  Existing `def_statement`-in-body hoisting
-                // (added in Phase 6f) is preserved as a fallback so
-                // pre-14a Ruby fixtures with non-empty class bodies
-                // still validate: the def names get hoisted to
-                // top-level Functions exactly as before, leaving the
-                // ClassDef itself with an empty body.  Phase 14b
-                // will populate `body` directly and retire the
-                // hoist-as-fallback path.
-                self.collect_def_statements_from_body(node)?;
+                // Method definitions (`def` / endless `def`) inside
+                // the body continue to be hoisted to top-level
+                // `Function`s — SIR v0 has no method-as-statement
+                // node, so a method can't live inside `body`
+                // (a `Vec<Stmt>`).  The hoisting is now done
+                // per-child inside `lower_class_body_statements`
+                // (replacing the whole-body `collect_def_statements_from_body`
+                // pre-pass the 14a arm used), so each nested `def` is
+                // hoisted exactly once and every non-`def` statement
+                // is preserved in `body` instead of being dropped.
                 let name = self.extract_class_name(node)?;
                 self.features_used.insert(Feature::Classes);
+                let body = self.lower_class_body_statements(node)?;
                 Ok(Stmt::ClassDef {
                     name,
-                    body: Vec::new(),
+                    body,
                     span: self.span_of(node),
                 })
             }
@@ -1593,6 +1595,61 @@ impl Lowerer {
             }
         }
         Ok(())
+    }
+
+    /// Phase 14b (FC) — lower a `class_statement` body into the
+    /// `Vec<Stmt>` carried by `Stmt::ClassDef.body`.
+    ///
+    /// Walks the class body's `statement` children once, in source
+    /// order:
+    ///
+    /// - `def_statement` / `endless_def_statement` are **hoisted** to
+    ///   top-level `Function`s on `self.user_functions` (SIR v0 has no
+    ///   method-as-statement node, so a method body can't live inside
+    ///   a `Vec<Stmt>`).  They contribute *nothing* to `body` — the
+    ///   hoisted function is the canonical representation.
+    /// - Every other statement (constant/expression assignments, bare
+    ///   expressions, nested `class` / `module` declarations, loops, …)
+    ///   is lowered via the same [`lower_statement_inner_multi`]
+    ///   dispatch used for the program body and pushed onto `body`,
+    ///   so it is preserved rather than discarded.
+    ///
+    /// Hoisting here is per-direct-child (not the recursive
+    /// whole-body `collect_def_statements_from_body` walk the Phase 14a
+    /// arm used).  A nested `class`/`module` statement is lowered via
+    /// the normal dispatch, whose own arm hoists *its* direct `def`s —
+    /// so every method is hoisted exactly once and no name is
+    /// double-registered (which would trip the validator's function
+    /// name-uniqueness check).
+    fn lower_class_body_statements(
+        &mut self,
+        node: &GrammarASTNode,
+    ) -> Result<Vec<Stmt>, RubyLowerError> {
+        let mut body: Vec<Stmt> = Vec::new();
+        for child in &node.children {
+            let stmt = match child {
+                ASTNodeOrToken::Node(n) if n.rule_name == "statement" => n,
+                _ => continue,
+            };
+            let inner = match self.first_node_child(stmt) {
+                Some(n) => n,
+                None => continue,
+            };
+            match inner.rule_name.as_str() {
+                "def_statement" => {
+                    let func = self.lower_def_statement(inner)?;
+                    self.user_functions.push(func);
+                }
+                "endless_def_statement" => {
+                    let func = self.lower_endless_def_statement(inner)?;
+                    self.user_functions.push(func);
+                }
+                _ => {
+                    body.extend(self.lower_statement_inner_multi(inner)?);
+                }
+            }
+        }
+        Ok(body)
     }
 
     /// Phase 14a (FC) — extract the class name from a `class_statement`

--- a/code/packages/rust/semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to the `semantic-ir` crate are documented here.
 
+## 0.2.1 — SIR17 validator: walk populated `ClassDef` bodies
+
+No node-shape change.  The Ruby frontend's Phase 14b begins emitting
+`Stmt::ClassDef` nodes with a *populated* `body` (Phase 14a always
+emitted an empty body), so the validator now actually walks it.
+
+### Changed
+
+- Factored the statement-sequence walk out of `check_block` into a
+  new private `check_stmt_seq(&[Stmt], env, depth)` helper.
+  `check_block` now calls it for `block.stmts` (then checks the
+  trailing `block.value`), preserving the exact prior behaviour —
+  parallel-`let` grouping, sequential `let*`, mutable `Assign`,
+  loop/scope handling.
+- `Stmt::ClassDef`'s validator arm now calls `check_stmt_seq` on the
+  body inside a fresh `env.mark()`/`env.rewind()` scope (Phase 14a
+  left this loop a documented no-op).  Class-body locals therefore
+  do **not** leak into the surrounding statement stream, and a
+  bad reference inside a class body is now reported instead of
+  silently accepted.  An explicit `MAX_IR_DEPTH` guard bounds
+  recursion for pathologically nested `class … class …` bodies.
+
+New tests (3): `class_def_body_with_let_binding_validates`,
+`class_def_body_undefined_varref_is_error` (proves the body is
+walked, not no-op'd), `class_def_body_local_does_not_leak_to_sibling`.
+Test count: 81 → 84 (+3).
+
 ## 0.2.0 — SIR17: class declarations
 
 Adds the first object-oriented IR node, introduced by the Ruby

--- a/code/packages/rust/semantic-ir/src/validator.rs
+++ b/code/packages/rust/semantic-ir/src/validator.rs
@@ -242,6 +242,21 @@ impl<'m> ValidatorState<'m> {
             return;
         }
         let mark = env.mark();
+        self.check_stmt_seq(&b.stmts, env, depth);
+        self.check_expr(&b.value, env, depth + 1);
+        env.rewind(mark);
+    }
+
+    /// Validate a flat statement sequence (`&[Stmt]`) against `env`.
+    ///
+    /// Factored out of [`check_block`] (Phase 14b) so a class body
+    /// (`Stmt::ClassDef.body`, a bare `Vec<Stmt>` with no trailing
+    /// value slot) can reuse the exact same statement-accounting
+    /// rules — parallel-`let` grouping, sequential `let*`, mutable
+    /// `Assign`, loop/scope handling — without wrapping the body in a
+    /// synthetic `Block`.  Callers are responsible for their own
+    /// `env.mark()`/`env.rewind()` scoping around the call.
+    fn check_stmt_seq(&mut self, stmts: &[Stmt], env: &mut LocalEnv, depth: usize) {
         // Walk statements in *groups*: a run of consecutive LetBinding
         // statements forms one parallel-let group whose RHS expressions
         // all evaluate in the scope BEFORE the group.  All names from
@@ -249,18 +264,18 @@ impl<'m> ValidatorState<'m> {
         // LetStarBinding and ExprStmt break the run; LetStarBinding
         // adds its name immediately (sequential semantics).
         let mut i = 0;
-        while i < b.stmts.len() {
-            match &b.stmts[i] {
+        while i < stmts.len() {
+            match &stmts[i] {
                 Stmt::LetBinding { .. } => {
                     // Find the maximal run of LetBindings starting at i.
                     let mut j = i;
-                    while j < b.stmts.len() && matches!(b.stmts[j], Stmt::LetBinding { .. }) {
+                    while j < stmts.len() && matches!(stmts[j], Stmt::LetBinding { .. }) {
                         j += 1;
                     }
                     // Check every RHS in the *outer* env (no new
                     // names added yet).
                     for k in i..j {
-                        if let Stmt::LetBinding { value, sir_type, .. } = &b.stmts[k] {
+                        if let Stmt::LetBinding { value, sir_type, .. } = &stmts[k] {
                             self.check_expr(value, env, depth + 1);
                             if sir_type.is_some() {
                                 self.observed.add(Feature::OptionalTypeAnnotations);
@@ -269,7 +284,7 @@ impl<'m> ValidatorState<'m> {
                     }
                     // Add every bound name to the env, all at once.
                     for k in i..j {
-                        if let Stmt::LetBinding { name, .. } = &b.stmts[k] {
+                        if let Stmt::LetBinding { name, .. } = &stmts[k] {
                             env.add_local(name.clone());
                         }
                     }
@@ -334,40 +349,37 @@ impl<'m> ValidatorState<'m> {
                     self.check_expr(value, env, depth + 1);
                     i += 1;
                 }
-                Stmt::ClassDef { body, .. } => {
+                Stmt::ClassDef { body, span, .. } => {
                     // A class declaration adds a name to the module
                     // surface (the class itself) and contributes any
-                    // statements in its body.  Phase 14a always lowers
-                    // an empty body, but the validator is structured
-                    // to handle the populated form too.
+                    // statements in its body.  Phase 14b populates the
+                    // body with the class's executable statements
+                    // (method defs are hoisted to top-level Functions
+                    // by the lowerer, so they don't appear here).
                     //
                     // We mark Feature::Classes and recurse into the
-                    // body using a fresh local-env mark (class body
+                    // body using a fresh local-env mark: class body
                     // names shouldn't leak into the surrounding
-                    // statement stream).  We do NOT add the class's
-                    // own name to the local env: classes are
+                    // statement stream.  We do NOT add the class's
+                    // own name to the local env — classes are
                     // top-level/module-level names, not locals.
+                    //
+                    // The explicit depth guard bounds recursion for a
+                    // pathological nest of `class A; class B; …` bodies
+                    // (each level re-enters check_stmt_seq); it mirrors
+                    // the MAX_IR_DEPTH guard check_block applies.
                     self.observed.add(Feature::Classes);
-                    let class_mark = env.mark();
-                    for inner in body {
-                        // Use a single-statement Block wrapper to
-                        // reuse check_block's accounting.  This is
-                        // safe because each inner stmt's effect on
-                        // the env is scoped by class_mark below.
-                        let _ = inner;
-                        // Defer body lowering: with vec![] this loop
-                        // is a no-op, and 14b will define the proper
-                        // recursive walk shape.  Keeping the explicit
-                        // mark/rewind preserves the contract for the
-                        // forward-compatible body case.
+                    if self.check_depth(depth, span) {
+                        i += 1;
+                        continue;
                     }
+                    let class_mark = env.mark();
+                    self.check_stmt_seq(body, env, depth + 1);
                     env.rewind(class_mark);
                     i += 1;
                 }
             }
         }
-        self.check_expr(&b.value, env, depth + 1);
-        env.rewind(mark);
     }
 
     fn check_expr(&mut self, e: &Expr, env: &mut LocalEnv, depth: usize) {
@@ -1119,5 +1131,126 @@ mod tests {
         });
         let r = validate(&m);
         assert!(r.is_ok(), "expected ok, got {:?}", r.issues);
+    }
+
+    // -----------------------------------------------------------------
+    // Phase 14b (FC) — `Stmt::ClassDef.body` is now a populated
+    // `Vec<Stmt>`; the validator walks it via `check_stmt_seq`.
+    // -----------------------------------------------------------------
+
+    /// Wrap a single `ClassDef` statement in a one-function module
+    /// declaring `Feature::Classes`.
+    fn module_with_class_body(name: &str, body: Vec<Stmt>) -> Module {
+        let mut m = empty_module(FeatureManifest::from_features(&[Feature::Classes]));
+        m.functions.push(Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![Stmt::ClassDef {
+                    name: name.into(),
+                    body,
+                    span: s(),
+                }],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        });
+        m
+    }
+
+    #[test]
+    fn class_def_body_with_let_binding_validates() {
+        // A class body holding a single LetBinding is now walked by the
+        // validator (Phase 14a no-op'd the body loop) and accepted.
+        let m = module_with_class_body(
+            "Foo",
+            vec![Stmt::LetBinding {
+                name: "MAX".into(),
+                sir_type: None,
+                value: Expr::IntLit { value: 10, span: s() },
+                span: s(),
+            }],
+        );
+        let r = validate(&m);
+        assert!(r.is_ok(), "expected ok, got {:?}", r.issues);
+    }
+
+    #[test]
+    fn class_def_body_undefined_varref_is_error() {
+        // Proves the body is *actually validated* now: a VarRef to an
+        // undefined local inside the class body must be reported as an
+        // error.  Under the Phase 14a no-op loop this would have been
+        // silently accepted.
+        let m = module_with_class_body(
+            "Foo",
+            vec![Stmt::ExprStmt {
+                expr: Expr::VarRef {
+                    name: "ghost".into(),
+                    scope: Scope::Local,
+                    span: s(),
+                },
+                span: s(),
+            }],
+        );
+        let r = validate(&m);
+        assert!(
+            !r.is_ok(),
+            "expected undefined-varref error from class body, got {:?}",
+            r.issues
+        );
+    }
+
+    #[test]
+    fn class_def_body_local_does_not_leak_to_sibling() {
+        // A binding introduced inside the class body must not be
+        // visible to statements *after* the class (the body is scoped
+        // by its own env mark/rewind).  Here `INNER` is bound inside
+        // the class, then referenced as a sibling statement after it —
+        // which must error.
+        let mut m = empty_module(FeatureManifest::from_features(&[Feature::Classes]));
+        m.functions.push(Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![
+                    Stmt::ClassDef {
+                        name: "Foo".into(),
+                        body: vec![Stmt::LetBinding {
+                            name: "INNER".into(),
+                            sir_type: None,
+                            value: Expr::IntLit { value: 1, span: s() },
+                            span: s(),
+                        }],
+                        span: s(),
+                    },
+                    Stmt::ExprStmt {
+                        expr: Expr::VarRef {
+                            name: "INNER".into(),
+                            scope: Scope::Local,
+                            span: s(),
+                        },
+                        span: s(),
+                    },
+                ],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        });
+        let r = validate(&m);
+        assert!(
+            !r.is_ok(),
+            "class-body local INNER must not leak to sibling stmt, got {:?}",
+            r.issues
+        );
     }
 }


### PR DESCRIPTION
## Summary

Phase 14b makes a Ruby `class` body **carry its executable statements**.
`class Foo … end` now lowers to

```
Stmt::ClassDef { name: "Foo", body: <lowered class-body statements>, span }
```

replacing Phase 14a's always-empty `body: vec![]`.  Method definitions
(`def` / endless `def`) inside the body continue to be hoisted to
top-level `Function`s — SIR v0 has no method-as-statement node, so a
method can't live inside `body` (a `Vec<Stmt>`) — but every **non-`def`**
statement (constant/expression assignments, bare expressions, nested
`class`/`module` declarations, loops, …) is now lowered in source order
and preserved in the body instead of being silently dropped.

No new `semantic_ir::nodes::*` variant; this builds on the SIR17
`Stmt::ClassDef` introduced by Phase 14a (PR #4584).

## ruby-to-semantic-ir (0.41.0)

- New `lower_class_body_statements` helper walks the class body's
  `statement` children once:
  - `def_statement` / `endless_def_statement` → **hoisted** to
    top-level `Function`s, contributing nothing to `body`.
  - every other statement → lowered via the shared
    `lower_statement_inner_multi` dispatch and pushed onto `body`.
- The `class_statement` arm no longer calls the recursive whole-body
  `collect_def_statements_from_body` pre-pass; hoisting is now
  per-direct-child.  A nested `class`/`module` statement is lowered via
  the normal dispatch (whose own arm hoists *its* direct `def`s), so
  every method is hoisted **exactly once** — no double-registration
  that would trip the validator's function-name-uniqueness check.
- A method-*only* class still produces an empty `body` (the methods
  hoist).  `module M; end` is unchanged (still NilLit no-op + def hoist,
  pending Phase 14d's `ModuleDef`).

## semantic-ir (0.2.1 — validator only, no node-shape change)

The validator now actually walks a populated `ClassDef.body` (Phase 14a
left the body loop a documented no-op).

- Factored the statement-sequence walk out of `check_block` into a new
  private `check_stmt_seq(&[Stmt], env, depth)` helper.  `check_block`
  calls it for `block.stmts` (then checks the trailing `block.value`),
  preserving the exact prior behaviour — parallel-`let` grouping,
  sequential `let*`, mutable `Assign`, loop/scope handling.
- `Stmt::ClassDef`'s arm calls `check_stmt_seq` on the body inside a
  fresh `env.mark()`/`env.rewind()` scope, so class-body locals do not
  leak into the surrounding statement stream, and a bad reference inside
  a class body is now reported instead of silently accepted.  An
  explicit `MAX_IR_DEPTH` guard bounds recursion for pathologically
  nested `class … class …` bodies.

## ruby-parser (0.39.0)

No grammar changes — `class_statement`'s body (`{ !"end" statement }`)
already accepts any statement.  Adds parser coverage pinning the body
shape the 14b lowerer walks.

## Backends (go / python / rust / typescript)

Unchanged.  `Feature::Classes` is still absent from every backend's
accepted-feature set, so a class-using module is rejected at the
capability check *before* `emit` — the backends' `ClassDef` panic arms
remain unreachable.  Emitting classes is deferred to a later phase.

| SIR shape (Phase 14b)                                         | Source                              |
|---------------------------------------------------------------|-------------------------------------|
| `ClassDef { "Foo", body: [LetBinding "MAX" = 10] }` + hoisted `bar` | `class Foo; MAX = 10; def bar; end; end` |
| `ClassDef { "Outer", body: [ClassDef { "Inner", body: [] }] }` + hoisted `o`,`i` | `class Outer; def o;end; class Inner; def i;end; end; end` |

## Tests

- `coding-adventures-ruby-lexer`: **173** (no change)
- `coding-adventures-ruby-parser`: 158 → **161** (+3):
  - `test_parse_class_body_mixes_def_and_assignment`
  - `test_parse_class_body_multiple_assignments_preserved`
  - `test_parse_nested_class_inside_class_body`
- `ruby-to-semantic-ir`: 189 → **193** (+4):
  - `class_body_preserves_executable_statement_and_hoists_method`
  - `class_body_preserves_multiple_statements_in_source_order`
  - `class_with_body_statements_passes_sir_validator` (E2E lower → validate)
  - `nested_class_methods_hoisted_exactly_once`
  - (`class_with_method_body_still_emits_class_def_and_hoists_method`
    retained: method-only → empty body, comment updated)
- `semantic-ir`: 81 → **84** (+3):
  - `class_def_body_with_let_binding_validates`
  - `class_def_body_undefined_varref_is_error` (proves the body is
    walked, not no-op'd)
  - `class_def_body_local_does_not_leak_to_sibling`
- All four backend suites + `twig-to-semantic-ir` green (capability
  check still rejects class-using modules pre-emit, so the panic arms
  stay unreachable).

## Test plan

- [x] `cargo test -p coding-adventures-ruby-lexer` (173/173)
- [x] `cargo test -p coding-adventures-ruby-parser` (161/161)
- [x] `cargo test -p ruby-to-semantic-ir` (193/193)
- [x] `cargo test -p semantic-ir` (84/84)
- [x] `cargo test -p semantic-ir-to-{go,python,rust,typescript} -p twig-to-semantic-ir` (all green)
- [x] Security review passed (1 round, no findings) — pure AST/IR logic:
      no I/O, no unsafe; the new validator + lowerer recursion is
      depth-bounded (validator via `MAX_IR_DEPTH`; lowerer shares the
      pre-existing recursive-descent property bounded upstream by the
      parser); per-child hoisting reaches each `def` exactly once.
- [ ] CI green

Follows PR #4584 (Phase 14a).  Next chunk: Phase 14c (inheritance
`class Foo < Bar`).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
