### PR TITLE
feat(ruby-parser+sir): Phase 14e (FC) — singleton class class << self

### DIFF
--- a/code/grammars/ruby.grammar
+++ b/code/grammars/ruby.grammar
@@ -124,7 +124,18 @@ endless_def_statement = "def" NAME [ LPAREN [ params ] RPAREN ] EQUALS expressio
 # note below), but the literal matcher compares the token value, so
 # `"<"` matches transparently.  The superclass is a single `NAME`; the
 # lowerer lifts it into `Stmt::ClassDef.superclass`.
-class_statement  = "class"  NAME [ "<" NAME ] { !"end" statement } "end" ;
+#
+# Phase 14e — singleton-class form `class << RECEIVER … end` (opens the
+# receiver's singleton/metaclass; `def`s inside become singleton
+# methods).  The `<<` literal matches the left-shift Op token by value
+# (`class << self` lexes as `class`, `<<`, `self` — the space before
+# `self` keeps `<<` a shift operator, not a heredoc opener).  The
+# receiver is `self` (the dominant idiom) or a bare `NAME`.  The
+# singleton alternative is listed FIRST so PEG tries it before the
+# `"class" NAME …` form (the `<<` after `class` disambiguates).
+class_statement  = "class" "<<" singleton_receiver { !"end" statement } "end"
+                 | "class" NAME [ "<" NAME ] { !"end" statement } "end" ;
+singleton_receiver = "self" | NAME ;
 module_statement = "module" NAME { !"end" statement } "end" ;
 # Phase 6g — blocks `do … end` and brace-blocks `method { … }`.
 method_with_block = ( NAME | KEYWORD ) [ LPAREN [ expression { COMMA expression } ] RPAREN ] block ;

--- a/code/packages/rust/ruby-parser/.pr-body-fc-14e.md
+++ b/code/packages/rust/ruby-parser/.pr-body-fc-14e.md
@@ -1,0 +1,101 @@
+## Summary
+
+Phase 14e lands **singleton-class declarations**.  `class << self … end`
+(and `class << obj`) now lowers to
+
+```
+Stmt::SingletonClassDef { target: "self", body, span }
+```
+
+opening the receiver's singleton/metaclass.  This introduces a new
+SIR17 node, so the semantic-ir crate is bumped as a separate sub-step
+(semantic-ir 0.5.0).
+
+## semantic-ir (0.5.0 — new node)
+
+- **`Stmt::SingletonClassDef { target: String, body: Vec<Stmt>, span: Span }`**
+  — `target` is the receiver (`"self"` for the dominant idiom, or a
+  bare object name).  Like `ClassDef`/`ModuleDef`, method `def`s in the
+  body hoist to top-level `Function`s; `body` carries the non-`def`
+  statements.  **Reuses `Feature::Classes`** (a singleton class is a
+  class-opening construct) — no manifest change.
+- `Stmt::span()`, the walker, the validator (marks `Feature::Classes`,
+  walks the body via `check_stmt_seq` in a scoped env mark/rewind with
+  the `MAX_IR_DEPTH` guard — same shape as `ClassDef`), the text printer
+  (`(singleton-class-def << Target …)`), and the intrinsic-walk backend
+  helper gain a `SingletonClassDef` arm.  The four reference backends
+  gain an unreachable `panic!` arm.
+
+## ruby-to-semantic-ir (0.44.0)
+
+- The `class_statement` lowering arm dispatches on the presence of a
+  `singleton_receiver` child node: present → `SingletonClassDef`,
+  absent → the ordinary `ClassDef` path (14b/14c).
+- New `extract_singleton_receiver` helper returns the receiver token's
+  value (`None` for the ordinary form).
+- Body handling reuses `lower_decl_body_statements` (shared with
+  class/module).  Requests `Feature::Classes`.
+
+## ruby-parser (0.42.0)
+
+Grammar — `class_statement` gains a singleton alternative (listed first
+so PEG tries it before the ordinary form):
+
+```
+class_statement   = "class" "<<" singleton_receiver { !"end" statement } "end"
+                  | "class" NAME [ "<" NAME ] { !"end" statement } "end" ;
+singleton_receiver = "self" | NAME ;
+```
+
+`<<` matches the left-shift Op token by value (`class << self` lexes as
+`class`, `<<`, `self`).  `_grammar.rs` regenerated.
+
+## Backends (go / python / rust / typescript)
+
+Unchanged behaviour.  `Feature::Classes` is absent from every backend's
+accepted-feature set, so singleton-class-using modules are rejected at
+the capability check *before* emit — the new panic arms stay
+unreachable.
+
+| SIR shape (Phase 14e)                                          | Source                       |
+|----------------------------------------------------------------|------------------------------|
+| `SingletonClassDef { "self", body: [] }`                       | `class << self; end`         |
+| `SingletonClassDef { "self", body: [LetBinding "X"=1] }` + hoisted `foo` | `class << self; X=1; def foo;end; end` |
+| printer: `(singleton-class-def << self)`                       | printer output               |
+
+## Tests
+
+- `coding-adventures-ruby-lexer`: **173** (no change)
+- `coding-adventures-ruby-parser`: 167 → **170** (+3):
+  `test_parse_singleton_class_of_self`,
+  `test_parse_singleton_class_body_with_def`,
+  `test_parse_ordinary_class_has_no_singleton_receiver`
+- `ruby-to-semantic-ir`: 201 → **206** (+5):
+  `singleton_class_of_self_lowers_to_singleton_class_def`,
+  `singleton_class_requests_classes_feature`,
+  `singleton_class_hoists_methods_and_keeps_statements`,
+  `singleton_class_passes_sir_validator` (E2E lower → validate),
+  `ordinary_class_still_lowers_to_class_def_not_singleton`
+- `semantic-ir`: 90 → **93** (+3): `print_singleton_class_def`,
+  `singleton_class_def_body_with_let_binding_validates`,
+  `singleton_class_def_body_undefined_varref_is_error`
+- All four backend suites + `twig-to-semantic-ir` green.
+
+## Test plan
+
+- [x] `cargo test -p coding-adventures-ruby-lexer` (173/173)
+- [x] `cargo test -p coding-adventures-ruby-parser` (170/170)
+- [x] `cargo test -p ruby-to-semantic-ir` (206/206)
+- [x] `cargo test -p semantic-ir` (93/93)
+- [x] `cargo test -p semantic-ir-to-{go,python,rust,typescript} -p twig-to-semantic-ir` (all green)
+- [x] Security review passed (1 round, no findings) — validator
+      recursion `MAX_IR_DEPTH`-bounded like ClassDef; `extract_singleton_receiver`
+      cannot panic (find_map + `?`, no indexing/unwrap); backend panic
+      arms unreachable behind the capability check; `target` is a
+      grammar-constrained identifier written verbatim (no injection).
+- [ ] CI green
+
+Follows PR #4599 (Phase 14d).  Next chunk: Phase 15a (instance vars
+`@x` inside method bodies).
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.42.0] - 2026-05-30
+
+### Added (Phase 14e (FC) — singleton class `class << receiver … end`)
+
+Grammar change: `class_statement` gains a singleton alternative, listed
+first so PEG tries it before the ordinary form:
+
+```
+class_statement   = "class" "<<" singleton_receiver { !"end" statement } "end"
+                  | "class" NAME [ "<" NAME ] { !"end" statement } "end" ;
+singleton_receiver = "self" | NAME ;
+```
+
+`<<` matches the left-shift Op token by value (`class << self` lexes as
+`class`, `<<`, `self` — the space before `self` keeps `<<` a shift
+operator, not a heredoc opener).  `_grammar.rs` regenerated via
+`grammar-tools compile-grammar`.
+
+New parser tests (+3): `test_parse_singleton_class_of_self`,
+`test_parse_singleton_class_body_with_def`,
+`test_parse_ordinary_class_has_no_singleton_receiver` (regression guard
+that the singleton alternative doesn't shadow `class Foo`).  Test
+count: 167 → 170 (+3).
+
 ## [0.41.0] - 2026-05-30
 
 ### Added (Phase 14d (FC) — `module M … end` parser coverage)

--- a/code/packages/rust/ruby-parser/src/_grammar.rs
+++ b/code/packages/rust/ruby-parser/src/_grammar.rs
@@ -124,20 +124,40 @@ pub fn parser_grammar() -> ParserGrammar {
         },
         GrammarRule {
             name: r#"class_statement"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::Literal { value: r#"class"#.to_string() },
-                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
-                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
-                        GrammarElement::Literal { value: r#"<"#.to_string() },
-                        GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
-                    ] }) },
-                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
-                        GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"end"#.to_string() }) },
-                        GrammarElement::RuleReference { name: r#"statement"#.to_string() },
-                    ] }) },
-                GrammarElement::Literal { value: r#"end"#.to_string() },
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::Literal { value: r#"class"#.to_string() },
+                    GrammarElement::Literal { value: r#"<<"#.to_string() },
+                    GrammarElement::RuleReference { name: r#"singleton_receiver"#.to_string() },
+                    GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                            GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"end"#.to_string() }) },
+                            GrammarElement::RuleReference { name: r#"statement"#.to_string() },
+                        ] }) },
+                    GrammarElement::Literal { value: r#"end"#.to_string() },
+                ] },
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::Literal { value: r#"class"#.to_string() },
+                    GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                    GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                            GrammarElement::Literal { value: r#"<"#.to_string() },
+                            GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                        ] }) },
+                    GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                            GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"end"#.to_string() }) },
+                            GrammarElement::RuleReference { name: r#"statement"#.to_string() },
+                        ] }) },
+                    GrammarElement::Literal { value: r#"end"#.to_string() },
+                ] },
             ] },
-            line_number: 127,
+            line_number: 136,
+        },
+        GrammarRule {
+            name: r#"singleton_receiver"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Literal { value: r#"self"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+            ] },
+            line_number: 138,
         },
         GrammarRule {
             name: r#"module_statement"#.to_string(),
@@ -150,7 +170,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 128,
+            line_number: 139,
         },
         GrammarRule {
             name: r#"method_with_block"#.to_string(),
@@ -172,7 +192,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"block"#.to_string() },
             ] },
-            line_number: 130,
+            line_number: 141,
         },
         GrammarRule {
             name: r#"block"#.to_string(),
@@ -180,7 +200,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"do_block"#.to_string() },
                 GrammarElement::RuleReference { name: r#"brace_block"#.to_string() },
             ] },
-            line_number: 131,
+            line_number: 142,
         },
         GrammarRule {
             name: r#"do_block"#.to_string(),
@@ -193,7 +213,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 132,
+            line_number: 143,
         },
         GrammarRule {
             name: r#"brace_block"#.to_string(),
@@ -203,7 +223,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"statement"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 133,
+            line_number: 144,
         },
         GrammarRule {
             name: r#"block_params"#.to_string(),
@@ -216,7 +236,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"|"#.to_string() },
             ] },
-            line_number: 134,
+            line_number: 145,
         },
         GrammarRule {
             name: r#"return_statement"#.to_string(),
@@ -224,7 +244,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"return"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"expression"#.to_string() }) },
             ] },
-            line_number: 136,
+            line_number: 147,
         },
         GrammarRule {
             name: r#"break_statement"#.to_string(),
@@ -232,7 +252,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"break"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"expression"#.to_string() }) },
             ] },
-            line_number: 137,
+            line_number: 148,
         },
         GrammarRule {
             name: r#"next_statement"#.to_string(),
@@ -240,7 +260,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"next"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"expression"#.to_string() }) },
             ] },
-            line_number: 138,
+            line_number: 149,
         },
         GrammarRule {
             name: r#"yield_statement"#.to_string(),
@@ -248,7 +268,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"yield"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"yield_args"#.to_string() }) },
             ] },
-            line_number: 160,
+            line_number: 171,
         },
         GrammarRule {
             name: r#"yield_args"#.to_string(),
@@ -272,7 +292,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) },
                 ] },
             ] },
-            line_number: 161,
+            line_number: 172,
         },
         GrammarRule {
             name: r#"params"#.to_string(),
@@ -283,7 +303,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"param"#.to_string() },
                     ] }) },
             ] },
-            line_number: 176,
+            line_number: 187,
         },
         GrammarRule {
             name: r#"param"#.to_string(),
@@ -294,7 +314,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
             ] },
-            line_number: 177,
+            line_number: 188,
         },
         GrammarRule {
             name: r#"if_statement"#.to_string(),
@@ -311,7 +331,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 178,
+            line_number: 189,
         },
         GrammarRule {
             name: r#"elsif_clause"#.to_string(),
@@ -325,7 +345,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 179,
+            line_number: 190,
         },
         GrammarRule {
             name: r#"else_clause"#.to_string(),
@@ -336,7 +356,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 180,
+            line_number: 191,
         },
         GrammarRule {
             name: r#"unless_statement"#.to_string(),
@@ -351,7 +371,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 181,
+            line_number: 192,
         },
         GrammarRule {
             name: r#"while_statement"#.to_string(),
@@ -364,7 +384,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 182,
+            line_number: 193,
         },
         GrammarRule {
             name: r#"until_statement"#.to_string(),
@@ -377,7 +397,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 183,
+            line_number: 194,
         },
         GrammarRule {
             name: r#"case_statement"#.to_string(),
@@ -391,7 +411,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 206,
+            line_number: 217,
         },
         GrammarRule {
             name: r#"when_clause"#.to_string(),
@@ -410,7 +430,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 207,
+            line_number: 218,
         },
         GrammarRule {
             name: r#"in_clause"#.to_string(),
@@ -425,7 +445,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 229,
+            line_number: 240,
         },
         GrammarRule {
             name: r#"pattern"#.to_string(),
@@ -435,7 +455,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"literal_pattern"#.to_string() },
                 GrammarElement::RuleReference { name: r#"binding_pattern"#.to_string() },
             ] },
-            line_number: 230,
+            line_number: 241,
         },
         GrammarRule {
             name: r#"literal_pattern"#.to_string(),
@@ -445,12 +465,12 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"symbol_literal"#.to_string() },
                 GrammarElement::TokenReference { name: r#"KEYWORD"#.to_string() },
             ] },
-            line_number: 231,
+            line_number: 242,
         },
         GrammarRule {
             name: r#"binding_pattern"#.to_string(),
             body: GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
-            line_number: 232,
+            line_number: 243,
         },
         GrammarRule {
             name: r#"array_pattern"#.to_string(),
@@ -465,7 +485,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 233,
+            line_number: 244,
         },
         GrammarRule {
             name: r#"hash_pattern"#.to_string(),
@@ -480,7 +500,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 234,
+            line_number: 245,
         },
         GrammarRule {
             name: r#"hash_pattern_pair"#.to_string(),
@@ -489,7 +509,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"pattern"#.to_string() }) },
             ] },
-            line_number: 235,
+            line_number: 246,
         },
         GrammarRule {
             name: r#"begin_statement"#.to_string(),
@@ -505,7 +525,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"ensure_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 256,
+            line_number: 267,
         },
         GrammarRule {
             name: r#"rescue_clause"#.to_string(),
@@ -523,7 +543,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 265,
+            line_number: 276,
         },
         GrammarRule {
             name: r#"exception_list"#.to_string(),
@@ -534,7 +554,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
                     ] }) },
             ] },
-            line_number: 266,
+            line_number: 277,
         },
         GrammarRule {
             name: r#"ensure_clause"#.to_string(),
@@ -545,7 +565,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 267,
+            line_number: 278,
         },
         GrammarRule {
             name: r#"assignment"#.to_string(),
@@ -569,7 +589,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 287,
+            line_number: 298,
         },
         GrammarRule {
             name: r#"rightward_assignment"#.to_string(),
@@ -578,7 +598,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"=>"#.to_string() },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
             ] },
-            line_number: 306,
+            line_number: 317,
         },
         GrammarRule {
             name: r#"method_call"#.to_string(),
@@ -598,7 +618,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"dot_call"#.to_string() }) },
             ] },
-            line_number: 317,
+            line_number: 328,
         },
         GrammarRule {
             name: r#"dot_call"#.to_string(),
@@ -620,7 +640,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                     ] }) },
             ] },
-            line_number: 318,
+            line_number: 329,
         },
         GrammarRule {
             name: r#"call_arg"#.to_string(),
@@ -631,7 +651,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 325,
+            line_number: 336,
         },
         GrammarRule {
             name: r#"method_call_no_paren"#.to_string(),
@@ -646,17 +666,17 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 339,
+            line_number: 350,
         },
         GrammarRule {
             name: r#"expression_stmt"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"expression"#.to_string() },
-            line_number: 340,
+            line_number: 351,
         },
         GrammarRule {
             name: r#"expression"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"ternary"#.to_string() },
-            line_number: 426,
+            line_number: 437,
         },
         GrammarRule {
             name: r#"ternary"#.to_string(),
@@ -669,7 +689,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 427,
+            line_number: 438,
         },
         GrammarRule {
             name: r#"range"#.to_string(),
@@ -683,7 +703,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_or"#.to_string() },
                     ] }) },
             ] },
-            line_number: 428,
+            line_number: 439,
         },
         GrammarRule {
             name: r#"logical_or"#.to_string(),
@@ -697,7 +717,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_and"#.to_string() },
                     ] }) },
             ] },
-            line_number: 429,
+            line_number: 440,
         },
         GrammarRule {
             name: r#"logical_and"#.to_string(),
@@ -711,7 +731,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_not"#.to_string() },
                     ] }) },
             ] },
-            line_number: 430,
+            line_number: 441,
         },
         GrammarRule {
             name: r#"logical_not"#.to_string(),
@@ -722,7 +742,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) }) },
                 GrammarElement::RuleReference { name: r#"comparison"#.to_string() },
             ] },
-            line_number: 437,
+            line_number: 448,
         },
         GrammarRule {
             name: r#"comparison"#.to_string(),
@@ -740,7 +760,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"sum"#.to_string() },
                     ] }) },
             ] },
-            line_number: 438,
+            line_number: 449,
         },
         GrammarRule {
             name: r#"sum"#.to_string(),
@@ -754,7 +774,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term"#.to_string() },
                     ] }) },
             ] },
-            line_number: 439,
+            line_number: 450,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -768,7 +788,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"factor"#.to_string() },
                     ] }) },
             ] },
-            line_number: 440,
+            line_number: 451,
         },
         GrammarRule {
             name: r#"factor"#.to_string(),
@@ -792,7 +812,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"dot_call"#.to_string() }) },
             ] },
-            line_number: 450,
+            line_number: 461,
         },
         GrammarRule {
             name: r#"lambda_literal"#.to_string(),
@@ -805,7 +825,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"block"#.to_string() },
             ] },
-            line_number: 469,
+            line_number: 480,
         },
         GrammarRule {
             name: r#"unary_minus"#.to_string(),
@@ -813,7 +833,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"factor"#.to_string() },
             ] },
-            line_number: 470,
+            line_number: 481,
         },
         GrammarRule {
             name: r#"symbol_literal"#.to_string(),
@@ -825,7 +845,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 471,
+            line_number: 482,
         },
         GrammarRule {
             name: r#"array_literal"#.to_string(),
@@ -840,7 +860,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 472,
+            line_number: 483,
         },
         GrammarRule {
             name: r#"hash_literal"#.to_string(),
@@ -855,7 +875,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 473,
+            line_number: 484,
         },
         GrammarRule {
             name: r#"hash_entry"#.to_string(),
@@ -875,7 +895,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                 ] },
             ] },
-            line_number: 474,
+            line_number: 485,
         },
     ],
         version: 1,

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -788,6 +788,65 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // Phase 14e (FC) — singleton class `class << receiver … end`.  The
+    // `class_statement` rule gains a singleton alternative
+    // (`"class" "<<" singleton_receiver …`); `<<` lexes as an Op token
+    // (value "<<"), `self` as a Keyword.  The parse carries a
+    // `singleton_receiver` child node the lowerer dispatches on.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_singleton_class_of_self() {
+        // `class << self; end` parses to a class_statement carrying a
+        // `singleton_receiver` child (whose token is `self`), plus the
+        // `<<` separator token.
+        let ast = parse_ruby("class << self\nend");
+        let cls = find_statement_inner(&ast, "class_statement")
+            .expect("expected class_statement");
+        assert!(body_has_token_value(cls, "<<"), "expected `<<` separator token");
+        let recv = cls.children.iter().find_map(|c| match c {
+            ASTNodeOrToken::Node(n) if n.rule_name == "singleton_receiver" => Some(n),
+            _ => None,
+        });
+        let recv = recv.expect("expected a singleton_receiver child node");
+        let recv_tok = recv.children.iter().find_map(|c| match c {
+            ASTNodeOrToken::Token(t) => Some(t.value.as_str()),
+            _ => None,
+        });
+        assert_eq!(recv_tok, Some("self"));
+    }
+
+    #[test]
+    fn test_parse_singleton_class_body_with_def() {
+        // A def inside a singleton class parses as a def_statement body
+        // child (hoisted by the lowerer).
+        let ast = parse_ruby("class << self\n  def foo\n  end\nend");
+        let cls = find_statement_inner(&ast, "class_statement")
+            .expect("expected class_statement");
+        let names = body_inner_rule_names(cls);
+        assert!(
+            names.iter().any(|r| r == "def_statement"),
+            "expected a def_statement in the singleton body; got {:?}",
+            names
+        );
+    }
+
+    #[test]
+    fn test_parse_ordinary_class_has_no_singleton_receiver() {
+        // Regression guard: `class Foo` must NOT carry a
+        // singleton_receiver child (the singleton alternative must not
+        // shadow the ordinary form).
+        let ast = parse_ruby("class Foo\nend");
+        let cls = find_statement_inner(&ast, "class_statement")
+            .expect("expected class_statement");
+        let has_recv = cls.children.iter().any(|c| matches!(
+            c,
+            ASTNodeOrToken::Node(n) if n.rule_name == "singleton_receiver"
+        ));
+        assert!(!has_recv, "ordinary class must have no singleton_receiver child");
+    }
+
+    // -----------------------------------------------------------------------
     // Phase 6g — blocks `do … end` and brace-blocks `method { … }`
     // -----------------------------------------------------------------------
 

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.44.0] - 2026-05-30
+
+### Added (Phase 14e (FC) — singleton class `class << self … end`)
+
+The singleton-class form `class << RECEIVER … end` now lowers to
+`Stmt::SingletonClassDef { target, body, span }` (semantic-ir 0.5.0).
+`target` is the receiver (`"self"` or a bare name).
+
+- The `class_statement` lowering arm dispatches on the presence of a
+  `singleton_receiver` child node: present → `SingletonClassDef`,
+  absent → the ordinary `ClassDef` path (Phase 14b/14c).
+- New `extract_singleton_receiver` helper returns the receiver token's
+  value (or `None` for the ordinary class form).
+- Body handling reuses `lower_decl_body_statements` (shared with
+  class/module): method `def`s hoist to top-level `Function`s; non-`def`
+  statements are preserved in `body`.  Requests `Feature::Classes`.
+
+New tests (+5): `singleton_class_of_self_lowers_to_singleton_class_def`,
+`singleton_class_requests_classes_feature`,
+`singleton_class_hoists_methods_and_keeps_statements`,
+`singleton_class_passes_sir_validator` (E2E lower → validate),
+`ordinary_class_still_lowers_to_class_def_not_singleton` (regression
+guard).  Test count: 201 → 206 (+5).
+
 ## [0.43.0] - 2026-05-30
 
 ### Changed (Phase 14d (FC) — `module M … end` → `Stmt::ModuleDef`)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -892,6 +892,81 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
+    // Phase 14e (FC) — singleton class `class << receiver … end` →
+    // `Stmt::SingletonClassDef`.  Body handling mirrors class/module:
+    // method defs hoist to top-level Functions; non-def statements stay
+    // in the body.  Triggers `Feature::Classes`.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn singleton_class_of_self_lowers_to_singleton_class_def() {
+        // `class << self; end` → SingletonClassDef { target: "self" }.
+        let m = lower("class << self\nend\n");
+        let main = main_body(&m);
+        match &main.stmts[0] {
+            Stmt::SingletonClassDef { target, body, .. } => {
+                assert_eq!(target, "self");
+                assert!(body.is_empty(), "empty singleton body");
+            }
+            other => panic!("expected Stmt::SingletonClassDef, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn singleton_class_requests_classes_feature() {
+        // A singleton class is a class-opening construct → it requests
+        // `Feature::Classes` (not a separate feature).
+        let m = lower("class << self\nend\n");
+        assert!(
+            m.manifest.contains(semantic_ir::Feature::Classes),
+            "manifest should contain Feature::Classes; got {:?}",
+            m.manifest
+        );
+    }
+
+    #[test]
+    fn singleton_class_hoists_methods_and_keeps_statements() {
+        // `class << self; X = 1; def foo; end; end` — `foo` hoists to a
+        // top-level Function; `X = 1` stays in the singleton body.
+        let m = lower("class << self\n  X = 1\n  def foo\n  end\nend\n");
+        assert!(
+            m.functions.iter().any(|f| f.name == "foo"),
+            "expected hoisted `foo`; got {:?}",
+            m.functions.iter().map(|f| &f.name).collect::<Vec<_>>()
+        );
+        let main = main_body(&m);
+        match &main.stmts[0] {
+            Stmt::SingletonClassDef { target, body, .. } => {
+                assert_eq!(target, "self");
+                assert_eq!(body.len(), 1, "only `X = 1` stays in body; got {:?}", body);
+                assert!(matches!(&body[0], Stmt::LetBinding { name, .. } if name == "X"));
+            }
+            other => panic!("expected Stmt::SingletonClassDef, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn singleton_class_passes_sir_validator() {
+        // E2E: lower → validate for a singleton class with a body.
+        let m = lower("class << self\n  X = 1\n  def foo\n  end\nend\n");
+        let result = semantic_ir::validate(&m);
+        assert!(result.is_ok(), "validator rejected singleton-class module: {:?}", result);
+    }
+
+    #[test]
+    fn ordinary_class_still_lowers_to_class_def_not_singleton() {
+        // Regression guard: the singleton dispatch must not hijack the
+        // ordinary `class Foo` form (no `singleton_receiver` child).
+        let m = lower("class Foo\nend\n");
+        let main = main_body(&m);
+        assert!(
+            matches!(&main.stmts[0], Stmt::ClassDef { .. }),
+            "ordinary class must lower to ClassDef, got {:?}",
+            &main.stmts[0]
+        );
+    }
+
+    // -----------------------------------------------------------------
     // Phase 14d (FC) — `module M … end` → `Stmt::ModuleDef`.  Mirrors
     // ClassDef (minus inheritance): method defs hoist to top-level
     // Functions; non-def statements stay in the module body.

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -277,8 +277,10 @@ fn block_references_any_name(block: &Block, names: &HashSet<String>) -> bool {
                     return true;
                 }
             }
-            Stmt::ClassDef { body, .. } | Stmt::ModuleDef { body, .. } => {
-                // A class/module declaration body is itself a
+            Stmt::ClassDef { body, .. }
+            | Stmt::ModuleDef { body, .. }
+            | Stmt::SingletonClassDef { body, .. } => {
+                // A class/module/singleton declaration body is itself a
                 // `Vec<Stmt>`.  Recurse over each contained statement
                 // using a synthetic wrapper Block, mirroring the loop /
                 // pattern-stmt arms above.
@@ -519,21 +521,38 @@ impl Lowerer {
                 })
             }
             "class_statement" => {
+                // Phase 14e (FC): the `class_statement` rule has two
+                // forms.  The *singleton* form `class << RECEIVER … end`
+                // parses with a `singleton_receiver` child node; the
+                // ordinary form `class Foo [< Bar] … end` does not.  We
+                // dispatch on that child's presence.
+                if let Some(target) = self.extract_singleton_receiver(node) {
+                    // Singleton class (`class << self` / `class << obj`)
+                    // → `Stmt::SingletonClassDef { target, body }`.
+                    // Body handling is identical to a class/module:
+                    // method `def`s hoist to top-level Functions,
+                    // non-`def` statements stay in `body`.
+                    self.features_used.insert(Feature::Classes);
+                    let body = self.lower_decl_body_statements(node)?;
+                    return Ok(Stmt::SingletonClassDef {
+                        target,
+                        body,
+                        span: self.span_of(node),
+                    });
+                }
                 // Phase 14b (FC): `class Foo … end` lowers to a
                 // first-class `Stmt::ClassDef { name, body, span }`
-                // whose `body` now carries the class's *executable*
-                // statements in source order (Phase 14a always
-                // emitted an empty body).
+                // whose `body` carries the class's *executable*
+                // statements in source order.
                 //
                 // Method definitions (`def` / endless `def`) inside
-                // the body continue to be hoisted to top-level
-                // `Function`s — SIR v0 has no method-as-statement
-                // node, so a method can't live inside `body`
-                // (a `Vec<Stmt>`).  The hoisting is done per-child
-                // inside `lower_decl_body_statements` (shared with
-                // `module_statement`), so each nested `def` is hoisted
-                // exactly once and every non-`def` statement is
-                // preserved in `body` instead of being dropped.
+                // the body are hoisted to top-level `Function`s — SIR
+                // v0 has no method-as-statement node, so a method can't
+                // live inside `body` (a `Vec<Stmt>`).  The hoisting is
+                // done per-child inside `lower_decl_body_statements`
+                // (shared with `module_statement`), so each nested
+                // `def` is hoisted exactly once and every non-`def`
+                // statement is preserved in `body` instead of dropped.
                 let name = self.extract_class_name(node)?;
                 // Phase 14c — optional `< Bar` superclass clause.
                 let superclass = self.extract_superclass(node);
@@ -1698,6 +1717,29 @@ impl Lowerer {
             }
         }
         None
+    }
+
+    /// Phase 14e (FC) — extract the singleton-class receiver from a
+    /// `class_statement` AST node, if it is the singleton form
+    /// `class << RECEIVER … end`.
+    ///
+    /// The singleton form parses with a `singleton_receiver` child node
+    /// (`singleton_receiver = "self" | NAME`); the ordinary
+    /// `class Foo [< Bar]` form has none.  Returns `Some(receiver)` —
+    /// the value of the receiver token (`"self"` or a bare name) — for
+    /// the singleton form, and `None` for the ordinary form (which
+    /// signals the caller to take the `ClassDef` path).
+    fn extract_singleton_receiver(&self, node: &GrammarASTNode) -> Option<String> {
+        let receiver_node = node.children.iter().find_map(|c| match c {
+            ASTNodeOrToken::Node(n) if n.rule_name == "singleton_receiver" => Some(n),
+            _ => None,
+        })?;
+        // The receiver node wraps exactly one token (`self` keyword or a
+        // Name) — return its value.
+        receiver_node.children.iter().find_map(|c| match c {
+            ASTNodeOrToken::Token(t) => Some(t.value.clone()),
+            _ => None,
+        })
     }
 
     /// Phase 7c — lower an endless method definition `def foo = expr`

--- a/code/packages/rust/semantic-ir-to-go/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/emit.rs
@@ -194,6 +194,9 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
         Stmt::ModuleDef { span, .. } => {
             panic!("go backend reached SIR17 module-def statement at {} — capability check should have rejected it", span);
         }
+        Stmt::SingletonClassDef { span, .. } => {
+            panic!("go backend reached SIR17 singleton-class-def statement at {} — capability check should have rejected it", span);
+        }
     }
 }
 

--- a/code/packages/rust/semantic-ir-to-python/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/emit.rs
@@ -182,6 +182,9 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
         Stmt::ModuleDef { span, .. } => {
             panic!("python backend reached SIR17 module-def statement at {} — capability check should have rejected it", span);
         }
+        Stmt::SingletonClassDef { span, .. } => {
+            panic!("python backend reached SIR17 singleton-class-def statement at {} — capability check should have rejected it", span);
+        }
     }
 }
 
@@ -384,6 +387,9 @@ fn emit_block_as_expr(out: &mut String, b: &Block, indent: usize) {
             }
             Stmt::ModuleDef { span, .. } => {
                 panic!("python backend (walrus path) reached SIR17 module-def statement at {} — capability check should have rejected it", span);
+            }
+            Stmt::SingletonClassDef { span, .. } => {
+                panic!("python backend (walrus path) reached SIR17 singleton-class-def statement at {} — capability check should have rejected it", span);
             }
         }
     }

--- a/code/packages/rust/semantic-ir-to-rust/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/emit.rs
@@ -189,6 +189,9 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
         Stmt::ModuleDef { span, .. } => {
             panic!("rust backend reached SIR17 module-def statement at {} — capability check should have rejected it", span);
         }
+        Stmt::SingletonClassDef { span, .. } => {
+            panic!("rust backend reached SIR17 singleton-class-def statement at {} — capability check should have rejected it", span);
+        }
     }
 }
 
@@ -519,6 +522,9 @@ fn emit_stmt_inline(out: &mut String, s: &Stmt, indent: usize) {
         }
         Stmt::ModuleDef { span, .. } => {
             panic!("rust backend (inline) reached SIR17 module-def statement at {} — capability check should have rejected it", span);
+        }
+        Stmt::SingletonClassDef { span, .. } => {
+            panic!("rust backend (inline) reached SIR17 singleton-class-def statement at {} — capability check should have rejected it", span);
         }
     }
 }

--- a/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
@@ -166,6 +166,9 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
         Stmt::ModuleDef { span, .. } => {
             panic!("ts backend reached SIR17 module-def statement at {} — capability check should have rejected it", span);
         }
+        Stmt::SingletonClassDef { span, .. } => {
+            panic!("ts backend reached SIR17 singleton-class-def statement at {} — capability check should have rejected it", span);
+        }
     }
 }
 

--- a/code/packages/rust/semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 All notable changes to the `semantic-ir` crate are documented here.
 
+## 0.5.0 — SIR17: singleton-class declarations (`Stmt::SingletonClassDef`)
+
+Introduced by the Ruby frontend's Phase 14e (`class << self … end`).
+
+### Added
+
+- `Stmt::SingletonClassDef { target: String, body: Vec<Stmt>, span: Span }`
+  — a singleton-class (metaclass) declaration.  `target` is the
+  receiver whose singleton class is opened (`"self"` for the dominant
+  `class << self` idiom, or a bare object name).  Like
+  `ClassDef`/`ModuleDef`, method `def`s in the body are hoisted to
+  top-level `Function`s by the Ruby lowerer; `body` carries the
+  non-`def` statements.  Reuses `Feature::Classes` (a singleton class
+  is a class-opening construct, not a new feature) — no manifest
+  change.
+
+### Changed
+
+- `Stmt::span()`, the walker, the validator (marks `Feature::Classes`,
+  walks the body via `check_stmt_seq` in a scoped env mark/rewind with
+  the `MAX_IR_DEPTH` guard — same shape as `ClassDef`), the text
+  printer (`(singleton-class-def << Target …)`), and the
+  intrinsic-walk backend helper gain a `SingletonClassDef` arm.  The
+  four reference backends gain an unreachable `panic!` arm
+  (`Feature::Classes` absent from their accepted sets → rejected at the
+  capability check before emit).
+
+New tests (3): `print_singleton_class_def`,
+`singleton_class_def_body_with_let_binding_validates`,
+`singleton_class_def_body_undefined_varref_is_error`.  Test count:
+90 → 93.
+
+This is a **breaking enum change** for any exhaustive `match` on `Stmt`
+without a `_` / `..` rest arm.
+
 ## 0.4.0 — SIR17: module declarations (`Stmt::ModuleDef`)
 
 Introduced by the Ruby frontend's Phase 14d (`module M … end`).

--- a/code/packages/rust/semantic-ir/src/backend.rs
+++ b/code/packages/rust/semantic-ir/src/backend.rs
@@ -235,6 +235,13 @@ where
                 walk_intrinsics_in_stmt(s, f, depth + 1);
             }
         }
+        Stmt::SingletonClassDef { body, .. } => {
+            // Same recursion for singleton-class bodies (Ruby
+            // Phase 14e).
+            for s in body {
+                walk_intrinsics_in_stmt(s, f, depth + 1);
+            }
+        }
     }
 }
 

--- a/code/packages/rust/semantic-ir/src/nodes.rs
+++ b/code/packages/rust/semantic-ir/src/nodes.rs
@@ -279,6 +279,23 @@ pub enum Stmt {
         body: Vec<Stmt>,
         span: Span,
     },
+
+    /// `class << receiver; body; end` — a singleton-class (metaclass)
+    /// declaration.  Introduced by the Ruby frontend's Phase 14e.
+    ///
+    /// `target` is the receiver whose singleton class is opened — the
+    /// dominant idiom is `class << self` (`target = "self"`), but a
+    /// bare object name is also accepted (`class << obj`).  Like
+    /// `ClassDef`/`ModuleDef`, method `def`s inside the body are
+    /// hoisted to top-level `Function`s by the lowerer; `body` carries
+    /// the non-`def` statements.  Triggers `Feature::Classes` (a
+    /// singleton class is a class-opening construct, not a new
+    /// feature).
+    SingletonClassDef {
+        target: String,
+        body: Vec<Stmt>,
+        span: Span,
+    },
 }
 
 impl Stmt {
@@ -295,6 +312,7 @@ impl Stmt {
             Stmt::MapSet { span, .. } => span,
             Stmt::ClassDef { span, .. } => span,
             Stmt::ModuleDef { span, .. } => span,
+            Stmt::SingletonClassDef { span, .. } => span,
         }
     }
 }

--- a/code/packages/rust/semantic-ir/src/text/printer.rs
+++ b/code/packages/rust/semantic-ir/src/text/printer.rs
@@ -251,6 +251,16 @@ fn print_stmt(out: &mut String, s: &Stmt, indent: usize, depth: usize) {
             }
             out.push(')');
         }
+        Stmt::SingletonClassDef { target, body, .. } => {
+            // `(singleton-class-def << Target)` head; body statements
+            // (if any) printed one per line (Ruby Phase 14e).
+            let _ = write!(out, "(singleton-class-def << {}", target);
+            for inner in body {
+                let _ = write!(out, "\n{}  ", " ".repeat(indent));
+                print_stmt(out, inner, indent + 2, depth + 1);
+            }
+            out.push(')');
+        }
     }
 }
 
@@ -778,6 +788,28 @@ mod tests {
         print_block(&mut out, &block, 0);
         assert!(out.contains("(module-def Config"));
         assert!(out.contains("(let v (int 3))"));
+    }
+
+    #[test]
+    fn print_singleton_class_def() {
+        // `class << self; end` → `(singleton-class-def << self)`.
+        let s_ = s();
+        let block = Block {
+            stmts: vec![Stmt::SingletonClassDef {
+                target: "self".into(),
+                body: vec![],
+                span: s_.clone(),
+            }],
+            value: Expr::NilLit { span: s_.clone() },
+            span: s_,
+        };
+        let mut out = String::new();
+        print_block(&mut out, &block, 0);
+        assert!(
+            out.contains("(singleton-class-def << self)"),
+            "expected `(singleton-class-def << self)` in output, got:\n{}",
+            out
+        );
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir/src/validator.rs
+++ b/code/packages/rust/semantic-ir/src/validator.rs
@@ -1388,4 +1388,77 @@ mod tests {
         assert!(!r.is_ok(), "expected missing-Modules-feature error");
         assert!(r.errors().any(|i| i.message.contains("modules")));
     }
+
+    // -----------------------------------------------------------------
+    // SIR17 Phase 14e — `Stmt::SingletonClassDef` validation.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn singleton_class_def_body_with_let_binding_validates() {
+        // A singleton-class body holding a LetBinding is walked and
+        // accepted; the module declares Feature::Classes.
+        let mut m = empty_module(FeatureManifest::from_features(&[Feature::Classes]));
+        m.functions.push(Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![Stmt::SingletonClassDef {
+                    target: "self".into(),
+                    body: vec![Stmt::LetBinding {
+                        name: "X".into(),
+                        sir_type: None,
+                        value: Expr::IntLit { value: 1, span: s() },
+                        span: s(),
+                    }],
+                    span: s(),
+                }],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        });
+        let r = validate(&m);
+        assert!(r.is_ok(), "expected ok, got {:?}", r.issues);
+    }
+
+    #[test]
+    fn singleton_class_def_body_undefined_varref_is_error() {
+        // Proves the singleton body is actually validated.
+        let mut m = empty_module(FeatureManifest::from_features(&[Feature::Classes]));
+        m.functions.push(Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![Stmt::SingletonClassDef {
+                    target: "self".into(),
+                    body: vec![Stmt::ExprStmt {
+                        expr: Expr::VarRef {
+                            name: "ghost".into(),
+                            scope: Scope::Local,
+                            span: s(),
+                        },
+                        span: s(),
+                    }],
+                    span: s(),
+                }],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        });
+        let r = validate(&m);
+        assert!(
+            !r.is_ok(),
+            "expected undefined-varref error from singleton body, got {:?}",
+            r.issues
+        );
+    }
 }

--- a/code/packages/rust/semantic-ir/src/validator.rs
+++ b/code/packages/rust/semantic-ir/src/validator.rs
@@ -394,6 +394,21 @@ impl<'m> ValidatorState<'m> {
                     env.rewind(module_mark);
                     i += 1;
                 }
+                Stmt::SingletonClassDef { body, span, .. } => {
+                    // A singleton-class declaration (Ruby Phase 14e) is
+                    // a class-opening construct → mark Feature::Classes,
+                    // then depth-guard and walk the body in a fresh
+                    // local-env scope, same as ClassDef.
+                    self.observed.add(Feature::Classes);
+                    if self.check_depth(depth, span) {
+                        i += 1;
+                        continue;
+                    }
+                    let singleton_mark = env.mark();
+                    self.check_stmt_seq(body, env, depth + 1);
+                    env.rewind(singleton_mark);
+                    i += 1;
+                }
             }
         }
     }

--- a/code/packages/rust/semantic-ir/src/walker.rs
+++ b/code/packages/rust/semantic-ir/src/walker.rs
@@ -137,6 +137,12 @@ pub fn walk_stmt_default<V: Visitor>(v: &mut V, s: &Stmt) {
                 v.visit_stmt(stmt);
             }
         }
+        Stmt::SingletonClassDef { body, .. } => {
+            // Singleton-class body — same recursion (Ruby Phase 14e).
+            for stmt in body {
+                v.visit_stmt(stmt);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Phase 14e lands **singleton-class declarations**.  `class << self … end`
(and `class << obj`) now lowers to

```
Stmt::SingletonClassDef { target: "self", body, span }
```

opening the receiver's singleton/metaclass.  This introduces a new
SIR17 node, so the semantic-ir crate is bumped as a separate sub-step
(semantic-ir 0.5.0).

## semantic-ir (0.5.0 — new node)

- **`Stmt::SingletonClassDef { target: String, body: Vec<Stmt>, span: Span }`**
  — `target` is the receiver (`"self"` for the dominant idiom, or a
  bare object name).  Like `ClassDef`/`ModuleDef`, method `def`s in the
  body hoist to top-level `Function`s; `body` carries the non-`def`
  statements.  **Reuses `Feature::Classes`** (a singleton class is a
  class-opening construct) — no manifest change.
- `Stmt::span()`, the walker, the validator (marks `Feature::Classes`,
  walks the body via `check_stmt_seq` in a scoped env mark/rewind with
  the `MAX_IR_DEPTH` guard — same shape as `ClassDef`), the text printer
  (`(singleton-class-def << Target …)`), and the intrinsic-walk backend
  helper gain a `SingletonClassDef` arm.  The four reference backends
  gain an unreachable `panic!` arm.

## ruby-to-semantic-ir (0.44.0)

- The `class_statement` lowering arm dispatches on the presence of a
  `singleton_receiver` child node: present → `SingletonClassDef`,
  absent → the ordinary `ClassDef` path (14b/14c).
- New `extract_singleton_receiver` helper returns the receiver token's
  value (`None` for the ordinary form).
- Body handling reuses `lower_decl_body_statements` (shared with
  class/module).  Requests `Feature::Classes`.

## ruby-parser (0.42.0)

Grammar — `class_statement` gains a singleton alternative (listed first
so PEG tries it before the ordinary form):

```
class_statement   = "class" "<<" singleton_receiver { !"end" statement } "end"
                  | "class" NAME [ "<" NAME ] { !"end" statement } "end" ;
singleton_receiver = "self" | NAME ;
```

`<<` matches the left-shift Op token by value (`class << self` lexes as
`class`, `<<`, `self`).  `_grammar.rs` regenerated.

## Backends (go / python / rust / typescript)

Unchanged behaviour.  `Feature::Classes` is absent from every backend's
accepted-feature set, so singleton-class-using modules are rejected at
the capability check *before* emit — the new panic arms stay
unreachable.

| SIR shape (Phase 14e)                                          | Source                       |
|----------------------------------------------------------------|------------------------------|
| `SingletonClassDef { "self", body: [] }`                       | `class << self; end`         |
| `SingletonClassDef { "self", body: [LetBinding "X"=1] }` + hoisted `foo` | `class << self; X=1; def foo;end; end` |
| printer: `(singleton-class-def << self)`                       | printer output               |

## Tests

- `coding-adventures-ruby-lexer`: **173** (no change)
- `coding-adventures-ruby-parser`: 167 → **170** (+3):
  `test_parse_singleton_class_of_self`,
  `test_parse_singleton_class_body_with_def`,
  `test_parse_ordinary_class_has_no_singleton_receiver`
- `ruby-to-semantic-ir`: 201 → **206** (+5):
  `singleton_class_of_self_lowers_to_singleton_class_def`,
  `singleton_class_requests_classes_feature`,
  `singleton_class_hoists_methods_and_keeps_statements`,
  `singleton_class_passes_sir_validator` (E2E lower → validate),
  `ordinary_class_still_lowers_to_class_def_not_singleton`
- `semantic-ir`: 90 → **93** (+3): `print_singleton_class_def`,
  `singleton_class_def_body_with_let_binding_validates`,
  `singleton_class_def_body_undefined_varref_is_error`
- All four backend suites + `twig-to-semantic-ir` green.

## Test plan

- [x] `cargo test -p coding-adventures-ruby-lexer` (173/173)
- [x] `cargo test -p coding-adventures-ruby-parser` (170/170)
- [x] `cargo test -p ruby-to-semantic-ir` (206/206)
- [x] `cargo test -p semantic-ir` (93/93)
- [x] `cargo test -p semantic-ir-to-{go,python,rust,typescript} -p twig-to-semantic-ir` (all green)
- [x] Security review passed (1 round, no findings) — validator
      recursion `MAX_IR_DEPTH`-bounded like ClassDef; `extract_singleton_receiver`
      cannot panic (find_map + `?`, no indexing/unwrap); backend panic
      arms unreachable behind the capability check; `target` is a
      grammar-constrained identifier written verbatim (no injection).
- [ ] CI green

Follows PR #4599 (Phase 14d).  Next chunk: Phase 15a (instance vars
`@x` inside method bodies).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
