### PR TITLE
feat(ruby-parser+sir): Phase 14d (FC) — module M; end → Stmt::ModuleDef

### DIFF
--- a/code/packages/rust/ruby-parser/.pr-body-fc-14d.md
+++ b/code/packages/rust/ruby-parser/.pr-body-fc-14d.md
@@ -1,0 +1,103 @@
+## Summary
+
+Phase 14d lands **first-class module declarations**.  `module M … end`
+now lowers to
+
+```
+Stmt::ModuleDef { name: "M", body, span }
+```
+
+replacing the pre-14d behaviour where a module lowered to a no-op
+`ExprStmt(NilLit)` (with its method `def`s hoisted as a side effect).
+A `ModuleDef` is structurally a `ClassDef` without inheritance.  This
+introduces a new SIR17 node + feature, so the semantic-ir crate is
+bumped as a separate sub-step (semantic-ir 0.4.0).
+
+## semantic-ir (0.4.0 — new node + feature)
+
+- **`Stmt::ModuleDef { name: String, body: Vec<Stmt>, span: Span }`** —
+  a module (namespace / mixin) declaration.  Like `ClassDef`, method
+  `def`s inside the body are hoisted to top-level `Function`s by the
+  lowerer; the `body` carries the module's non-`def` statements.
+- **`Feature::Modules`** (kebab `modules`) — declared by any module
+  containing a `Stmt::ModuleDef`.  Distinct from `Classes`.
+- `Stmt::span()`, the walker, the validator (marks `Feature::Modules`,
+  walks the body via `check_stmt_seq` in a scoped env mark/rewind with
+  the `MAX_IR_DEPTH` guard — same shape as the `ClassDef` arm), the
+  text printer (`(module-def Name …)`), and the intrinsic-walk backend
+  helper all gain a `ModuleDef` arm.  The four reference backends gain
+  an unreachable `panic!` arm.
+
+## ruby-to-semantic-ir (0.43.0)
+
+- `module_statement` lowers to `Stmt::ModuleDef`; new `extract_module_name`
+  helper (symmetric with `extract_class_name`).  Emitting a `ModuleDef`
+  requests `Feature::Modules`, materialised into the manifest.
+- Module body handling is **identical to a class** and shares the
+  helper, renamed `lower_class_body_statements` → `lower_decl_body_statements`:
+  method `def`s hoist to top-level `Function`s; non-`def` statements are
+  preserved in `body` in source order.
+- Retired the Phase 6f `collect_def_statements_from_body` whole-body
+  pre-pass (now dead — both the class and module arms hoist per-direct
+  child, and nested declarations hoist their own direct `def`s via the
+  normal dispatch, so every method is hoisted exactly once).
+
+## ruby-parser (0.41.0)
+
+No grammar change — `module_statement = "module" NAME { !"end"
+statement } "end"` already accepts a module body.  Adds parser coverage
+for the parse properties the lowerer relies on.
+
+## Backends (go / python / rust / typescript)
+
+Unchanged behaviour.  `Feature::Modules` is absent from every backend's
+accepted-feature set, so module-using modules are rejected at the
+capability check *before* emit — the new `ModuleDef` panic arms stay
+unreachable.
+
+| SIR shape (Phase 14d)                                        | Source                       |
+|--------------------------------------------------------------|------------------------------|
+| `ModuleDef { "M", body: [] }`                                | `module M; end`              |
+| `ModuleDef { "Config", body: [LetBinding "VERSION" = 3] }`   | `module Config; VERSION = 3; end` |
+| printer: `(module-def M)`                                    | printer output               |
+
+## Tests
+
+- `coding-adventures-ruby-lexer`: **173** (no change)
+- `coding-adventures-ruby-parser`: 164 → **167** (+3):
+  `test_parse_module_name_is_first_name_token`,
+  `test_parse_module_body_with_def`,
+  `test_parse_module_body_mixes_def_and_assignment`
+- `ruby-to-semantic-ir`: 198 → **201** (net +3): adds
+  `empty_module_lowers_to_module_def_stmt`,
+  `empty_module_requests_modules_feature`,
+  `empty_module_passes_sir_validator`,
+  `module_body_preserves_executable_statement`, and rewrites
+  `module_with_def_hoists_def_to_top_level` to assert `ModuleDef`;
+  the pre-14d `module_still_lowers_to_nil_no_op_in_phase_14a` test is
+  removed (contract changed).
+- `semantic-ir`: 85 → **90** (+5): `print_empty_module_def`,
+  `print_module_def_with_body_stmt`,
+  `module_def_body_with_let_binding_validates`,
+  `module_def_body_undefined_varref_is_error`,
+  `module_def_without_manifest_feature_is_error`
+- All four backend suites + `twig-to-semantic-ir` green.
+
+## Test plan
+
+- [x] `cargo test -p coding-adventures-ruby-lexer` (173/173)
+- [x] `cargo test -p coding-adventures-ruby-parser` (167/167)
+- [x] `cargo test -p ruby-to-semantic-ir` (201/201)
+- [x] `cargo test -p semantic-ir` (90/90)
+- [x] `cargo test -p semantic-ir-to-{go,python,rust,typescript} -p twig-to-semantic-ir` (all green)
+- [x] Security review passed (1 round, no findings) — validator
+      ModuleDef recursion is `MAX_IR_DEPTH`-bounded like ClassDef; the
+      deleted pre-pass was fully superseded by `lower_decl_body_statements`
+      (each method hoisted exactly once, no double-registration); backend
+      panic arms unreachable behind the capability check.
+- [ ] CI green
+
+Follows PR #4592 (Phase 14c).  Next chunk: Phase 14e (singleton class
+`class << self; end`).
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.41.0] - 2026-05-30
+
+### Added (Phase 14d (FC) — `module M … end` parser coverage)
+
+No grammar change — `module_statement = "module" NAME { !"end"
+statement } "end"` already accepts a module body.  Phase 14d adds
+parser coverage for the parse properties the lowerer relies on (name
+extraction, def/non-def body children):
+
+- `test_parse_module_name_is_first_name_token` — the module name is the
+  first Name token (the `module` keyword is a Keyword-type token).
+- `test_parse_module_body_with_def` — a `def` inside a module parses as
+  a `def_statement` body child.
+- `test_parse_module_body_mixes_def_and_assignment` — the body holds
+  both an `assignment` and a `def_statement`.
+
+Test count: 164 → 167 (+3).
+
 ## [0.40.0] - 2026-05-30
 
 ### Added (Phase 14c (FC) — inheritance `class Foo < Bar`)

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -509,6 +509,65 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // Phase 14d (FC) — `module M … end` → `Stmt::ModuleDef`.  Grammar is
+    // unchanged (`module_statement = "module" NAME { !"end" statement }
+    // "end"`); these tests pin the parse properties the 14d lowerer
+    // relies on (name extraction, def/non-def body children).
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_module_name_is_first_name_token() {
+        // `module Config; end` — the module name is the first Name
+        // token (the `module` keyword is a Keyword-type token).
+        let ast = parse_ruby("module Config\nend");
+        let m = find_statement_inner(&ast, "module_statement")
+            .expect("expected module_statement");
+        let name_tok = m.children.iter().find_map(|c| match c {
+            ASTNodeOrToken::Token(t) if matches!(t.type_, lexer::token::TokenType::Name) => {
+                Some(t.value.as_str())
+            }
+            _ => None,
+        });
+        assert_eq!(name_tok, Some("Config"));
+    }
+
+    #[test]
+    fn test_parse_module_body_with_def() {
+        // A method def inside a module parses as a `def_statement` body
+        // child (the lowerer hoists it to a top-level Function).
+        let ast = parse_ruby("module M\n  def helper\n  end\nend");
+        let m = find_statement_inner(&ast, "module_statement")
+            .expect("expected module_statement");
+        let names = body_inner_rule_names(m);
+        assert!(
+            names.iter().any(|r| r == "def_statement"),
+            "expected a def_statement in the module body; got {:?}",
+            names
+        );
+    }
+
+    #[test]
+    fn test_parse_module_body_mixes_def_and_assignment() {
+        // `module M; VERSION = 3; def helper; end; end` — the body
+        // holds both an `assignment` (stays in ModuleDef.body) and a
+        // `def_statement` (hoisted).
+        let ast = parse_ruby("module M\n  VERSION = 3\n  def helper\n  end\nend");
+        let m = find_statement_inner(&ast, "module_statement")
+            .expect("expected module_statement");
+        let names = body_inner_rule_names(m);
+        assert!(
+            names.iter().any(|r| r == "assignment"),
+            "expected an assignment in the module body; got {:?}",
+            names
+        );
+        assert!(
+            names.iter().any(|r| r == "def_statement"),
+            "expected a def_statement in the module body; got {:?}",
+            names
+        );
+    }
+
+    // -----------------------------------------------------------------------
     // Phase 14a (FC) — empty `class Foo; end` first-class lowering.
     //
     // The grammar is unchanged (the `class_statement` rule already

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.43.0] - 2026-05-30
+
+### Changed (Phase 14d (FC) — `module M … end` → `Stmt::ModuleDef`)
+
+`module M … end` now lowers to a first-class
+`Stmt::ModuleDef { name, body, span }` (semantic-ir 0.4.0), replacing
+the pre-14d behaviour where a module lowered to a no-op
+`ExprStmt(NilLit)` (with its `def`s hoisted as a side effect).
+
+- New `extract_module_name` helper (symmetric with
+  `extract_class_name`, module-specific error message).
+- Emitting a `ModuleDef` requests `Feature::Modules`, now materialised
+  into the module manifest.
+- Module body handling is **identical to a class** and shares the
+  helper, renamed `lower_class_body_statements` →
+  `lower_decl_body_statements`: method `def`s hoist to top-level
+  `Function`s; non-`def` statements are preserved in `body` in source
+  order.
+- Retired the Phase 6f `collect_def_statements_from_body` whole-body
+  pre-pass (now dead — both the class and module arms hoist per-direct
+  child via `lower_decl_body_statements`, and nested declarations
+  hoist their own direct `def`s through the normal dispatch).
+
+The pre-14d `module_still_lowers_to_nil_no_op_in_phase_14a` test is
+replaced by the new ModuleDef contract tests. New/updated tests:
+`empty_module_lowers_to_module_def_stmt`,
+`empty_module_requests_modules_feature`,
+`empty_module_passes_sir_validator`,
+`module_with_def_hoists_def_to_top_level` (now also asserts ModuleDef),
+`module_body_preserves_executable_statement`.  Test count: 198 → 201.
+
 ## [0.42.0] - 2026-05-30
 
 ### Added (Phase 14c (FC) — inheritance `class Foo < Bar`)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -891,26 +891,83 @@ mod tests {
         }
     }
 
+    // -----------------------------------------------------------------
+    // Phase 14d (FC) — `module M … end` → `Stmt::ModuleDef`.  Mirrors
+    // ClassDef (minus inheritance): method defs hoist to top-level
+    // Functions; non-def statements stay in the module body.
+    // -----------------------------------------------------------------
+
     #[test]
-    fn module_still_lowers_to_nil_no_op_in_phase_14a() {
-        // Phase 14a covers `class` only.  `module M; end` continues
-        // to lower to the Phase 6f NilLit no-op until Phase 14d adds
-        // a `Stmt::ModuleDef` analog.  This test pins the contract so
-        // a future refactor that accidentally merges class/module
-        // arms again is caught.
+    fn empty_module_lowers_to_module_def_stmt() {
+        // Phase 14d: `module M; end` lowers to a first-class
+        // `Stmt::ModuleDef { name: "M", body: vec![], .. }`, replacing
+        // the pre-14d NilLit no-op contract.
         let m = lower("module M\nend\n");
         let main = main_body(&m);
         assert_eq!(main.stmts.len(), 1);
-        assert!(matches!(
-            &main.stmts[0],
-            Stmt::ExprStmt { expr: Expr::NilLit { .. }, .. }
-        ));
+        match &main.stmts[0] {
+            Stmt::ModuleDef { name, body, .. } => {
+                assert_eq!(name, "M");
+                assert!(body.is_empty(), "empty module → empty body");
+            }
+            other => panic!("expected Stmt::ModuleDef, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn empty_module_requests_modules_feature() {
+        // Emitting a `Stmt::ModuleDef` triggers the `Feature::Modules`
+        // manifest entry (distinct from `Classes`).
+        let m = lower("module M\nend\n");
+        assert!(
+            m.manifest.contains(semantic_ir::Feature::Modules),
+            "manifest should contain Feature::Modules; got {:?}",
+            m.manifest
+        );
+        assert!(
+            !m.manifest.contains(semantic_ir::Feature::Classes),
+            "a module-only program must not request Feature::Classes"
+        );
+    }
+
+    #[test]
+    fn empty_module_passes_sir_validator() {
+        // E2E: lower → validate for a module-only program.
+        let m = lower("module M\nend\n");
+        let result = semantic_ir::validate(&m);
+        assert!(result.is_ok(), "validator rejected module-only program: {:?}", result);
     }
 
     #[test]
     fn module_with_def_hoists_def_to_top_level() {
+        // Method defs inside a module hoist to top-level Functions
+        // (unchanged contract); the ModuleDef body stays empty.
         let m = lower("module M\n  def helper\n  end\nend\n");
         assert!(m.functions.iter().any(|f| f.name == "helper"));
+        let main = main_body(&m);
+        match &main.stmts[0] {
+            Stmt::ModuleDef { name, body, .. } => {
+                assert_eq!(name, "M");
+                assert!(body.is_empty(), "method-only module body stays empty (defs hoist)");
+            }
+            other => panic!("expected Stmt::ModuleDef, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn module_body_preserves_executable_statement() {
+        // A non-def statement in a module body is preserved in
+        // ModuleDef.body (Phase 14d), mirroring ClassDef Phase 14b.
+        let m = lower("module Config\n  VERSION = 3\nend\n");
+        let main = main_body(&m);
+        match &main.stmts[0] {
+            Stmt::ModuleDef { name, body, .. } => {
+                assert_eq!(name, "Config");
+                assert_eq!(body.len(), 1, "VERSION = 3 preserved; got {:?}", body);
+                assert!(matches!(&body[0], Stmt::LetBinding { name, .. } if name == "VERSION"));
+            }
+            other => panic!("expected Stmt::ModuleDef, got {:?}", other),
+        }
     }
 
     #[test]

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -120,6 +120,9 @@ pub fn compile(program: &GrammarASTNode, module_name: &str) -> Result<Module, Ru
         // Phase 14a (FC) — `class Foo; end` lowers to
         // `Stmt::ClassDef` and triggers the `Classes` feature.
         Feature::Classes,
+        // Phase 14d (FC) — `module M; end` lowers to
+        // `Stmt::ModuleDef` and triggers the `Modules` feature.
+        Feature::Modules,
     ] {
         if lw.features_used.contains(&f) {
             manifest.add(f);
@@ -274,13 +277,11 @@ fn block_references_any_name(block: &Block, names: &HashSet<String>) -> bool {
                     return true;
                 }
             }
-            Stmt::ClassDef { body, .. } => {
-                // A class declaration body is itself a `Vec<Stmt>`.
-                // Recurse over each contained statement using a
-                // synthetic wrapper Block, mirroring the loop /
-                // pattern-stmt arms above.  Phase 14a always lowers
-                // an empty body so this loop is a no-op; included
-                // for forward-compatibility with later phases.
+            Stmt::ClassDef { body, .. } | Stmt::ModuleDef { body, .. } => {
+                // A class/module declaration body is itself a
+                // `Vec<Stmt>`.  Recurse over each contained statement
+                // using a synthetic wrapper Block, mirroring the loop /
+                // pattern-stmt arms above.
                 for inner in body {
                     let synthetic = Block {
                         stmts: vec![inner.clone()],
@@ -528,17 +529,16 @@ impl Lowerer {
                 // the body continue to be hoisted to top-level
                 // `Function`s — SIR v0 has no method-as-statement
                 // node, so a method can't live inside `body`
-                // (a `Vec<Stmt>`).  The hoisting is now done
-                // per-child inside `lower_class_body_statements`
-                // (replacing the whole-body `collect_def_statements_from_body`
-                // pre-pass the 14a arm used), so each nested `def` is
-                // hoisted exactly once and every non-`def` statement
-                // is preserved in `body` instead of being dropped.
+                // (a `Vec<Stmt>`).  The hoisting is done per-child
+                // inside `lower_decl_body_statements` (shared with
+                // `module_statement`), so each nested `def` is hoisted
+                // exactly once and every non-`def` statement is
+                // preserved in `body` instead of being dropped.
                 let name = self.extract_class_name(node)?;
                 // Phase 14c — optional `< Bar` superclass clause.
                 let superclass = self.extract_superclass(node);
                 self.features_used.insert(Feature::Classes);
-                let body = self.lower_class_body_statements(node)?;
+                let body = self.lower_decl_body_statements(node)?;
                 Ok(Stmt::ClassDef {
                     name,
                     superclass,
@@ -547,28 +547,30 @@ impl Lowerer {
                 })
             }
             "module_statement" => {
-                // Phase 6f: module declarations parse but don't
-                // yet introduce a real namespace in SIR v0 (Phase
-                // 14d will land `Stmt::ModuleDef`).  We walk the
-                // body so nested `def` declarations *are* hoisted to
-                // top-level Functions (matching the def_statement
-                // behaviour at the program level), then emit a no-op
-                // ExprStmt(NilLit) in place of the module so the
-                // main-body statement stream stays in sync with the
-                // source line count.
+                // Phase 14d (FC): `module M … end` now lowers to a
+                // first-class `Stmt::ModuleDef { name, body, span }`,
+                // structurally a `ClassDef` without inheritance
+                // (replacing the Phase 6f NilLit no-op).
                 //
-                // Caveat (documented for backends): the hoisted
-                // methods land at top-level, not nested under the
-                // module name.  In real Ruby, `module M; def bar`
-                // makes `bar` a module-level method of `M`.  v0 SIR
-                // collapses the namespace; the validator still
-                // accepts the result because every function has a
-                // unique name and `main` is the only export.
-                self.collect_def_statements_from_body(node)?;
-                Ok(Stmt::ExprStmt {
-                    expr: Expr::NilLit {
-                        span: self.span_of(node),
-                    },
+                // Body handling is identical to a class
+                // (`lower_decl_body_statements`): method `def`s are
+                // hoisted to top-level `Function`s — SIR v0 has no
+                // method-as-statement node — while every non-`def`
+                // statement is preserved in `body` in source order.
+                //
+                // Caveat (documented for backends, unchanged from 6f):
+                // the hoisted methods land at top-level, not nested
+                // under the module name.  In real Ruby, `module M; def
+                // bar` makes `bar` a module-level method of `M`.  v0 SIR
+                // collapses the namespace; the validator still accepts
+                // the result because every function has a unique name
+                // and `main` is the only export.
+                let name = self.extract_module_name(node)?;
+                self.features_used.insert(Feature::Modules);
+                let body = self.lower_decl_body_statements(node)?;
+                Ok(Stmt::ModuleDef {
+                    name,
+                    body,
                     span: self.span_of(node),
                 })
             }
@@ -1556,55 +1558,22 @@ impl Lowerer {
         Ok(())
     }
 
-    /// Phase 6f: walk the body of a `class_statement` / `module_statement`
-    /// and hoist every nested `def_statement` to a top-level `Function`
-    /// on `self.user_functions`.  This mirrors the program-level
-    /// `collect_def_statements` pre-pass — same hoisting semantics,
-    /// same scope-isolation behaviour (each method body gets a fresh
-    /// `declared_locals` / `current_params`).  Called from
-    /// `lower_statement_inner` when the class/module is first reached,
-    /// not from the global pre-pass, so each nested `def` is hoisted
-    /// exactly once.
-    fn collect_def_statements_from_body(
-        &mut self,
-        body_owner: &GrammarASTNode,
-    ) -> Result<(), RubyLowerError> {
-        for child in &body_owner.children {
-            let stmt = match child {
-                ASTNodeOrToken::Node(n) if n.rule_name == "statement" => n,
-                _ => continue,
-            };
-            let inner = match self.first_node_child(stmt) {
-                Some(n) => n,
-                None => continue,
-            };
-            // Phase 7c — both `def_statement` and `endless_def_statement`
-            // are hoisted from inside class / module bodies.
-            match inner.rule_name.as_str() {
-                "def_statement" => {
-                    let func = self.lower_def_statement(inner)?;
-                    self.user_functions.push(func);
-                }
-                "endless_def_statement" => {
-                    let func = self.lower_endless_def_statement(inner)?;
-                    self.user_functions.push(func);
-                }
-                "class_statement" | "module_statement" => {
-                    // Nested class/module — recurse so deeply-nested
-                    // `def`s still get hoisted.
-                    self.collect_def_statements_from_body(inner)?;
-                }
-                _ => {}
-            }
-        }
-        Ok(())
-    }
+    // Phase 6f's `collect_def_statements_from_body` (a whole-body
+    // recursive def-hoisting pre-pass) was retired in Phase 14b/14d:
+    // `lower_decl_body_statements` now hoists each declaration's direct
+    // `def` children itself and delegates nested `class`/`module`
+    // declarations to the normal dispatch (whose own arm hoists their
+    // direct `def`s), so every method is still hoisted exactly once
+    // without a separate pre-pass.
 
-    /// Phase 14b (FC) — lower a `class_statement` body into the
-    /// `Vec<Stmt>` carried by `Stmt::ClassDef.body`.
+    /// Phase 14b/14d (FC) — lower a `class_statement` *or*
+    /// `module_statement` body into the `Vec<Stmt>` carried by
+    /// `Stmt::ClassDef.body` / `Stmt::ModuleDef.body`.  Both
+    /// declaration forms share identical body semantics, so they share
+    /// this helper.
     ///
-    /// Walks the class body's `statement` children once, in source
-    /// order:
+    /// Walks the declaration body's `statement` children once, in
+    /// source order:
     ///
     /// - `def_statement` / `endless_def_statement` are **hoisted** to
     ///   top-level `Function`s on `self.user_functions` (SIR v0 has no
@@ -1617,14 +1586,12 @@ impl Lowerer {
     ///   dispatch used for the program body and pushed onto `body`,
     ///   so it is preserved rather than discarded.
     ///
-    /// Hoisting here is per-direct-child (not the recursive
-    /// whole-body `collect_def_statements_from_body` walk the Phase 14a
-    /// arm used).  A nested `class`/`module` statement is lowered via
-    /// the normal dispatch, whose own arm hoists *its* direct `def`s —
-    /// so every method is hoisted exactly once and no name is
-    /// double-registered (which would trip the validator's function
-    /// name-uniqueness check).
-    fn lower_class_body_statements(
+    /// Hoisting here is per-direct-child.  A nested `class`/`module`
+    /// statement is lowered via the normal dispatch, whose own arm
+    /// hoists *its* direct `def`s — so every method is hoisted exactly
+    /// once and no name is double-registered (which would trip the
+    /// validator's function name-uniqueness check).
+    fn lower_decl_body_statements(
         &mut self,
         node: &GrammarASTNode,
     ) -> Result<Vec<Stmt>, RubyLowerError> {
@@ -1675,6 +1642,28 @@ impl Lowerer {
         });
         let name_token = name_token.ok_or_else(|| RubyLowerError {
             message: "class_statement missing class-name token".to_string(),
+            line: node.start_line.unwrap_or(0),
+            column: node.start_column.unwrap_or(0),
+        })?;
+        Ok(name_token.value.clone())
+    }
+
+    /// Phase 14d (FC) — extract the module name from a
+    /// `module_statement` AST node (`module M … end`).
+    ///
+    /// Shape: `KEYWORD("module") NAME { !"end" statement } "end"`.  The
+    /// name is the first `TokenType::Name` token — symmetric with
+    /// `extract_class_name`, but with a module-specific error message.
+    fn extract_module_name(
+        &self,
+        node: &GrammarASTNode,
+    ) -> Result<String, RubyLowerError> {
+        let name_token = node.children.iter().find_map(|c| match c {
+            ASTNodeOrToken::Token(t) if matches!(t.type_, TokenType::Name) => Some(t),
+            _ => None,
+        });
+        let name_token = name_token.ok_or_else(|| RubyLowerError {
+            message: "module_statement missing module-name token".to_string(),
             line: node.start_line.unwrap_or(0),
             column: node.start_column.unwrap_or(0),
         })?;

--- a/code/packages/rust/semantic-ir-to-go/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/emit.rs
@@ -191,6 +191,9 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
         Stmt::ClassDef { span, .. } => {
             panic!("go backend reached SIR17 class-def statement at {} — capability check should have rejected it", span);
         }
+        Stmt::ModuleDef { span, .. } => {
+            panic!("go backend reached SIR17 module-def statement at {} — capability check should have rejected it", span);
+        }
     }
 }
 

--- a/code/packages/rust/semantic-ir-to-python/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/emit.rs
@@ -179,6 +179,9 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
         Stmt::ClassDef { span, .. } => {
             panic!("python backend reached SIR17 class-def statement at {} — capability check should have rejected it", span);
         }
+        Stmt::ModuleDef { span, .. } => {
+            panic!("python backend reached SIR17 module-def statement at {} — capability check should have rejected it", span);
+        }
     }
 }
 
@@ -378,6 +381,9 @@ fn emit_block_as_expr(out: &mut String, b: &Block, indent: usize) {
             // walrus-expression form regardless.
             Stmt::ClassDef { span, .. } => {
                 panic!("python backend (walrus path) reached SIR17 class-def statement at {} — capability check should have rejected it", span);
+            }
+            Stmt::ModuleDef { span, .. } => {
+                panic!("python backend (walrus path) reached SIR17 module-def statement at {} — capability check should have rejected it", span);
             }
         }
     }

--- a/code/packages/rust/semantic-ir-to-rust/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/emit.rs
@@ -186,6 +186,9 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
         Stmt::ClassDef { span, .. } => {
             panic!("rust backend reached SIR17 class-def statement at {} — capability check should have rejected it", span);
         }
+        Stmt::ModuleDef { span, .. } => {
+            panic!("rust backend reached SIR17 module-def statement at {} — capability check should have rejected it", span);
+        }
     }
 }
 
@@ -513,6 +516,9 @@ fn emit_stmt_inline(out: &mut String, s: &Stmt, indent: usize) {
         // form regardless.
         Stmt::ClassDef { span, .. } => {
             panic!("rust backend (inline) reached SIR17 class-def statement at {} — capability check should have rejected it", span);
+        }
+        Stmt::ModuleDef { span, .. } => {
+            panic!("rust backend (inline) reached SIR17 module-def statement at {} — capability check should have rejected it", span);
         }
     }
 }

--- a/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
@@ -163,6 +163,9 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
         Stmt::ClassDef { span, .. } => {
             panic!("ts backend reached SIR17 class-def statement at {} — capability check should have rejected it", span);
         }
+        Stmt::ModuleDef { span, .. } => {
+            panic!("ts backend reached SIR17 module-def statement at {} — capability check should have rejected it", span);
+        }
     }
 }
 

--- a/code/packages/rust/semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 All notable changes to the `semantic-ir` crate are documented here.
 
+## 0.4.0 — SIR17: module declarations (`Stmt::ModuleDef`)
+
+Introduced by the Ruby frontend's Phase 14d (`module M … end`).
+
+### Added
+
+- `Stmt::ModuleDef { name: String, body: Vec<Stmt>, span: Span }` — a
+  module (namespace / mixin) declaration.  Structurally a `ClassDef`
+  without inheritance: a named declaration whose `body` is a list of
+  statements.  Like `ClassDef`, method `def`s inside the body are
+  hoisted to top-level `Function`s by the Ruby lowerer; the `body`
+  carries the module's non-`def` statements.
+- `Feature::Modules` (kebab name `modules`) — declared by any module
+  that contains a `Stmt::ModuleDef`.  Distinct from `Classes`: a Ruby
+  `module` is a namespace/mixin, not an instantiable class.  Backends
+  that do not list it in their accepted-feature set reject such modules
+  at the capability check, before emit.
+
+### Changed
+
+- `Stmt::span()`, the walker, the validator (marks `Feature::Modules`,
+  walks the body via `check_stmt_seq` in a scoped env mark/rewind with
+  the `MAX_IR_DEPTH` guard — same shape as the `ClassDef` arm), the
+  text printer (`(module-def Name …)` s-expression), and the
+  intrinsic-walk backend helper all gain a `ModuleDef` arm.  The four
+  reference backends (TypeScript, Rust, Python, Go) gain an unreachable
+  `panic!` arm; `Feature::Modules` is absent from their accepted sets,
+  so module-using modules are rejected at the capability check before
+  emit.
+
+New tests (5): `print_empty_module_def`, `print_module_def_with_body_stmt`,
+`module_def_body_with_let_binding_validates`,
+`module_def_body_undefined_varref_is_error`,
+`module_def_without_manifest_feature_is_error`.  Test count: 85 → 90.
+
+This is a **breaking enum change** for any exhaustive `match` on `Stmt`
+that does not use a `_` / `..` rest arm.
+
 ## 0.3.0 — SIR17: class inheritance (`ClassDef.superclass`)
 
 Introduced by the Ruby frontend's Phase 14c (`class Foo < Bar`).

--- a/code/packages/rust/semantic-ir/src/backend.rs
+++ b/code/packages/rust/semantic-ir/src/backend.rs
@@ -228,6 +228,13 @@ where
                 walk_intrinsics_in_stmt(s, f, depth + 1);
             }
         }
+        Stmt::ModuleDef { body, .. } => {
+            // Same recursion as ClassDef for module bodies (Ruby
+            // Phase 14d).
+            for s in body {
+                walk_intrinsics_in_stmt(s, f, depth + 1);
+            }
+        }
     }
 }
 

--- a/code/packages/rust/semantic-ir/src/manifest.rs
+++ b/code/packages/rust/semantic-ir/src/manifest.rs
@@ -50,6 +50,11 @@ pub enum Feature {
     /// `class Foo; end`.  Future Ruby phases extend the body shape
     /// without renaming the feature.
     Classes,
+    /// Module contains at least one `Stmt::ModuleDef`.  Phase 14d
+    /// (Ruby) introduces this feature with `module M … end`.
+    /// Distinct from `Classes`: a Ruby `module` is a namespace/mixin,
+    /// not an instantiable class.
+    Modules,
 }
 
 impl Feature {
@@ -72,6 +77,7 @@ impl Feature {
         Feature::Maps,
         Feature::ShortCircuit,
         Feature::Classes,
+        Feature::Modules,
     ];
 
     /// Kebab-case name for the SIR text format.
@@ -94,6 +100,7 @@ impl Feature {
             Feature::Maps => "maps",
             Feature::ShortCircuit => "short-circuit",
             Feature::Classes => "classes",
+            Feature::Modules => "modules",
         }
     }
 

--- a/code/packages/rust/semantic-ir/src/nodes.rs
+++ b/code/packages/rust/semantic-ir/src/nodes.rs
@@ -263,6 +263,22 @@ pub enum Stmt {
         body: Vec<Stmt>,
         span: Span,
     },
+
+    /// `module Name; body; end` — a module (namespace / mixin)
+    /// declaration.  Structurally a `ClassDef` without inheritance:
+    /// a named declaration whose `body` is a list of statements.
+    ///
+    /// Introduced by the Ruby frontend's Phase 14d.  Like `ClassDef`,
+    /// method `def`s inside the body are hoisted to top-level
+    /// `Function`s by the lowerer (SIR v0 has no method-as-statement
+    /// node); the `body` carries the module's *non-def* statements in
+    /// source order.  A module has no superclass, so there is no
+    /// `superclass` field.
+    ModuleDef {
+        name: String,
+        body: Vec<Stmt>,
+        span: Span,
+    },
 }
 
 impl Stmt {
@@ -278,6 +294,7 @@ impl Stmt {
             Stmt::SeqSet { span, .. } => span,
             Stmt::MapSet { span, .. } => span,
             Stmt::ClassDef { span, .. } => span,
+            Stmt::ModuleDef { span, .. } => span,
         }
     }
 }

--- a/code/packages/rust/semantic-ir/src/text/printer.rs
+++ b/code/packages/rust/semantic-ir/src/text/printer.rs
@@ -240,6 +240,17 @@ fn print_stmt(out: &mut String, s: &Stmt, indent: usize, depth: usize) {
             }
             out.push(')');
         }
+        Stmt::ModuleDef { name, body, .. } => {
+            // `(module-def Name)` for the empty case; body statements
+            // (if any) printed one per line (Ruby Phase 14d).  Mirrors
+            // the ClassDef printer minus the superclass clause.
+            let _ = write!(out, "(module-def {}", name);
+            for inner in body {
+                let _ = write!(out, "\n{}  ", " ".repeat(indent));
+                print_stmt(out, inner, indent + 2, depth + 1);
+            }
+            out.push(')');
+        }
     }
 }
 
@@ -720,6 +731,53 @@ mod tests {
         print_block(&mut out, &block, 0);
         assert!(out.contains("(class-def Bar"));
         assert!(out.contains("(let y (int 2))"));
+    }
+
+    #[test]
+    fn print_empty_module_def() {
+        // `module M; end` → `(module-def M)` (no body lines).
+        let s_ = s();
+        let block = Block {
+            stmts: vec![Stmt::ModuleDef {
+                name: "M".into(),
+                body: vec![],
+                span: s_.clone(),
+            }],
+            value: Expr::NilLit { span: s_.clone() },
+            span: s_,
+        };
+        let mut out = String::new();
+        print_block(&mut out, &block, 0);
+        assert!(
+            out.contains("(module-def M)"),
+            "expected `(module-def M)` in output, got:\n{}",
+            out
+        );
+    }
+
+    #[test]
+    fn print_module_def_with_body_stmt() {
+        // A populated module body prints each statement indented under
+        // the module-def head.
+        let s_ = s();
+        let block = Block {
+            stmts: vec![Stmt::ModuleDef {
+                name: "Config".into(),
+                body: vec![Stmt::LetBinding {
+                    name: "v".into(),
+                    sir_type: None,
+                    value: Expr::IntLit { value: 3, span: s_.clone() },
+                    span: s_.clone(),
+                }],
+                span: s_.clone(),
+            }],
+            value: Expr::NilLit { span: s_.clone() },
+            span: s_,
+        };
+        let mut out = String::new();
+        print_block(&mut out, &block, 0);
+        assert!(out.contains("(module-def Config"));
+        assert!(out.contains("(let v (int 3))"));
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir/src/validator.rs
+++ b/code/packages/rust/semantic-ir/src/validator.rs
@@ -378,6 +378,22 @@ impl<'m> ValidatorState<'m> {
                     env.rewind(class_mark);
                     i += 1;
                 }
+                Stmt::ModuleDef { body, span, .. } => {
+                    // A module declaration (Ruby Phase 14d) is validated
+                    // exactly like a class body: mark Feature::Modules,
+                    // depth-guard the recursion, and walk the body in a
+                    // fresh local-env scope so module-body names don't
+                    // leak into the surrounding statement stream.
+                    self.observed.add(Feature::Modules);
+                    if self.check_depth(depth, span) {
+                        i += 1;
+                        continue;
+                    }
+                    let module_mark = env.mark();
+                    self.check_stmt_seq(body, env, depth + 1);
+                    env.rewind(module_mark);
+                    i += 1;
+                }
             }
         }
     }
@@ -1254,5 +1270,107 @@ mod tests {
             "class-body local INNER must not leak to sibling stmt, got {:?}",
             r.issues
         );
+    }
+
+    // -----------------------------------------------------------------
+    // SIR17 Phase 14d — `Stmt::ModuleDef` validation (mirrors ClassDef).
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn module_def_body_with_let_binding_validates() {
+        // A module body holding a LetBinding is walked by the validator
+        // and accepted; the module declares Feature::Modules.
+        let mut m = empty_module(FeatureManifest::from_features(&[Feature::Modules]));
+        m.functions.push(Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![Stmt::ModuleDef {
+                    name: "Config".into(),
+                    body: vec![Stmt::LetBinding {
+                        name: "V".into(),
+                        sir_type: None,
+                        value: Expr::IntLit { value: 3, span: s() },
+                        span: s(),
+                    }],
+                    span: s(),
+                }],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        });
+        let r = validate(&m);
+        assert!(r.is_ok(), "expected ok, got {:?}", r.issues);
+    }
+
+    #[test]
+    fn module_def_body_undefined_varref_is_error() {
+        // Proves the module body is actually validated: a VarRef to an
+        // undefined local inside the module body must be reported.
+        let mut m = empty_module(FeatureManifest::from_features(&[Feature::Modules]));
+        m.functions.push(Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![Stmt::ModuleDef {
+                    name: "M".into(),
+                    body: vec![Stmt::ExprStmt {
+                        expr: Expr::VarRef {
+                            name: "ghost".into(),
+                            scope: Scope::Local,
+                            span: s(),
+                        },
+                        span: s(),
+                    }],
+                    span: s(),
+                }],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        });
+        let r = validate(&m);
+        assert!(
+            !r.is_ok(),
+            "expected undefined-varref error from module body, got {:?}",
+            r.issues
+        );
+    }
+
+    #[test]
+    fn module_def_without_manifest_feature_is_error() {
+        // A ModuleDef present but `Feature::Modules` not declared →
+        // the used-but-undeclared check fires.
+        let mut m = empty_module(FeatureManifest::new());
+        m.functions.push(Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![Stmt::ModuleDef {
+                    name: "M".into(),
+                    body: vec![],
+                    span: s(),
+                }],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        });
+        let r = validate(&m);
+        assert!(!r.is_ok(), "expected missing-Modules-feature error");
+        assert!(r.errors().any(|i| i.message.contains("modules")));
     }
 }

--- a/code/packages/rust/semantic-ir/src/walker.rs
+++ b/code/packages/rust/semantic-ir/src/walker.rs
@@ -130,6 +130,13 @@ pub fn walk_stmt_default<V: Visitor>(v: &mut V, s: &Stmt) {
                 v.visit_stmt(stmt);
             }
         }
+        Stmt::ModuleDef { body, .. } => {
+            // Module body is a list of statements — same recursion as
+            // ClassDef (Ruby Phase 14d).
+            for stmt in body {
+                v.visit_stmt(stmt);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Phase 14d lands **first-class module declarations**.  `module M … end`
now lowers to

```
Stmt::ModuleDef { name: "M", body, span }
```

replacing the pre-14d behaviour where a module lowered to a no-op
`ExprStmt(NilLit)` (with its method `def`s hoisted as a side effect).
A `ModuleDef` is structurally a `ClassDef` without inheritance.  This
introduces a new SIR17 node + feature, so the semantic-ir crate is
bumped as a separate sub-step (semantic-ir 0.4.0).

## semantic-ir (0.4.0 — new node + feature)

- **`Stmt::ModuleDef { name: String, body: Vec<Stmt>, span: Span }`** —
  a module (namespace / mixin) declaration.  Like `ClassDef`, method
  `def`s inside the body are hoisted to top-level `Function`s by the
  lowerer; the `body` carries the module's non-`def` statements.
- **`Feature::Modules`** (kebab `modules`) — declared by any module
  containing a `Stmt::ModuleDef`.  Distinct from `Classes`.
- `Stmt::span()`, the walker, the validator (marks `Feature::Modules`,
  walks the body via `check_stmt_seq` in a scoped env mark/rewind with
  the `MAX_IR_DEPTH` guard — same shape as the `ClassDef` arm), the
  text printer (`(module-def Name …)`), and the intrinsic-walk backend
  helper all gain a `ModuleDef` arm.  The four reference backends gain
  an unreachable `panic!` arm.

## ruby-to-semantic-ir (0.43.0)

- `module_statement` lowers to `Stmt::ModuleDef`; new `extract_module_name`
  helper (symmetric with `extract_class_name`).  Emitting a `ModuleDef`
  requests `Feature::Modules`, materialised into the manifest.
- Module body handling is **identical to a class** and shares the
  helper, renamed `lower_class_body_statements` → `lower_decl_body_statements`:
  method `def`s hoist to top-level `Function`s; non-`def` statements are
  preserved in `body` in source order.
- Retired the Phase 6f `collect_def_statements_from_body` whole-body
  pre-pass (now dead — both the class and module arms hoist per-direct
  child, and nested declarations hoist their own direct `def`s via the
  normal dispatch, so every method is hoisted exactly once).

## ruby-parser (0.41.0)

No grammar change — `module_statement = "module" NAME { !"end"
statement } "end"` already accepts a module body.  Adds parser coverage
for the parse properties the lowerer relies on.

## Backends (go / python / rust / typescript)

Unchanged behaviour.  `Feature::Modules` is absent from every backend's
accepted-feature set, so module-using modules are rejected at the
capability check *before* emit — the new `ModuleDef` panic arms stay
unreachable.

| SIR shape (Phase 14d)                                        | Source                       |
|--------------------------------------------------------------|------------------------------|
| `ModuleDef { "M", body: [] }`                                | `module M; end`              |
| `ModuleDef { "Config", body: [LetBinding "VERSION" = 3] }`   | `module Config; VERSION = 3; end` |
| printer: `(module-def M)`                                    | printer output               |

## Tests

- `coding-adventures-ruby-lexer`: **173** (no change)
- `coding-adventures-ruby-parser`: 164 → **167** (+3):
  `test_parse_module_name_is_first_name_token`,
  `test_parse_module_body_with_def`,
  `test_parse_module_body_mixes_def_and_assignment`
- `ruby-to-semantic-ir`: 198 → **201** (net +3): adds
  `empty_module_lowers_to_module_def_stmt`,
  `empty_module_requests_modules_feature`,
  `empty_module_passes_sir_validator`,
  `module_body_preserves_executable_statement`, and rewrites
  `module_with_def_hoists_def_to_top_level` to assert `ModuleDef`;
  the pre-14d `module_still_lowers_to_nil_no_op_in_phase_14a` test is
  removed (contract changed).
- `semantic-ir`: 85 → **90** (+5): `print_empty_module_def`,
  `print_module_def_with_body_stmt`,
  `module_def_body_with_let_binding_validates`,
  `module_def_body_undefined_varref_is_error`,
  `module_def_without_manifest_feature_is_error`
- All four backend suites + `twig-to-semantic-ir` green.

## Test plan

- [x] `cargo test -p coding-adventures-ruby-lexer` (173/173)
- [x] `cargo test -p coding-adventures-ruby-parser` (167/167)
- [x] `cargo test -p ruby-to-semantic-ir` (201/201)
- [x] `cargo test -p semantic-ir` (90/90)
- [x] `cargo test -p semantic-ir-to-{go,python,rust,typescript} -p twig-to-semantic-ir` (all green)
- [x] Security review passed (1 round, no findings) — validator
      ModuleDef recursion is `MAX_IR_DEPTH`-bounded like ClassDef; the
      deleted pre-pass was fully superseded by `lower_decl_body_statements`
      (each method hoisted exactly once, no double-registration); backend
      panic arms unreachable behind the capability check.
- [ ] CI green

Follows PR #4592 (Phase 14c).  Next chunk: Phase 14e (singleton class
`class << self; end`).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
