### PR TITLE
feat(closurec): --correlation_vector_summary stdout one-liner (CLOC11.73)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.36.0] - 2026-05-30
+
+### Added — CLOC11.73: `--correlation_vector_summary` stdout one-liner
+
+Boolean flag. When on, prints a single summary line to stdout (`CompilerOutput.stdout_text`) after the CV sidecar write (or skipped under `--correlation_vector_format NONE`). Lets build pipelines see how many entries / contributions / tombstones the run produced without parsing the JSON itself.
+
+Output format:
+
+```
+cv sidecar: <path>: N entries, M contributions, T tombstones, pass_order=[a,b,c]
+```
+
+When the format is `NONE`:
+
+```
+cv sidecar: skipped (format=NONE): N entries, M contributions, T tombstones, pass_order=[a,b,c]
+```
+
+### Counts are post-filter
+
+`compute_cv_summary` calls the same `prune_entries_by_source` helper the formatters use (with the same `include_origin` and `invert` flags), so the printed counts describe **what's actually on disk** when a filter is in play.
+
+### Composition
+
+- Default off → no change to existing stdout output.
+- Composes orthogonally with every other CV flag — `summary` reads what the formatters wrote, it doesn't second-guess them.
+- Trails the JS / source map / manifest stdout (only fires when CV is on; the line ends in `\n`).
+
+### Implementation
+
+- New private `compute_cv_summary(cv_log, filter, include_origin, invert, wrote_path)` returns the rendered line. Parses `cv_log.to_json_string()` once, applies the filter, counts entries / contributions / tombstones, extracts `pass_order`.
+- `summary_line` helper formats the rendered string; isolated from the count walk so format changes don't bleed into the counting path.
+- `result.stdout_text` is now bound `mut` to allow the summary append.
+
+### Changed
+
+- `SpecialModesConfig` gains `correlation_vector_summary: bool`.
+- `wire::read_special_modes` reads the bool.
+- Versions: `Cargo.toml` `0.35.0` → `0.36.0`, `cli.spec.json` `0.35.0` → `0.36.0`.
+
 ## [0.35.0] - 2026-05-30
 
 ### Added — CLOC11.72: `--correlation_vector_filter_invert`

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.35.0"
+version = "0.36.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },
@@ -102,6 +102,7 @@
     { "id": "correlation_vector_filter", "long": "correlation_vector_filter", "type": "string", "default": "", "description": "Comma-separated allowlist of CV source names (e.g. \"lex,defines\"). Entries with no contribution.source in the allowlist are pruned from the written sidecar. Empty (default) keeps every entry. Ignored unless --correlation_vector is also set (CLOC11.70)." },
     { "id": "correlation_vector_filter_includes_origin", "long": "correlation_vector_filter_includes_origin", "type": "boolean", "default": false, "description": "When --correlation_vector_filter is set, also match entries by their origin.source (in addition to contribution.source). Lets `--correlation_vector_filter lex` keep the per-token CV entries whose Origin.source is \"lexer_token\". Default off preserves CLOC11.70 strict semantics (CLOC11.71)." },
     { "id": "correlation_vector_filter_invert", "long": "correlation_vector_filter_invert", "type": "boolean", "default": false, "description": "Invert the --correlation_vector_filter from an allowlist to a blocklist. With --correlation_vector_filter lex and --correlation_vector_filter_invert true, entries that DO match (i.e. carry a `lex` contribution and/or origin) are dropped; everything else is kept. Useful for \"everything except X\" filters where enumerating the allowlist is impractical (CLOC11.72)." },
+    { "id": "correlation_vector_summary", "long": "correlation_vector_summary", "type": "boolean", "default": false, "description": "Print a one-line summary of the correlation-vector trace to stdout after the sidecar is written (or skipped under --correlation_vector_format NONE). Format: `cv sidecar: <path>: N entries, M contributions, T tombstones, pass_order=[a,b,c]`. Counts reflect post-filter state. Useful for build pipelines that don't want to parse the JSON to see if anything interesting happened (CLOC11.73)." },
     { "id": "instrument_for_coverage_option", "long": "instrument_for_coverage_option", "type": "enum", "enum_values": ["NONE", "LINE", "BRANCH", "PRODUCTION"], "default": "NONE", "description": "Enable code instrumentation for coverage analysis." },
     { "id": "production_instrumentation_array_name", "long": "production_instrumentation_array_name", "type": "string", "default": "", "description": "Global array name used by production instrumentation." },
     { "id": "chunk_output_type", "long": "chunk_output_type", "type": "enum", "enum_values": ["GLOBAL_NAMESPACE", "ES_MODULES"], "default": "GLOBAL_NAMESPACE", "description": "Format for output chunks." },

--- a/code/programs/rust/closurec/src/config.rs
+++ b/code/programs/rust/closurec/src/config.rs
@@ -605,6 +605,18 @@ pub struct SpecialModesConfig {
     /// empty filter is a no-op, so we keep the empty-filter
     /// short-circuit).
     pub correlation_vector_filter_invert: bool,
+    /// CLOC11.73: when true, after the CV sidecar is
+    /// written (or skipped under
+    /// `correlation_vector_format = None`), print a one-line
+    /// summary of the trace to `stdout_text`. Lets a build
+    /// pipeline see how many entries / contributions /
+    /// tombstones the run produced without parsing the JSON
+    /// itself. Counts reflect the post-filter state, so
+    /// the summary describes what was actually written to
+    /// disk.
+    ///
+    /// Only consulted when `correlation_vector` is true.
+    pub correlation_vector_summary: bool,
 }
 
 /// CLOC11.69 — sidecar persistence format. Default is

--- a/code/programs/rust/closurec/src/run.rs
+++ b/code/programs/rust/closurec/src/run.rs
@@ -1062,7 +1062,7 @@ pub fn run_compiler(config: &CompilerConfig) -> Result<CompilerOutput, CompilerE
     // None arm moves `encoded` into stdout_text; without the
     // pre-capture we'd see a borrow-of-moved error.
     let encoded_byte_len = encoded.len();
-    let result = match &config.io.js_output_file {
+    let mut result = match &config.io.js_output_file {
         Some(path) => {
             write_output_file(path, &encoded)?;
             CompilerOutput {
@@ -1241,6 +1241,10 @@ pub fn run_compiler(config: &CompilerConfig) -> Result<CompilerOutput, CompilerE
     //   3. Else (stdout output), the sidecar lands at
     //      `closurec-cv.json` in the working directory.
     //      Discoverable; user can rename / move.
+    // Track whether we actually wrote a sidecar (vs. NONE
+    // format that skipped) and where, so CLOC11.73 can name
+    // the file in the summary line.
+    let mut cv_sidecar_written: Option<PathBuf> = None;
     if config.special_modes.correlation_vector {
         // CLOC11.69 — format selection. `None` short-circuits
         // the whole write step: the CV log is still computed
@@ -1282,8 +1286,23 @@ pub fn run_compiler(config: &CompilerConfig) -> Result<CompilerOutput, CompilerE
                     ),
                 };
                 write_output_file(&sidecar_path, &body)?;
-                wrote_files.push(sidecar_path);
+                wrote_files.push(sidecar_path.clone());
+                cv_sidecar_written = Some(sidecar_path);
             }
+        }
+
+        // CLOC11.73 — opt-in stdout summary. Computed
+        // post-filter so the line describes what's actually
+        // on disk (or would have been, under NONE format).
+        if config.special_modes.correlation_vector_summary {
+            let summary = compute_cv_summary(
+                &cv_log,
+                &config.special_modes.correlation_vector_filter,
+                config.special_modes.correlation_vector_filter_includes_origin,
+                config.special_modes.correlation_vector_filter_invert,
+                cv_sidecar_written.as_deref(),
+            );
+            result.stdout_text.push_str(&summary);
         }
     }
 
@@ -1291,6 +1310,116 @@ pub fn run_compiler(config: &CompilerConfig) -> Result<CompilerOutput, CompilerE
         stdout_text: result.stdout_text,
         wrote_files,
     })
+}
+
+/// CLOC11.73 — produce a one-line stdout summary of the CV
+/// log, *after* the same filter would have been applied for
+/// the sidecar. The output ends with a newline so it composes
+/// cleanly with the rest of `stdout_text`.
+///
+/// Two flavors:
+///   - `wrote_path = Some(p)` (Json / Ndjson format):
+///     "cv sidecar: <p>: N entries, M contributions, T
+///      tombstones, pass_order=[...]"
+///   - `wrote_path = None` (NONE format / write skipped):
+///     "cv sidecar: skipped (format=NONE): N entries, M
+///      contributions, T tombstones, pass_order=[...]"
+///
+/// Counts reflect the post-filter view; under filter=[] the
+/// summary describes the unfiltered log.
+fn compute_cv_summary(
+    cv_log: &coding_adventures_correlation_vector::CVLog,
+    filter: &[String],
+    filter_includes_origin: bool,
+    filter_invert: bool,
+    wrote_path: Option<&std::path::Path>,
+) -> String {
+    // Build the same parsed-Value form the formatters use,
+    // apply the same filter, then count.
+    let compact = cv_log
+        .to_json_string()
+        .unwrap_or_else(|_| "{}".to_string());
+    let mut root: serde_json::Value = match serde_json::from_str(&compact) {
+        Ok(v) => v,
+        Err(_) => {
+            // Fallback to a stub summary; pass_order is
+            // unknown but we still print zeros so the line
+            // is well-formed.
+            return summary_line(wrote_path, 0, 0, 0, &[]);
+        }
+    };
+    if !filter.is_empty() {
+        prune_entries_by_source(
+            &mut root,
+            filter,
+            filter_includes_origin,
+            filter_invert,
+        );
+    }
+    let entries = root
+        .get("entries")
+        .and_then(|v| v.as_object())
+        .map(|o| o.values().cloned().collect::<Vec<_>>())
+        .unwrap_or_default();
+    let entry_count = entries.len();
+    let contribution_count: usize = entries
+        .iter()
+        .map(|e| {
+            e.get("contributions")
+                .and_then(|v| v.as_array())
+                .map(|a| a.len())
+                .unwrap_or(0)
+        })
+        .sum();
+    let tombstone_count: usize = entries
+        .iter()
+        .filter(|e| {
+            e.get("deleted")
+                .map(|d| !d.is_null())
+                .unwrap_or(false)
+        })
+        .count();
+    let pass_order: Vec<String> = root
+        .get("pass_order")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default();
+    summary_line(
+        wrote_path,
+        entry_count,
+        contribution_count,
+        tombstone_count,
+        &pass_order,
+    )
+}
+
+/// Render the CLOC11.73 summary as a single line ending in
+/// `\n`. Kept separate from `compute_cv_summary` so the
+/// formatting can be tested / changed without re-running the
+/// CV count walk.
+fn summary_line(
+    wrote_path: Option<&std::path::Path>,
+    entries: usize,
+    contributions: usize,
+    tombstones: usize,
+    pass_order: &[String],
+) -> String {
+    let prefix = match wrote_path {
+        Some(p) => format!("cv sidecar: {}", p.display()),
+        None => "cv sidecar: skipped (format=NONE)".to_string(),
+    };
+    format!(
+        "{}: {} entries, {} contributions, {} tombstones, pass_order=[{}]\n",
+        prefix,
+        entries,
+        contributions,
+        tombstones,
+        pass_order.join(","),
+    )
 }
 
 /// Serialize a `CVLog` to a JSON string for the
@@ -3906,6 +4035,147 @@ mod tests {
         assert!(
             body.contains("\"source\":\"lexer_token\""),
             "expected lexer_token Origins under empty inverted filter: {body}"
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    // ------------------------------------------------------------------
+    // CLOC11.73 — --correlation_vector_summary
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn correlation_vector_summary_writes_one_line_after_sidecar() {
+        // With --correlation_vector + --correlation_vector_summary,
+        // stdout_text should end with the summary line and
+        // the sidecar should still land on disk.
+        let dir =
+            std::env::temp_dir().join("closurec_cloc11_73_summary_default");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("create dir");
+        let in_path = dir.join("a.js");
+        fs::write(&in_path, "var x = 1;").expect("write");
+        let out_path = dir.join("out.js");
+        let sidecar_path = dir.join("out.js.cv.json");
+        let cfg = CompilerConfig {
+            io: IoConfig {
+                js_patterns: vec![in_path.to_string_lossy().to_string()],
+                js_output_file: Some(out_path.clone()),
+                ..Default::default()
+            },
+            special_modes: crate::config::SpecialModesConfig {
+                correlation_vector: true,
+                correlation_vector_summary: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let out = run_compiler(&cfg).expect("ok");
+        assert!(
+            sidecar_path.exists(),
+            "expected sidecar at {:?}",
+            sidecar_path
+        );
+        // stdout summary present.
+        assert!(
+            out.stdout_text.contains("cv sidecar:"),
+            "expected `cv sidecar:` prefix, got: {:?}",
+            out.stdout_text
+        );
+        assert!(
+            out.stdout_text.contains(" entries, "),
+            "expected entries field, got: {:?}",
+            out.stdout_text
+        );
+        assert!(
+            out.stdout_text.contains("pass_order=["),
+            "expected pass_order field, got: {:?}",
+            out.stdout_text
+        );
+        // The summary line ends in `\n`.
+        assert!(
+            out.stdout_text.ends_with('\n'),
+            "expected trailing newline, got: {:?}",
+            out.stdout_text
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn correlation_vector_summary_reports_skipped_under_format_none() {
+        // Format=NONE: sidecar is not written. Summary line
+        // should say "skipped (format=NONE)" but still count
+        // entries / contributions / tombstones from the
+        // (in-memory) cv_log.
+        let dir =
+            std::env::temp_dir().join("closurec_cloc11_73_summary_none");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("create dir");
+        let in_path = dir.join("a.js");
+        fs::write(&in_path, "var x = 1;").expect("write");
+        let out_path = dir.join("out.js");
+        let default_sidecar = dir.join("out.js.cv.json");
+        let cfg = CompilerConfig {
+            io: IoConfig {
+                js_patterns: vec![in_path.to_string_lossy().to_string()],
+                js_output_file: Some(out_path.clone()),
+                ..Default::default()
+            },
+            special_modes: crate::config::SpecialModesConfig {
+                correlation_vector: true,
+                correlation_vector_format:
+                    crate::config::CorrelationVectorFormat::None,
+                correlation_vector_summary: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let out = run_compiler(&cfg).expect("ok");
+        assert!(
+            !default_sidecar.exists(),
+            "NONE format should skip sidecar write"
+        );
+        assert!(
+            out.stdout_text.contains("skipped (format=NONE)"),
+            "expected `skipped (format=NONE)` marker, got: {:?}",
+            out.stdout_text
+        );
+        // Still reports counts.
+        assert!(
+            out.stdout_text.contains(" entries, "),
+            "expected entries field even under NONE: {:?}",
+            out.stdout_text
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn correlation_vector_summary_off_emits_no_summary() {
+        // Default flag off → no summary line in stdout_text
+        // even when CV is enabled.
+        let dir = std::env::temp_dir().join("closurec_cloc11_73_summary_off");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("create dir");
+        let in_path = dir.join("a.js");
+        fs::write(&in_path, "var x = 1;").expect("write");
+        let out_path = dir.join("out.js");
+        let cfg = CompilerConfig {
+            io: IoConfig {
+                js_patterns: vec![in_path.to_string_lossy().to_string()],
+                js_output_file: Some(out_path.clone()),
+                ..Default::default()
+            },
+            special_modes: crate::config::SpecialModesConfig {
+                correlation_vector: true,
+                // correlation_vector_summary defaults to false
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let out = run_compiler(&cfg).expect("ok");
+        assert!(
+            !out.stdout_text.contains("cv sidecar:"),
+            "expected no summary line under default flag, got: {:?}",
+            out.stdout_text
         );
         let _ = fs::remove_dir_all(&dir);
     }

--- a/code/programs/rust/closurec/src/wire.rs
+++ b/code/programs/rust/closurec/src/wire.rs
@@ -517,6 +517,7 @@ fn read_special_modes(p: &ParseResult) -> Result<SpecialModesConfig, ConfigError
             p,
             "correlation_vector_filter_invert",
         )?,
+        correlation_vector_summary: get_bool(p, "correlation_vector_summary")?,
     })
 }
 

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.35.0
+Version: 0.36.0
 
 ## Flags
 
@@ -393,6 +393,10 @@ When --correlation_vector_filter is set, also match entries by their origin.sour
 ### `--correlation_vector_filter_invert` (boolean, default: false)
 
 Invert the --correlation_vector_filter from an allowlist to a blocklist. With --correlation_vector_filter lex and --correlation_vector_filter_invert true, entries that DO match (i.e. carry a `lex` contribution and/or origin) are dropped; everything else is kept. Useful for "everything except X" filters where enumerating the allowlist is impractical (CLOC11.72).
+
+### `--correlation_vector_summary` (boolean, default: false)
+
+Print a one-line summary of the correlation-vector trace to stdout after the sidecar is written (or skipped under --correlation_vector_format NONE). Format: `cv sidecar: <path>: N entries, M contributions, T tombstones, pass_order=[a,b,c]`. Counts reflect post-filter state. Useful for build pipelines that don't want to parse the JSON to see if anything interesting happened (CLOC11.73).
 
 ### `--instrument_for_coverage_option` (enum, default: NONE)
 


### PR DESCRIPTION
## Summary

Boolean flag. When on, `run_compiler` appends one summary line to `CompilerOutput.stdout_text` after the CV sidecar write (or skipped under `--correlation_vector_format NONE`).

```
cv sidecar: <path>: N entries, M contributions, T tombstones, pass_order=[a,b,c]
```

When format is `NONE`:

```
cv sidecar: skipped (format=NONE): N entries, M contributions, T tombstones, pass_order=[a,b,c]
```

## Counts are post-filter

`compute_cv_summary` calls the same `prune_entries_by_source` helper the formatters use (with the same `include_origin` and `invert` flags), so the printed counts describe **what's actually on disk** when a filter is in play. Divergence between JSON and summary is impossible by construction.

## Composition

- Default off → no change to existing stdout output.
- Composes orthogonally with every other CV flag.
- Trails JS / source map / manifest stdout; only fires when `--correlation_vector` is on; line ends in `\n`.

## Implementation

- New private `compute_cv_summary(cv_log, filter, include_origin, invert, wrote_path)` returns the rendered line. Parses `cv_log.to_json_string()` once, applies the filter, counts entries / contributions / tombstones, extracts `pass_order`.
- `summary_line` helper formats the string; isolated from the count walk so format changes don't bleed into counting.
- `run_compiler`'s `let result` is now `let mut result` to allow the summary append.

## Test plan
- [x] cargo build clean
- [x] 256 unit + 17 integration suites pass
- [x] New tests:
  - `correlation_vector_summary_writes_one_line_after_sidecar` — default JSON → `cv sidecar:` prefix + ` entries, ` + `pass_order=[` + trailing newline
  - `correlation_vector_summary_reports_skipped_under_format_none` — NONE → `skipped (format=NONE)` marker, counts still reported
  - `correlation_vector_summary_off_emits_no_summary` — default off → no summary
- [x] help-markdown fixture regenerated for 0.36.0

## Security review (inline)
- Re-uses the same parse path as the formatters; no new untrusted-input surface.
- `p.display()` is lossy-safe for arbitrary `OsString`/non-UTF-8 bytes.
- All Option chains are infallible (no `unwrap`, no panic).
- Default-off byte-identical to CLOC11.72.

## Versions
- `Cargo.toml`: 0.35.0 → 0.36.0
- `cli.spec.json`: 0.35.0 → 0.36.0
- `CHANGELOG.md`: new `[0.36.0]` section

🤖 Generated with [Claude Code](https://claude.com/claude-code)