### PR TITLE
feat(closurec): --correlation_vector_filter_invert (CLOC11.72)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.35.0] - 2026-05-30
+
+### Added — CLOC11.72: `--correlation_vector_filter_invert`
+
+Boolean flag that flips the CLOC11.70 allowlist into a **blocklist**. With:
+
+```bash
+closurec --correlation_vector \
+         --correlation_vector_filter lex \
+         --correlation_vector_filter_invert
+```
+
+entries that DO match (i.e. carry a `lex` contribution and/or — under `--correlation_vector_filter_includes_origin` — a `lex` origin) are dropped; everything else is kept.
+
+Use case: "everything except X" filters where enumerating the allowlist would be impractical (the lexer alone produces many `lexer_token` entries; flipping to `--correlation_vector_filter_invert` lets you exclude one stage instead of listing every other).
+
+### Composition
+
+Invert composes orthogonally with `include_origin`:
+- `include_origin` selects WHICH sources count as a match (contribution.source only, or contribution.source ∪ origin.source).
+- `invert` then decides whether matches are kept or dropped.
+
+| include_origin | invert | Behavior                                                  |
+|----------------|--------|-----------------------------------------------------------|
+| false          | false  | CLOC11.70 strict allowlist on contribution.source         |
+| true           | false  | CLOC11.71 broadened allowlist (also origin.source)        |
+| false          | true   | CLOC11.72 blocklist on contribution.source                |
+| true           | true   | CLOC11.72 blocklist on contribution.source ∪ origin.source |
+
+### Implementation
+
+- `prune_entries_by_source` signature: now `(root, allowlist, include_origin, invert)`. The match-computation logic is unchanged; only the keep-rule terminal expression is `if invert { !matches } else { matches }`.
+- Both `format_cv_log_json` and `format_cv_log_ndjson` thread the flag through. Empty-allowlist short-circuit unchanged: an inverted empty filter is a no-op (no entry can match → none are blocked), so we keep the fast path.
+
+### Changed
+
+- `SpecialModesConfig` gains `correlation_vector_filter_invert: bool`.
+- `wire::read_special_modes` reads the bool.
+- Versions: `Cargo.toml` `0.34.0` → `0.35.0`, `cli.spec.json` `0.34.0` → `0.35.0`.
+
 ## [0.34.0] - 2026-05-30
 
 ### Added — CLOC11.71: `--correlation_vector_filter_includes_origin`

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.34.0"
+version = "0.35.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },
@@ -101,6 +101,7 @@
     { "id": "correlation_vector_format", "long": "correlation_vector_format", "type": "enum", "enum_values": ["JSON", "NDJSON", "NONE"], "default": "JSON", "description": "Sidecar format: JSON = single document (default), NDJSON = one CV entry per line for streaming consumers, NONE = compute CV but skip write (useful for benchmarking overhead). Ignored unless --correlation_vector is also set (CLOC11.69)." },
     { "id": "correlation_vector_filter", "long": "correlation_vector_filter", "type": "string", "default": "", "description": "Comma-separated allowlist of CV source names (e.g. \"lex,defines\"). Entries with no contribution.source in the allowlist are pruned from the written sidecar. Empty (default) keeps every entry. Ignored unless --correlation_vector is also set (CLOC11.70)." },
     { "id": "correlation_vector_filter_includes_origin", "long": "correlation_vector_filter_includes_origin", "type": "boolean", "default": false, "description": "When --correlation_vector_filter is set, also match entries by their origin.source (in addition to contribution.source). Lets `--correlation_vector_filter lex` keep the per-token CV entries whose Origin.source is \"lexer_token\". Default off preserves CLOC11.70 strict semantics (CLOC11.71)." },
+    { "id": "correlation_vector_filter_invert", "long": "correlation_vector_filter_invert", "type": "boolean", "default": false, "description": "Invert the --correlation_vector_filter from an allowlist to a blocklist. With --correlation_vector_filter lex and --correlation_vector_filter_invert true, entries that DO match (i.e. carry a `lex` contribution and/or origin) are dropped; everything else is kept. Useful for \"everything except X\" filters where enumerating the allowlist is impractical (CLOC11.72)." },
     { "id": "instrument_for_coverage_option", "long": "instrument_for_coverage_option", "type": "enum", "enum_values": ["NONE", "LINE", "BRANCH", "PRODUCTION"], "default": "NONE", "description": "Enable code instrumentation for coverage analysis." },
     { "id": "production_instrumentation_array_name", "long": "production_instrumentation_array_name", "type": "string", "default": "", "description": "Global array name used by production instrumentation." },
     { "id": "chunk_output_type", "long": "chunk_output_type", "type": "enum", "enum_values": ["GLOBAL_NAMESPACE", "ES_MODULES"], "default": "GLOBAL_NAMESPACE", "description": "Format for output chunks." },

--- a/code/programs/rust/closurec/src/config.rs
+++ b/code/programs/rust/closurec/src/config.rs
@@ -581,6 +581,30 @@ pub struct SpecialModesConfig {
     /// Only consulted when `correlation_vector` is true AND
     /// `correlation_vector_filter` is non-empty.
     pub correlation_vector_filter_includes_origin: bool,
+    /// CLOC11.72: flip the allowlist sense. When `false`
+    /// (default), entries are kept iff they match (CLOC11.70
+    /// + CLOC11.71 semantics). When `true`, entries are kept
+    /// iff they do NOT match — the allowlist becomes a
+    /// blocklist.
+    ///
+    /// Composes orthogonally with `include_origin`:
+    /// `include_origin` selects WHICH sources count as a
+    /// "match" for an entry (contribution.source only, or
+    /// contribution.source ∪ origin.source); `invert` then
+    /// decides whether matches are kept or dropped.
+    ///
+    /// Empty allowlist with `invert=true` keeps everything
+    /// (no entry can match → none are blocked). Empty
+    /// allowlist with `invert=false` is the
+    /// no-filter-configured fast path that pre-CLOC11.70
+    /// callers used; both branches preserve byte-for-byte
+    /// default behavior.
+    ///
+    /// Only consulted when `correlation_vector` is true AND
+    /// `correlation_vector_filter` is non-empty (an inverted
+    /// empty filter is a no-op, so we keep the empty-filter
+    /// short-circuit).
+    pub correlation_vector_filter_invert: bool,
 }
 
 /// CLOC11.69 — sidecar persistence format. Default is

--- a/code/programs/rust/closurec/src/run.rs
+++ b/code/programs/rust/closurec/src/run.rs
@@ -1271,12 +1271,14 @@ pub fn run_compiler(config: &CompilerConfig) -> Result<CompilerOutput, CompilerE
                         &cv_log,
                         &config.special_modes.correlation_vector_filter,
                         config.special_modes.correlation_vector_filter_includes_origin,
+                        config.special_modes.correlation_vector_filter_invert,
                     ),
                     _ => format_cv_log_json(
                         &cv_log,
                         config.special_modes.correlation_vector_pretty,
                         &config.special_modes.correlation_vector_filter,
                         config.special_modes.correlation_vector_filter_includes_origin,
+                        config.special_modes.correlation_vector_filter_invert,
                     ),
                 };
                 write_output_file(&sidecar_path, &body)?;
@@ -1321,6 +1323,7 @@ fn format_cv_log_json(
     pretty: bool,
     filter: &[String],
     filter_includes_origin: bool,
+    filter_invert: bool,
 ) -> String {
     let compact = cv_log
         .to_json_string()
@@ -1337,7 +1340,12 @@ fn format_cv_log_json(
             Err(_) => return compact,
         };
     if need_filter {
-        prune_entries_by_source(&mut value, filter, filter_includes_origin);
+        prune_entries_by_source(
+            &mut value,
+            filter,
+            filter_includes_origin,
+            filter_invert,
+        );
     }
     if pretty {
         serde_json::to_string_pretty(&value).unwrap_or_else(|_| compact)
@@ -1372,6 +1380,7 @@ fn format_cv_log_ndjson(
     cv_log: &coding_adventures_correlation_vector::CVLog,
     filter: &[String],
     filter_includes_origin: bool,
+    filter_invert: bool,
 ) -> String {
     let compact = cv_log
         .to_json_string()
@@ -1381,7 +1390,12 @@ fn format_cv_log_ndjson(
         Err(_) => return compact,
     };
     if !filter.is_empty() {
-        prune_entries_by_source(&mut root, filter, filter_includes_origin);
+        prune_entries_by_source(
+            &mut root,
+            filter,
+            filter_includes_origin,
+            filter_invert,
+        );
     }
     let mut out = String::new();
     if let Some(entries) = root.get("entries").and_then(|v| v.as_object()) {
@@ -1443,6 +1457,7 @@ fn prune_entries_by_source(
     root: &mut serde_json::Value,
     allowlist: &[String],
     include_origin: bool,
+    invert: bool,
 ) {
     let Some(entries) = root
         .get_mut("entries")
@@ -1455,7 +1470,9 @@ fn prune_entries_by_source(
     let allow: std::collections::HashSet<&str> =
         allowlist.iter().map(String::as_str).collect();
     entries.retain(|_id, entry| {
-        // (1) Any contribution.source in the allowlist?
+        // Compute "does this entry match the source list?"
+        // (1) any contribution.source in the allowlist, OR
+        // (2) (CLOC11.71 opt-in) origin.source in the allowlist.
         let contrib_match = entry
             .get("contributions")
             .and_then(|v| v.as_array())
@@ -1468,23 +1485,19 @@ fn prune_entries_by_source(
                 })
             })
             .unwrap_or(false);
-        if contrib_match {
-            return true;
-        }
-        // (2) CLOC11.71 — also accept entries whose Origin
-        // source is allowlisted.
-        if include_origin {
-            let origin_match = entry
+        let origin_match = include_origin
+            && entry
                 .get("origin")
                 .and_then(|o| o.get("source"))
                 .and_then(|s| s.as_str())
                 .map(|s| allow.contains(s))
                 .unwrap_or(false);
-            if origin_match {
-                return true;
-            }
-        }
-        false
+        let matches = contrib_match || origin_match;
+        // CLOC11.72 — invert flips the keep rule. Default
+        // (invert=false): keep matches, drop non-matches
+        // (allowlist). invert=true: keep non-matches, drop
+        // matches (blocklist).
+        if invert { !matches } else { matches }
     });
 }
 
@@ -3785,6 +3798,114 @@ mod tests {
         assert!(
             !body.contains("\"source\":\"input_file\""),
             "input_file Origin should not match filter=lexer_token, got: {body}"
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    // ------------------------------------------------------------------
+    // CLOC11.72 — --correlation_vector_filter_invert (blocklist)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn correlation_vector_filter_invert_drops_matched_keeps_rest() {
+        // With filter=lex AND invert=true, entries that have
+        // a lex contribution are DROPPED and entries without
+        // are kept. So the per-file CV root (which has the
+        // lex.tokens_emitted contribution) should be gone,
+        // but token CVs (no lex contribution) should remain
+        // alongside the combined/output entries.
+        let dir =
+            std::env::temp_dir().join("closurec_cloc11_72_invert_basic");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("create dir");
+        let in_path = dir.join("a.js");
+        fs::write(&in_path, "var x = 1;").expect("write");
+        let out_path = dir.join("out.js");
+        let sidecar_path = dir.join("out.js.cv.json");
+        let cfg = CompilerConfig {
+            io: IoConfig {
+                js_patterns: vec![in_path.to_string_lossy().to_string()],
+                js_output_file: Some(out_path.clone()),
+                ..Default::default()
+            },
+            special_modes: crate::config::SpecialModesConfig {
+                correlation_vector: true,
+                correlation_vector_filter: vec!["lex".to_string()],
+                correlation_vector_filter_invert: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let _ = run_compiler(&cfg).expect("ok");
+        let body = fs::read_to_string(&sidecar_path).expect("read sidecar");
+        let root: serde_json::Value =
+            serde_json::from_str(&body).expect("parse");
+        let entries = root
+            .get("entries")
+            .and_then(|v| v.as_object())
+            .expect("entries object");
+        // No surviving entry has a lex contribution.
+        for (id, entry) in entries.iter() {
+            let contribs = entry
+                .get("contributions")
+                .and_then(|v| v.as_array())
+                .expect("contributions array");
+            let has_lex = contribs.iter().any(|c| {
+                c.get("source").and_then(|s| s.as_str()) == Some("lex")
+            });
+            assert!(
+                !has_lex,
+                "entry {id} survived but has a lex contribution under invert: {entry}"
+            );
+        }
+        // Entries DO still exist — invert is not "drop
+        // everything". The non-input_file entries (combined,
+        // js_output_file, manifest, etc.) live on.
+        assert!(
+            !entries.is_empty(),
+            "invert should keep non-matching entries, got empty: {body}"
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn correlation_vector_filter_invert_empty_filter_is_noop() {
+        // An empty filter with invert=true is still a
+        // no-op (nothing can match an empty allowlist, so
+        // nothing is blocked). Same byte-identical output
+        // as no-filter-set.
+        let dir = std::env::temp_dir().join("closurec_cloc11_72_invert_empty");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("create dir");
+        let in_path = dir.join("a.js");
+        fs::write(&in_path, "var x = 1;").expect("write");
+        let out_path = dir.join("out.js");
+        let sidecar_path = dir.join("out.js.cv.json");
+        let cfg = CompilerConfig {
+            io: IoConfig {
+                js_patterns: vec![in_path.to_string_lossy().to_string()],
+                js_output_file: Some(out_path.clone()),
+                ..Default::default()
+            },
+            special_modes: crate::config::SpecialModesConfig {
+                correlation_vector: true,
+                // correlation_vector_filter left empty
+                correlation_vector_filter_invert: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let _ = run_compiler(&cfg).expect("ok");
+        let body = fs::read_to_string(&sidecar_path).expect("read sidecar");
+        // Sanity: input_file root + lexer_token entries both
+        // appear (no pruning happened).
+        assert!(
+            body.contains("\"source\":\"input_file\""),
+            "expected input_file Origin under empty inverted filter: {body}"
+        );
+        assert!(
+            body.contains("\"source\":\"lexer_token\""),
+            "expected lexer_token Origins under empty inverted filter: {body}"
         );
         let _ = fs::remove_dir_all(&dir);
     }

--- a/code/programs/rust/closurec/src/wire.rs
+++ b/code/programs/rust/closurec/src/wire.rs
@@ -513,6 +513,10 @@ fn read_special_modes(p: &ParseResult) -> Result<SpecialModesConfig, ConfigError
             p,
             "correlation_vector_filter_includes_origin",
         )?,
+        correlation_vector_filter_invert: get_bool(
+            p,
+            "correlation_vector_filter_invert",
+        )?,
     })
 }
 

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.34.0
+Version: 0.35.0
 
 ## Flags
 
@@ -389,6 +389,10 @@ Comma-separated allowlist of CV source names (e.g. "lex,defines"). Entries with 
 ### `--correlation_vector_filter_includes_origin` (boolean, default: false)
 
 When --correlation_vector_filter is set, also match entries by their origin.source (in addition to contribution.source). Lets `--correlation_vector_filter lex` keep the per-token CV entries whose Origin.source is "lexer_token". Default off preserves CLOC11.70 strict semantics (CLOC11.71).
+
+### `--correlation_vector_filter_invert` (boolean, default: false)
+
+Invert the --correlation_vector_filter from an allowlist to a blocklist. With --correlation_vector_filter lex and --correlation_vector_filter_invert true, entries that DO match (i.e. carry a `lex` contribution and/or origin) are dropped; everything else is kept. Useful for "everything except X" filters where enumerating the allowlist is impractical (CLOC11.72).
 
 ### `--instrument_for_coverage_option` (enum, default: NONE)
 


### PR DESCRIPTION
## Summary

Boolean flag that flips CLOC11.70's allowlist into a **blocklist**.

```bash
closurec --correlation_vector \
         --correlation_vector_filter lex \
         --correlation_vector_filter_invert
```

Entries that DO match (a `lex` contribution, and/or — under `include_origin` — a `lex` origin) are dropped; everything else is kept.

## Use case

"Everything except X" filters where enumerating the allowlist would be impractical (the lexer alone produces many `lexer_token` entries; `--filter_invert` lets you exclude one stage instead of listing every other).

## Composition (orthogonal to `include_origin`)

| `include_origin` | `invert` | Behavior |
|---|---|---|
| false | false | CLOC11.70 strict allowlist on `contribution.source` |
| true | false | CLOC11.71 broadened allowlist (also `origin.source`) |
| false | true | CLOC11.72 blocklist on `contribution.source` |
| true | true | CLOC11.72 blocklist on `contribution.source` ∪ `origin.source` |

## Implementation

- `prune_entries_by_source` signature gains `invert: bool`. Match-computation unchanged; terminal keep-rule becomes `if invert { !matches } else { matches }`.
- Both `format_cv_log_json` and `format_cv_log_ndjson` thread the flag through.
- **Empty-allowlist short-circuit unchanged**: an inverted empty filter is a no-op (no entry can match → none are blocked).

## Test plan
- [x] cargo build clean
- [x] 253 unit + 17 integration suites pass
- [x] New tests:
  - `correlation_vector_filter_invert_drops_matched_keeps_rest` — `filter=lex + invert=true` → no surviving entry has a lex contribution; non-input_file entries remain
  - `correlation_vector_filter_invert_empty_filter_is_noop` — empty filter + invert → input_file root and lexer_token entries both present
- [x] help-markdown fixture regenerated for 0.35.0

## Security review (inline)
- Default-false reduces the terminal expression to `matches`, byte-identical to CLOC11.71.
- Empty filter fast-path preserved in both formatters.
- No new I/O, no unsafe, no new deps.
- `serde_json::Map::retain` still drives the loop.

## Versions
- `Cargo.toml`: 0.34.0 → 0.35.0
- `cli.spec.json`: 0.34.0 → 0.35.0
- `CHANGELOG.md`: new `[0.35.0]` section

🤖 Generated with [Claude Code](https://claude.com/claude-code)