### PR TITLE
feat(ruby-parser+sir): Phase 14c (FC) — class inheritance class Foo < Bar

### DIFF
--- a/code/grammars/ruby.grammar
+++ b/code/grammars/ruby.grammar
@@ -117,7 +117,14 @@ endless_def_statement = "def" NAME [ LPAREN [ params ] RPAREN ] EQUALS expressio
 # sequence of statements (which may include nested `def`s).  Like
 # `def_statement`, the body repetition uses a negative lookahead so it
 # stops at the closing `end` keyword instead of greedily consuming it.
-class_statement  = "class"  NAME { !"end" statement } "end" ;
+#
+# Phase 14c — optional superclass clause `< Bar` after the class name
+# (`class Foo < Bar`).  The `"<"` literal matches by *value*: the lexer
+# reclassifies `<` to a `Name`-type token (see the comparison-operator
+# note below), but the literal matcher compares the token value, so
+# `"<"` matches transparently.  The superclass is a single `NAME`; the
+# lowerer lifts it into `Stmt::ClassDef.superclass`.
+class_statement  = "class"  NAME [ "<" NAME ] { !"end" statement } "end" ;
 module_statement = "module" NAME { !"end" statement } "end" ;
 # Phase 6g — blocks `do … end` and brace-blocks `method { … }`.
 method_with_block = ( NAME | KEYWORD ) [ LPAREN [ expression { COMMA expression } ] RPAREN ] block ;

--- a/code/packages/rust/ruby-parser/.pr-body-fc-14c.md
+++ b/code/packages/rust/ruby-parser/.pr-body-fc-14c.md
@@ -1,0 +1,99 @@
+## Summary
+
+Phase 14c adds **class inheritance** — `class Foo < Bar` now lowers to
+
+```
+Stmt::ClassDef { name: "Foo", superclass: Some("Bar"), body, span }
+```
+
+A base class (`class Foo`) keeps `superclass: None`.  This introduces a
+new field on the SIR17 `Stmt::ClassDef` node, so the semantic-ir crate
+is bumped as a separate sub-step (semantic-ir 0.3.0).
+
+## semantic-ir (0.3.0 — node-shape change)
+
+- **`Stmt::ClassDef` gains `superclass: Option<String>`** — the parent
+  class name.  It is an *advisory* name only: SIR v0 has no class symbol
+  table, so the validator does not resolve it (mirroring how the class's
+  own `name` is not bound as a local).
+- The text printer emits a `(< Super)` clause after the class name:
+  `(class-def Foo (< Bar))`.  Base classes are unchanged
+  (`(class-def Foo)`).
+- The walker, validator, intrinsic-walk helper, and the four reference
+  backends' `ClassDef` arms are unaffected (the new field carries no
+  sub-expressions and no capability impact); all in-tree `ClassDef`
+  constructors were updated to pass `superclass`.
+
+## ruby-to-semantic-ir (0.42.0)
+
+- New `extract_superclass` helper scans the `class_statement` node's
+  **direct child tokens** for the `<` separator (a `Name`-type token
+  with value `"<"` — the lexer reclassifies comparison operators as
+  Name tokens) and returns the next `Name` token's value.  Only direct
+  tokens are inspected, so a `<` *inside* a body statement (e.g.
+  `a < b`) is never mistaken for the superclass separator — body
+  statements are `statement` *nodes*, not bare tokens.
+- Inheritance composes with Phase 14b: a subclass body still hoists its
+  `def`s to top-level `Function`s and preserves non-def statements in
+  `ClassDef.body`.
+
+## ruby-parser (0.40.0)
+
+Grammar change — `class_statement` gains an optional superclass clause:
+
+```
+class_statement = "class" NAME [ "<" NAME ] { !"end" statement } "end" ;
+```
+
+`"<"` matches by value (the lexer reclassifies `<` to a Name-type
+token; the literal matcher compares the value).  `_grammar.rs` was
+regenerated via `grammar-tools compile-grammar`.
+
+## Backends (go / python / rust / typescript)
+
+Unchanged.  `Feature::Classes` is still absent from every backend's
+accepted-feature set, so class-using modules are rejected at the
+capability check before `emit` — the panic arms stay unreachable.
+
+| SIR shape (Phase 14c)                                         | Source                       |
+|---------------------------------------------------------------|------------------------------|
+| `ClassDef { "Dog", superclass: Some("Animal"), body: [] }`    | `class Dog < Animal; end`    |
+| `ClassDef { "Widget", superclass: None, body: [] }`           | `class Widget; end`          |
+| printer: `(class-def Dog (< Animal))`                         | printer output               |
+
+## Tests
+
+- `coding-adventures-ruby-lexer`: **173** (no change)
+- `coding-adventures-ruby-parser`: 161 → **164** (+3):
+  - `test_parse_class_with_superclass`
+  - `test_parse_base_class_has_no_superclass_separator`
+  - `test_parse_subclass_with_method_body`
+- `ruby-to-semantic-ir`: 193 → **198** (+5):
+  - `class_with_superclass_records_parent_name`
+  - `base_class_has_no_superclass`
+  - `subclass_with_body_records_superclass_and_hoists_methods`
+  - `subclass_passes_sir_validator` (E2E lower → validate)
+  - `comparison_in_class_body_is_not_mistaken_for_superclass`
+- `semantic-ir`: 84 → **85** (+1): `print_class_def_with_superclass`
+- All four backend suites + `twig-to-semantic-ir` green (node-shape
+  change recompiles cleanly; capability check still rejects class-using
+  modules pre-emit).
+
+## Test plan
+
+- [x] `cargo test -p coding-adventures-ruby-lexer` (173/173)
+- [x] `cargo test -p coding-adventures-ruby-parser` (164/164)
+- [x] `cargo test -p ruby-to-semantic-ir` (198/198)
+- [x] `cargo test -p semantic-ir` (85/85)
+- [x] `cargo test -p semantic-ir-to-{go,python,rust,typescript} -p twig-to-semantic-ir` (all green)
+- [x] Security review passed (1 round, no findings) — pure AST/IR logic:
+      no I/O, no unsafe; `extract_superclass` is a single O(n) token
+      scan with no panics/recursion; the superclass is a
+      grammar-constrained identifier written verbatim (no injection into
+      the S-expression printer).
+- [ ] CI green
+
+Follows PR #4588 (Phase 14b).  Next chunk: Phase 14d (`module M; end` +
+methods → `Stmt::ModuleDef`).
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.40.0] - 2026-05-30
+
+### Added (Phase 14c (FC) — inheritance `class Foo < Bar`)
+
+Grammar change: `class_statement` gains an optional superclass clause:
+
+```
+class_statement = "class" NAME [ "<" NAME ] { !"end" statement } "end" ;
+```
+
+The `"<"` literal matches by *value* — the lexer reclassifies `<` to a
+`Name`-type token (the comparison-operator trick), and the grammar's
+literal matcher compares the token value, so `"<"` matches
+transparently.  `packages/rust/ruby-parser/src/_grammar.rs` was
+regenerated via `grammar-tools compile-grammar`.
+
+New parser tests (+3):
+
+- `test_parse_class_with_superclass` — `class Dog < Animal; end` parses
+  with the `<` separator and superclass `Animal` tokens in the class
+  header, and zero body statements.
+- `test_parse_base_class_has_no_superclass_separator` — a base class
+  `class Widget; end` carries no `<` token.
+- `test_parse_subclass_with_method_body` — inheritance composes with a
+  non-empty body (`<` separator + a `def_statement` body child).
+
+A `body_has_token_value` test helper checks for a direct child token by
+value.  Test count: 161 → 164 (+3).
+
 ## [0.39.0] - 2026-05-30
 
 ### Added (Phase 14b (FC) — class body with method defs + statements)

--- a/code/packages/rust/ruby-parser/src/_grammar.rs
+++ b/code/packages/rust/ruby-parser/src/_grammar.rs
@@ -127,13 +127,17 @@ pub fn parser_grammar() -> ParserGrammar {
             body: GrammarElement::Sequence { elements: vec![
                 GrammarElement::Literal { value: r#"class"#.to_string() },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Literal { value: r#"<"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                    ] }) },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
                         GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"end"#.to_string() }) },
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 120,
+            line_number: 127,
         },
         GrammarRule {
             name: r#"module_statement"#.to_string(),
@@ -146,7 +150,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 121,
+            line_number: 128,
         },
         GrammarRule {
             name: r#"method_with_block"#.to_string(),
@@ -168,7 +172,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"block"#.to_string() },
             ] },
-            line_number: 123,
+            line_number: 130,
         },
         GrammarRule {
             name: r#"block"#.to_string(),
@@ -176,7 +180,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"do_block"#.to_string() },
                 GrammarElement::RuleReference { name: r#"brace_block"#.to_string() },
             ] },
-            line_number: 124,
+            line_number: 131,
         },
         GrammarRule {
             name: r#"do_block"#.to_string(),
@@ -189,7 +193,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 125,
+            line_number: 132,
         },
         GrammarRule {
             name: r#"brace_block"#.to_string(),
@@ -199,7 +203,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"statement"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 126,
+            line_number: 133,
         },
         GrammarRule {
             name: r#"block_params"#.to_string(),
@@ -212,7 +216,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"|"#.to_string() },
             ] },
-            line_number: 127,
+            line_number: 134,
         },
         GrammarRule {
             name: r#"return_statement"#.to_string(),
@@ -220,7 +224,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"return"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"expression"#.to_string() }) },
             ] },
-            line_number: 129,
+            line_number: 136,
         },
         GrammarRule {
             name: r#"break_statement"#.to_string(),
@@ -228,7 +232,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"break"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"expression"#.to_string() }) },
             ] },
-            line_number: 130,
+            line_number: 137,
         },
         GrammarRule {
             name: r#"next_statement"#.to_string(),
@@ -236,7 +240,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"next"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"expression"#.to_string() }) },
             ] },
-            line_number: 131,
+            line_number: 138,
         },
         GrammarRule {
             name: r#"yield_statement"#.to_string(),
@@ -244,7 +248,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"yield"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"yield_args"#.to_string() }) },
             ] },
-            line_number: 153,
+            line_number: 160,
         },
         GrammarRule {
             name: r#"yield_args"#.to_string(),
@@ -268,7 +272,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) },
                 ] },
             ] },
-            line_number: 154,
+            line_number: 161,
         },
         GrammarRule {
             name: r#"params"#.to_string(),
@@ -279,7 +283,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"param"#.to_string() },
                     ] }) },
             ] },
-            line_number: 169,
+            line_number: 176,
         },
         GrammarRule {
             name: r#"param"#.to_string(),
@@ -290,7 +294,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
             ] },
-            line_number: 170,
+            line_number: 177,
         },
         GrammarRule {
             name: r#"if_statement"#.to_string(),
@@ -307,7 +311,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 171,
+            line_number: 178,
         },
         GrammarRule {
             name: r#"elsif_clause"#.to_string(),
@@ -321,7 +325,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 172,
+            line_number: 179,
         },
         GrammarRule {
             name: r#"else_clause"#.to_string(),
@@ -332,7 +336,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 173,
+            line_number: 180,
         },
         GrammarRule {
             name: r#"unless_statement"#.to_string(),
@@ -347,7 +351,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 174,
+            line_number: 181,
         },
         GrammarRule {
             name: r#"while_statement"#.to_string(),
@@ -360,7 +364,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 175,
+            line_number: 182,
         },
         GrammarRule {
             name: r#"until_statement"#.to_string(),
@@ -373,7 +377,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 176,
+            line_number: 183,
         },
         GrammarRule {
             name: r#"case_statement"#.to_string(),
@@ -387,7 +391,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 199,
+            line_number: 206,
         },
         GrammarRule {
             name: r#"when_clause"#.to_string(),
@@ -406,7 +410,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 200,
+            line_number: 207,
         },
         GrammarRule {
             name: r#"in_clause"#.to_string(),
@@ -421,7 +425,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 222,
+            line_number: 229,
         },
         GrammarRule {
             name: r#"pattern"#.to_string(),
@@ -431,7 +435,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"literal_pattern"#.to_string() },
                 GrammarElement::RuleReference { name: r#"binding_pattern"#.to_string() },
             ] },
-            line_number: 223,
+            line_number: 230,
         },
         GrammarRule {
             name: r#"literal_pattern"#.to_string(),
@@ -441,12 +445,12 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"symbol_literal"#.to_string() },
                 GrammarElement::TokenReference { name: r#"KEYWORD"#.to_string() },
             ] },
-            line_number: 224,
+            line_number: 231,
         },
         GrammarRule {
             name: r#"binding_pattern"#.to_string(),
             body: GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
-            line_number: 225,
+            line_number: 232,
         },
         GrammarRule {
             name: r#"array_pattern"#.to_string(),
@@ -461,7 +465,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 226,
+            line_number: 233,
         },
         GrammarRule {
             name: r#"hash_pattern"#.to_string(),
@@ -476,7 +480,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 227,
+            line_number: 234,
         },
         GrammarRule {
             name: r#"hash_pattern_pair"#.to_string(),
@@ -485,7 +489,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"pattern"#.to_string() }) },
             ] },
-            line_number: 228,
+            line_number: 235,
         },
         GrammarRule {
             name: r#"begin_statement"#.to_string(),
@@ -501,7 +505,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"ensure_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 249,
+            line_number: 256,
         },
         GrammarRule {
             name: r#"rescue_clause"#.to_string(),
@@ -519,7 +523,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 258,
+            line_number: 265,
         },
         GrammarRule {
             name: r#"exception_list"#.to_string(),
@@ -530,7 +534,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
                     ] }) },
             ] },
-            line_number: 259,
+            line_number: 266,
         },
         GrammarRule {
             name: r#"ensure_clause"#.to_string(),
@@ -541,7 +545,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 260,
+            line_number: 267,
         },
         GrammarRule {
             name: r#"assignment"#.to_string(),
@@ -565,7 +569,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 280,
+            line_number: 287,
         },
         GrammarRule {
             name: r#"rightward_assignment"#.to_string(),
@@ -574,7 +578,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"=>"#.to_string() },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
             ] },
-            line_number: 299,
+            line_number: 306,
         },
         GrammarRule {
             name: r#"method_call"#.to_string(),
@@ -594,7 +598,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"dot_call"#.to_string() }) },
             ] },
-            line_number: 310,
+            line_number: 317,
         },
         GrammarRule {
             name: r#"dot_call"#.to_string(),
@@ -616,7 +620,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                     ] }) },
             ] },
-            line_number: 311,
+            line_number: 318,
         },
         GrammarRule {
             name: r#"call_arg"#.to_string(),
@@ -627,7 +631,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 318,
+            line_number: 325,
         },
         GrammarRule {
             name: r#"method_call_no_paren"#.to_string(),
@@ -642,17 +646,17 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 332,
+            line_number: 339,
         },
         GrammarRule {
             name: r#"expression_stmt"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"expression"#.to_string() },
-            line_number: 333,
+            line_number: 340,
         },
         GrammarRule {
             name: r#"expression"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"ternary"#.to_string() },
-            line_number: 419,
+            line_number: 426,
         },
         GrammarRule {
             name: r#"ternary"#.to_string(),
@@ -665,7 +669,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 420,
+            line_number: 427,
         },
         GrammarRule {
             name: r#"range"#.to_string(),
@@ -679,7 +683,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_or"#.to_string() },
                     ] }) },
             ] },
-            line_number: 421,
+            line_number: 428,
         },
         GrammarRule {
             name: r#"logical_or"#.to_string(),
@@ -693,7 +697,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_and"#.to_string() },
                     ] }) },
             ] },
-            line_number: 422,
+            line_number: 429,
         },
         GrammarRule {
             name: r#"logical_and"#.to_string(),
@@ -707,7 +711,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_not"#.to_string() },
                     ] }) },
             ] },
-            line_number: 423,
+            line_number: 430,
         },
         GrammarRule {
             name: r#"logical_not"#.to_string(),
@@ -718,7 +722,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) }) },
                 GrammarElement::RuleReference { name: r#"comparison"#.to_string() },
             ] },
-            line_number: 430,
+            line_number: 437,
         },
         GrammarRule {
             name: r#"comparison"#.to_string(),
@@ -736,7 +740,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"sum"#.to_string() },
                     ] }) },
             ] },
-            line_number: 431,
+            line_number: 438,
         },
         GrammarRule {
             name: r#"sum"#.to_string(),
@@ -750,7 +754,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term"#.to_string() },
                     ] }) },
             ] },
-            line_number: 432,
+            line_number: 439,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -764,7 +768,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"factor"#.to_string() },
                     ] }) },
             ] },
-            line_number: 433,
+            line_number: 440,
         },
         GrammarRule {
             name: r#"factor"#.to_string(),
@@ -788,7 +792,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"dot_call"#.to_string() }) },
             ] },
-            line_number: 443,
+            line_number: 450,
         },
         GrammarRule {
             name: r#"lambda_literal"#.to_string(),
@@ -801,7 +805,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"block"#.to_string() },
             ] },
-            line_number: 462,
+            line_number: 469,
         },
         GrammarRule {
             name: r#"unary_minus"#.to_string(),
@@ -809,7 +813,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"factor"#.to_string() },
             ] },
-            line_number: 463,
+            line_number: 470,
         },
         GrammarRule {
             name: r#"symbol_literal"#.to_string(),
@@ -821,7 +825,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 464,
+            line_number: 471,
         },
         GrammarRule {
             name: r#"array_literal"#.to_string(),
@@ -836,7 +840,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 465,
+            line_number: 472,
         },
         GrammarRule {
             name: r#"hash_literal"#.to_string(),
@@ -851,7 +855,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 466,
+            line_number: 473,
         },
         GrammarRule {
             name: r#"hash_entry"#.to_string(),
@@ -871,7 +875,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                 ] },
             ] },
-            line_number: 467,
+            line_number: 474,
         },
     ],
         version: 1,

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -659,6 +659,76 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // Phase 14c (FC) — inheritance `class Foo < Bar`.  The grammar's
+    // `class_statement` gains an optional `[ "<" NAME ]` superclass
+    // clause; `<` lexes as a Name-type token whose value is "<".
+    // -----------------------------------------------------------------------
+
+    /// Direct child tokens of `node` whose value equals `value`.
+    fn body_has_token_value(node: &GrammarASTNode, value: &str) -> bool {
+        node.children.iter().any(|c| matches!(
+            c,
+            ASTNodeOrToken::Token(t) if t.value == value
+        ))
+    }
+
+    #[test]
+    fn test_parse_class_with_superclass() {
+        // `class Dog < Animal\nend` parses to a class_statement whose
+        // direct children include the `<` separator token and the
+        // superclass Name token `Animal`.
+        let ast = parse_ruby("class Dog < Animal\nend");
+        let cls = find_statement_inner(&ast, "class_statement")
+            .expect("expected class_statement");
+        assert!(
+            body_has_token_value(cls, "<"),
+            "expected a `<` superclass separator token in the class header"
+        );
+        assert!(
+            body_has_token_value(cls, "Animal"),
+            "expected the superclass name `Animal` token in the class header"
+        );
+        // The empty subclass has no body statements.
+        let body_count = cls
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "statement"))
+            .count();
+        assert_eq!(body_count, 0, "empty subclass should have no body statements");
+    }
+
+    #[test]
+    fn test_parse_base_class_has_no_superclass_separator() {
+        // A base class `class Widget\nend` has no `<` token — the
+        // optional superclass clause matched zero times.
+        let ast = parse_ruby("class Widget\nend");
+        let cls = find_statement_inner(&ast, "class_statement")
+            .expect("expected class_statement");
+        assert!(
+            !body_has_token_value(cls, "<"),
+            "base class must not carry a `<` superclass separator"
+        );
+    }
+
+    #[test]
+    fn test_parse_subclass_with_method_body() {
+        // Inheritance composes with a non-empty body: `class Cat <
+        // Animal; def meow; end; end` parses with the `<` separator AND
+        // a def_statement body child.
+        let ast = parse_ruby("class Cat < Animal\n  def meow\n  end\nend");
+        let cls = find_statement_inner(&ast, "class_statement")
+            .expect("expected class_statement");
+        assert!(body_has_token_value(cls, "<"), "expected `<` separator");
+        assert!(body_has_token_value(cls, "Animal"), "expected superclass `Animal`");
+        let names = body_inner_rule_names(cls);
+        assert!(
+            names.iter().any(|r| r == "def_statement"),
+            "expected a def_statement in the subclass body; got {:?}",
+            names
+        );
+    }
+
+    // -----------------------------------------------------------------------
     // Phase 6g — blocks `do … end` and brace-blocks `method { … }`
     // -----------------------------------------------------------------------
 

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.42.0] - 2026-05-30
+
+### Added (Phase 14c (FC) — inheritance `class Foo < Bar`)
+
+`class Foo < Bar` now lowers to `Stmt::ClassDef` with
+`superclass: Some("Bar")` (semantic-ir 0.3.0's new field); a base class
+`class Foo` keeps `superclass: None`.
+
+- New `extract_superclass` helper scans the `class_statement` node's
+  *direct* child tokens for the `<` separator (a `Name`-type token with
+  value `"<"`) and returns the value of the next `Name` token — the
+  superclass.  Only direct tokens are inspected, so a `<` comparison
+  *inside* a body statement (`a < b`) is never mistaken for the
+  superclass separator (body statements are `statement` nodes, not bare
+  tokens).
+- Inheritance composes with Phase 14b: a subclass body still hoists its
+  `def`s to top-level Functions and preserves non-def statements in
+  `ClassDef.body`.
+
+New tests (+5): `class_with_superclass_records_parent_name`,
+`base_class_has_no_superclass`,
+`subclass_with_body_records_superclass_and_hoists_methods`,
+`subclass_passes_sir_validator` (E2E lower → validate),
+`comparison_in_class_body_is_not_mistaken_for_superclass`.
+Test count: 193 → 198 (+5).
+
 ## [0.41.0] - 2026-05-30
 
 ### Changed (Phase 14b (FC) — class body with method defs + statements)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -802,6 +802,95 @@ mod tests {
         assert!(semantic_ir::validate(&m).is_ok());
     }
 
+    // -----------------------------------------------------------------
+    // Phase 14c (FC) — inheritance `class Foo < Bar`.  The superclass
+    // name lands in `Stmt::ClassDef.superclass` (semantic-ir 0.3.0);
+    // a base class keeps `superclass: None`.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn class_with_superclass_records_parent_name() {
+        // `class Dog < Animal` → ClassDef.superclass == Some("Animal").
+        let m = lower("class Dog < Animal\nend\n");
+        let main = main_body(&m);
+        match &main.stmts[0] {
+            Stmt::ClassDef { name, superclass, body, .. } => {
+                assert_eq!(name, "Dog");
+                assert_eq!(superclass.as_deref(), Some("Animal"));
+                assert!(body.is_empty());
+            }
+            other => panic!("expected Stmt::ClassDef, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn base_class_has_no_superclass() {
+        // A class without `< Parent` keeps `superclass: None` — the
+        // 14c grammar's superclass clause is optional.
+        let m = lower("class Widget\nend\n");
+        let main = main_body(&m);
+        match &main.stmts[0] {
+            Stmt::ClassDef { name, superclass, .. } => {
+                assert_eq!(name, "Widget");
+                assert_eq!(*superclass, None, "base class must have no superclass");
+            }
+            other => panic!("expected Stmt::ClassDef, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn subclass_with_body_records_superclass_and_hoists_methods() {
+        // Inheritance composes with Phase 14b: the superclass is
+        // captured AND the body's `def`s hoist while non-def statements
+        // stay in the body.
+        let m = lower("class Cat < Animal\n  LEGS = 4\n  def meow\n  end\nend\n");
+        assert!(
+            m.functions.iter().any(|f| f.name == "meow"),
+            "expected hoisted `meow`; got {:?}",
+            m.functions.iter().map(|f| &f.name).collect::<Vec<_>>()
+        );
+        let main = main_body(&m);
+        match &main.stmts[0] {
+            Stmt::ClassDef { name, superclass, body, .. } => {
+                assert_eq!(name, "Cat");
+                assert_eq!(superclass.as_deref(), Some("Animal"));
+                assert_eq!(body.len(), 1, "only `LEGS = 4` stays in body; got {:?}", body);
+                assert!(matches!(&body[0], Stmt::LetBinding { name, .. } if name == "LEGS"));
+            }
+            other => panic!("expected Stmt::ClassDef, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn subclass_passes_sir_validator() {
+        // E2E: a subclass with a populated body lowers to a module the
+        // validator accepts (the superclass name is advisory; it is
+        // not resolved against a symbol table).
+        let m = lower("class Cat < Animal\n  LEGS = 4\nend\n");
+        let result = semantic_ir::validate(&m);
+        assert!(result.is_ok(), "validator rejected subclass module: {:?}", result);
+    }
+
+    #[test]
+    fn comparison_in_class_body_is_not_mistaken_for_superclass() {
+        // A `<` *inside* a body statement (a comparison expression)
+        // must not be lifted as the superclass: only the direct
+        // `class NAME < NAME` separator counts.  `class Plain` here has
+        // no superclass even though its body contains `a < b`.
+        let m = lower("class Plain\n  a = 1\n  a < 2\nend\n");
+        let main = main_body(&m);
+        match &main.stmts[0] {
+            Stmt::ClassDef { name, superclass, .. } => {
+                assert_eq!(name, "Plain");
+                assert_eq!(
+                    *superclass, None,
+                    "a comparison in the body must not become the superclass"
+                );
+            }
+            other => panic!("expected Stmt::ClassDef, got {:?}", other),
+        }
+    }
+
     #[test]
     fn module_still_lowers_to_nil_no_op_in_phase_14a() {
         // Phase 14a covers `class` only.  `module M; end` continues

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -535,10 +535,13 @@ impl Lowerer {
                 // hoisted exactly once and every non-`def` statement
                 // is preserved in `body` instead of being dropped.
                 let name = self.extract_class_name(node)?;
+                // Phase 14c — optional `< Bar` superclass clause.
+                let superclass = self.extract_superclass(node);
                 self.features_used.insert(Feature::Classes);
                 let body = self.lower_class_body_statements(node)?;
                 Ok(Stmt::ClassDef {
                     name,
+                    superclass,
                     body,
                     span: self.span_of(node),
                 })
@@ -1676,6 +1679,36 @@ impl Lowerer {
             column: node.start_column.unwrap_or(0),
         })?;
         Ok(name_token.value.clone())
+    }
+
+    /// Phase 14c (FC) — extract the optional superclass name from a
+    /// `class_statement` AST node (`class Foo < Bar`).
+    ///
+    /// Grammar shape: `"class" NAME [ "<" NAME ] { … } "end"`.  The
+    /// `"<"` separator lexes as a `TokenType::Name` token whose *value*
+    /// is `"<"` (the lexer reclassifies comparison operators as Name
+    /// tokens; the grammar's `"<"` literal matches by value).  We scan
+    /// the direct child tokens for that `<` separator and return the
+    /// value of the *next* `Name`-type token — the superclass.  Returns
+    /// `None` for a base class (`class Foo`), where no `<` is present.
+    ///
+    /// Only direct child tokens are inspected, so a `<` appearing deep
+    /// inside a body statement (e.g. `a < b` as a comparison) is never
+    /// mistaken for the superclass separator: body statements are
+    /// `statement` *nodes*, not bare tokens, in the child list.
+    fn extract_superclass(&self, node: &GrammarASTNode) -> Option<String> {
+        let mut seen_lt = false;
+        for child in &node.children {
+            if let ASTNodeOrToken::Token(t) = child {
+                if seen_lt && matches!(t.type_, TokenType::Name) {
+                    return Some(t.value.clone());
+                }
+                if t.value == "<" {
+                    seen_lt = true;
+                }
+            }
+        }
+        None
     }
 
     /// Phase 7c — lower an endless method definition `def foo = expr`

--- a/code/packages/rust/semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to the `semantic-ir` crate are documented here.
 
+## 0.3.0 — SIR17: class inheritance (`ClassDef.superclass`)
+
+Introduced by the Ruby frontend's Phase 14c (`class Foo < Bar`).
+
+### Added
+
+- `Stmt::ClassDef` gains a `superclass: Option<String>` field — the
+  parent class name (`Some("Bar")` for `class Foo < Bar`, `None` for a
+  base class `class Foo`).  It is an advisory name only: SIR v0 has no
+  class symbol table, so the validator does not resolve it (mirroring
+  how the class's own `name` is not bound as a local).
+
+### Changed
+
+- The text printer emits a `(< Super)` clause right after the class
+  name when `superclass` is set: `(class-def Foo (< Bar))`.  Base
+  classes are unchanged (`(class-def Foo)`).
+- The walker, validator, intrinsic-walk backend helper, and the four
+  reference backends' `ClassDef` arms are unaffected by the new field
+  (it carries no sub-expressions to traverse and no capability impact);
+  class-using modules are still rejected at the capability check before
+  emit.
+
+New test: `print_class_def_with_superclass`.  This is a **breaking
+struct change** for any code constructing `Stmt::ClassDef` literally —
+all in-tree constructors updated to pass `superclass`.
+
 ## 0.2.1 — SIR17 validator: walk populated `ClassDef` bodies
 
 No node-shape change.  The Ruby frontend's Phase 14b begins emitting

--- a/code/packages/rust/semantic-ir/src/nodes.rs
+++ b/code/packages/rust/semantic-ir/src/nodes.rs
@@ -251,8 +251,15 @@ pub enum Stmt {
     /// produces no value — it is a declaration, not an expression —
     /// so the per-Block trailing `value` field doesn't apply.
     /// Backends emit each statement in source order.
+    ///
+    /// `superclass` (SIR17, Ruby Phase 14c) carries the parent class
+    /// name for `class Foo < Bar` — `Some("Bar")` — and is `None` for
+    /// a base class (`class Foo`).  It is an advisory name only: SIR v0
+    /// has no class symbol table, so the validator does not resolve it
+    /// (mirroring how the class's own `name` is not bound as a local).
     ClassDef {
         name: String,
+        superclass: Option<String>,
         body: Vec<Stmt>,
         span: Span,
     },

--- a/code/packages/rust/semantic-ir/src/text/printer.rs
+++ b/code/packages/rust/semantic-ir/src/text/printer.rs
@@ -224,14 +224,16 @@ fn print_stmt(out: &mut String, s: &Stmt, indent: usize, depth: usize) {
             print_expr_inline_depth(out, value, depth + 1);
             out.push(')');
         }
-        Stmt::ClassDef { name, body, .. } => {
-            // `(class-def Name)` for the empty-body case;
-            // `(class-def Name (stmt ...) (stmt ...))` with body
-            // statements printed one per line for the populated form.
-            // Phase 14a always lands the empty form; the populated
-            // form is printed forward-compatibly so future phases
-            // don't need to touch the printer.
+        Stmt::ClassDef { name, superclass, body, .. } => {
+            // `(class-def Name)` for the empty base-class case;
+            // `(class-def Name (< Super))` when the class inherits
+            // (Ruby Phase 14c `class Foo < Bar`); body statements, if
+            // any, are printed one per line after the optional
+            // superclass clause.
             let _ = write!(out, "(class-def {}", name);
+            if let Some(sup) = superclass {
+                let _ = write!(out, " (< {})", sup);
+            }
             for inner in body {
                 let _ = write!(out, "\n{}  ", " ".repeat(indent));
                 print_stmt(out, inner, indent + 2, depth + 1);
@@ -677,6 +679,7 @@ mod tests {
         let block = Block {
             stmts: vec![Stmt::ClassDef {
                 name: "Foo".into(),
+                superclass: None,
                 body: vec![],
                 span: s_.clone(),
             }],
@@ -701,6 +704,7 @@ mod tests {
         let block = Block {
             stmts: vec![Stmt::ClassDef {
                 name: "Bar".into(),
+                superclass: None,
                 body: vec![Stmt::LetBinding {
                     name: "y".into(),
                     sir_type: None,
@@ -716,5 +720,29 @@ mod tests {
         print_block(&mut out, &block, 0);
         assert!(out.contains("(class-def Bar"));
         assert!(out.contains("(let y (int 2))"));
+    }
+
+    #[test]
+    fn print_class_def_with_superclass() {
+        // Ruby Phase 14c: `class Foo < Bar` prints the superclass
+        // clause `(< Bar)` right after the class name.
+        let s_ = s();
+        let block = Block {
+            stmts: vec![Stmt::ClassDef {
+                name: "Foo".into(),
+                superclass: Some("Bar".into()),
+                body: vec![],
+                span: s_.clone(),
+            }],
+            value: Expr::NilLit { span: s_.clone() },
+            span: s_,
+        };
+        let mut out = String::new();
+        print_block(&mut out, &block, 0);
+        assert!(
+            out.contains("(class-def Foo (< Bar))"),
+            "expected `(class-def Foo (< Bar))` in output, got:\n{}",
+            out
+        );
     }
 }

--- a/code/packages/rust/semantic-ir/src/validator.rs
+++ b/code/packages/rust/semantic-ir/src/validator.rs
@@ -1150,6 +1150,7 @@ mod tests {
             body: Block {
                 stmts: vec![Stmt::ClassDef {
                     name: name.into(),
+                    superclass: None,
                     body,
                     span: s(),
                 }],
@@ -1222,6 +1223,7 @@ mod tests {
                 stmts: vec![
                     Stmt::ClassDef {
                         name: "Foo".into(),
+                        superclass: None,
                         body: vec![Stmt::LetBinding {
                             name: "INNER".into(),
                             sir_type: None,


### PR DESCRIPTION
## Summary

Phase 14c adds **class inheritance** — `class Foo < Bar` now lowers to

```
Stmt::ClassDef { name: "Foo", superclass: Some("Bar"), body, span }
```

A base class (`class Foo`) keeps `superclass: None`.  This introduces a
new field on the SIR17 `Stmt::ClassDef` node, so the semantic-ir crate
is bumped as a separate sub-step (semantic-ir 0.3.0).

## semantic-ir (0.3.0 — node-shape change)

- **`Stmt::ClassDef` gains `superclass: Option<String>`** — the parent
  class name.  It is an *advisory* name only: SIR v0 has no class symbol
  table, so the validator does not resolve it (mirroring how the class's
  own `name` is not bound as a local).
- The text printer emits a `(< Super)` clause after the class name:
  `(class-def Foo (< Bar))`.  Base classes are unchanged
  (`(class-def Foo)`).
- The walker, validator, intrinsic-walk helper, and the four reference
  backends' `ClassDef` arms are unaffected (the new field carries no
  sub-expressions and no capability impact); all in-tree `ClassDef`
  constructors were updated to pass `superclass`.

## ruby-to-semantic-ir (0.42.0)

- New `extract_superclass` helper scans the `class_statement` node's
  **direct child tokens** for the `<` separator (a `Name`-type token
  with value `"<"` — the lexer reclassifies comparison operators as
  Name tokens) and returns the next `Name` token's value.  Only direct
  tokens are inspected, so a `<` *inside* a body statement (e.g.
  `a < b`) is never mistaken for the superclass separator — body
  statements are `statement` *nodes*, not bare tokens.
- Inheritance composes with Phase 14b: a subclass body still hoists its
  `def`s to top-level `Function`s and preserves non-def statements in
  `ClassDef.body`.

## ruby-parser (0.40.0)

Grammar change — `class_statement` gains an optional superclass clause:

```
class_statement = "class" NAME [ "<" NAME ] { !"end" statement } "end" ;
```

`"<"` matches by value (the lexer reclassifies `<` to a Name-type
token; the literal matcher compares the value).  `_grammar.rs` was
regenerated via `grammar-tools compile-grammar`.

## Backends (go / python / rust / typescript)

Unchanged.  `Feature::Classes` is still absent from every backend's
accepted-feature set, so class-using modules are rejected at the
capability check before `emit` — the panic arms stay unreachable.

| SIR shape (Phase 14c)                                         | Source                       |
|---------------------------------------------------------------|------------------------------|
| `ClassDef { "Dog", superclass: Some("Animal"), body: [] }`    | `class Dog < Animal; end`    |
| `ClassDef { "Widget", superclass: None, body: [] }`           | `class Widget; end`          |
| printer: `(class-def Dog (< Animal))`                         | printer output               |

## Tests

- `coding-adventures-ruby-lexer`: **173** (no change)
- `coding-adventures-ruby-parser`: 161 → **164** (+3):
  - `test_parse_class_with_superclass`
  - `test_parse_base_class_has_no_superclass_separator`
  - `test_parse_subclass_with_method_body`
- `ruby-to-semantic-ir`: 193 → **198** (+5):
  - `class_with_superclass_records_parent_name`
  - `base_class_has_no_superclass`
  - `subclass_with_body_records_superclass_and_hoists_methods`
  - `subclass_passes_sir_validator` (E2E lower → validate)
  - `comparison_in_class_body_is_not_mistaken_for_superclass`
- `semantic-ir`: 84 → **85** (+1): `print_class_def_with_superclass`
- All four backend suites + `twig-to-semantic-ir` green (node-shape
  change recompiles cleanly; capability check still rejects class-using
  modules pre-emit).

## Test plan

- [x] `cargo test -p coding-adventures-ruby-lexer` (173/173)
- [x] `cargo test -p coding-adventures-ruby-parser` (164/164)
- [x] `cargo test -p ruby-to-semantic-ir` (198/198)
- [x] `cargo test -p semantic-ir` (85/85)
- [x] `cargo test -p semantic-ir-to-{go,python,rust,typescript} -p twig-to-semantic-ir` (all green)
- [x] Security review passed (1 round, no findings) — pure AST/IR logic:
      no I/O, no unsafe; `extract_superclass` is a single O(n) token
      scan with no panics/recursion; the superclass is a
      grammar-constrained identifier written verbatim (no injection into
      the S-expression printer).
- [ ] CI green

Follows PR #4588 (Phase 14b).  Next chunk: Phase 14d (`module M; end` +
methods → `Stmt::ModuleDef`).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
