### PR TITLE
fix(visicalc): wire inline cell editor so typing & commit actually work

### DIFF
--- a/demo/visicalc-webcomp/README.md
+++ b/demo/visicalc-webcomp/README.md
@@ -41,12 +41,22 @@ custom element should render.
 
 ## How to view
 
+The page uses an ES module import (`import "./build/FormulaBar.js"`)
+to register the `<mos-formula-bar>` custom element. Browsers
+restrict module loading over `file://` — Safari and Chrome both
+block it. Serve over `http://` instead:
+
 ```
-open demo/visicalc-webcomp/index.html
+cd demo/visicalc-webcomp
+bash scripts/build.sh           # regenerate build/FormulaBar.js
+python3 -m http.server 8765      # any static server works
+open http://127.0.0.1:8765/      # then open the URL in any browser
 ```
 
-(Or just double-click the file in a file browser. Type into the
-formula bar and watch the events stream into the log below.)
+(Type into the formula bar and watch the events stream into the log
+below. If you serve the file via `file://` instead, the grid still
+renders but the formula bar will be missing — the browser silently
+refused to load the module.)
 
 ## Where this fits in the cross-backend demo plan
 

--- a/demo/visicalc/mosaic/Grid.desktop.mll
+++ b/demo/visicalc/mosaic/Grid.desktop.mll
@@ -109,8 +109,16 @@ layout Grid {
               state-when-editing:  ( r == editRow && c == editCol )
             ) {
               If ( when: ( r == editRow && c == editCol ) ) {
+                // value: ( slot: edit-content ) reflects the host's
+                // live edit buffer.  Using `( v )` would freeze the
+                // input at the cell's stored value because React's
+                // controlled `<input value={v} />` rejects keystrokes
+                // when there is no onChange.  Pairing edit-content
+                // with onFormulaChange below restores the writable
+                // round-trip the FormulaBar already enjoys.
                 HostInput (
-                  value:    ( v ) ,
+                  value:    slot: edit-content ,
+                  onChange: emit: onFormulaChange ,
                   onCommit: emit: onEditCommit ,
                   onCancel: emit: onEditCancel
                 )

--- a/demo/visicalc/mosaic/Grid.mil
+++ b/demo/visicalc/mosaic/Grid.mil
@@ -38,10 +38,22 @@
 // onEditCommit / onEditCancel are forwarded by the inline cell's
 // HostInput so the host's reducer can react to the user pressing
 // Enter or Escape inside the cell editor.  The App's reducer in
-// src/app/state.ts already has the matching action types
-// (`editCommit { value }` and `editCancel`) — they were dispatched
+// src/app/state.ts has matching action types — they were dispatched
 // only from FormulaBar before; now they're also dispatched from
 // per-cell editing.
+//
+// v0.2.0 FOLLOW-UP (this fix) — the inline cell HostInput is also
+// wired to onFormulaChange so each keystroke updates the host's
+// `edit-content` slot.  Without this, the React/HostInput emitter
+// generates a controlled <input value={v} /> with NO onChange, and
+// the cell input silently rejects every keystroke.  onEditCommit
+// then reads from `edit-content` (NOT from a dispatch payload),
+// which matches the FormulaBar's commit semantics — UI28-1 §6.4.
+//
+// onEditCommit carries no payload now: HostInput's `onCommit:` emit
+// is intentionally void (see mosaic-emit-react::emit_host_input_jsx),
+// so the host's reducer reads the buffered `state.editContent`
+// instead of `action.value`.
 
 component Grid {
   // Display data (host computes from cells + viewport offset).
@@ -73,7 +85,22 @@ component Grid {
   slot edit-content : text ;
 
   // Events fired up to the host reducer.
-  emit onNavigate     ( row : number , col : number ) ;
-  emit onEditCommit   ( value : text ) ;
+  //
+  //   onNavigate       — host selects (row, col).  Currently unreached
+  //                      from the layout because per-cell click needs
+  //                      parameterized emit-dispatch (grammar follow-up,
+  //                      UI28-2 §X).  Keyboard navigation handled in
+  //                      App.tsx covers it for now.
+  //   onFormulaChange  — each keystroke inside the inline cell editor;
+  //                      payload is the new buffer text.  Matches
+  //                      FormulaBar.mil's emit of the same name.
+  //   onEditCommit     — Enter pressed inside the inline cell editor.
+  //                      VOID payload — the reducer reads the buffered
+  //                      `edit-content` it has been accumulating from
+  //                      onFormulaChange.
+  //   onEditCancel     — Escape pressed inside the inline cell editor.
+  emit onNavigate       ( row : number , col : number ) ;
+  emit onFormulaChange  ( value : text ) ;
+  emit onEditCommit ;
   emit onEditCancel ;
 }

--- a/demo/visicalc/mosaic/Grid.touch.mll
+++ b/demo/visicalc/mosaic/Grid.touch.mll
@@ -49,8 +49,11 @@ layout Grid {
               state-when-editing:  ( r == editRow && c == editCol )
             ) {
               If ( when: ( r == editRow && c == editCol ) ) {
+                // Mirrors Grid.desktop.mll — see that file for the
+                // edit-content/onFormulaChange rationale.
                 HostInput (
-                  value:    ( v ) ,
+                  value:    slot: edit-content ,
+                  onChange: emit: onFormulaChange ,
                   onCommit: emit: onEditCommit ,
                   onCancel: emit: onEditCancel
                 )

--- a/demo/visicalc/src/app/state.ts
+++ b/demo/visicalc/src/app/state.ts
@@ -21,7 +21,7 @@ export type { GridEvent, FormulaBarEvent };
 /** Host-internal events not produced by any Mosaic component. */
 export type HostEvent =
   | { type: "editStart"; row: number; col: number }
-  | { type: "editCommit"; value: string }
+  | { type: "editCommit" }
   | { type: "editCancel" }
   | { type: "scroll"; offset: number }
   | {
@@ -113,9 +113,15 @@ export function reducer(state: AppState, action: AppAction): AppState {
     }
 
     case "editCommit": {
+      // The inline cell HostInput's `onCommit:` emit is void by design
+      // (see mosaic-emit-react::emit_host_input_jsx) — the buffered
+      // text already lives in state.editContent, accumulated keystroke-
+      // by-keystroke via the `formulaChange` action.  Reading from
+      // action.value would always be `undefined` because the dispatch
+      // payload is `{ type: "editCommit" }` with no fields.
       if (state.editRow === -1) return state;
       const k = cellKey(state.editRow, state.editCol);
-      const newCells = { ...state.cells, [k]: action.value };
+      const newCells = { ...state.cells, [k]: state.editContent };
       // Move selection down one row after commit (Excel convention).
       const nextRow = Math.min(state.editRow + 1, state.totalRows - 1);
       const nextCol = state.editCol;


### PR DESCRIPTION
## Summary

Functional verification of the React VisiCalc demo (via Claude Preview interactive testing) revealed that **typing into a cell and committing did nothing** — three architectural gaps in the v0.2.0 cell-and-column composition that visual demos masked:

1. **Typing was a no-op.** The inline `<input>` rendered when a cell enters edit mode had `value={v}` (the cell's stored value) but **no `onChange`**. React's controlled-input contract silently rejects every keystroke when the value prop never updates.
2. **Commit clobbered the cell with `undefined`.** The HostInput's `onCommit:` emit declared a `value: text` payload in `Grid.mil`, but `mosaic-emit-react::emit_host_input_jsx` intentionally generates a VOID `dispatch({type: "editCommit"})` for Enter (the buffered text is supposed to live in host state, accumulated via `onChange`). The reducer's `editCommit` case wrote `action.value` (= `undefined`) to the cell.
3. Same failure mirrored in `Grid.touch.mll`.

## Fix

- **`Grid.{desktop,touch}.mll`** — cell HostInput now binds `value: slot: edit-content` and adds `onChange: emit: onFormulaChange` so each keystroke updates the host's live edit buffer.
- **`Grid.mil`** — `onEditCommit` is void (no payload), `onFormulaChange (value: text)` added; doc block explains the contract.
- **`src/app/state.ts`** — `editCommit` reducer reads `state.editContent` (mirrors the existing `commit` case); `AppAction.editCommit` no longer carries `value`.

## Test plan

Verified interactively in the React demo via `preview_eval`:

- [x] Keyboard navigation (arrow keys) — works
- [x] Enter starts editing — cell turns editing-green, input appears
- [x] Typing — input reflects each keystroke, formula bar mirrors live
- [x] Enter commits — cell holds value, selection moves down (Excel)
- [x] Persistence — navigate away and back, value still there
- [x] Escape cancels — no value committed
- [x] Printable char starts editing
- [x] A1 initial selection highlight renders correctly on fresh load

## Still broken (follow-up)

Per-cell click does nothing because \`Box [cell]\` has no \`onClick: emit: onNavigate(row: r, col: c)\` wiring. That fix requires a grammar surface for **parameterized emit dispatch with loop-bound names** — distinct from this PR. Will track separately as UI28-2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)