### PR TITLE
feat(closurec): --correlation_vector_pretty flag (CLOC11.68)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.31.0] - 2026-05-30
+
+### Added — CLOC11.68: `--correlation_vector_pretty` flag
+
+Adds a toggle between compact and pretty-printed CV sidecar JSON. Default is compact (single-line, what CI / build pipelines want); `--correlation_vector_pretty` switches to multi-line, 2-space-indented output for human inspection.
+
+Resolution:
+- `--correlation_vector_pretty` (default `false`) → compact JSON via `CVLog::to_json_string`.
+- `--correlation_vector_pretty true` → round-trip via `serde_json::Value` and `to_string_pretty` for the multi-line form.
+
+The flag is only consulted when `--correlation_vector` is also enabled. With CV off, the formatter never runs.
+
+### Why round-trip rather than a new upstream method
+
+`CVLog::to_json_string` is the only path that knows the `LogSnapshot` shape (the fields aren't `pub`). Parsing back to a `serde_json::Value` and re-emitting via `to_string_pretty` is wasteful but correct, and only happens on the opt-in slow path. The performance hit is irrelevant — humans-eyes mode is already off the critical path of a build.
+
+### Changed
+
+- `SpecialModesConfig` gains `correlation_vector_pretty: bool`.
+- `wire::read_special_modes` now reads `correlation_vector_pretty` from the parse result.
+- `format_cv_log_json` signature changed from `(&CVLog) -> String` to `(&CVLog, pretty: bool) -> String`. Private to the crate; no external API impact.
+- Versions: `Cargo.toml` `0.30.0` → `0.31.0`, `cli.spec.json` `0.30.0` → `0.31.0`.
+
 ## [0.30.0] - 2026-05-30
 
 ### Added — CLOC11.67: `--correlation_vector_output <path>` flag

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.30.0"
+version = "0.31.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },
@@ -97,6 +97,7 @@
     { "id": "help_markdown", "long": "help_markdown", "type": "boolean", "default": false, "description": "Print markdown-formatted flag usage (hidden)." },
     { "id": "correlation_vector", "long": "correlation_vector", "type": "boolean", "default": false, "description": "Thread a correlation-vector trace through every transform stage so output bytes are traceable back to input. Default off; opt in via this flag (CLOC11.60)." },
     { "id": "correlation_vector_output", "long": "correlation_vector_output", "type": "string", "default": "", "description": "Path to write the correlation-vector sidecar JSON. Default empty → `<js_output_file>.cv.json` next to the JS output, or `closurec-cv.json` in CWD when output is stdout (CLOC11.67)." },
+    { "id": "correlation_vector_pretty", "long": "correlation_vector_pretty", "type": "boolean", "default": false, "description": "Pretty-print the correlation-vector sidecar JSON (multi-line, 2-space indent). Default off → compact single-line JSON. Useful for human inspection; CI tooling typically prefers compact (CLOC11.68)." },
     { "id": "instrument_for_coverage_option", "long": "instrument_for_coverage_option", "type": "enum", "enum_values": ["NONE", "LINE", "BRANCH", "PRODUCTION"], "default": "NONE", "description": "Enable code instrumentation for coverage analysis." },
     { "id": "production_instrumentation_array_name", "long": "production_instrumentation_array_name", "type": "string", "default": "", "description": "Global array name used by production instrumentation." },
     { "id": "chunk_output_type", "long": "chunk_output_type", "type": "enum", "enum_values": ["GLOBAL_NAMESPACE", "ES_MODULES"], "default": "GLOBAL_NAMESPACE", "description": "Format for output chunks." },

--- a/code/programs/rust/closurec/src/config.rs
+++ b/code/programs/rust/closurec/src/config.rs
@@ -520,6 +520,17 @@ pub struct SpecialModesConfig {
     /// when output is stdout. Only consulted when
     /// `correlation_vector` is also true; ignored otherwise.
     pub correlation_vector_output: Option<PathBuf>,
+    /// CLOC11.68: when true, the CV sidecar is written as
+    /// pretty-printed JSON (multi-line, 2-space indent) rather
+    /// than the default compact single-line form. Pretty mode
+    /// inflates byte size 3–5× for typical traces but is much
+    /// easier to read by hand. CI / build pipelines should
+    /// leave this off; humans inspecting a trace should turn
+    /// it on.
+    ///
+    /// Only consulted when `correlation_vector` is true; the
+    /// formatter never runs when the trace is disabled.
+    pub correlation_vector_pretty: bool,
 }
 
 // ---------------------------------------------------------------------------

--- a/code/programs/rust/closurec/src/run.rs
+++ b/code/programs/rust/closurec/src/run.rs
@@ -1254,7 +1254,10 @@ pub fn run_compiler(config: &CompilerConfig) -> Result<CompilerOutput, CompilerE
                 None => PathBuf::from("closurec-cv.json"),
             },
         };
-        let body = format_cv_log_json(&cv_log);
+        let body = format_cv_log_json(
+            &cv_log,
+            config.special_modes.correlation_vector_pretty,
+        );
         write_output_file(&sidecar_path, &body)?;
         wrote_files.push(sidecar_path);
     }
@@ -1265,21 +1268,49 @@ pub fn run_compiler(config: &CompilerConfig) -> Result<CompilerOutput, CompilerE
     })
 }
 
-/// Serialize a `CVLog` to a pretty-printed JSON string for the
-/// `--correlation_vector` sidecar. We use `serde_json::to_string_pretty`
-/// rather than hand-rolling the format because the CV crate's
-/// `CVEntry` / `Contribution` types are already `Serialize`, and
-/// the sidecar is consumed by tooling (not pinned in fixtures), so
-/// serde's formatting choices don't bite us.
+/// Serialize a `CVLog` to a JSON string for the
+/// `--correlation_vector` sidecar.
 ///
-/// On serialization failure (vanishingly rare for the CV crate's
-/// well-formed structs), we fall back to a minimal `{}` document so
-/// the write still succeeds — a missing sidecar would be worse than
-/// a stub one for the build-pipeline-consumes-the-file case.
-fn format_cv_log_json(cv_log: &coding_adventures_correlation_vector::CVLog) -> String {
-    cv_log
+/// `pretty` (CLOC11.68): when true, pretty-prints the JSON
+/// (multi-line, 2-space indent) by round-tripping through
+/// `serde_json::Value` and `to_string_pretty`. When false
+/// (the default, and what CI / build pipelines want), emits
+/// compact single-line JSON via the CV crate's native
+/// `to_json_string`.
+///
+/// Why the round-trip for pretty mode: the CV crate's
+/// `to_json_string` is hard-coded to compact output and it's
+/// the only path that knows the `LogSnapshot` shape (the
+/// fields aren't pub). Parsing back to a `serde_json::Value`
+/// and re-emitting via `to_string_pretty` is wasteful but
+/// correct, and only happens on the opt-in slow path. The
+/// performance hit is irrelevant — humans-eyes mode is
+/// already off the critical path of a build.
+///
+/// On any serialization failure (vanishingly rare for the
+/// CV crate's well-formed structs, and additionally
+/// surviving a round-trip in pretty mode), we fall back to
+/// a minimal `{}` document so the write still succeeds —
+/// a missing sidecar would be worse than a stub one for the
+/// build-pipeline-consumes-the-file case.
+fn format_cv_log_json(
+    cv_log: &coding_adventures_correlation_vector::CVLog,
+    pretty: bool,
+) -> String {
+    let compact = cv_log
         .to_json_string()
-        .unwrap_or_else(|_| "{}".to_string())
+        .unwrap_or_else(|_| "{}".to_string());
+    if !pretty {
+        return compact;
+    }
+    // Round-trip: compact text → serde_json::Value → pretty
+    // text. The intermediate Value is heap-allocated but only
+    // exists for one serialization pass.
+    match serde_json::from_str::<serde_json::Value>(&compact) {
+        Ok(v) => serde_json::to_string_pretty(&v)
+            .unwrap_or_else(|_| compact),
+        Err(_) => compact,
+    }
 }
 
 /// Format the contents of an `--output_manifest` file from a
@@ -3122,6 +3153,90 @@ mod tests {
             !explicit_sidecar.exists(),
             "expected NO sidecar when correlation_vector is off, got file at {:?}",
             explicit_sidecar
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    // ------------------------------------------------------------------
+    // CLOC11.68 — --correlation_vector_pretty flag
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn correlation_vector_pretty_off_emits_compact_json() {
+        // Default behavior: compact single-line JSON. We
+        // detect compact form by absence of "\n  " (indented
+        // newlines). The body has at least one entry so
+        // pretty would definitely insert newlines.
+        let dir = std::env::temp_dir().join("closurec_cloc11_68_compact");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("create dir");
+        let in_path = dir.join("a.js");
+        fs::write(&in_path, "var x = 1;").expect("write");
+        let out_path = dir.join("out.js");
+        let sidecar_path = dir.join("out.js.cv.json");
+        let cfg = CompilerConfig {
+            io: IoConfig {
+                js_patterns: vec![in_path.to_string_lossy().to_string()],
+                js_output_file: Some(out_path.clone()),
+                ..Default::default()
+            },
+            special_modes: crate::config::SpecialModesConfig {
+                correlation_vector: true,
+                // correlation_vector_pretty defaults to false
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let _ = run_compiler(&cfg).expect("ok");
+        let body = fs::read_to_string(&sidecar_path).expect("read");
+        assert!(
+            !body.contains("\n  "),
+            "expected compact JSON (no indented newlines), got: {body}"
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn correlation_vector_pretty_on_emits_indented_json() {
+        // With --correlation_vector_pretty, the sidecar JSON
+        // should have indented newlines. We check for "\n  "
+        // (newline + 2 spaces) which serde_json::to_string_pretty
+        // emits at every nested key.
+        let dir = std::env::temp_dir().join("closurec_cloc11_68_pretty");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("create dir");
+        let in_path = dir.join("a.js");
+        fs::write(&in_path, "var x = 1;").expect("write");
+        let out_path = dir.join("out.js");
+        let sidecar_path = dir.join("out.js.cv.json");
+        let cfg = CompilerConfig {
+            io: IoConfig {
+                js_patterns: vec![in_path.to_string_lossy().to_string()],
+                js_output_file: Some(out_path.clone()),
+                ..Default::default()
+            },
+            special_modes: crate::config::SpecialModesConfig {
+                correlation_vector: true,
+                correlation_vector_pretty: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let _ = run_compiler(&cfg).expect("ok");
+        let body = fs::read_to_string(&sidecar_path).expect("read");
+        assert!(
+            body.contains("\n  "),
+            "expected pretty JSON with indented newlines, got: {body}"
+        );
+        // Same data content as compact: still has entries key
+        // and pass_order. Pretty mode is just whitespace.
+        assert!(
+            body.contains("\"entries\""),
+            "pretty JSON missing entries key: {body}"
+        );
+        assert!(
+            body.contains("\"pass_order\""),
+            "pretty JSON missing pass_order key: {body}"
         );
         let _ = fs::remove_dir_all(&dir);
     }

--- a/code/programs/rust/closurec/src/wire.rs
+++ b/code/programs/rust/closurec/src/wire.rs
@@ -491,6 +491,7 @@ fn read_special_modes(p: &ParseResult) -> Result<SpecialModesConfig, ConfigError
         correlation_vector_output: get_str(p, "correlation_vector_output")?
             .filter(|s| !s.is_empty())
             .map(std::path::PathBuf::from),
+        correlation_vector_pretty: get_bool(p, "correlation_vector_pretty")?,
     })
 }
 

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.30.0
+Version: 0.31.0
 
 ## Flags
 
@@ -373,6 +373,10 @@ Thread a correlation-vector trace through every transform stage so output bytes 
 ### `--correlation_vector_output` (string, default: "")
 
 Path to write the correlation-vector sidecar JSON. Default empty → `<js_output_file>.cv.json` next to the JS output, or `closurec-cv.json` in CWD when output is stdout (CLOC11.67).
+
+### `--correlation_vector_pretty` (boolean, default: false)
+
+Pretty-print the correlation-vector sidecar JSON (multi-line, 2-space indent). Default off → compact single-line JSON. Useful for human inspection; CI tooling typically prefers compact (CLOC11.68).
 
 ### `--instrument_for_coverage_option` (enum, default: NONE)
 


### PR DESCRIPTION
## Summary

Adds `--correlation_vector_pretty` flag to toggle the CV sidecar JSON between compact (default) and pretty-printed multi-line output. CI / build pipelines stay on the compact path; humans inspecting a trace flip the flag.

## Resolution

- `--correlation_vector_pretty` (default `false`) → compact single-line JSON via `CVLog::to_json_string`.
- `--correlation_vector_pretty true` → round-trip via `serde_json::Value` → `to_string_pretty` for multi-line, 2-space indent.

Only consulted when `--correlation_vector` is also enabled. With CV off, the formatter never runs.

## Why round-trip rather than a new upstream method

`CVLog::to_json_string` is the only path that knows the `LogSnapshot` shape (the fields aren't `pub`). Parsing back to a `serde_json::Value` and re-emitting via `to_string_pretty` is wasteful but correct, and only happens on the opt-in slow path. The performance hit is irrelevant — humans-eyes mode is already off the critical path of a build.

## Changes

- `cli.spec.json`: new flag (boolean, default `false`)
- `config.rs`: `SpecialModesConfig` gains `correlation_vector_pretty: bool`
- `wire.rs`: `read_special_modes` pulls the flag
- `run.rs`: `format_cv_log_json` signature changed from `(&CVLog) -> String` to `(&CVLog, pretty: bool) -> String`. Private to crate.

## Test plan
- [x] cargo build clean
- [x] 243 unit tests + 17 integration suites pass
- [x] New tests:
  - `correlation_vector_pretty_off_emits_compact_json` — default → no indented newlines
  - `correlation_vector_pretty_on_emits_indented_json` — flag on → `\n  ` appears; entries + pass_order keys preserved
- [x] help-markdown fixture regenerated for 0.31.0

## Security review (inline)
- No unsafe; no new deps (`serde_json` already transitive via the CV crate).
- `serde_json` default recursion limit (128) bounds the round-trip; CV log shape (flat entries + contributions) is well below.
- Three-layer fallback: `to_json_string` error → `"{}"`; parse error → compact; pretty serialize error → compact. Always returns valid JSON.
- No panics, no `unwrap`, no `expect` on the hot path.

## Versions
- `Cargo.toml`: 0.30.0 → 0.31.0
- `cli.spec.json`: 0.30.0 → 0.31.0
- `CHANGELOG.md`: new `[0.31.0]` section

🤖 Generated with [Claude Code](https://claude.com/claude-code)