### PR TITLE
feat(closurec): --correlation_vector_filter_includes_origin (CLOC11.71)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.34.0] - 2026-05-30
+
+### Added — CLOC11.71: `--correlation_vector_filter_includes_origin`
+
+Adds an opt-in sub-flag to extend the CLOC11.70 filter so it also matches against each entry's `origin.source`, not just `contribution.source`.
+
+Default `false` preserves CLOC11.70's strict semantics byte-for-byte: only entries with a contribution whose source is in the allowlist survive.
+
+With `--correlation_vector_filter_includes_origin true` and `--correlation_vector_filter lex`, an entry is kept iff:
+
+1. any element of `contributions` has `source` in the allowlist (the CLOC11.70 rule), OR
+2. the entry's `origin.source` is in the allowlist.
+
+This is how you get a `--correlation_vector_filter lex` invocation to also retain the per-token CV entries created with `Origin{source: "lexer_token", ...}` — their "lex" association lives in the Origin, not in a contribution.
+
+### Why opt-in rather than the new default
+
+Default-on would silently change the result of every existing `--correlation_vector_filter X` invocation. Default-off keeps CLOC11.70 unchanged; users who want the broader match flip the flag. Standard backward-compat policy for evolving CLI semantics.
+
+### Changed
+
+- `SpecialModesConfig` gains `correlation_vector_filter_includes_origin: bool`.
+- `wire::read_special_modes` reads the bool flag.
+- `prune_entries_by_source` signature: now `(root, allowlist, include_origin)`. Inline doc updated; the contribution-match branch still short-circuits before the Origin check so the fast path is unchanged.
+- Both `format_cv_log_json` and `format_cv_log_ndjson` thread the flag through.
+- Versions: `Cargo.toml` `0.33.0` → `0.34.0`, `cli.spec.json` `0.33.0` → `0.34.0`.
+
 ## [0.33.0] - 2026-05-30
 
 ### Added — CLOC11.70: `--correlation_vector_filter` allowlist flag

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },
@@ -100,6 +100,7 @@
     { "id": "correlation_vector_pretty", "long": "correlation_vector_pretty", "type": "boolean", "default": false, "description": "Pretty-print the correlation-vector sidecar JSON (multi-line, 2-space indent). Default off → compact single-line JSON. Useful for human inspection; CI tooling typically prefers compact (CLOC11.68)." },
     { "id": "correlation_vector_format", "long": "correlation_vector_format", "type": "enum", "enum_values": ["JSON", "NDJSON", "NONE"], "default": "JSON", "description": "Sidecar format: JSON = single document (default), NDJSON = one CV entry per line for streaming consumers, NONE = compute CV but skip write (useful for benchmarking overhead). Ignored unless --correlation_vector is also set (CLOC11.69)." },
     { "id": "correlation_vector_filter", "long": "correlation_vector_filter", "type": "string", "default": "", "description": "Comma-separated allowlist of CV source names (e.g. \"lex,defines\"). Entries with no contribution.source in the allowlist are pruned from the written sidecar. Empty (default) keeps every entry. Ignored unless --correlation_vector is also set (CLOC11.70)." },
+    { "id": "correlation_vector_filter_includes_origin", "long": "correlation_vector_filter_includes_origin", "type": "boolean", "default": false, "description": "When --correlation_vector_filter is set, also match entries by their origin.source (in addition to contribution.source). Lets `--correlation_vector_filter lex` keep the per-token CV entries whose Origin.source is \"lexer_token\". Default off preserves CLOC11.70 strict semantics (CLOC11.71)." },
     { "id": "instrument_for_coverage_option", "long": "instrument_for_coverage_option", "type": "enum", "enum_values": ["NONE", "LINE", "BRANCH", "PRODUCTION"], "default": "NONE", "description": "Enable code instrumentation for coverage analysis." },
     { "id": "production_instrumentation_array_name", "long": "production_instrumentation_array_name", "type": "string", "default": "", "description": "Global array name used by production instrumentation." },
     { "id": "chunk_output_type", "long": "chunk_output_type", "type": "enum", "enum_values": ["GLOBAL_NAMESPACE", "ES_MODULES"], "default": "GLOBAL_NAMESPACE", "description": "Format for output chunks." },

--- a/code/programs/rust/closurec/src/config.rs
+++ b/code/programs/rust/closurec/src/config.rs
@@ -566,6 +566,21 @@ pub struct SpecialModesConfig {
     /// written. Only consulted when `correlation_vector` is
     /// also true.
     pub correlation_vector_filter: Vec<String>,
+    /// CLOC11.71: when true, the filter also matches against
+    /// each entry's `origin.source`, not just
+    /// `contribution.source` (the CLOC11.70 default).
+    ///
+    /// Default `false` preserves the CLOC11.70 strict
+    /// semantics: per-token CV entries created with
+    /// `Origin{source: "lexer_token", ...}` and zero
+    /// contributions are *still* pruned under
+    /// `--correlation_vector_filter lex` — because their
+    /// "lex" association lives in the Origin, not in a
+    /// contribution. Setting this flag to true keeps them.
+    ///
+    /// Only consulted when `correlation_vector` is true AND
+    /// `correlation_vector_filter` is non-empty.
+    pub correlation_vector_filter_includes_origin: bool,
 }
 
 /// CLOC11.69 — sidecar persistence format. Default is

--- a/code/programs/rust/closurec/src/run.rs
+++ b/code/programs/rust/closurec/src/run.rs
@@ -1270,11 +1270,13 @@ pub fn run_compiler(config: &CompilerConfig) -> Result<CompilerOutput, CompilerE
                     CorrelationVectorFormat::Ndjson => format_cv_log_ndjson(
                         &cv_log,
                         &config.special_modes.correlation_vector_filter,
+                        config.special_modes.correlation_vector_filter_includes_origin,
                     ),
                     _ => format_cv_log_json(
                         &cv_log,
                         config.special_modes.correlation_vector_pretty,
                         &config.special_modes.correlation_vector_filter,
+                        config.special_modes.correlation_vector_filter_includes_origin,
                     ),
                 };
                 write_output_file(&sidecar_path, &body)?;
@@ -1318,6 +1320,7 @@ fn format_cv_log_json(
     cv_log: &coding_adventures_correlation_vector::CVLog,
     pretty: bool,
     filter: &[String],
+    filter_includes_origin: bool,
 ) -> String {
     let compact = cv_log
         .to_json_string()
@@ -1334,7 +1337,7 @@ fn format_cv_log_json(
             Err(_) => return compact,
         };
     if need_filter {
-        prune_entries_by_source(&mut value, filter);
+        prune_entries_by_source(&mut value, filter, filter_includes_origin);
     }
     if pretty {
         serde_json::to_string_pretty(&value).unwrap_or_else(|_| compact)
@@ -1368,6 +1371,7 @@ fn format_cv_log_json(
 fn format_cv_log_ndjson(
     cv_log: &coding_adventures_correlation_vector::CVLog,
     filter: &[String],
+    filter_includes_origin: bool,
 ) -> String {
     let compact = cv_log
         .to_json_string()
@@ -1377,7 +1381,7 @@ fn format_cv_log_ndjson(
         Err(_) => return compact,
     };
     if !filter.is_empty() {
-        prune_entries_by_source(&mut root, filter);
+        prune_entries_by_source(&mut root, filter, filter_includes_origin);
     }
     let mut out = String::new();
     if let Some(entries) = root.get("entries").and_then(|v| v.as_object()) {
@@ -1405,15 +1409,23 @@ fn format_cv_log_ndjson(
     out
 }
 
-/// CLOC11.70 — in-place prune of the `entries` object on a
-/// parsed CVLog JSON `Value` by `contribution.source`
-/// allowlist.
+/// CLOC11.70 + CLOC11.71 — in-place prune of the `entries`
+/// object on a parsed CVLog JSON `Value` by a source allowlist.
 ///
 /// Walks `root["entries"]` (an object map id → entry). An
-/// entry is kept iff it has at least one element in its
-/// `contributions` array whose `source` field equals any
-/// string in `allowlist`. Entries with empty / missing
-/// `contributions` are dropped (no source can match).
+/// entry is kept iff at least one of the following matches a
+/// string in `allowlist`:
+///
+///   1. any element of `contributions` whose `source` is in
+///      the allowlist (the CLOC11.70 rule, always applied);
+///   2. **if** `include_origin` is true (CLOC11.71): the
+///      entry's `origin.source` string.
+///
+/// `include_origin=false` preserves CLOC11.70 strict
+/// semantics byte-for-byte. `include_origin=true` lets
+/// `--correlation_vector_filter lex` also keep per-token CV
+/// entries whose `Origin.source == "lexer_token"` even
+/// though they have zero contributions.
 ///
 /// `allowlist` is treated as a closed set of exact-match
 /// strings — no wildcards, no prefix matching. The empty
@@ -1430,6 +1442,7 @@ fn format_cv_log_ndjson(
 fn prune_entries_by_source(
     root: &mut serde_json::Value,
     allowlist: &[String],
+    include_origin: bool,
 ) {
     let Some(entries) = root
         .get_mut("entries")
@@ -1442,18 +1455,36 @@ fn prune_entries_by_source(
     let allow: std::collections::HashSet<&str> =
         allowlist.iter().map(String::as_str).collect();
     entries.retain(|_id, entry| {
-        let Some(contribs) = entry
+        // (1) Any contribution.source in the allowlist?
+        let contrib_match = entry
             .get("contributions")
             .and_then(|v| v.as_array())
-        else {
-            return false;
-        };
-        contribs.iter().any(|c| {
-            c.get("source")
+            .map(|contribs| {
+                contribs.iter().any(|c| {
+                    c.get("source")
+                        .and_then(|s| s.as_str())
+                        .map(|s| allow.contains(s))
+                        .unwrap_or(false)
+                })
+            })
+            .unwrap_or(false);
+        if contrib_match {
+            return true;
+        }
+        // (2) CLOC11.71 — also accept entries whose Origin
+        // source is allowlisted.
+        if include_origin {
+            let origin_match = entry
+                .get("origin")
+                .and_then(|o| o.get("source"))
                 .and_then(|s| s.as_str())
                 .map(|s| allow.contains(s))
-                .unwrap_or(false)
-        })
+                .unwrap_or(false);
+            if origin_match {
+                return true;
+            }
+        }
+        false
     });
 }
 
@@ -3665,6 +3696,95 @@ mod tests {
             entries.is_empty(),
             "expected empty entries under unmatched filter, got {}: {body}",
             entries.len()
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    // ------------------------------------------------------------------
+    // CLOC11.71 — --correlation_vector_filter_includes_origin
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn correlation_vector_filter_origin_off_drops_lexer_token_origin() {
+        // Default semantics (sub-flag off): filter=lexer_token
+        // alone prunes every entry that doesn't have a
+        // contribution with source="lexer_token". Token CV
+        // entries have NO contributions; only their Origin
+        // says "lexer_token". So they should all be dropped.
+        let dir =
+            std::env::temp_dir().join("closurec_cloc11_71_origin_off");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("create dir");
+        let in_path = dir.join("a.js");
+        fs::write(&in_path, "var x = 1;").expect("write");
+        let out_path = dir.join("out.js");
+        let sidecar_path = dir.join("out.js.cv.json");
+        let cfg = CompilerConfig {
+            io: IoConfig {
+                js_patterns: vec![in_path.to_string_lossy().to_string()],
+                js_output_file: Some(out_path.clone()),
+                ..Default::default()
+            },
+            special_modes: crate::config::SpecialModesConfig {
+                correlation_vector: true,
+                correlation_vector_filter: vec!["lexer_token".to_string()],
+                // correlation_vector_filter_includes_origin defaults to false
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let _ = run_compiler(&cfg).expect("ok");
+        let body = fs::read_to_string(&sidecar_path).expect("read sidecar");
+        // No entry has a contribution with source="lexer_token",
+        // so under strict semantics every entry is pruned.
+        assert!(
+            !body.contains("\"source\":\"lexer_token\""),
+            "filter=lexer_token without include_origin should drop all token entries, got: {body}"
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn correlation_vector_filter_origin_on_keeps_lexer_token_origin() {
+        // With include_origin = true, filter=lexer_token now
+        // keeps the entries whose Origin.source is
+        // "lexer_token" (i.e. the per-token CV entries) even
+        // though they have zero contributions. The per-file
+        // CV root (Origin.source="input_file") is dropped
+        // because neither its Origin nor its contributions
+        // mention "lexer_token".
+        let dir = std::env::temp_dir().join("closurec_cloc11_71_origin_on");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("create dir");
+        let in_path = dir.join("a.js");
+        fs::write(&in_path, "var x = 1;").expect("write");
+        let out_path = dir.join("out.js");
+        let sidecar_path = dir.join("out.js.cv.json");
+        let cfg = CompilerConfig {
+            io: IoConfig {
+                js_patterns: vec![in_path.to_string_lossy().to_string()],
+                js_output_file: Some(out_path.clone()),
+                ..Default::default()
+            },
+            special_modes: crate::config::SpecialModesConfig {
+                correlation_vector: true,
+                correlation_vector_filter: vec!["lexer_token".to_string()],
+                correlation_vector_filter_includes_origin: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let _ = run_compiler(&cfg).expect("ok");
+        let body = fs::read_to_string(&sidecar_path).expect("read sidecar");
+        // Origin.source=lexer_token entries survived.
+        assert!(
+            body.contains("\"source\":\"lexer_token\""),
+            "filter=lexer_token + include_origin=true should keep token entries, got: {body}"
+        );
+        // input_file root entry was pruned.
+        assert!(
+            !body.contains("\"source\":\"input_file\""),
+            "input_file Origin should not match filter=lexer_token, got: {body}"
         );
         let _ = fs::remove_dir_all(&dir);
     }

--- a/code/programs/rust/closurec/src/wire.rs
+++ b/code/programs/rust/closurec/src/wire.rs
@@ -509,6 +509,10 @@ fn read_special_modes(p: &ParseResult) -> Result<SpecialModesConfig, ConfigError
                     .collect::<Vec<_>>()
             })
             .unwrap_or_default(),
+        correlation_vector_filter_includes_origin: get_bool(
+            p,
+            "correlation_vector_filter_includes_origin",
+        )?,
     })
 }
 

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.33.0
+Version: 0.34.0
 
 ## Flags
 
@@ -385,6 +385,10 @@ Sidecar format: JSON = single document (default), NDJSON = one CV entry per line
 ### `--correlation_vector_filter` (string, default: "")
 
 Comma-separated allowlist of CV source names (e.g. "lex,defines"). Entries with no contribution.source in the allowlist are pruned from the written sidecar. Empty (default) keeps every entry. Ignored unless --correlation_vector is also set (CLOC11.70).
+
+### `--correlation_vector_filter_includes_origin` (boolean, default: false)
+
+When --correlation_vector_filter is set, also match entries by their origin.source (in addition to contribution.source). Lets `--correlation_vector_filter lex` keep the per-token CV entries whose Origin.source is "lexer_token". Default off preserves CLOC11.70 strict semantics (CLOC11.71).
 
 ### `--instrument_for_coverage_option` (enum, default: NONE)
 


### PR DESCRIPTION
## Summary

Opt-in sub-flag that extends the CLOC11.70 filter to also match against each entry's `origin.source`, not just `contribution.source`.

```bash
closurec --correlation_vector \
         --correlation_vector_filter lex \
         --correlation_vector_filter_includes_origin
```

now keeps the per-token CV entries created with `Origin{source: "lexer_token", ...}` — their "lex" association lives in the Origin, not in a contribution. (Without this flag, CLOC11.70's strict semantics drop them.)

## Resolution

An entry is kept iff:
1. any element of `contributions` has `source` in the allowlist (the CLOC11.70 rule), OR
2. `correlation_vector_filter_includes_origin = true` AND the entry's `origin.source` is in the allowlist.

Default `false` preserves CLOC11.70's strict semantics **byte-for-byte**.

## Why opt-in rather than the new default

Default-on would silently change the result of every existing `--correlation_vector_filter X` invocation. Default-off keeps CLOC11.70 unchanged; users who want the broader match flip the flag. Standard backward-compat policy.

## Implementation

`prune_entries_by_source` now takes `include_origin: bool`. The contribution-match branch short-circuits **before** the Origin check, so with the flag off the new code path is unreachable — semantically identical to CLOC11.70.

## Test plan
- [x] cargo build clean
- [x] 251 unit + 17 integration suites pass
- [x] New tests:
  - `correlation_vector_filter_origin_off_drops_lexer_token_origin` — strict default still drops Origin-only entries
  - `correlation_vector_filter_origin_on_keeps_lexer_token_origin` — flag on keeps token entries; `input_file` root (Origin mismatch) still pruned
- [x] help-markdown fixture regenerated for 0.34.0

## Security review (inline)
- Origin lookup uses chained `Option` helpers — missing/wrong-typed origin fields collapse to no match, no panic.
- Contribution-match short-circuits before Origin check → flag-off code path unreachable.
- `allowlist` is `HashSet<&str>` exact-match closed set (no regex/wildcards).
- No unsafe, no new deps.

## Versions
- `Cargo.toml`: 0.33.0 → 0.34.0
- `cli.spec.json`: 0.33.0 → 0.34.0
- `CHANGELOG.md`: new `[0.34.0]` section

🤖 Generated with [Claude Code](https://claude.com/claude-code)