### PR TITLE
feat(closurec): --correlation_vector_format enum (CLOC11.69)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.32.0] - 2026-05-30
+
+### Added — CLOC11.69: `--correlation_vector_format` enum (JSON | NDJSON | NONE)
+
+Adds a sidecar format selector to cover streaming consumers and benchmark modes.
+
+- `JSON` (default) — single JSON document, same shape as CLOC11.60+. `--correlation_vector_pretty` still applies.
+- `NDJSON` — newline-delimited JSON: one CV entry per line, ending with a `{"_meta": {"pass_order":[...], "enabled":...}}` footer line. Tooling can `tail -f` mid-build without waiting for a closing brace. The `pretty` flag is ignored under NDJSON (line-delimited JSON is inherently single-line per record).
+- `NONE` — compute the CV log but **do not** write the sidecar. Lets benchmarks measure CV compute overhead in isolation from write/serialize overhead.
+
+The flag is ignored when `--correlation_vector` is off.
+
+### Implementation notes
+
+- `format_cv_log_ndjson` round-trips through `serde_json::Value` (same approach as the pretty path) to walk the `entries` map without touching CV crate internals. Fallback chain: any parse/serialize hiccup yields the compact single-doc JSON instead of an empty file.
+- The `None` arm is a single-statement no-op gated by the existing `if config.special_modes.correlation_vector` block, so default behavior is unchanged when the flag is absent.
+
+### Changed
+
+- `SpecialModesConfig` gains `correlation_vector_format: CorrelationVectorFormat` (new enum).
+- `wire::read_special_modes` reads the enum from the parse result; unknown / empty values fall back to `Json`.
+- Versions: `Cargo.toml` `0.31.0` → `0.32.0`, `cli.spec.json` `0.31.0` → `0.32.0`.
+
 ## [0.31.0] - 2026-05-30
 
 ### Added — CLOC11.68: `--correlation_vector_pretty` flag

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.31.0"
+version = "0.32.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },
@@ -98,6 +98,7 @@
     { "id": "correlation_vector", "long": "correlation_vector", "type": "boolean", "default": false, "description": "Thread a correlation-vector trace through every transform stage so output bytes are traceable back to input. Default off; opt in via this flag (CLOC11.60)." },
     { "id": "correlation_vector_output", "long": "correlation_vector_output", "type": "string", "default": "", "description": "Path to write the correlation-vector sidecar JSON. Default empty → `<js_output_file>.cv.json` next to the JS output, or `closurec-cv.json` in CWD when output is stdout (CLOC11.67)." },
     { "id": "correlation_vector_pretty", "long": "correlation_vector_pretty", "type": "boolean", "default": false, "description": "Pretty-print the correlation-vector sidecar JSON (multi-line, 2-space indent). Default off → compact single-line JSON. Useful for human inspection; CI tooling typically prefers compact (CLOC11.68)." },
+    { "id": "correlation_vector_format", "long": "correlation_vector_format", "type": "enum", "enum_values": ["JSON", "NDJSON", "NONE"], "default": "JSON", "description": "Sidecar format: JSON = single document (default), NDJSON = one CV entry per line for streaming consumers, NONE = compute CV but skip write (useful for benchmarking overhead). Ignored unless --correlation_vector is also set (CLOC11.69)." },
     { "id": "instrument_for_coverage_option", "long": "instrument_for_coverage_option", "type": "enum", "enum_values": ["NONE", "LINE", "BRANCH", "PRODUCTION"], "default": "NONE", "description": "Enable code instrumentation for coverage analysis." },
     { "id": "production_instrumentation_array_name", "long": "production_instrumentation_array_name", "type": "string", "default": "", "description": "Global array name used by production instrumentation." },
     { "id": "chunk_output_type", "long": "chunk_output_type", "type": "enum", "enum_values": ["GLOBAL_NAMESPACE", "ES_MODULES"], "default": "GLOBAL_NAMESPACE", "description": "Format for output chunks." },

--- a/code/programs/rust/closurec/src/config.rs
+++ b/code/programs/rust/closurec/src/config.rs
@@ -531,6 +531,35 @@ pub struct SpecialModesConfig {
     /// Only consulted when `correlation_vector` is true; the
     /// formatter never runs when the trace is disabled.
     pub correlation_vector_pretty: bool,
+    /// CLOC11.69: how to format and persist the CV sidecar.
+    ///   - `Json` (default): single JSON document, same shape
+    ///     as CLOC11.60 → 11.68. The `pretty` toggle still
+    ///     applies.
+    ///   - `Ndjson`: one CV entry per line, no enclosing
+    ///     object. Streaming consumers (jq, log aggregators)
+    ///     can `tail -f` mid-build. `pretty` is ignored under
+    ///     Ndjson — line-delimited JSON is inherently
+    ///     single-line per record.
+    ///   - `None`: compute the CV log but do NOT write a
+    ///     sidecar. Useful for benchmarking how much the CV
+    ///     trace itself costs versus the write.
+    pub correlation_vector_format: CorrelationVectorFormat,
+}
+
+/// CLOC11.69 — sidecar persistence format. Default is
+/// `Json` (the historical CLOC11.60+ behaviour).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CorrelationVectorFormat {
+    /// Single JSON document. The `correlation_vector_pretty`
+    /// flag toggles compact vs indented.
+    #[default]
+    Json,
+    /// Newline-delimited JSON: one entry per line. `pretty`
+    /// is ignored.
+    Ndjson,
+    /// No sidecar written; CV log is still computed in
+    /// memory and discarded. For benchmarks.
+    None,
 }
 
 // ---------------------------------------------------------------------------

--- a/code/programs/rust/closurec/src/run.rs
+++ b/code/programs/rust/closurec/src/run.rs
@@ -1242,24 +1242,41 @@ pub fn run_compiler(config: &CompilerConfig) -> Result<CompilerOutput, CompilerE
     //      `closurec-cv.json` in the working directory.
     //      Discoverable; user can rename / move.
     if config.special_modes.correlation_vector {
-        let sidecar_path = match &config.special_modes.correlation_vector_output {
-            // CLOC11.67 — explicit override wins.
-            Some(p) => p.clone(),
-            None => match &config.io.js_output_file {
-                Some(p) => {
-                    let mut s = p.as_os_str().to_owned();
-                    s.push(".cv.json");
-                    PathBuf::from(s)
-                }
-                None => PathBuf::from("closurec-cv.json"),
-            },
-        };
-        let body = format_cv_log_json(
-            &cv_log,
-            config.special_modes.correlation_vector_pretty,
-        );
-        write_output_file(&sidecar_path, &body)?;
-        wrote_files.push(sidecar_path);
+        // CLOC11.69 — format selection. `None` short-circuits
+        // the whole write step: the CV log is still computed
+        // (the rest of the function ran) but nothing hits disk.
+        // Useful for benchmarks measuring CV compute overhead
+        // vs CV write overhead in isolation.
+        use crate::config::CorrelationVectorFormat;
+        match config.special_modes.correlation_vector_format {
+            CorrelationVectorFormat::None => {
+                // explicit no-op
+            }
+            fmt @ (CorrelationVectorFormat::Json
+            | CorrelationVectorFormat::Ndjson) => {
+                let sidecar_path = match &config.special_modes.correlation_vector_output {
+                    // CLOC11.67 — explicit override wins.
+                    Some(p) => p.clone(),
+                    None => match &config.io.js_output_file {
+                        Some(p) => {
+                            let mut s = p.as_os_str().to_owned();
+                            s.push(".cv.json");
+                            PathBuf::from(s)
+                        }
+                        None => PathBuf::from("closurec-cv.json"),
+                    },
+                };
+                let body = match fmt {
+                    CorrelationVectorFormat::Ndjson => format_cv_log_ndjson(&cv_log),
+                    _ => format_cv_log_json(
+                        &cv_log,
+                        config.special_modes.correlation_vector_pretty,
+                    ),
+                };
+                write_output_file(&sidecar_path, &body)?;
+                wrote_files.push(sidecar_path);
+            }
+        }
     }
 
     Ok(CompilerOutput {
@@ -1311,6 +1328,64 @@ fn format_cv_log_json(
             .unwrap_or_else(|_| compact),
         Err(_) => compact,
     }
+}
+
+/// CLOC11.69 — serialize a `CVLog` as newline-delimited JSON.
+///
+/// Output shape:
+///   - one line per CV entry, formatted as the JSON for the
+///     entry's `CVEntry` struct,
+///   - followed by one final line with the metadata object:
+///     `{"_meta": {"pass_order": [...], "enabled": <bool>}}`.
+///
+/// Why a final `_meta` line: streaming consumers reading the
+/// sidecar with `tail -f` or line-by-line want the entries
+/// available as they arrive without waiting for a closing
+/// brace. Trailing the metadata keeps `pass_order` parseable
+/// once the producer is done without polluting any individual
+/// entry line.
+///
+/// We reuse `to_json_string` + parse-as-Value rather than
+/// touching CV crate internals. The compact JSON has the shape
+/// `{"entries":{"id":{...}}, "pass_order":[...], "enabled":...}`
+/// so we walk the `entries` map and re-emit each value as a
+/// single-line JSON document. On any parse / serialize hiccup
+/// we fall through to the compact JSON document (a valid
+/// fallback the consumer's `tail` will still see).
+fn format_cv_log_ndjson(
+    cv_log: &coding_adventures_correlation_vector::CVLog,
+) -> String {
+    let compact = cv_log
+        .to_json_string()
+        .unwrap_or_else(|_| "{}".to_string());
+    let root: serde_json::Value = match serde_json::from_str(&compact) {
+        Ok(v) => v,
+        Err(_) => return compact,
+    };
+    let mut out = String::new();
+    if let Some(entries) = root.get("entries").and_then(|v| v.as_object()) {
+        for entry in entries.values() {
+            if let Ok(line) = serde_json::to_string(entry) {
+                out.push_str(&line);
+                out.push('\n');
+            }
+        }
+    }
+    // Append the metadata footer line.
+    let mut meta = serde_json::Map::new();
+    if let Some(po) = root.get("pass_order") {
+        meta.insert("pass_order".to_string(), po.clone());
+    }
+    if let Some(en) = root.get("enabled") {
+        meta.insert("enabled".to_string(), en.clone());
+    }
+    let mut footer = serde_json::Map::new();
+    footer.insert("_meta".to_string(), serde_json::Value::Object(meta));
+    if let Ok(line) = serde_json::to_string(&serde_json::Value::Object(footer)) {
+        out.push_str(&line);
+        out.push('\n');
+    }
+    out
 }
 
 /// Format the contents of an `--output_manifest` file from a
@@ -3237,6 +3312,142 @@ mod tests {
         assert!(
             body.contains("\"pass_order\""),
             "pretty JSON missing pass_order key: {body}"
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    // ------------------------------------------------------------------
+    // CLOC11.69 — --correlation_vector_format (JSON | NDJSON | NONE)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn correlation_vector_format_ndjson_writes_one_entry_per_line() {
+        // NDJSON: every line should parse as JSON; the count
+        // of lines should be `entries + 1` (one per CV entry,
+        // one footer `_meta` line). We don't pin the exact
+        // count to avoid brittleness as the pipeline grows; we
+        // just assert ≥2 lines and every line is valid JSON.
+        let dir = std::env::temp_dir().join("closurec_cloc11_69_ndjson");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("create dir");
+        let in_path = dir.join("a.js");
+        fs::write(&in_path, "var x = 1;").expect("write");
+        let out_path = dir.join("out.js");
+        let sidecar_path = dir.join("out.js.cv.json");
+        let cfg = CompilerConfig {
+            io: IoConfig {
+                js_patterns: vec![in_path.to_string_lossy().to_string()],
+                js_output_file: Some(out_path.clone()),
+                ..Default::default()
+            },
+            special_modes: crate::config::SpecialModesConfig {
+                correlation_vector: true,
+                correlation_vector_format:
+                    crate::config::CorrelationVectorFormat::Ndjson,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let _ = run_compiler(&cfg).expect("ok");
+        let body = fs::read_to_string(&sidecar_path).expect("read sidecar");
+        let lines: Vec<&str> =
+            body.lines().filter(|l| !l.is_empty()).collect();
+        assert!(
+            lines.len() >= 2,
+            "expected ≥2 NDJSON lines (entries + meta), got {}: {body}",
+            lines.len()
+        );
+        // Every line must parse as JSON on its own.
+        for (i, line) in lines.iter().enumerate() {
+            serde_json::from_str::<serde_json::Value>(line)
+                .unwrap_or_else(|_| panic!(
+                    "NDJSON line {i} did not parse as JSON: {line}"
+                ));
+        }
+        // The last line should be the _meta footer.
+        assert!(
+            lines.last().unwrap().contains("\"_meta\""),
+            "expected last line to be _meta footer, got: {}",
+            lines.last().unwrap()
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn correlation_vector_format_none_skips_sidecar_write() {
+        // NONE format: CV is enabled, the trace is computed,
+        // but NO sidecar file is created. The would-be default
+        // path must not exist after the run.
+        let dir = std::env::temp_dir().join("closurec_cloc11_69_none");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("create dir");
+        let in_path = dir.join("a.js");
+        fs::write(&in_path, "var x = 1;").expect("write");
+        let out_path = dir.join("out.js");
+        let default_sidecar = dir.join("out.js.cv.json");
+        let cfg = CompilerConfig {
+            io: IoConfig {
+                js_patterns: vec![in_path.to_string_lossy().to_string()],
+                js_output_file: Some(out_path.clone()),
+                ..Default::default()
+            },
+            special_modes: crate::config::SpecialModesConfig {
+                correlation_vector: true,
+                correlation_vector_format:
+                    crate::config::CorrelationVectorFormat::None,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let _ = run_compiler(&cfg).expect("ok");
+        assert!(
+            !default_sidecar.exists(),
+            "NONE format should skip sidecar write, found file at {:?}",
+            default_sidecar
+        );
+        // JS output still produced — CV gating doesn't affect
+        // the normal pipeline.
+        assert!(
+            out_path.exists(),
+            "JS output should still be written under NONE: {:?}",
+            out_path
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn correlation_vector_format_json_default_unchanged() {
+        // Default (JSON) format: existing behavior preserved.
+        // Sidecar exists and is a single JSON document.
+        let dir = std::env::temp_dir().join("closurec_cloc11_69_json");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("create dir");
+        let in_path = dir.join("a.js");
+        fs::write(&in_path, "var x = 1;").expect("write");
+        let out_path = dir.join("out.js");
+        let sidecar_path = dir.join("out.js.cv.json");
+        let cfg = CompilerConfig {
+            io: IoConfig {
+                js_patterns: vec![in_path.to_string_lossy().to_string()],
+                js_output_file: Some(out_path.clone()),
+                ..Default::default()
+            },
+            special_modes: crate::config::SpecialModesConfig {
+                correlation_vector: true,
+                // correlation_vector_format defaults to Json
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let _ = run_compiler(&cfg).expect("ok");
+        let body = fs::read_to_string(&sidecar_path).expect("read sidecar");
+        // Whole body must parse as a single JSON document.
+        serde_json::from_str::<serde_json::Value>(&body)
+            .expect("JSON format should produce a single JSON doc");
+        // And NOT contain a _meta footer (that's NDJSON-only).
+        assert!(
+            !body.contains("\"_meta\""),
+            "JSON format should not include the NDJSON _meta footer"
         );
         let _ = fs::remove_dir_all(&dir);
     }

--- a/code/programs/rust/closurec/src/wire.rs
+++ b/code/programs/rust/closurec/src/wire.rs
@@ -492,6 +492,14 @@ fn read_special_modes(p: &ParseResult) -> Result<SpecialModesConfig, ConfigError
             .filter(|s| !s.is_empty())
             .map(std::path::PathBuf::from),
         correlation_vector_pretty: get_bool(p, "correlation_vector_pretty")?,
+        correlation_vector_format: match get_str(p, "correlation_vector_format")?
+            .as_deref()
+        {
+            Some("NDJSON") => crate::config::CorrelationVectorFormat::Ndjson,
+            Some("NONE") => crate::config::CorrelationVectorFormat::None,
+            // JSON, empty, or absent → default
+            _ => crate::config::CorrelationVectorFormat::Json,
+        },
     })
 }
 

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.31.0
+Version: 0.32.0
 
 ## Flags
 
@@ -377,6 +377,10 @@ Path to write the correlation-vector sidecar JSON. Default empty → `<js_output
 ### `--correlation_vector_pretty` (boolean, default: false)
 
 Pretty-print the correlation-vector sidecar JSON (multi-line, 2-space indent). Default off → compact single-line JSON. Useful for human inspection; CI tooling typically prefers compact (CLOC11.68).
+
+### `--correlation_vector_format` (enum, default: JSON)
+
+Sidecar format: JSON = single document (default), NDJSON = one CV entry per line for streaming consumers, NONE = compute CV but skip write (useful for benchmarking overhead). Ignored unless --correlation_vector is also set (CLOC11.69).
 
 ### `--instrument_for_coverage_option` (enum, default: NONE)
 


### PR DESCRIPTION
## Summary

Adds `--correlation_vector_format` enum to the CV sidecar writer. Covers streaming consumers and benchmark modes.

- `JSON` (default) — single JSON document. `--correlation_vector_pretty` still applies.
- `NDJSON` — newline-delimited JSON: one CV entry per line, ending with a `{"_meta": {"pass_order":[...], "enabled":...}}` footer line. Tooling can `tail -f` mid-build without waiting for a closing brace.
- `NONE` — compute the CV log but **do not** write the sidecar. Lets benchmarks measure CV compute overhead in isolation from write/serialize overhead.

The flag is ignored when `--correlation_vector` is off.

## Implementation

- `format_cv_log_ndjson` round-trips through `serde_json::Value` (same approach as the pretty path) to walk the `entries` map without touching CV crate internals. Fallback chain: any parse/serialize hiccup yields the compact single-doc JSON instead of an empty file.
- The `None` arm is a single-statement no-op gated by the existing `if config.special_modes.correlation_vector` block.
- New public enum `CorrelationVectorFormat` with `#[default] = Json`.

## Test plan
- [x] cargo build clean
- [x] 246 unit + 17 integration suites pass
- [x] New tests:
  - `correlation_vector_format_ndjson_writes_one_entry_per_line` — every line parses as JSON; last line is `_meta` footer
  - `correlation_vector_format_none_skips_sidecar_write` — no sidecar at default path; JS output still written
  - `correlation_vector_format_json_default_unchanged` — default behavior preserves single-document JSON; no `_meta` footer
- [x] help-markdown fixture regenerated for 0.32.0

## Security review (inline)
- Same threat surface as the CLOC11.68 round-trip (internally-generated input, serde_json recursion limit 128, fallback to compact on error).
- NONE arm is a no-op — no file handle, no path construction.
- No unsafe; no new deps (`serde_json` already transitive).
- Wire-side permissive string match is fine — cli-builder validates `enum_values` upstream; default is the safest option (write the document).

## Versions
- `Cargo.toml`: 0.31.0 → 0.32.0
- `cli.spec.json`: 0.31.0 → 0.32.0
- `CHANGELOG.md`: new `[0.32.0]` section

🤖 Generated with [Claude Code](https://claude.com/claude-code)