### PR TITLE
feat(closurec): --correlation_vector_filter allowlist (CLOC11.70)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.33.0] - 2026-05-30
+
+### Added — CLOC11.70: `--correlation_vector_filter` allowlist flag
+
+Adds a CSV allowlist of CV `contribution.source` names. When non-empty, the sidecar serializer prunes any CV entry whose `contributions` does not include at least one record whose `source` is in the allowlist.
+
+Example: `--correlation_vector_filter lex,defines` writes only entries that the `lex` or `defines` stages touched.
+
+### Semantics
+
+- Strict match on `contribution.source`. The per-token CV entries created with `Origin{source: "lexer_token", ...}` but with zero contributions are dropped when the filter is `lex` — their "lex" association lives in the Origin, not in a contribution. The per-file CV root (which holds the `lex.tokens_emitted` contribution) is kept. Documented in the config-level rustdoc and pinned by tests.
+- Empty allowlist = no pruning (default behavior). The fast path in `format_cv_log_json` short-circuits the round-trip when both `pretty` and `filter` are unset.
+- Whitespace around CSV tokens is trimmed; empty tokens are ignored. `"lex, defines"` is the same as `"lex,defines"`.
+
+### Implementation
+
+- New shared helper `prune_entries_by_source(&mut serde_json::Value, &[String])` mutates the parsed CV log in-place. Uses a `HashSet` for O(1) source lookup.
+- Both `format_cv_log_json` and `format_cv_log_ndjson` now take the filter slice and call the helper between parse and re-emit.
+
+### Changed
+
+- `SpecialModesConfig` gains `correlation_vector_filter: Vec<String>`.
+- `wire::read_special_modes` splits the comma-separated string; trims whitespace; drops empty tokens.
+- `format_cv_log_json` signature: now `(cv_log, pretty, filter) -> String`. Private to the crate.
+- `format_cv_log_ndjson` signature: now `(cv_log, filter) -> String`. Private to the crate.
+- Versions: `Cargo.toml` `0.32.0` → `0.33.0`, `cli.spec.json` `0.32.0` → `0.33.0`.
+
 ## [0.32.0] - 2026-05-30
 
 ### Added — CLOC11.69: `--correlation_vector_format` enum (JSON | NDJSON | NONE)

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.32.0"
+version = "0.33.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },
@@ -99,6 +99,7 @@
     { "id": "correlation_vector_output", "long": "correlation_vector_output", "type": "string", "default": "", "description": "Path to write the correlation-vector sidecar JSON. Default empty → `<js_output_file>.cv.json` next to the JS output, or `closurec-cv.json` in CWD when output is stdout (CLOC11.67)." },
     { "id": "correlation_vector_pretty", "long": "correlation_vector_pretty", "type": "boolean", "default": false, "description": "Pretty-print the correlation-vector sidecar JSON (multi-line, 2-space indent). Default off → compact single-line JSON. Useful for human inspection; CI tooling typically prefers compact (CLOC11.68)." },
     { "id": "correlation_vector_format", "long": "correlation_vector_format", "type": "enum", "enum_values": ["JSON", "NDJSON", "NONE"], "default": "JSON", "description": "Sidecar format: JSON = single document (default), NDJSON = one CV entry per line for streaming consumers, NONE = compute CV but skip write (useful for benchmarking overhead). Ignored unless --correlation_vector is also set (CLOC11.69)." },
+    { "id": "correlation_vector_filter", "long": "correlation_vector_filter", "type": "string", "default": "", "description": "Comma-separated allowlist of CV source names (e.g. \"lex,defines\"). Entries with no contribution.source in the allowlist are pruned from the written sidecar. Empty (default) keeps every entry. Ignored unless --correlation_vector is also set (CLOC11.70)." },
     { "id": "instrument_for_coverage_option", "long": "instrument_for_coverage_option", "type": "enum", "enum_values": ["NONE", "LINE", "BRANCH", "PRODUCTION"], "default": "NONE", "description": "Enable code instrumentation for coverage analysis." },
     { "id": "production_instrumentation_array_name", "long": "production_instrumentation_array_name", "type": "string", "default": "", "description": "Global array name used by production instrumentation." },
     { "id": "chunk_output_type", "long": "chunk_output_type", "type": "enum", "enum_values": ["GLOBAL_NAMESPACE", "ES_MODULES"], "default": "GLOBAL_NAMESPACE", "description": "Format for output chunks." },

--- a/code/programs/rust/closurec/src/config.rs
+++ b/code/programs/rust/closurec/src/config.rs
@@ -544,6 +544,28 @@ pub struct SpecialModesConfig {
     ///     sidecar. Useful for benchmarking how much the CV
     ///     trace itself costs versus the write.
     pub correlation_vector_format: CorrelationVectorFormat,
+    /// CLOC11.70: allowlist of CV `contribution.source`
+    /// values. When non-empty, the sidecar serializer prunes
+    /// any entry whose `contributions` does NOT include at
+    /// least one record whose `source` field appears in this
+    /// vector.
+    ///
+    /// Caveat (documented and tested):
+    ///   - Filtering matches against `contribution.source`,
+    ///     **not** `origin.source`. So a per-token CV entry
+    ///     created with `Origin{source: "lexer_token", ...}`
+    ///     but with zero contributions will be pruned by
+    ///     `--correlation_vector_filter lex` — its "lex"
+    ///     association lives in the Origin, not in a
+    ///     contribution. The per-file CV root (which holds
+    ///     the `lex.tokens_emitted` contribution) is kept.
+    ///     Later slices may extend the filter to also match
+    ///     `origin.source` if a use-case demands.
+    ///
+    /// Empty (the default) → no pruning; every entry is
+    /// written. Only consulted when `correlation_vector` is
+    /// also true.
+    pub correlation_vector_filter: Vec<String>,
 }
 
 /// CLOC11.69 — sidecar persistence format. Default is

--- a/code/programs/rust/closurec/src/run.rs
+++ b/code/programs/rust/closurec/src/run.rs
@@ -1267,10 +1267,14 @@ pub fn run_compiler(config: &CompilerConfig) -> Result<CompilerOutput, CompilerE
                     },
                 };
                 let body = match fmt {
-                    CorrelationVectorFormat::Ndjson => format_cv_log_ndjson(&cv_log),
+                    CorrelationVectorFormat::Ndjson => format_cv_log_ndjson(
+                        &cv_log,
+                        &config.special_modes.correlation_vector_filter,
+                    ),
                     _ => format_cv_log_json(
                         &cv_log,
                         config.special_modes.correlation_vector_pretty,
+                        &config.special_modes.correlation_vector_filter,
                     ),
                 };
                 write_output_file(&sidecar_path, &body)?;
@@ -1313,20 +1317,29 @@ pub fn run_compiler(config: &CompilerConfig) -> Result<CompilerOutput, CompilerE
 fn format_cv_log_json(
     cv_log: &coding_adventures_correlation_vector::CVLog,
     pretty: bool,
+    filter: &[String],
 ) -> String {
     let compact = cv_log
         .to_json_string()
         .unwrap_or_else(|_| "{}".to_string());
-    if !pretty {
+    let need_filter = !filter.is_empty();
+    if !pretty && !need_filter {
+        // Fast path: default-default — no parse, no transform.
         return compact;
     }
-    // Round-trip: compact text → serde_json::Value → pretty
-    // text. The intermediate Value is heap-allocated but only
-    // exists for one serialization pass.
-    match serde_json::from_str::<serde_json::Value>(&compact) {
-        Ok(v) => serde_json::to_string_pretty(&v)
-            .unwrap_or_else(|_| compact),
-        Err(_) => compact,
+    // Round-trip: compact text → serde_json::Value → (filter?) → text.
+    let mut value: serde_json::Value =
+        match serde_json::from_str(&compact) {
+            Ok(v) => v,
+            Err(_) => return compact,
+        };
+    if need_filter {
+        prune_entries_by_source(&mut value, filter);
+    }
+    if pretty {
+        serde_json::to_string_pretty(&value).unwrap_or_else(|_| compact)
+    } else {
+        serde_json::to_string(&value).unwrap_or_else(|_| compact)
     }
 }
 
@@ -1354,14 +1367,18 @@ fn format_cv_log_json(
 /// fallback the consumer's `tail` will still see).
 fn format_cv_log_ndjson(
     cv_log: &coding_adventures_correlation_vector::CVLog,
+    filter: &[String],
 ) -> String {
     let compact = cv_log
         .to_json_string()
         .unwrap_or_else(|_| "{}".to_string());
-    let root: serde_json::Value = match serde_json::from_str(&compact) {
+    let mut root: serde_json::Value = match serde_json::from_str(&compact) {
         Ok(v) => v,
         Err(_) => return compact,
     };
+    if !filter.is_empty() {
+        prune_entries_by_source(&mut root, filter);
+    }
     let mut out = String::new();
     if let Some(entries) = root.get("entries").and_then(|v| v.as_object()) {
         for entry in entries.values() {
@@ -1386,6 +1403,58 @@ fn format_cv_log_ndjson(
         out.push('\n');
     }
     out
+}
+
+/// CLOC11.70 — in-place prune of the `entries` object on a
+/// parsed CVLog JSON `Value` by `contribution.source`
+/// allowlist.
+///
+/// Walks `root["entries"]` (an object map id → entry). An
+/// entry is kept iff it has at least one element in its
+/// `contributions` array whose `source` field equals any
+/// string in `allowlist`. Entries with empty / missing
+/// `contributions` are dropped (no source can match).
+///
+/// `allowlist` is treated as a closed set of exact-match
+/// strings — no wildcards, no prefix matching. The empty
+/// allowlist case is the caller's responsibility (caller
+/// should skip this function entirely; we'd otherwise prune
+/// everything).
+///
+/// Why a separate helper rather than inlining at each
+/// formatter: the json and ndjson paths both round-trip
+/// through `serde_json::Value` (the former for pretty mode,
+/// the latter unconditionally), so one helper handling both
+/// is cheaper than two near-identical loops and keeps the
+/// "entry is kept iff …" rule in one auditable place.
+fn prune_entries_by_source(
+    root: &mut serde_json::Value,
+    allowlist: &[String],
+) {
+    let Some(entries) = root
+        .get_mut("entries")
+        .and_then(|v| v.as_object_mut())
+    else {
+        return;
+    };
+    // Build a HashSet for O(1) lookup; the loop runs over
+    // every entry × every contribution otherwise.
+    let allow: std::collections::HashSet<&str> =
+        allowlist.iter().map(String::as_str).collect();
+    entries.retain(|_id, entry| {
+        let Some(contribs) = entry
+            .get("contributions")
+            .and_then(|v| v.as_array())
+        else {
+            return false;
+        };
+        contribs.iter().any(|c| {
+            c.get("source")
+                .and_then(|s| s.as_str())
+                .map(|s| allow.contains(s))
+                .unwrap_or(false)
+        })
+    });
 }
 
 /// Format the contents of an `--output_manifest` file from a
@@ -3448,6 +3517,154 @@ mod tests {
         assert!(
             !body.contains("\"_meta\""),
             "JSON format should not include the NDJSON _meta footer"
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    // ------------------------------------------------------------------
+    // CLOC11.70 — --correlation_vector_filter allowlist
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn correlation_vector_filter_keeps_only_allowlisted_sources() {
+        // With filter=["lex"], only entries containing a
+        // contribution with source="lex" should survive.
+        // Empty-contribution entries (token CVs) are dropped.
+        // Entries with allowlisted contributions (per-file
+        // CV root has lex.tokens_emitted) are kept.
+        let dir = std::env::temp_dir().join("closurec_cloc11_70_filter_lex");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("create dir");
+        let in_path = dir.join("a.js");
+        fs::write(&in_path, "var x = 1;").expect("write");
+        let out_path = dir.join("out.js");
+        let sidecar_path = dir.join("out.js.cv.json");
+        let cfg = CompilerConfig {
+            io: IoConfig {
+                js_patterns: vec![in_path.to_string_lossy().to_string()],
+                js_output_file: Some(out_path.clone()),
+                ..Default::default()
+            },
+            special_modes: crate::config::SpecialModesConfig {
+                correlation_vector: true,
+                correlation_vector_filter: vec!["lex".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let _ = run_compiler(&cfg).expect("ok");
+        let body = fs::read_to_string(&sidecar_path).expect("read sidecar");
+        let root: serde_json::Value =
+            serde_json::from_str(&body).expect("parse");
+        let entries = root
+            .get("entries")
+            .and_then(|v| v.as_object())
+            .expect("entries object");
+        // Every surviving entry must have at least one
+        // contribution with source="lex".
+        for (id, entry) in entries.iter() {
+            let contribs = entry
+                .get("contributions")
+                .and_then(|v| v.as_array())
+                .expect("contributions array");
+            let has_lex = contribs.iter().any(|c| {
+                c.get("source").and_then(|s| s.as_str()) == Some("lex")
+            });
+            assert!(
+                has_lex,
+                "entry {id} survived but has no lex contribution: {entry}"
+            );
+        }
+        // No lexer_token entries (no contributions) should
+        // appear under filter=lex.
+        for (id, entry) in entries.iter() {
+            let origin_source = entry
+                .get("origin")
+                .and_then(|o| o.get("source"))
+                .and_then(|s| s.as_str());
+            assert_ne!(
+                origin_source,
+                Some("lexer_token"),
+                "lexer_token entry {id} should have been pruned: {entry}"
+            );
+        }
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn correlation_vector_filter_empty_keeps_everything() {
+        // Empty filter = no pruning. Sanity check that the
+        // default config behaves identically to pre-CLOC11.70.
+        let dir = std::env::temp_dir().join("closurec_cloc11_70_filter_empty");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("create dir");
+        let in_path = dir.join("a.js");
+        fs::write(&in_path, "var x = 1;").expect("write");
+        let out_path = dir.join("out.js");
+        let sidecar_path = dir.join("out.js.cv.json");
+        let cfg = CompilerConfig {
+            io: IoConfig {
+                js_patterns: vec![in_path.to_string_lossy().to_string()],
+                js_output_file: Some(out_path.clone()),
+                ..Default::default()
+            },
+            special_modes: crate::config::SpecialModesConfig {
+                correlation_vector: true,
+                // correlation_vector_filter defaults to empty Vec
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let _ = run_compiler(&cfg).expect("ok");
+        let body = fs::read_to_string(&sidecar_path).expect("read sidecar");
+        // Confirm at least one lexer_token entry exists (it
+        // would be pruned under filter=lex per the test above).
+        assert!(
+            body.contains("\"source\":\"lexer_token\""),
+            "expected lexer_token entries in unfiltered sidecar: {body}"
+        );
+    }
+
+    #[test]
+    fn correlation_vector_filter_unmatched_prunes_all() {
+        // Filter with a source name that never appears →
+        // entries object becomes empty. The skeleton
+        // (entries / pass_order / enabled) is still valid
+        // JSON.
+        let dir = std::env::temp_dir().join("closurec_cloc11_70_filter_none");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("create dir");
+        let in_path = dir.join("a.js");
+        fs::write(&in_path, "var x = 1;").expect("write");
+        let out_path = dir.join("out.js");
+        let sidecar_path = dir.join("out.js.cv.json");
+        let cfg = CompilerConfig {
+            io: IoConfig {
+                js_patterns: vec![in_path.to_string_lossy().to_string()],
+                js_output_file: Some(out_path.clone()),
+                ..Default::default()
+            },
+            special_modes: crate::config::SpecialModesConfig {
+                correlation_vector: true,
+                correlation_vector_filter: vec![
+                    "nonexistent_source_xyz".to_string()
+                ],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let _ = run_compiler(&cfg).expect("ok");
+        let body = fs::read_to_string(&sidecar_path).expect("read sidecar");
+        let root: serde_json::Value =
+            serde_json::from_str(&body).expect("parse");
+        let entries = root
+            .get("entries")
+            .and_then(|v| v.as_object())
+            .expect("entries object");
+        assert!(
+            entries.is_empty(),
+            "expected empty entries under unmatched filter, got {}: {body}",
+            entries.len()
         );
         let _ = fs::remove_dir_all(&dir);
     }

--- a/code/programs/rust/closurec/src/wire.rs
+++ b/code/programs/rust/closurec/src/wire.rs
@@ -500,6 +500,15 @@ fn read_special_modes(p: &ParseResult) -> Result<SpecialModesConfig, ConfigError
             // JSON, empty, or absent → default
             _ => crate::config::CorrelationVectorFormat::Json,
         },
+        correlation_vector_filter: get_str(p, "correlation_vector_filter")?
+            .map(|s| {
+                s.split(',')
+                    .map(str::trim)
+                    .filter(|t| !t.is_empty())
+                    .map(str::to_string)
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default(),
     })
 }
 

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.32.0
+Version: 0.33.0
 
 ## Flags
 
@@ -381,6 +381,10 @@ Pretty-print the correlation-vector sidecar JSON (multi-line, 2-space indent). D
 ### `--correlation_vector_format` (enum, default: JSON)
 
 Sidecar format: JSON = single document (default), NDJSON = one CV entry per line for streaming consumers, NONE = compute CV but skip write (useful for benchmarking overhead). Ignored unless --correlation_vector is also set (CLOC11.69).
+
+### `--correlation_vector_filter` (string, default: "")
+
+Comma-separated allowlist of CV source names (e.g. "lex,defines"). Entries with no contribution.source in the allowlist are pruned from the written sidecar. Empty (default) keeps every entry. Ignored unless --correlation_vector is also set (CLOC11.70).
 
 ### `--instrument_for_coverage_option` (enum, default: NONE)
 


### PR DESCRIPTION
## Summary

Adds a CSV allowlist of CV `contribution.source` names. When non-empty, the sidecar serializer prunes any CV entry whose `contributions` does not include at least one record whose `source` is in the allowlist.

```bash
closurec --correlation_vector \
         --correlation_vector_filter lex,defines
```

writes only entries that the `lex` or `defines` stages touched.

## Semantics

- **Strict match on `contribution.source`.** Per-token CV entries with `Origin{source: "lexer_token"}` but no contributions are dropped under `filter=lex` — their "lex" association lives in the Origin, not in a contribution. The per-file CV root (which holds `lex.tokens_emitted`) is kept. Pinned by test.
- Empty allowlist = no pruning (default). Fast path in `format_cv_log_json` short-circuits the round-trip when both `pretty` and `filter` are unset.
- Whitespace around CSV tokens is trimmed; empty tokens are ignored. `"lex, defines"` ≡ `"lex,defines"`.

## Implementation

- New shared helper `prune_entries_by_source(&mut serde_json::Value, &[String])` mutates the parsed CV log in-place. `HashSet` membership for O(1) source lookup.
- Both `format_cv_log_json` and `format_cv_log_ndjson` take the filter slice and call the helper between parse and re-emit.

## Test plan
- [x] cargo build clean
- [x] 249 unit + 17 integration suites pass
- [x] New tests:
  - `correlation_vector_filter_keeps_only_allowlisted_sources` — `filter=lex` → every surviving entry has a lex contribution; no lexer_token Origin entries leak through
  - `correlation_vector_filter_empty_keeps_everything` — empty filter → lexer_token entries still present
  - `correlation_vector_filter_unmatched_prunes_all` — unknown source → entries map is empty
- [x] help-markdown fixture regenerated for 0.33.0

## Security review (inline)
- CSV parsing operates on Rust `&str` (UTF-8 guaranteed); feeds a `HashSet` for membership only — no shell/SQL/regex/path API.
- `prune_entries_by_source` uses `Map::retain` with chained `get/and_then/unwrap_or(false)` — missing/wrong-typed fields short-circuit to "drop entry", no panics.
- Fast path preserves byte-for-byte default behavior.
- No unsafe, no new deps, no FS path manipulation.

## Versions
- `Cargo.toml`: 0.32.0 → 0.33.0
- `cli.spec.json`: 0.32.0 → 0.33.0
- `CHANGELOG.md`: new `[0.33.0]` section

🤖 Generated with [Claude Code](https://claude.com/claude-code)