### PR TITLE
feat(closurec): --correlation_vector_output <path> flag (CLOC11.67)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.30.0] - 2026-05-30
+
+### Added — CLOC11.67: `--correlation_vector_output <path>` flag
+
+Adds an explicit path override for the correlation-vector sidecar JSON. Lets CI pipelines route the CV trace to an artifact directory (or `/dev/null` for benchmarks) without relying on the sidecar-of-output convention.
+
+Resolution order (highest precedence first):
+
+1. `--correlation_vector_output <path>` → that path, verbatim, no decoration.
+2. Else if `--js_output_file` is set → `<output>.cv.json` beside it.
+3. Else (stdout output) → `closurec-cv.json` in the working directory.
+
+The flag is only consulted when `--correlation_vector` is also enabled — the trace itself is still opt-in. With CV off, the path flag is ignored.
+
+### Changed
+
+- `SpecialModesConfig` gains `correlation_vector_output: Option<PathBuf>`.
+- `wire::read_special_modes` now reads `correlation_vector_output` from the parse result; empty string maps to `None`.
+- Versions: `Cargo.toml` `0.29.0` → `0.30.0`, `cli.spec.json` `0.29.0` → `0.30.0`.
+
 ## [0.29.0] - 2026-05-30
 
 ### Added — CLOC11.66: WHITESPACE_ONLY token tombstones

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.29.0"
+version = "0.30.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },
@@ -96,6 +96,7 @@
     { "id": "renaming", "long": "renaming", "type": "boolean", "default": true, "description": "Disable variable renaming. Cannot be combined with ADVANCED compilation level." },
     { "id": "help_markdown", "long": "help_markdown", "type": "boolean", "default": false, "description": "Print markdown-formatted flag usage (hidden)." },
     { "id": "correlation_vector", "long": "correlation_vector", "type": "boolean", "default": false, "description": "Thread a correlation-vector trace through every transform stage so output bytes are traceable back to input. Default off; opt in via this flag (CLOC11.60)." },
+    { "id": "correlation_vector_output", "long": "correlation_vector_output", "type": "string", "default": "", "description": "Path to write the correlation-vector sidecar JSON. Default empty → `<js_output_file>.cv.json` next to the JS output, or `closurec-cv.json` in CWD when output is stdout (CLOC11.67)." },
     { "id": "instrument_for_coverage_option", "long": "instrument_for_coverage_option", "type": "enum", "enum_values": ["NONE", "LINE", "BRANCH", "PRODUCTION"], "default": "NONE", "description": "Enable code instrumentation for coverage analysis." },
     { "id": "production_instrumentation_array_name", "long": "production_instrumentation_array_name", "type": "string", "default": "", "description": "Global array name used by production instrumentation." },
     { "id": "chunk_output_type", "long": "chunk_output_type", "type": "enum", "enum_values": ["GLOBAL_NAMESPACE", "ES_MODULES"], "default": "GLOBAL_NAMESPACE", "description": "Format for output chunks." },

--- a/code/programs/rust/closurec/src/config.rs
+++ b/code/programs/rust/closurec/src/config.rs
@@ -512,6 +512,14 @@ pub struct SpecialModesConfig {
     /// mode (zero overhead — the crate short-circuits every
     /// `create` / `contribute` call).
     pub correlation_vector: bool,
+    /// CLOC11.67: explicit path for the correlation-vector
+    /// sidecar JSON. When `None` (the default), the writer
+    /// falls back to placing the sidecar next to
+    /// `--js_output_file` as `<output>.cv.json`, or to
+    /// `closurec-cv.json` in the current working directory
+    /// when output is stdout. Only consulted when
+    /// `correlation_vector` is also true; ignored otherwise.
+    pub correlation_vector_output: Option<PathBuf>,
 }
 
 // ---------------------------------------------------------------------------

--- a/code/programs/rust/closurec/src/run.rs
+++ b/code/programs/rust/closurec/src/run.rs
@@ -1228,27 +1228,31 @@ pub fn run_compiler(config: &CompilerConfig) -> Result<CompilerOutput, CompilerE
     // Step 7 (CLOC11.60): write the correlation-vector trace as
     // a JSON sidecar file when `--correlation_vector` was set.
     //
-    // Path policy:
-    //   - When `--js_output_file` is set, the sidecar sits
-    //     beside it as `<output>.cv.json`. Build pipelines
-    //     consuming the JS get the trace automatically without
-    //     a separate flag for the path.
-    //   - When `--js_output_file` is absent (stdout), the
-    //     sidecar lands at `closurec-cv.json` in the working
-    //     directory. Discoverable; user can rename / move.
-    //
-    // CLOC11.6N (a follow-up slice) will add an explicit
-    // `--correlation_vector_output <path>` flag so callers who
-    // want a custom location don't have to rely on the
-    // sidecar-of-output convention.
+    // Path policy (CLOC11.67):
+    //   1. If `--correlation_vector_output <path>` is set,
+    //      honor it verbatim. Highest precedence — callers
+    //      who want a custom location (CI artifact dir,
+    //      tmpfs, /dev/null for benchmarks) get exactly that
+    //      path with no decoration.
+    //   2. Else if `--js_output_file` is set, the sidecar sits
+    //      beside it as `<output>.cv.json`. Build pipelines
+    //      consuming the JS get the trace automatically
+    //      without an extra flag.
+    //   3. Else (stdout output), the sidecar lands at
+    //      `closurec-cv.json` in the working directory.
+    //      Discoverable; user can rename / move.
     if config.special_modes.correlation_vector {
-        let sidecar_path = match &config.io.js_output_file {
-            Some(p) => {
-                let mut s = p.as_os_str().to_owned();
-                s.push(".cv.json");
-                PathBuf::from(s)
-            }
-            None => PathBuf::from("closurec-cv.json"),
+        let sidecar_path = match &config.special_modes.correlation_vector_output {
+            // CLOC11.67 — explicit override wins.
+            Some(p) => p.clone(),
+            None => match &config.io.js_output_file {
+                Some(p) => {
+                    let mut s = p.as_os_str().to_owned();
+                    s.push(".cv.json");
+                    PathBuf::from(s)
+                }
+                None => PathBuf::from("closurec-cv.json"),
+            },
         };
         let body = format_cv_log_json(&cv_log);
         write_output_file(&sidecar_path, &body)?;
@@ -3033,6 +3037,91 @@ mod tests {
         assert!(
             !body.contains("\"reason\":\"whitespace_only_dropped\""),
             "expected NO whitespace_only_dropped tombstones under SIMPLE, got: {body}"
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    // ------------------------------------------------------------------
+    // CLOC11.67 — --correlation_vector_output <path> flag
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn correlation_vector_output_flag_overrides_sidecar_path() {
+        // With --correlation_vector_output set to an explicit
+        // path, the sidecar should land THERE (verbatim, no
+        // .cv.json decoration) and NOT at the default location.
+        let dir = std::env::temp_dir().join("closurec_cloc11_67_explicit");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("create dir");
+        let in_path = dir.join("a.js");
+        fs::write(&in_path, "var x = 1;").expect("write input");
+        let out_path = dir.join("out.js");
+        let default_sidecar = dir.join("out.js.cv.json"); // would-be default
+        let explicit_sidecar = dir.join("custom-trace.json");
+        let cfg = CompilerConfig {
+            io: IoConfig {
+                js_patterns: vec![in_path.to_string_lossy().to_string()],
+                js_output_file: Some(out_path.clone()),
+                ..Default::default()
+            },
+            special_modes: crate::config::SpecialModesConfig {
+                correlation_vector: true,
+                correlation_vector_output: Some(explicit_sidecar.clone()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let _ = run_compiler(&cfg).expect("ok");
+        assert!(
+            explicit_sidecar.exists(),
+            "expected sidecar at explicit path {:?}",
+            explicit_sidecar
+        );
+        assert!(
+            !default_sidecar.exists(),
+            "expected NO sidecar at default path {:?}",
+            default_sidecar
+        );
+        // Sanity: file contains the CV JSON structure.
+        let body = fs::read_to_string(&explicit_sidecar).expect("read");
+        assert!(
+            body.contains("\"entries\""),
+            "explicit-path sidecar missing CVLog structure: {body}"
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn correlation_vector_output_flag_ignored_when_cv_disabled() {
+        // With --correlation_vector off, --correlation_vector_output
+        // is silently ignored — no sidecar of any kind is written.
+        // Pins the contract that the path flag does not
+        // accidentally enable the trace.
+        let dir = std::env::temp_dir().join("closurec_cloc11_67_off");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("create dir");
+        let in_path = dir.join("a.js");
+        fs::write(&in_path, "var x = 1;").expect("write input");
+        let out_path = dir.join("out.js");
+        let explicit_sidecar = dir.join("should-not-exist.json");
+        let cfg = CompilerConfig {
+            io: IoConfig {
+                js_patterns: vec![in_path.to_string_lossy().to_string()],
+                js_output_file: Some(out_path.clone()),
+                ..Default::default()
+            },
+            special_modes: crate::config::SpecialModesConfig {
+                // correlation_vector remains false
+                correlation_vector_output: Some(explicit_sidecar.clone()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let _ = run_compiler(&cfg).expect("ok");
+        assert!(
+            !explicit_sidecar.exists(),
+            "expected NO sidecar when correlation_vector is off, got file at {:?}",
+            explicit_sidecar
         );
         let _ = fs::remove_dir_all(&dir);
     }

--- a/code/programs/rust/closurec/src/wire.rs
+++ b/code/programs/rust/closurec/src/wire.rs
@@ -488,6 +488,9 @@ fn read_special_modes(p: &ParseResult) -> Result<SpecialModesConfig, ConfigError
         print_source_after_each_pass: get_bool(p, "print_source_after_each_pass")?,
         help_markdown: get_bool(p, "help_markdown")?,
         correlation_vector: get_bool(p, "correlation_vector")?,
+        correlation_vector_output: get_str(p, "correlation_vector_output")?
+            .filter(|s| !s.is_empty())
+            .map(std::path::PathBuf::from),
     })
 }
 

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.29.0
+Version: 0.30.0
 
 ## Flags
 
@@ -369,6 +369,10 @@ Print markdown-formatted flag usage (hidden).
 ### `--correlation_vector` (boolean, default: false)
 
 Thread a correlation-vector trace through every transform stage so output bytes are traceable back to input. Default off; opt in via this flag (CLOC11.60).
+
+### `--correlation_vector_output` (string, default: "")
+
+Path to write the correlation-vector sidecar JSON. Default empty → `<js_output_file>.cv.json` next to the JS output, or `closurec-cv.json` in CWD when output is stdout (CLOC11.67).
 
 ### `--instrument_for_coverage_option` (enum, default: NONE)
 


### PR DESCRIPTION
## Summary

Adds an explicit `--correlation_vector_output <path>` flag to control the correlation-vector sidecar JSON location. CI pipelines can now route the trace to an artifact directory (or `/dev/null` for benchmarks) without relying on the sidecar-of-output convention.

## Resolution order

1. `--correlation_vector_output <path>` → that path, **verbatim, no `.cv.json` decoration**.
2. Else if `--js_output_file` is set → `<output>.cv.json` beside it.
3. Else (stdout output) → `closurec-cv.json` in the working directory.

The flag is only consulted when `--correlation_vector` is also enabled — the trace itself is still opt-in. With CV off, the path flag is silently ignored.

## Changes

- `cli.spec.json`: new flag (string, default `""`)
- `config.rs`: `SpecialModesConfig` gains `correlation_vector_output: Option<PathBuf>`
- `wire.rs`: `read_special_modes` pulls the new flag; empty string → `None`
- `run.rs`: sidecar path resolution checks the override first; falls back to existing behaviour
- `tests/diff/help-markdown/expected.stdout`: regenerated

## Test plan
- [x] cargo build clean
- [x] 241 unit tests + 17 integration suites pass
- [x] New tests:
  - `correlation_vector_output_flag_overrides_sidecar_path` — explicit path lands; default path does NOT exist
  - `correlation_vector_output_flag_ignored_when_cv_disabled` — `correlation_vector=false` + explicit path → no sidecar
- [x] help-markdown fixture regenerated for 0.30.0 + new flag

## Security review (inline)
- The new flag's capability surface mirrors `--js_output_file` (user-supplied `PathBuf` → `write_output_file`) — same existing contract.
- CV-disabled gate is test-pinned.
- No unsafe, no new deps; only stdlib `PathBuf`.

## Versions
- `Cargo.toml`: 0.29.0 → 0.30.0
- `cli.spec.json`: 0.29.0 → 0.30.0
- `CHANGELOG.md`: new `[0.30.0]` section

🤖 Generated with [Claude Code](https://claude.com/claude-code)