### PR TITLE
feat(closurec): WHITESPACE_ONLY token tombstones (CLOC11.66)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.29.0] - 2026-05-30
+
+### Added — CLOC11.66: WHITESPACE_ONLY token tombstones
+
+When `--correlation_vector` is on and `--compilation_level WHITESPACE_ONLY` is set, every token CV that the minifier drops (trivia + EOF) now gets a `DeletionRecord` (tombstone) via `CVLog::delete`. The CV trace shows precisely which input bytes the WHITESPACE_ONLY pass killed.
+
+Tombstone shape (one per dropped token):
+
+```
+source: "compilation_level"
+reason: "whitespace_only_dropped"
+meta: {
+  kind:                  "trivia" | "eof",
+  token_index:           <0-based position in lexer stream>,
+  token_lexeme_byte_len: <token.value.len()>,
+}
+```
+
+Implementation reuses `whitespace_only::is_trivia` / `is_eof` (now `pub(crate)`) — the same predicate the minifier itself uses — so the tombstone set is guaranteed identical to the dropped set without a second lex pass.
+
+Other compilation levels (SIMPLE, ADVANCED, BUNDLE, TRANSPILE_ONLY) are currently identity on the string and don't drop tokens, so no tombstones land for those. As those levels grow real bodies in later CLOC11.* slices, each will need its own tombstone block.
+
+### Changed
+
+- `whitespace_only::is_trivia` and `whitespace_only::is_eof` promoted from private `fn` to `pub(crate) fn` so the per-token CV path can call them directly without duplicating the predicate.
+- Versions: `Cargo.toml` `0.28.0` → `0.29.0`, `cli.spec.json` `0.28.0` → `0.29.0`.
+
 ## [0.28.0] - 2026-05-30
 
 ### Added — CLOC11.65: per-token `defines.applied` contributions

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.28.0"
+version = "0.29.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/run.rs
+++ b/code/programs/rust/closurec/src/run.rs
@@ -713,6 +713,74 @@ pub fn run_compiler(config: &CompilerConfig) -> Result<CompilerOutput, CompilerE
                             );
                         }
                     }
+
+                    // CLOC11.66 — WHITESPACE_ONLY token
+                    // tombstones. Only the WHITESPACE_ONLY
+                    // compilation level filters tokens at this
+                    // stage (`whitespace_only_minify` drops
+                    // trivia and EOF). For every token CV that
+                    // matches the same trivia / EOF predicate
+                    // the minifier uses, record a
+                    // DeletionRecord (tombstone) on the token
+                    // CV so the trace shows precisely which
+                    // bytes the pass killed.
+                    //
+                    // Why not lex twice (pre + post) and diff
+                    // the streams? The trivia / EOF predicate
+                    // *is* the contract — `is_trivia` and
+                    // `is_eof` in `whitespace_only.rs` are
+                    // what the minifier itself uses. Reusing
+                    // them keeps the tombstone set guaranteed
+                    // identical to the dropped set without a
+                    // second lex pass.
+                    //
+                    // Other compilation levels (SIMPLE,
+                    // ADVANCED, BUNDLE, TRANSPILE_ONLY) are
+                    // currently identity on the string —
+                    // they don't drop any tokens — so no
+                    // tombstones land for those. As those
+                    // levels grow real bodies in later
+                    // CLOC11.* slices, each will need its own
+                    // tombstone block.
+                    if matches!(
+                        config.compilation.level,
+                        crate::config::CompilationLevel::WhitespaceOnly,
+                    ) {
+                        for (idx, tok) in tokens.iter().enumerate() {
+                            let is_trivia_tok = crate::whitespace_only::is_trivia(tok);
+                            let is_eof_tok = crate::whitespace_only::is_eof(tok);
+                            if !is_trivia_tok && !is_eof_tok {
+                                continue;
+                            }
+                            let mut wmeta = std::collections::HashMap::new();
+                            wmeta.insert(
+                                "kind".to_string(),
+                                serde_json::Value::String(
+                                    if is_eof_tok {
+                                        "eof".into()
+                                    } else {
+                                        "trivia".into()
+                                    },
+                                ),
+                            );
+                            wmeta.insert(
+                                "token_index".to_string(),
+                                serde_json::Value::Number((idx as u64).into()),
+                            );
+                            wmeta.insert(
+                                "token_lexeme_byte_len".to_string(),
+                                serde_json::Value::Number(
+                                    (tok.value.len() as u64).into(),
+                                ),
+                            );
+                            cv_log.delete(
+                                &token_cv_ids[idx],
+                                "compilation_level",
+                                "whitespace_only_dropped",
+                                wmeta,
+                            );
+                        }
+                    }
                 }
                 Err(err) => {
                     let mut emeta = std::collections::HashMap::new();
@@ -2858,6 +2926,113 @@ mod tests {
         assert!(
             !body.contains("\"define_name\""),
             "expected NO token-level defines.applied, got: {body}"
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    // ------------------------------------------------------------------
+    // CLOC11.66 — WHITESPACE_ONLY token tombstones
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn correlation_vector_tombstones_trivia_tokens_under_whitespace_only() {
+        // With --correlation_vector + --compilation_level
+        // WHITESPACE_ONLY, the dropped trivia + EOF tokens
+        // should appear in the sidecar as deleted CV entries
+        // (DeletionRecord present, source=compilation_level,
+        // reason=whitespace_only_dropped). The surviving Name
+        // tokens (var, x, etc.) should NOT be tombstoned.
+        let dir = std::env::temp_dir().join("closurec_cloc11_66_ws_drop");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("create dir");
+        let in_path = dir.join("a.js");
+        // Comments + whitespace generate trivia tokens; EOF
+        // is always emitted at end.
+        fs::write(
+            &in_path,
+            "// a comment\nvar x = 1; /* block */ var y = 2;",
+        )
+        .expect("write input");
+        let out_path = dir.join("out.js");
+        let sidecar_path = dir.join("out.js.cv.json");
+        let cfg = CompilerConfig {
+            io: IoConfig {
+                js_patterns: vec![in_path.to_string_lossy().to_string()],
+                js_output_file: Some(out_path.clone()),
+                ..Default::default()
+            },
+            compilation: crate::config::CompilationConfig {
+                level: crate::config::CompilationLevel::WhitespaceOnly,
+                ..Default::default()
+            },
+            special_modes: crate::config::SpecialModesConfig {
+                correlation_vector: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let _ = run_compiler(&cfg).expect("ok");
+        let body = fs::read_to_string(&sidecar_path).expect("read sidecar");
+        // The tombstone reason string lands in the sidecar.
+        assert!(
+            body.contains("\"reason\":\"whitespace_only_dropped\""),
+            "expected whitespace_only_dropped tombstone, got: {body}"
+        );
+        // EOF kind always lands (every file ends with EOF
+        // sentinel; the JS grammar happens not to emit COMMENT
+        // tokens — comments are skipped at lex time — so trivia
+        // kind never fires for this grammar today, but the code
+        // path covers both cases against future grammar
+        // evolution).
+        assert!(
+            body.contains("\"kind\":\"eof\""),
+            "expected eof kind tombstone, got: {body}"
+        );
+        // The tombstone landed via the DeletionRecord field.
+        assert!(
+            body.contains("\"source\":\"compilation_level\",\"reason\":\"whitespace_only_dropped\""),
+            "expected DeletionRecord with compilation_level source, got: {body}"
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn correlation_vector_no_tombstones_under_simple_level() {
+        // Non-WHITESPACE_ONLY levels currently don't drop
+        // tokens at the compilation_level stage, so no
+        // tombstones should appear. (As later slices add
+        // real bodies to SIMPLE/ADVANCED/etc., each will
+        // need its own block + test; this pins the current
+        // contract.)
+        let dir = std::env::temp_dir().join("closurec_cloc11_66_simple");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("create dir");
+        let in_path = dir.join("a.js");
+        fs::write(&in_path, "// a comment\nvar x = 1;").expect("write");
+        let out_path = dir.join("out.js");
+        let sidecar_path = dir.join("out.js.cv.json");
+        let cfg = CompilerConfig {
+            io: IoConfig {
+                js_patterns: vec![in_path.to_string_lossy().to_string()],
+                js_output_file: Some(out_path.clone()),
+                ..Default::default()
+            },
+            // SIMPLE is the default; spelled out for clarity.
+            compilation: crate::config::CompilationConfig {
+                level: crate::config::CompilationLevel::Simple,
+                ..Default::default()
+            },
+            special_modes: crate::config::SpecialModesConfig {
+                correlation_vector: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let _ = run_compiler(&cfg).expect("ok");
+        let body = fs::read_to_string(&sidecar_path).expect("read sidecar");
+        assert!(
+            !body.contains("\"reason\":\"whitespace_only_dropped\""),
+            "expected NO whitespace_only_dropped tombstones under SIMPLE, got: {body}"
         );
         let _ = fs::remove_dir_all(&dir);
     }

--- a/code/programs/rust/closurec/src/whitespace_only.rs
+++ b/code/programs/rust/closurec/src/whitespace_only.rs
@@ -189,7 +189,7 @@ fn push_quoted_string_content(out: &mut String, content: &str) {
 /// We check both the grammar-supplied `type_name` (an `Option<String>`)
 /// and the structural `TokenType`'s `is_trivia()`. The two should
 /// agree but we accept either: defensive against grammar evolution.
-fn is_trivia(tok: &lexer::token::Token) -> bool {
+pub(crate) fn is_trivia(tok: &lexer::token::Token) -> bool {
     // Match grammar-supplied type names *exactly* — substring
     // matching against "COMMENT" would misclassify hypothetical
     // tokens like "NON_COMMENT_LITERAL". The set below is the
@@ -218,7 +218,7 @@ fn is_trivia(tok: &lexer::token::Token) -> bool {
 }
 
 /// True iff this is the EOF sentinel emitted by the lexer.
-fn is_eof(tok: &lexer::token::Token) -> bool {
+pub(crate) fn is_eof(tok: &lexer::token::Token) -> bool {
     matches!(tok.type_, lexer::token::TokenType::Eof)
 }
 

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.28.0
+Version: 0.29.0
 
 ## Flags
 


### PR DESCRIPTION
## Summary

Continues the per-token CV instrumentation. When `--correlation_vector` is on and `--compilation_level WHITESPACE_ONLY` is set, every token CV that the minifier drops (trivia + EOF) gets a `DeletionRecord` (tombstone) via `CVLog::delete`.

The CV trace now shows precisely which input bytes the WHITESPACE_ONLY pass killed — not just "tokens were dropped" but the specific token CV IDs of the dead bytes.

## Tombstone shape

```
source: "compilation_level"
reason: "whitespace_only_dropped"
meta: {
  kind:                  "trivia" | "eof",
  token_index:           <0-based position in lexer stream>,
  token_lexeme_byte_len: <token.value.len()>,
}
```

## Implementation

- Reuses `whitespace_only::is_trivia` and `whitespace_only::is_eof` (now `pub(crate)` — visibility widening only, no logic change) as the trivia/EOF predicate. Same predicate the minifier itself uses → tombstone set is guaranteed identical to the dropped set without a second lex pass.

## Note on the JS grammar today

`tokenize_javascript_typed` does **not** emit COMMENT/WHITESPACE/NEWLINE tokens — comments are skipped at lex time. So `is_trivia` doesn't match anything today and only `is_eof` actually fires for JS inputs. The code still handles both — as the lexer grammar evolves to emit trivia tokens (or as other language frontends with COMMENT-emitting grammars get wired in), the tombstone block picks them up automatically.

## Other compilation levels

SIMPLE, ADVANCED, BUNDLE, TRANSPILE_ONLY are currently identity on the string and don't drop tokens, so no tombstones land for those. As those levels grow real bodies in later CLOC11.* slices, each will need its own tombstone block.

## Test plan
- [x] cargo build clean
- [x] 239 unit tests + 17 integration suites pass
- [x] New tests:
  - `correlation_vector_tombstones_trivia_tokens_under_whitespace_only` — WHITESPACE_ONLY input → tombstone with `kind=eof` + full DeletionRecord lands
  - `correlation_vector_no_tombstones_under_simple_level` — SIMPLE level → no `whitespace_only_dropped` tombstones in sidecar
- [x] help-markdown fixture regenerated for 0.29.0

## Security review (inline)
- No unsafe; no new I/O.
- DeletionRecord values are fixed strings + u64 from indices/lengths (no user-controlled data).
- `token_cv_ids[idx]` indexing safe — vec built lock-step with `tokens`.
- `is_trivia`/`is_eof` visibility widened from `fn` to `pub(crate) fn` — no behavioral change.

## Versions
- `Cargo.toml`: 0.28.0 → 0.29.0
- `cli.spec.json`: 0.28.0 → 0.29.0
- `CHANGELOG.md`: new `[0.29.0]` section

🤖 Generated with [Claude Code](https://claude.com/claude-code)