### PR TITLE
feat(ruby-fc): Phase 15b — class variables @@x → Scope::ClassVar

### DIFF
--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.44.0] - 2026-05-30
+
+### Added (Phase 15b (FC) — class variables `@@x`)
+
+No grammar change — the lexer already emits `@@x` as a `Name` token
+(sigil included, since Phase 4i/4j), so `@@x = 1` parses as an
+`assignment` and a bare `@@x` as an expression.  Cvar assignment and
+expression parsing are already covered by the Phase 6x tests
+(`test_parse_class_var_assignment`, etc.).  Phase 15b adds one parse pin
+for the new lowering path:
+
+- `test_parse_class_var_compound_assignment` — `@@n += 1` parses as an
+  assignment carrying the `@@n` Name token and the fused `+=` operator
+  token.
+
+Test count: 171 → 172 (+1).
+
 ## [0.43.0] - 2026-05-30
 
 ### Added (Phase 15a (FC) — instance variables `@x`)

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -873,6 +873,24 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_parse_class_var_compound_assignment() {
+        // `@@n += 1` parses as an assignment carrying the `@@n` Name token
+        // and the fused `+=` operator token (the shape the 15b lowerer's
+        // compound-cvar path dispatches on).
+        let ast = parse_ruby("@@n += 1");
+        let asn = find_statement_inner(&ast, "assignment")
+            .expect("expected assignment");
+        assert!(
+            body_has_token_value(asn, "@@n"),
+            "expected the `@@n` cvar Name token in the assignment header"
+        );
+        assert!(
+            body_has_token_value(asn, "+="),
+            "expected the fused `+=` compound-assign operator token"
+        );
+    }
+
     // -----------------------------------------------------------------------
     // Phase 6g — blocks `do … end` and brace-blocks `method { … }`
     // -----------------------------------------------------------------------

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.46.0] - 2026-05-30
+
+### Changed (Phase 15b (FC) — class variables `@@x`)
+
+Class variables now lower to the first-class `Scope::ClassVar`
+(semantic-ir 0.7.0) instead of the Phase 6x `Scope::Local` placeholder,
+mirroring Phase 15a's treatment of `@x`:
+
+- A `@@x` **read** lowers to `Expr::VarRef { scope: ClassVar }` — and,
+  crucially, no longer errors as an undefined local when read before any
+  assignment (reading an unset `@@x` is nil in Ruby).
+- A `@@x` **assignment** (`@@x = …`, `@@x += …`) lowers to
+  `Stmt::Assign { scope: ClassVar }` — never a `LetBinding` — and does
+  not register `@@x` as a local.  Emitting it requests
+  `Feature::ClassVars` (and `MutableBindings`, since the store is a
+  `Stmt::Assign`).
+- New `is_class_var_name` helper (`starts_with("@@")`).  Because `@@x`
+  also begins with `@`, the read/assign paths test for class var
+  **before** instance var, so `@@x` → ClassVar and `@x` → Instance stay
+  distinct.
+
+New tests (+4): `class_var_read_lowers_to_classvar_scope`,
+`class_var_read_without_assignment_passes_validator` (E2E),
+`class_var_in_method_roundtrips_through_validator` (E2E),
+`instance_and_class_vars_are_distinct_scopes` (regression guard).  Two
+pre-existing tests were updated to the new ClassVar contract:
+`class_var_double_at_is_not_instance_scope` (now asserts
+`Scope::ClassVar` + `ClassVars`/not-`InstanceVars`) and the Phase 6x
+`class_var_ref_lowers_with_local_scope_and_double_at_preserved` (now
+asserts `Scope::ClassVar`).  Test count: 211 → 215 (+4).
+
 ## [0.45.0] - 2026-05-30
 
 ### Changed (Phase 15a (FC) — instance variables `@x`)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -1037,20 +1037,84 @@ mod tests {
 
     #[test]
     fn class_var_double_at_is_not_instance_scope() {
-        // Regression guard: `@@x` (class var, Phase 15b) must NOT be
-        // mistaken for an instance var — it keeps the pre-15a
-        // local-modelling (single `@` only is an instance var).
+        // `@@x` (double `@`) is a *class* variable — Phase 15b lowers it
+        // to `Assign { scope: ClassVar }` (not Instance, not a local),
+        // requesting `ClassVars` (and never `InstanceVars`).
         let m = lower("@@total = 0\n");
         match &main_body(&m).stmts[0] {
-            Stmt::LetBinding { name, .. } => assert_eq!(name, "@@total"),
-            // (If a later phase changes @@ handling, this guard should be
-            // updated — but it must not become Scope::Instance here.)
-            other => panic!("expected `@@total` LetBinding (not instance), got {:?}", other),
+            Stmt::Assign { name, scope, .. } => {
+                assert_eq!(name, "@@total");
+                assert_eq!(*scope, Scope::ClassVar);
+            }
+            other => panic!("expected `@@total` Assign(ClassVar), got {:?}", other),
         }
         assert!(
-            !m.manifest.contains(semantic_ir::Feature::InstanceVars),
-            "`@@x` must not request InstanceVars"
+            m.manifest.contains(semantic_ir::Feature::ClassVars),
+            "`@@x` should request ClassVars; got {:?}",
+            m.manifest
         );
+        assert!(
+            !m.manifest.contains(semantic_ir::Feature::InstanceVars),
+            "`@@x` must not request InstanceVars (it is a class var)"
+        );
+    }
+
+    #[test]
+    fn class_var_read_lowers_to_classvar_scope() {
+        // A bare `@@x` read lowers to `VarRef { scope: ClassVar }` and
+        // requests `Feature::ClassVars` (no declaration needed).
+        let m = lower("@@x\n");
+        match &main_body(&m).value {
+            Expr::VarRef { name, scope, .. } => {
+                assert_eq!(name, "@@x");
+                assert_eq!(*scope, Scope::ClassVar);
+            }
+            other => panic!("expected VarRef classvar, got {:?}", other),
+        }
+        assert!(
+            m.manifest.contains(semantic_ir::Feature::ClassVars),
+            "manifest should declare ClassVars; got {:?}",
+            m.manifest
+        );
+    }
+
+    #[test]
+    fn class_var_read_without_assignment_passes_validator() {
+        // E2E: reading an unset `@@x` (as an assignment RHS) validates —
+        // class vars need no prior declaration.
+        let m = lower("y = @@x\n");
+        let result = semantic_ir::validate(&m);
+        assert!(result.is_ok(), "validator rejected unset-cvar read: {:?}", result);
+    }
+
+    #[test]
+    fn class_var_in_method_roundtrips_through_validator() {
+        // `def bump; @@count = @@count + 1; end` — class-var assign +
+        // read inside a method; validates end-to-end.
+        let m = lower("def bump\n  @@count = @@count + 1\nend\n");
+        assert!(
+            m.functions.iter().any(|f| f.name == "bump"),
+            "expected hoisted `bump`; got {:?}",
+            m.functions.iter().map(|f| &f.name).collect::<Vec<_>>()
+        );
+        assert!(semantic_ir::validate(&m).is_ok(), "validator rejected cvar method: {:?}", semantic_ir::validate(&m));
+    }
+
+    #[test]
+    fn instance_and_class_vars_are_distinct_scopes() {
+        // `@x` → Instance, `@@x` → ClassVar — the single/double `@`
+        // distinction routes to different scopes (and both features).
+        let m = lower("@x = 1\n@@x = 2\n");
+        let stmts = &main_body(&m).stmts;
+        match (&stmts[0], &stmts[1]) {
+            (Stmt::Assign { scope: s0, .. }, Stmt::Assign { scope: s1, .. }) => {
+                assert_eq!(*s0, Scope::Instance, "`@x` → Instance");
+                assert_eq!(*s1, Scope::ClassVar, "`@@x` → ClassVar");
+            }
+            other => panic!("expected two Assigns, got {:?}", other),
+        }
+        assert!(m.manifest.contains(semantic_ir::Feature::InstanceVars));
+        assert!(m.manifest.contains(semantic_ir::Feature::ClassVars));
     }
 
     // -----------------------------------------------------------------
@@ -3199,7 +3263,10 @@ mod tests {
         match ref_expr {
             Expr::VarRef { name, scope, .. } => {
                 assert_eq!(name, "@@count", "cvar value should retain `@@`");
-                assert_eq!(*scope, Scope::Local, "v0 puts cvars on Scope::Local");
+                // Phase 15b (FC): class vars now lower to
+                // `Scope::ClassVar` (was `Scope::Local` in the Phase 6x
+                // v0 placeholder).
+                assert_eq!(*scope, Scope::ClassVar, "Phase 15b: cvars use Scope::ClassVar");
             }
             other => panic!("expected VarRef(@@count), got {:?}", other),
         }

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -126,6 +126,9 @@ pub fn compile(program: &GrammarASTNode, module_name: &str) -> Result<Module, Ru
         // Phase 15a (FC) — an instance-var ref (`@x`, `Scope::Instance`)
         // triggers the `InstanceVars` feature.
         Feature::InstanceVars,
+        // Phase 15b (FC) — a class-var ref (`@@x`, `Scope::ClassVar`)
+        // triggers the `ClassVars` feature.
+        Feature::ClassVars,
     ] {
         if lw.features_used.contains(&f) {
             manifest.add(f);
@@ -310,6 +313,13 @@ fn block_references_any_name(block: &Block, names: &HashSet<String>) -> bool {
 /// global — both excluded here so they keep their pre-15a handling.
 fn is_instance_var_name(name: &str) -> bool {
     name.starts_with('@') && !name.starts_with("@@")
+}
+
+/// Phase 15b (FC) — is this Name-token value a Ruby *class variable*
+/// (`@@x`)?  Class vars lex as a `Name` token carrying the `@@` sigil.
+/// (A single `@` is an *instance* variable — see `is_instance_var_name`.)
+fn is_class_var_name(name: &str) -> bool {
+    name.starts_with("@@")
 }
 
 // ---------------------------------------------------------------------------
@@ -2238,15 +2248,18 @@ impl Lowerer {
                 // branch above (Phase 8b) and never reach this match.
                 _ => unreachable!("op_token matched only the eager compound forms above"),
             };
-            // Phase 15a — a compound assign to an instance variable
-            // (`@x += 1`) reads `@x` with `Scope::Instance` too.
+            // Phase 15a/15b — a compound assign to a sigil var
+            // (`@x += 1`, `@@x += 1`) reads it with the matching scope.
+            let lhs_scope = if is_class_var_name(&name) {
+                Scope::ClassVar
+            } else if is_instance_var_name(&name) {
+                Scope::Instance
+            } else {
+                Scope::Local
+            };
             let lhs_ref = Expr::VarRef {
                 name: name.clone(),
-                scope: if is_instance_var_name(&name) {
-                    Scope::Instance
-                } else {
-                    Scope::Local
-                },
+                scope: lhs_scope,
                 span: span.clone(),
             };
             Expr::BuiltinCall {
@@ -2259,13 +2272,24 @@ impl Lowerer {
             rhs
         };
 
-        // Phase 15a (FC) — instance-variable assignment (`@x = …`,
-        // `@x += …`) lowers to `Stmt::Assign { scope: Instance }`
-        // regardless of prior sightings: an instance var needs no
-        // `let` declaration and is never a local.  The store lowers to
-        // `Stmt::Assign`, whose validator arm observes
-        // `MutableBindings`, so we declare both features.  We do NOT
-        // touch `declared_locals` (an ivar is not a local).
+        // Phase 15a/15b (FC) — instance- / class-variable assignment
+        // (`@x = …`, `@@x = …`, and their compound forms) lowers to
+        // `Stmt::Assign { scope: Instance | ClassVar }` regardless of
+        // prior sightings: a sigil var needs no `let` declaration and is
+        // never a local.  The store is a `Stmt::Assign`, whose validator
+        // arm observes `MutableBindings`, so we declare both features.
+        // We do NOT touch `declared_locals`.  Class var is checked first
+        // (`@@x` also starts with `@`).
+        if is_class_var_name(&name) {
+            self.features_used.insert(Feature::ClassVars);
+            self.features_used.insert(Feature::MutableBindings);
+            return Ok(Stmt::Assign {
+                name,
+                scope: Scope::ClassVar,
+                value,
+                span,
+            });
+        }
         if is_instance_var_name(&name) {
             self.features_used.insert(Feature::InstanceVars);
             self.features_used.insert(Feature::MutableBindings);
@@ -4960,13 +4984,17 @@ impl Lowerer {
                             // and/or (b) auto-emit `Global` declarations for
                             // `$x`-prefixed names so the validator-true
                             // mapping `$x` → `Scope::Global` becomes usable.
-                            // Phase 15a (FC) — a single-`@` sigil name is
-                            // an *instance variable* (`@x`); it lowers to
-                            // `Scope::Instance` (no declaration needed).
-                            // `@@x` (class var, double `@`) and `$x`
-                            // (global) keep the pre-15a `Scope::Local`
-                            // fallback for now (Phase 15b / later).
-                            let scope = if is_instance_var_name(&tok.value) {
+                            // Phase 15a/15b (FC) — sigil-prefixed names
+                            // lower to dedicated scopes (no declaration
+                            // needed): `@@x` (double `@`) → class var,
+                            // `@x` (single `@`) → instance var.  `$x`
+                            // (global) keeps the pre-15a `Scope::Local`
+                            // fallback for now.  Class var is checked
+                            // first since `@@x` also starts with `@`.
+                            let scope = if is_class_var_name(&tok.value) {
+                                self.features_used.insert(Feature::ClassVars);
+                                Scope::ClassVar
+                            } else if is_instance_var_name(&tok.value) {
                                 self.features_used.insert(Feature::InstanceVars);
                                 Scope::Instance
                             } else if self.current_params.contains(&tok.value) {

--- a/code/packages/rust/semantic-ir-to-go/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/emit.rs
@@ -337,6 +337,11 @@ fn emit_var_ref(out: &mut String, name: &str, scope: Scope) {
             // rejected at the capability check before emit.  Unreachable.
             panic!("go backend reached SIR17 instance-var ref `{}` — capability check should have rejected it", name);
         }
+        Scope::ClassVar => {
+            // SIR17 Phase 15b — `Feature::ClassVars` likewise unaccepted;
+            // class-var modules are rejected before emit.  Unreachable.
+            panic!("go backend reached SIR17 class-var ref `{}` — capability check should have rejected it", name);
+        }
     }
 }
 

--- a/code/packages/rust/semantic-ir-to-python/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/emit.rs
@@ -291,6 +291,11 @@ fn emit_var_ref(out: &mut String, name: &str, scope: Scope) {
             // at the capability check before emit.  Unreachable.
             panic!("python backend reached SIR17 instance-var ref `{}` — capability check should have rejected it", name);
         }
+        Scope::ClassVar => {
+            // SIR17 Phase 15b — `Feature::ClassVars` likewise unaccepted;
+            // class-var modules are rejected before emit.  Unreachable.
+            panic!("python backend reached SIR17 class-var ref `{}` — capability check should have rejected it", name);
+        }
     }
 }
 

--- a/code/packages/rust/semantic-ir-to-rust/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/emit.rs
@@ -281,6 +281,11 @@ fn emit_var_ref(out: &mut String, name: &str, scope: Scope) {
             // at the capability check before emit.  Unreachable.
             panic!("rust backend reached SIR17 instance-var ref `{}` — capability check should have rejected it", name);
         }
+        Scope::ClassVar => {
+            // SIR17 Phase 15b — `Feature::ClassVars` likewise unaccepted;
+            // class-var modules are rejected before emit.  Unreachable.
+            panic!("rust backend reached SIR17 class-var ref `{}` — capability check should have rejected it", name);
+        }
     }
 }
 

--- a/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
@@ -275,6 +275,11 @@ fn emit_var_ref(out: &mut String, name: &str, scope: Scope) {
             // at the capability check before emit.  Unreachable.
             panic!("ts backend reached SIR17 instance-var ref `{}` — capability check should have rejected it", name);
         }
+        Scope::ClassVar => {
+            // SIR17 Phase 15b — `Feature::ClassVars` likewise unaccepted;
+            // class-var modules are rejected before emit.  Unreachable.
+            panic!("ts backend reached SIR17 class-var ref `{}` — capability check should have rejected it", name);
+        }
     }
 }
 

--- a/code/packages/rust/semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to the `semantic-ir` crate are documented here.
 
+## 0.7.0 — SIR17: class-variable scope (`Scope::ClassVar`)
+
+Introduced by the Ruby frontend's Phase 15b (`@@x`).
+
+### Added
+
+- `Scope::ClassVar` — a class variable (Ruby `@@x`).  Like
+  `Scope::Instance`, a class var needs **no prior declaration**:
+  `check_varref` performs no scope-existence check for it (reading an
+  unset `@@x` yields nil in Ruby).  `Scope::name()` / `from_name()` gain
+  the `"class-var"` tag.
+- `Feature::ClassVars` (kebab `class-vars`) — declared by any module
+  that references a `Scope::ClassVar` var.  The validator observes it
+  from each ClassVar-scoped `VarRef`; backends that don't list it in
+  their accepted set reject such modules at the capability check,
+  before emit.
+
+### Changed
+
+- `check_varref` gains a `Scope::ClassVar` arm (no resolution; observes
+  `Feature::ClassVars`).  The text printer renders
+  `(var-ref @@x class-var)` via the existing `scope.name()` path.  The
+  four reference backends' `emit_var_ref` gain an unreachable `panic!`
+  arm for `Scope::ClassVar` (rejected pre-emit by the capability check).
+
+New tests (3): `print_var_ref_class_var_scope`,
+`class_var_ref_needs_no_declaration`,
+`class_var_ref_without_manifest_feature_is_error`.  Test count:
+96 → 99.
+
+This is a **breaking enum change** for any exhaustive `match` on
+`Scope` without a `_` rest arm.
+
 ## 0.6.0 — SIR17: instance-variable scope (`Scope::Instance`)
 
 Introduced by the Ruby frontend's Phase 15a (`@x`).

--- a/code/packages/rust/semantic-ir/src/manifest.rs
+++ b/code/packages/rust/semantic-ir/src/manifest.rs
@@ -60,6 +60,11 @@ pub enum Feature {
     /// vars need no prior declaration and are scoped to the receiver
     /// object, so they are distinct from `Local`/`Global` bindings.
     InstanceVars,
+    /// Module references a class variable (`Scope::ClassVar`, Ruby
+    /// `@@x`).  Phase 15b (Ruby).  Like instance vars, class vars need
+    /// no prior declaration; they are shared across the class
+    /// hierarchy rather than per-object.
+    ClassVars,
 }
 
 impl Feature {
@@ -84,6 +89,7 @@ impl Feature {
         Feature::Classes,
         Feature::Modules,
         Feature::InstanceVars,
+        Feature::ClassVars,
     ];
 
     /// Kebab-case name for the SIR text format.
@@ -108,6 +114,7 @@ impl Feature {
             Feature::Classes => "classes",
             Feature::Modules => "modules",
             Feature::InstanceVars => "instance-vars",
+            Feature::ClassVars => "class-vars",
         }
     }
 

--- a/code/packages/rust/semantic-ir/src/nodes.rs
+++ b/code/packages/rust/semantic-ir/src/nodes.rs
@@ -338,6 +338,13 @@ pub enum Scope {
     /// preserved in the `VarRef` / `Assign` name.  Introduced by the
     /// Ruby frontend's Phase 15a; gated by `Feature::InstanceVars`.
     Instance,
+    /// Class variable (Ruby `@@x`).  Like `Instance`, it needs **no
+    /// prior declaration** (the validator performs no scope-existence
+    /// check) — but it is shared across the class hierarchy rather than
+    /// per-object.  The leading `@@` sigil is preserved in the name.
+    /// Introduced by the Ruby frontend's Phase 15b; gated by
+    /// `Feature::ClassVars`.
+    ClassVar,
 }
 
 impl Scope {
@@ -350,6 +357,7 @@ impl Scope {
             Scope::Global => "global",
             Scope::Builtin => "builtin",
             Scope::Instance => "instance",
+            Scope::ClassVar => "class-var",
         }
     }
 
@@ -362,6 +370,7 @@ impl Scope {
             "global" => Scope::Global,
             "builtin" => Scope::Builtin,
             "instance" => Scope::Instance,
+            "class-var" => Scope::ClassVar,
             _ => return None,
         })
     }

--- a/code/packages/rust/semantic-ir/src/text/printer.rs
+++ b/code/packages/rust/semantic-ir/src/text/printer.rs
@@ -530,6 +530,18 @@ mod tests {
     }
 
     #[test]
+    fn print_var_ref_class_var_scope() {
+        // Phase 15b — a class-var ref prints with the `class-var`
+        // scope tag and the `@@`-sigil name preserved verbatim.
+        let e = Expr::VarRef {
+            name: "@@count".into(),
+            scope: Scope::ClassVar,
+            span: s(),
+        };
+        assert_eq!(print_expr(&e), "(var-ref @@count class-var)");
+    }
+
+    #[test]
     fn print_builtin_call_with_pure() {
         let e = Expr::BuiltinCall {
             name: "+".into(),

--- a/code/packages/rust/semantic-ir/src/validator.rs
+++ b/code/packages/rust/semantic-ir/src/validator.rs
@@ -577,6 +577,11 @@ impl<'m> ValidatorState<'m> {
                 // manifest comparison stays honest.
                 self.observed.add(Feature::InstanceVars);
             }
+            Scope::ClassVar => {
+                // Class variables (Ruby `@@x`) likewise need no prior
+                // declaration; record the feature only.
+                self.observed.add(Feature::ClassVars);
+            }
         }
     }
 
@@ -1518,5 +1523,55 @@ mod tests {
         let r = validate(&m);
         assert!(!r.is_ok(), "expected missing-InstanceVars-feature error");
         assert!(r.errors().any(|i| i.message.contains("instance-vars")));
+    }
+
+    // -----------------------------------------------------------------
+    // SIR17 Phase 15b — `Scope::ClassVar` (class variables).
+    // -----------------------------------------------------------------
+
+    /// Build a one-function module whose body value is a single
+    /// class-var ref, declaring the given features.
+    fn module_with_class_var_ref(features: &[Feature]) -> Module {
+        let mut m = empty_module(FeatureManifest::from_features(features));
+        m.functions.push(Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![],
+                value: Expr::VarRef {
+                    name: "@@count".into(),
+                    scope: Scope::ClassVar,
+                    span: s(),
+                },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        });
+        m
+    }
+
+    #[test]
+    fn class_var_ref_needs_no_declaration() {
+        // A class-var ref is accepted with no prior `let`/param —
+        // reading an unset `@@x` is nil in Ruby.  Module declares
+        // `ClassVars`.
+        let m = module_with_class_var_ref(&[Feature::ClassVars]);
+        let r = validate(&m);
+        assert!(r.is_ok(), "expected ok, got {:?}", r.issues);
+    }
+
+    #[test]
+    fn class_var_ref_without_manifest_feature_is_error() {
+        // The validator observes `ClassVars` from the ClassVar-scoped
+        // ref; if the manifest doesn't declare it, the
+        // used-but-undeclared check fires.
+        let m = module_with_class_var_ref(&[]);
+        let r = validate(&m);
+        assert!(!r.is_ok(), "expected missing-ClassVars-feature error");
+        assert!(r.errors().any(|i| i.message.contains("class-vars")));
     }
 }


### PR DESCRIPTION
## Phase 15b (FC) — class variables `@@x` → `Scope::ClassVar`

Mirrors the merged Phase 15a (`@x` → `Scope::Instance`) for Ruby **class
variables**. Previously `@@x` reads/assigns fell through to the Phase 6x
`Scope::Local` placeholder, which (a) wrongly registered the cvar as a
local and (b) errored when a cvar was read before any assignment.

### `semantic-ir` 0.7.0

- **New `Scope::ClassVar`** (kebab `class-var`) — a no-declaration scope
  like `Scope::Instance`; `name()` / `from_name()` gain the tag.
- **New `Feature::ClassVars`** (kebab `class-vars`) — observed by the
  validator from each ClassVar-scoped `VarRef`; gated by the backends'
  capability check.
- `check_varref` gains a `Scope::ClassVar` arm (observe-only, no
  resolution — reading an unset `@@x` is nil in Ruby).
- The four reference backends' `emit_var_ref` gain an **unreachable**
  `panic!` arm for `Scope::ClassVar` (rejected pre-emit by the
  capability check).
- Text printer renders `(var-ref @@x class-var)` via `scope.name()`.

> ⚠️ **Breaking enum change** for any exhaustive `match` on `Scope`
> without a `_` rest arm.

### `ruby-to-semantic-ir` 0.46.0

- New `is_class_var_name` helper (`starts_with("@@")`). Because `@@x`
  also begins with `@`, the read/assign paths test for **class var
  before instance var**, so `@@x` → ClassVar and `@x` → Instance stay
  distinct.
- `@@x` assignment lowers to `Stmt::Assign { scope: ClassVar }`
  (requesting `ClassVars` + `MutableBindings`); the manifest
  materialization loop emits `Feature::ClassVars`.

### `ruby-parser` 0.44.0

- No grammar change (the lexer already emits `@@x` as a `Name` token).
  New parse pin `test_parse_class_var_compound_assignment` (`@@n += 1`).

### Tests

- `semantic-ir`: 96 → 99 (printer + 2 validator).
- `ruby-to-semantic-ir`: 211 → 215 (read→ClassVar, unset-read E2E,
  cvar-method E2E, instance/class-var distinctness; 2 pre-existing tests
  updated to the ClassVar contract).
- `ruby-parser`: 171 → 172 (compound-cvar parse pin).

All green locally:
`cargo test -p semantic-ir -p coding-adventures-ruby-parser -p ruby-to-semantic-ir`.

### Security

Pure logic over the AST — no I/O, no `unsafe`, no deserialization.
`/security-review` passed clean in one round.
