### PR TITLE
feat(ruby-parser+sir): Phase 15a (FC) — instance vars @x → Scope::Instance

### DIFF
--- a/code/packages/rust/ruby-parser/.pr-body-fc-15a.md
+++ b/code/packages/rust/ruby-parser/.pr-body-fc-15a.md
@@ -1,0 +1,91 @@
+## Summary
+
+Phase 15a gives Ruby **instance variables** (`@x`) a first-class SIR
+representation.  A `@x` read now lowers to `Expr::VarRef { scope:
+Scope::Instance }` and `@x = …` to `Stmt::Assign { scope: Instance }` —
+replacing the Phase 6x placeholder that modelled ivars as plain locals
+(`Scope::Local`).  The key win: **reading an unset `@x` no longer fails
+validation** as an undefined local (an unset ivar is `nil` in Ruby).
+
+This introduces a new `Scope` variant + feature, so the semantic-ir
+crate is bumped as a separate sub-step (semantic-ir 0.6.0).
+
+## semantic-ir (0.6.0 — new scope + feature)
+
+- **`Scope::Instance`** — object instance variable.  Unlike `Local`, it
+  needs no prior declaration; `check_varref` performs no
+  scope-existence check (and observes `Feature::InstanceVars`).
+  `Scope::name()`/`from_name()` gain the `"instance"` tag; the printer
+  renders `(var-ref @x instance)` via the existing `scope.name()` path.
+- **`Feature::InstanceVars`** (kebab `instance-vars`).
+- The four reference backends' `emit_var_ref` gain an unreachable
+  `panic!` arm for `Scope::Instance` (the feature is in no backend's
+  accepted set → rejected at the capability check before emit).
+
+## ruby-to-semantic-ir (0.45.0)
+
+- A single-`@` Name lowers to `Scope::Instance` for both reads and
+  assignments.  `@x = …` / `@x += …` lower to `Stmt::Assign { scope:
+  Instance }` (never a `LetBinding`) and don't register `@x` as a local.
+- New `is_instance_var_name` helper: single `@` only — `@@x` (class var,
+  Phase 15b) and `$x` (global) keep their pre-15a handling.
+- Emitting an instance-var node requests `Feature::InstanceVars` (and
+  `MutableBindings` for the `Assign` store).
+
+## ruby-parser (0.43.0)
+
+No grammar change — the lexer already emits `@x` as a `Name` token
+(sigil included, since Phase 4i/4j).  Ivar assignment/expression parsing
+is already covered by the Phase 6x tests; 15a adds one compound-assign
+parse pin (`@n += 1`).
+
+## Backends (go / python / rust / typescript)
+
+Unchanged behaviour.  `Feature::InstanceVars` is absent from every
+backend's accepted set, so instance-var-using modules are rejected at
+the capability check *before* emit — the new panic arms stay
+unreachable.
+
+| SIR shape (Phase 15a)                          | Source       |
+|------------------------------------------------|--------------|
+| `Assign { "@count", scope: Instance }`         | `@count = 0` |
+| `VarRef { "@x", scope: Instance }`             | `@x`         |
+| printer: `(var-ref @x instance)`               | printer      |
+
+## Tests
+
+- `coding-adventures-ruby-lexer`: **173** (no change)
+- `coding-adventures-ruby-parser`: 170 → **171** (+1):
+  `test_parse_instance_var_compound_assignment`
+- `ruby-to-semantic-ir`: 206 → **211** (+5):
+  `instance_var_read_lowers_to_instance_scope`,
+  `instance_var_assignment_lowers_to_instance_assign`,
+  `instance_var_read_without_assignment_passes_validator` (E2E),
+  `instance_var_in_method_roundtrips_through_validator` (E2E),
+  `class_var_double_at_is_not_instance_scope` (regression guard).
+  Pre-existing Phase 6x test updated to the new `Scope::Instance`
+  contract.
+- `semantic-ir`: 93 → **96** (+3): `print_var_ref_instance_scope`,
+  `instance_var_ref_needs_no_declaration`,
+  `instance_var_ref_without_manifest_feature_is_error`
+- All four backend suites + `twig-to-semantic-ir` green.
+
+## Test plan
+
+- [x] `cargo test -p coding-adventures-ruby-lexer` (173/173)
+- [x] `cargo test -p coding-adventures-ruby-parser` (171/171)
+- [x] `cargo test -p ruby-to-semantic-ir` (211/211)
+- [x] `cargo test -p semantic-ir` (96/96)
+- [x] `cargo test -p semantic-ir-to-{go,python,rust,typescript} -p twig-to-semantic-ir` (all green)
+- [x] Security review passed (1 round, no findings) — pure AST/IR logic;
+      `is_instance_var_name` is a total `starts_with`-only function (no
+      panics, correctly excludes `@@`/`$`); the no-declaration check is
+      scoped strictly to `Scope::Instance` (other scopes keep full
+      resolution); backend panic arms unreachable behind the capability
+      check; ivar names are lexer-constrained identifiers (no printer
+      injection).
+- [ ] CI green
+
+Follows PR #4605 (Phase 14e).  Next chunk: Phase 15b (class vars `@@x`).
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.43.0] - 2026-05-30
+
+### Added (Phase 15a (FC) — instance variables `@x`)
+
+No grammar change — the lexer already emits `@x` as a `Name` token
+(sigil included, since Phase 4i/4j), so `@x = 1` parses as an
+`assignment` and a bare `@x` as an expression.  Ivar assignment and
+expression parsing are already covered by the Phase 6x tests
+(`test_parse_instance_var_assignment`,
+`test_parse_instance_var_in_expression`).  Phase 15a adds one parse pin
+for the new lowering path:
+
+- `test_parse_instance_var_compound_assignment` — `@n += 1` parses as an
+  assignment carrying the `@n` Name token and the fused `+=` operator
+  token.
+
+Test count: 170 → 171 (+1).
+
 ## [0.42.0] - 2026-05-30
 
 ### Added (Phase 14e (FC) — singleton class `class << receiver … end`)

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -847,6 +847,33 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // Phase 15a (FC) — instance variables `@x`.  No grammar change: the
+    // lexer already emits `@x` as a `Name` token (sigil included), and
+    // ivar assignment / expression parsing is covered by the Phase 6x
+    // tests (`test_parse_instance_var_assignment`,
+    // `test_parse_instance_var_in_expression`).  Phase 15a adds only the
+    // compound-assign parse pin the new lowering path exercises.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_instance_var_compound_assignment() {
+        // `@n += 1` parses as an assignment carrying the `@n` Name token
+        // and the fused `+=` operator token (the shape the 15a lowerer's
+        // compound-ivar path dispatches on).
+        let ast = parse_ruby("@n += 1");
+        let asn = find_statement_inner(&ast, "assignment")
+            .expect("expected assignment");
+        assert!(
+            body_has_token_value(asn, "@n"),
+            "expected the `@n` ivar Name token in the assignment header"
+        );
+        assert!(
+            body_has_token_value(asn, "+="),
+            "expected the fused `+=` compound-assign operator token"
+        );
+    }
+
+    // -----------------------------------------------------------------------
     // Phase 6g — blocks `do … end` and brace-blocks `method { … }`
     // -----------------------------------------------------------------------
 

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.45.0] - 2026-05-30
+
+### Changed (Phase 15a (FC) — instance variables `@x`)
+
+Instance variables now lower to the first-class `Scope::Instance`
+(semantic-ir 0.6.0) instead of the Phase 6x `Scope::Local` placeholder:
+
+- A `@x` **read** lowers to `Expr::VarRef { scope: Instance }` — and,
+  crucially, no longer errors as an undefined local when read before any
+  assignment (reading an unset `@x` is nil in Ruby).
+- A `@x` **assignment** (`@x = …`, `@x += …`) lowers to
+  `Stmt::Assign { scope: Instance }` — never a `LetBinding` — and does
+  not register `@x` as a local.  Emitting it requests
+  `Feature::InstanceVars` (and `MutableBindings`, since the store is a
+  `Stmt::Assign`).
+- New `is_instance_var_name` helper: a single-`@` sigil name is an
+  instance var; `@@x` (class var, Phase 15b) and `$x` (global) keep
+  their pre-15a handling.
+
+New tests (+5): `instance_var_read_lowers_to_instance_scope`,
+`instance_var_assignment_lowers_to_instance_assign`,
+`instance_var_read_without_assignment_passes_validator` (E2E),
+`instance_var_in_method_roundtrips_through_validator` (E2E),
+`class_var_double_at_is_not_instance_scope` (regression guard).  The
+pre-existing Phase 6x test
+`instance_var_ref_lowers_with_local_scope_and_sigil_preserved` was
+updated to assert the new `Scope::Instance` contract.  Test count:
+206 → 211 (+5).
+
 ## [0.44.0] - 2026-05-30
 
 ### Added (Phase 14e (FC) — singleton class `class << self … end`)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -967,6 +967,93 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
+    // Phase 15a (FC) — instance variables `@x`.  Reads lower to
+    // `VarRef { scope: Instance }`, assignments to
+    // `Assign { scope: Instance }` (no `let` declaration needed).
+    // Triggers `Feature::InstanceVars`.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn instance_var_read_lowers_to_instance_scope() {
+        // A bare `@x` read with no prior assignment lowers to
+        // `VarRef { scope: Instance }` — and crucially does NOT error
+        // as an undefined local (reading an unset ivar is nil in Ruby).
+        let m = lower("@x\n");
+        match &main_body(&m).value {
+            Expr::VarRef { name, scope, .. } => {
+                assert_eq!(name, "@x");
+                assert_eq!(*scope, Scope::Instance);
+            }
+            other => panic!("expected VarRef instance, got {:?}", other),
+        }
+        assert!(
+            m.manifest.contains(semantic_ir::Feature::InstanceVars),
+            "manifest should declare InstanceVars; got {:?}",
+            m.manifest
+        );
+    }
+
+    #[test]
+    fn instance_var_assignment_lowers_to_instance_assign() {
+        // `@count = 0` → `Assign { scope: Instance }` (not a
+        // `LetBinding`), since an instance var is never a local.
+        let m = lower("@count = 0\n");
+        match &main_body(&m).stmts[0] {
+            Stmt::Assign { name, scope, .. } => {
+                assert_eq!(name, "@count");
+                assert_eq!(*scope, Scope::Instance);
+            }
+            other => panic!("expected Assign instance, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn instance_var_read_without_assignment_passes_validator() {
+        // E2E: reading an unset `@x` (here as an assignment RHS, with no
+        // prior `@x = …`) must lower to a module the validator accepts —
+        // the key win over the pre-15a local-modelling, which rejected
+        // `@x` as an unknown local.
+        let m = lower("y = @x\n");
+        let result = semantic_ir::validate(&m);
+        assert!(
+            result.is_ok(),
+            "validator rejected unset-ivar read: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn instance_var_in_method_roundtrips_through_validator() {
+        // `def inc; @count = @count + 1; end` — assignment + read of the
+        // same ivar inside a method body; validates end-to-end.
+        let m = lower("def inc\n  @count = @count + 1\nend\n");
+        assert!(
+            m.functions.iter().any(|f| f.name == "inc"),
+            "expected hoisted `inc`; got {:?}",
+            m.functions.iter().map(|f| &f.name).collect::<Vec<_>>()
+        );
+        assert!(semantic_ir::validate(&m).is_ok(), "validator rejected ivar method: {:?}", semantic_ir::validate(&m));
+    }
+
+    #[test]
+    fn class_var_double_at_is_not_instance_scope() {
+        // Regression guard: `@@x` (class var, Phase 15b) must NOT be
+        // mistaken for an instance var — it keeps the pre-15a
+        // local-modelling (single `@` only is an instance var).
+        let m = lower("@@total = 0\n");
+        match &main_body(&m).stmts[0] {
+            Stmt::LetBinding { name, .. } => assert_eq!(name, "@@total"),
+            // (If a later phase changes @@ handling, this guard should be
+            // updated — but it must not become Scope::Instance here.)
+            other => panic!("expected `@@total` LetBinding (not instance), got {:?}", other),
+        }
+        assert!(
+            !m.manifest.contains(semantic_ir::Feature::InstanceVars),
+            "`@@x` must not request InstanceVars"
+        );
+    }
+
+    // -----------------------------------------------------------------
     // Phase 14d (FC) — `module M … end` → `Stmt::ModuleDef`.  Mirrors
     // ClassDef (minus inheritance): method defs hoist to top-level
     // Functions; non-def statements stay in the module body.
@@ -3084,7 +3171,10 @@ mod tests {
         match ref_expr {
             Expr::VarRef { name, scope, .. } => {
                 assert_eq!(name, "@a", "ivar value should retain leading `@`");
-                assert_eq!(*scope, Scope::Local, "v0 puts ivars on Scope::Local");
+                // Phase 15a (FC): instance vars now lower to
+                // `Scope::Instance` (was `Scope::Local` in the Phase 6x
+                // v0 placeholder).
+                assert_eq!(*scope, Scope::Instance, "Phase 15a: ivars use Scope::Instance");
             }
             other => panic!("expected VarRef(@a), got {:?}", other),
         }

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -123,6 +123,9 @@ pub fn compile(program: &GrammarASTNode, module_name: &str) -> Result<Module, Ru
         // Phase 14d (FC) — `module M; end` lowers to
         // `Stmt::ModuleDef` and triggers the `Modules` feature.
         Feature::Modules,
+        // Phase 15a (FC) — an instance-var ref (`@x`, `Scope::Instance`)
+        // triggers the `InstanceVars` feature.
+        Feature::InstanceVars,
     ] {
         if lw.features_used.contains(&f) {
             manifest.add(f);
@@ -298,6 +301,15 @@ fn block_references_any_name(block: &Block, names: &HashSet<String>) -> bool {
         }
     }
     false
+}
+
+/// Phase 15a (FC) — is this Name-token value a Ruby *instance
+/// variable* (`@x`)?  Instance vars lex as a `Name` token carrying the
+/// leading sigil.  A single `@` marks an instance variable; a double
+/// `@@` is a *class* variable (Phase 15b) and a leading `$` is a
+/// global — both excluded here so they keep their pre-15a handling.
+fn is_instance_var_name(name: &str) -> bool {
+    name.starts_with('@') && !name.starts_with("@@")
 }
 
 // ---------------------------------------------------------------------------
@@ -2226,9 +2238,15 @@ impl Lowerer {
                 // branch above (Phase 8b) and never reach this match.
                 _ => unreachable!("op_token matched only the eager compound forms above"),
             };
+            // Phase 15a — a compound assign to an instance variable
+            // (`@x += 1`) reads `@x` with `Scope::Instance` too.
             let lhs_ref = Expr::VarRef {
                 name: name.clone(),
-                scope: Scope::Local,
+                scope: if is_instance_var_name(&name) {
+                    Scope::Instance
+                } else {
+                    Scope::Local
+                },
                 span: span.clone(),
             };
             Expr::BuiltinCall {
@@ -2240,6 +2258,24 @@ impl Lowerer {
         } else {
             rhs
         };
+
+        // Phase 15a (FC) — instance-variable assignment (`@x = …`,
+        // `@x += …`) lowers to `Stmt::Assign { scope: Instance }`
+        // regardless of prior sightings: an instance var needs no
+        // `let` declaration and is never a local.  The store lowers to
+        // `Stmt::Assign`, whose validator arm observes
+        // `MutableBindings`, so we declare both features.  We do NOT
+        // touch `declared_locals` (an ivar is not a local).
+        if is_instance_var_name(&name) {
+            self.features_used.insert(Feature::InstanceVars);
+            self.features_used.insert(Feature::MutableBindings);
+            return Ok(Stmt::Assign {
+                name,
+                scope: Scope::Instance,
+                value,
+                span,
+            });
+        }
 
         // A compound assignment ALWAYS reads then re-binds, so it
         // must emit `Stmt::Assign` (never `LetBinding`).  Plain `=`
@@ -4924,7 +4960,16 @@ impl Lowerer {
                             // and/or (b) auto-emit `Global` declarations for
                             // `$x`-prefixed names so the validator-true
                             // mapping `$x` → `Scope::Global` becomes usable.
-                            let scope = if self.current_params.contains(&tok.value) {
+                            // Phase 15a (FC) — a single-`@` sigil name is
+                            // an *instance variable* (`@x`); it lowers to
+                            // `Scope::Instance` (no declaration needed).
+                            // `@@x` (class var, double `@`) and `$x`
+                            // (global) keep the pre-15a `Scope::Local`
+                            // fallback for now (Phase 15b / later).
+                            let scope = if is_instance_var_name(&tok.value) {
+                                self.features_used.insert(Feature::InstanceVars);
+                                Scope::Instance
+                            } else if self.current_params.contains(&tok.value) {
                                 Scope::Param
                             } else {
                                 Scope::Local

--- a/code/packages/rust/semantic-ir-to-go/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/emit.rs
@@ -331,6 +331,12 @@ fn emit_var_ref(out: &mut String, name: &str, scope: Scope) {
         Scope::Builtin => {
             let _ = write!(out, "_sir_builtin_closure({})", quote_go_string(name));
         }
+        Scope::Instance => {
+            // SIR17 Phase 15a — `Feature::InstanceVars` is not in this
+            // backend's accepted set, so an instance-var-using module is
+            // rejected at the capability check before emit.  Unreachable.
+            panic!("go backend reached SIR17 instance-var ref `{}` — capability check should have rejected it", name);
+        }
     }
 }
 

--- a/code/packages/rust/semantic-ir-to-python/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/emit.rs
@@ -285,6 +285,12 @@ fn emit_var_ref(out: &mut String, name: &str, scope: Scope) {
         Scope::Builtin => {
             let _ = write!(out, "_sir_builtin_closure({})", quote_py_string(name));
         }
+        Scope::Instance => {
+            // SIR17 Phase 15a — `Feature::InstanceVars` is not accepted
+            // by this backend; instance-var-using modules are rejected
+            // at the capability check before emit.  Unreachable.
+            panic!("python backend reached SIR17 instance-var ref `{}` — capability check should have rejected it", name);
+        }
     }
 }
 

--- a/code/packages/rust/semantic-ir-to-rust/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/emit.rs
@@ -275,6 +275,12 @@ fn emit_var_ref(out: &mut String, name: &str, scope: Scope) {
         Scope::Builtin => {
             let _ = write!(out, "__sir::builtin_closure({})", quote_rs_string(name));
         }
+        Scope::Instance => {
+            // SIR17 Phase 15a — `Feature::InstanceVars` is not accepted
+            // by this backend; instance-var-using modules are rejected
+            // at the capability check before emit.  Unreachable.
+            panic!("rust backend reached SIR17 instance-var ref `{}` — capability check should have rejected it", name);
+        }
     }
 }
 

--- a/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
@@ -269,6 +269,12 @@ fn emit_var_ref(out: &mut String, name: &str, scope: Scope) {
         Scope::Builtin => {
             let _ = write!(out, "__Sir.builtins[{}]", quote_ts_string(name));
         }
+        Scope::Instance => {
+            // SIR17 Phase 15a — `Feature::InstanceVars` is not accepted
+            // by this backend; instance-var-using modules are rejected
+            // at the capability check before emit.  Unreachable.
+            panic!("ts backend reached SIR17 instance-var ref `{}` — capability check should have rejected it", name);
+        }
     }
 }
 

--- a/code/packages/rust/semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to the `semantic-ir` crate are documented here.
 
+## 0.6.0 — SIR17: instance-variable scope (`Scope::Instance`)
+
+Introduced by the Ruby frontend's Phase 15a (`@x`).
+
+### Added
+
+- `Scope::Instance` — an object instance variable (Ruby `@x`).  Unlike
+  `Scope::Local`, an instance var needs **no prior declaration**:
+  `check_varref` performs no scope-existence check for it (reading an
+  unset `@x` yields nil in Ruby).  `Scope::name()` / `from_name()` gain
+  the `"instance"` tag.
+- `Feature::InstanceVars` (kebab `instance-vars`) — declared by any
+  module that references a `Scope::Instance` var.  The validator
+  observes it from each Instance-scoped `VarRef`; backends that don't
+  list it in their accepted set reject such modules at the capability
+  check, before emit.
+
+### Changed
+
+- `check_varref` gains a `Scope::Instance` arm (no resolution; observes
+  `Feature::InstanceVars`).  The text printer renders
+  `(var-ref @x instance)` via the existing `scope.name()` path.  The
+  four reference backends' `emit_var_ref` gain an unreachable `panic!`
+  arm for `Scope::Instance` (rejected pre-emit by the capability check).
+
+New tests (3): `print_var_ref_instance_scope`,
+`instance_var_ref_needs_no_declaration`,
+`instance_var_ref_without_manifest_feature_is_error`.  Test count:
+93 → 96.
+
+This is a **breaking enum change** for any exhaustive `match` on
+`Scope` without a `_` rest arm.
+
 ## 0.5.0 — SIR17: singleton-class declarations (`Stmt::SingletonClassDef`)
 
 Introduced by the Ruby frontend's Phase 14e (`class << self … end`).

--- a/code/packages/rust/semantic-ir/src/manifest.rs
+++ b/code/packages/rust/semantic-ir/src/manifest.rs
@@ -55,6 +55,11 @@ pub enum Feature {
     /// Distinct from `Classes`: a Ruby `module` is a namespace/mixin,
     /// not an instantiable class.
     Modules,
+    /// Module references an object instance variable
+    /// (`Scope::Instance`, Ruby `@x`).  Phase 15a (Ruby).  Instance
+    /// vars need no prior declaration and are scoped to the receiver
+    /// object, so they are distinct from `Local`/`Global` bindings.
+    InstanceVars,
 }
 
 impl Feature {
@@ -78,6 +83,7 @@ impl Feature {
         Feature::ShortCircuit,
         Feature::Classes,
         Feature::Modules,
+        Feature::InstanceVars,
     ];
 
     /// Kebab-case name for the SIR text format.
@@ -101,6 +107,7 @@ impl Feature {
             Feature::ShortCircuit => "short-circuit",
             Feature::Classes => "classes",
             Feature::Modules => "modules",
+            Feature::InstanceVars => "instance-vars",
         }
     }
 

--- a/code/packages/rust/semantic-ir/src/nodes.rs
+++ b/code/packages/rust/semantic-ir/src/nodes.rs
@@ -331,6 +331,13 @@ pub enum Scope {
     Global,
     /// Language built-in (`+`, `cons`, etc.).
     Builtin,
+    /// Object instance variable (Ruby `@x`).  Unlike `Local`, an
+    /// instance variable needs **no prior declaration**: reading an
+    /// unset `@x` yields nil in Ruby, so the validator performs no
+    /// scope-existence check for this kind.  The leading `@` sigil is
+    /// preserved in the `VarRef` / `Assign` name.  Introduced by the
+    /// Ruby frontend's Phase 15a; gated by `Feature::InstanceVars`.
+    Instance,
 }
 
 impl Scope {
@@ -342,6 +349,7 @@ impl Scope {
             Scope::Capture => "capture",
             Scope::Global => "global",
             Scope::Builtin => "builtin",
+            Scope::Instance => "instance",
         }
     }
 
@@ -353,6 +361,7 @@ impl Scope {
             "capture" => Scope::Capture,
             "global" => Scope::Global,
             "builtin" => Scope::Builtin,
+            "instance" => Scope::Instance,
             _ => return None,
         })
     }

--- a/code/packages/rust/semantic-ir/src/text/printer.rs
+++ b/code/packages/rust/semantic-ir/src/text/printer.rs
@@ -518,6 +518,18 @@ mod tests {
     }
 
     #[test]
+    fn print_var_ref_instance_scope() {
+        // Phase 15a — an instance-var ref prints with the `instance`
+        // scope tag and the `@`-sigil name preserved verbatim.
+        let e = Expr::VarRef {
+            name: "@x".into(),
+            scope: Scope::Instance,
+            span: s(),
+        };
+        assert_eq!(print_expr(&e), "(var-ref @x instance)");
+    }
+
+    #[test]
     fn print_builtin_call_with_pure() {
         let e = Expr::BuiltinCall {
             name: "+".into(),

--- a/code/packages/rust/semantic-ir/src/validator.rs
+++ b/code/packages/rust/semantic-ir/src/validator.rs
@@ -569,6 +569,14 @@ impl<'m> ValidatorState<'m> {
                 // Builtin names are not enumerated by the SIR;
                 // resolution is the backend's responsibility.
             }
+            Scope::Instance => {
+                // Instance variables (Ruby `@x`) need no prior
+                // declaration — reading an unset `@x` yields nil — so
+                // there is nothing to resolve against the local env.
+                // We only record that the feature is in use so the
+                // manifest comparison stays honest.
+                self.observed.add(Feature::InstanceVars);
+            }
         }
     }
 
@@ -1460,5 +1468,55 @@ mod tests {
             "expected undefined-varref error from singleton body, got {:?}",
             r.issues
         );
+    }
+
+    // -----------------------------------------------------------------
+    // SIR17 Phase 15a — `Scope::Instance` (instance variables).
+    // -----------------------------------------------------------------
+
+    /// Build a one-function module whose body value is a single
+    /// instance-var ref, declaring the given features.
+    fn module_with_instance_ref(features: &[Feature]) -> Module {
+        let mut m = empty_module(FeatureManifest::from_features(features));
+        m.functions.push(Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![],
+                value: Expr::VarRef {
+                    name: "@x".into(),
+                    scope: Scope::Instance,
+                    span: s(),
+                },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        });
+        m
+    }
+
+    #[test]
+    fn instance_var_ref_needs_no_declaration() {
+        // An instance-var ref is accepted with no prior `let`/param —
+        // reading an unset `@x` is nil in Ruby.  Module declares
+        // `InstanceVars`.
+        let m = module_with_instance_ref(&[Feature::InstanceVars]);
+        let r = validate(&m);
+        assert!(r.is_ok(), "expected ok, got {:?}", r.issues);
+    }
+
+    #[test]
+    fn instance_var_ref_without_manifest_feature_is_error() {
+        // The validator observes `InstanceVars` from the Instance-scoped
+        // ref; if the manifest doesn't declare it, the
+        // used-but-undeclared check fires.
+        let m = module_with_instance_ref(&[]);
+        let r = validate(&m);
+        assert!(!r.is_ok(), "expected missing-InstanceVars-feature error");
+        assert!(r.errors().any(|i| i.message.contains("instance-vars")));
     }
 }


### PR DESCRIPTION
## Summary

Phase 15a gives Ruby **instance variables** (`@x`) a first-class SIR
representation.  A `@x` read now lowers to `Expr::VarRef { scope:
Scope::Instance }` and `@x = …` to `Stmt::Assign { scope: Instance }` —
replacing the Phase 6x placeholder that modelled ivars as plain locals
(`Scope::Local`).  The key win: **reading an unset `@x` no longer fails
validation** as an undefined local (an unset ivar is `nil` in Ruby).

This introduces a new `Scope` variant + feature, so the semantic-ir
crate is bumped as a separate sub-step (semantic-ir 0.6.0).

## semantic-ir (0.6.0 — new scope + feature)

- **`Scope::Instance`** — object instance variable.  Unlike `Local`, it
  needs no prior declaration; `check_varref` performs no
  scope-existence check (and observes `Feature::InstanceVars`).
  `Scope::name()`/`from_name()` gain the `"instance"` tag; the printer
  renders `(var-ref @x instance)` via the existing `scope.name()` path.
- **`Feature::InstanceVars`** (kebab `instance-vars`).
- The four reference backends' `emit_var_ref` gain an unreachable
  `panic!` arm for `Scope::Instance` (the feature is in no backend's
  accepted set → rejected at the capability check before emit).

## ruby-to-semantic-ir (0.45.0)

- A single-`@` Name lowers to `Scope::Instance` for both reads and
  assignments.  `@x = …` / `@x += …` lower to `Stmt::Assign { scope:
  Instance }` (never a `LetBinding`) and don't register `@x` as a local.
- New `is_instance_var_name` helper: single `@` only — `@@x` (class var,
  Phase 15b) and `$x` (global) keep their pre-15a handling.
- Emitting an instance-var node requests `Feature::InstanceVars` (and
  `MutableBindings` for the `Assign` store).

## ruby-parser (0.43.0)

No grammar change — the lexer already emits `@x` as a `Name` token
(sigil included, since Phase 4i/4j).  Ivar assignment/expression parsing
is already covered by the Phase 6x tests; 15a adds one compound-assign
parse pin (`@n += 1`).

## Backends (go / python / rust / typescript)

Unchanged behaviour.  `Feature::InstanceVars` is absent from every
backend's accepted set, so instance-var-using modules are rejected at
the capability check *before* emit — the new panic arms stay
unreachable.

| SIR shape (Phase 15a)                          | Source       |
|------------------------------------------------|--------------|
| `Assign { "@count", scope: Instance }`         | `@count = 0` |
| `VarRef { "@x", scope: Instance }`             | `@x`         |
| printer: `(var-ref @x instance)`               | printer      |

## Tests

- `coding-adventures-ruby-lexer`: **173** (no change)
- `coding-adventures-ruby-parser`: 170 → **171** (+1):
  `test_parse_instance_var_compound_assignment`
- `ruby-to-semantic-ir`: 206 → **211** (+5):
  `instance_var_read_lowers_to_instance_scope`,
  `instance_var_assignment_lowers_to_instance_assign`,
  `instance_var_read_without_assignment_passes_validator` (E2E),
  `instance_var_in_method_roundtrips_through_validator` (E2E),
  `class_var_double_at_is_not_instance_scope` (regression guard).
  Pre-existing Phase 6x test updated to the new `Scope::Instance`
  contract.
- `semantic-ir`: 93 → **96** (+3): `print_var_ref_instance_scope`,
  `instance_var_ref_needs_no_declaration`,
  `instance_var_ref_without_manifest_feature_is_error`
- All four backend suites + `twig-to-semantic-ir` green.

## Test plan

- [x] `cargo test -p coding-adventures-ruby-lexer` (173/173)
- [x] `cargo test -p coding-adventures-ruby-parser` (171/171)
- [x] `cargo test -p ruby-to-semantic-ir` (211/211)
- [x] `cargo test -p semantic-ir` (96/96)
- [x] `cargo test -p semantic-ir-to-{go,python,rust,typescript} -p twig-to-semantic-ir` (all green)
- [x] Security review passed (1 round, no findings) — pure AST/IR logic;
      `is_instance_var_name` is a total `starts_with`-only function (no
      panics, correctly excludes `@@`/`$`); the no-declaration check is
      scoped strictly to `Scope::Instance` (other scopes keep full
      resolution); backend panic arms unreachable behind the capability
      check; ivar names are lexer-constrained identifiers (no printer
      injection).
- [ ] CI green

Follows PR #4605 (Phase 14e).  Next chunk: Phase 15b (class vars `@@x`).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
