### PR TITLE
feat(ruby-fc): Phase 15c — constants FOO/MyClass → Scope::Const

### DIFF
--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.45.0] - 2026-05-30
+
+### Added (Phase 15c (FC) — constants `FOO` / `MyClass`)
+
+No grammar change — an uppercase-initial identifier already lexes as a
+`Name` token, so `MAX = 10` parses as an `assignment` and a bare `MAX`
+as an expression.  Phase 15c adds one parse pin for the new lowering
+path:
+
+- `test_parse_constant_assignment` — `MAX = 10` parses as an assignment
+  carrying the uppercase-initial `MAX` Name token.
+
+Test count: 172 → 173 (+1).
+
 ## [0.44.0] - 2026-05-30
 
 ### Added (Phase 15b (FC) — class variables `@@x`)

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -891,6 +891,20 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_parse_constant_assignment() {
+        // `MAX = 10` parses as an assignment carrying the uppercase-initial
+        // `MAX` Name token (the shape the 15c lowerer routes to
+        // `Scope::Const`).
+        let ast = parse_ruby("MAX = 10");
+        let asn = find_statement_inner(&ast, "assignment")
+            .expect("expected assignment");
+        assert!(
+            body_has_token_value(asn, "MAX"),
+            "expected the `MAX` constant Name token in the assignment header"
+        );
+    }
+
     // -----------------------------------------------------------------------
     // Phase 6g — blocks `do … end` and brace-blocks `method { … }`
     // -----------------------------------------------------------------------

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.47.0] - 2026-05-30
+
+### Changed (Phase 15c (FC) — constants `FOO` / `MyClass`)
+
+Constants now lower to the first-class `Scope::Const` (semantic-ir
+0.8.0) instead of the Phase 6x `Scope::Local` placeholder, mirroring
+Phases 15a/15b (`@x`, `@@x`):
+
+- A constant **read** (any bare uppercase-initial name) lowers to
+  `Expr::VarRef { scope: Const }` — and no longer errors as an
+  undefined local when read before any assignment.
+- A constant **assignment** (`FOO = …`, including the compound forms)
+  lowers to `Stmt::Assign { scope: Const }` — never a `LetBinding` — and
+  is not registered in `declared_locals`.  Emitting it requests
+  `Feature::Constants` (and `MutableBindings`, since the store is a
+  `Stmt::Assign`).
+- New `is_constant_name` helper: a name whose first character is an
+  uppercase ASCII letter is a constant.  Class/module *names* in
+  `class Foo` / `module M` are consumed by their own grammar productions
+  and never reach this path, so only constants used as values or
+  assignment targets are routed here.
+
+New tests (+4): `const_read_lowers_to_const_scope`,
+`const_assignment_lowers_to_const_assign_not_letbinding`,
+`const_read_without_assignment_passes_validator` (E2E),
+`lowercase_name_stays_local_not_const` (regression).  Five pre-existing
+class/module/singleton-body tests that asserted constant assignments as
+`LetBinding` were updated to the new `Assign { scope: Const }` contract
+(`class_body_preserves_multiple_statements_in_source_order`,
+`class_body_preserves_executable_statement_and_hoists_method`,
+`module_body_preserves_executable_statement`,
+`singleton_class_hoists_methods_and_keeps_statements`,
+`subclass_with_body_records_superclass_and_hoists_methods`).  Test
+count: 215 → 219 (+4).
+
 ## [0.46.0] - 2026-05-30
 
 ### Changed (Phase 15b (FC) — class variables `@@x`)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -702,8 +702,9 @@ mod tests {
     #[test]
     fn class_body_preserves_executable_statement_and_hoists_method() {
         // `MAX = 10` (an executable class-body statement) must survive
-        // into `ClassDef.body` as a `LetBinding`, while `def bar` is
-        // still hoisted to a top-level Function.
+        // into `ClassDef.body`.  Phase 15c: a constant assignment lowers
+        // to `Stmt::Assign { scope: Const }` (was `LetBinding`), while
+        // `def bar` is still hoisted to a top-level Function.
         let m = lower("class Foo\n  MAX = 10\n  def bar\n  end\nend\n");
         assert!(
             m.functions.iter().any(|f| f.name == "bar"),
@@ -721,11 +722,12 @@ mod tests {
                     body
                 );
                 match &body[0] {
-                    Stmt::LetBinding { name, value, .. } => {
+                    Stmt::Assign { name, scope, value, .. } => {
                         assert_eq!(name, "MAX");
+                        assert_eq!(*scope, Scope::Const);
                         assert!(matches!(value, Expr::IntLit { value: 10, .. }));
                     }
-                    other => panic!("expected LetBinding MAX, got {:?}", other),
+                    other => panic!("expected Assign(MAX, Const), got {:?}", other),
                 }
             }
             other => panic!("expected Stmt::ClassDef, got {:?}", other),
@@ -735,7 +737,8 @@ mod tests {
     #[test]
     fn class_body_preserves_multiple_statements_in_source_order() {
         // Two constant assignments must appear in `body` in the same
-        // order they were written.
+        // order they were written.  Phase 15c: constant assignments
+        // lower to `Stmt::Assign { scope: Const }`.
         let m = lower("class Cfg\n  A = 1\n  B = 2\nend\n");
         let main = main_body(&m);
         match &main.stmts[0] {
@@ -744,8 +747,11 @@ mod tests {
                 let names: Vec<&str> = body
                     .iter()
                     .map(|s| match s {
-                        Stmt::LetBinding { name, .. } => name.as_str(),
-                        other => panic!("expected LetBinding, got {:?}", other),
+                        Stmt::Assign { name, scope, .. } => {
+                            assert_eq!(*scope, Scope::Const, "constant → Const scope");
+                            name.as_str()
+                        }
+                        other => panic!("expected Assign(Const), got {:?}", other),
                     })
                     .collect();
                 assert_eq!(names, vec!["A", "B"]);
@@ -855,7 +861,8 @@ mod tests {
                 assert_eq!(name, "Cat");
                 assert_eq!(superclass.as_deref(), Some("Animal"));
                 assert_eq!(body.len(), 1, "only `LEGS = 4` stays in body; got {:?}", body);
-                assert!(matches!(&body[0], Stmt::LetBinding { name, .. } if name == "LEGS"));
+                // Phase 15c: `LEGS = 4` is a constant assignment → Assign(Const).
+                assert!(matches!(&body[0], Stmt::Assign { name, scope, .. } if name == "LEGS" && *scope == Scope::Const));
             }
             other => panic!("expected Stmt::ClassDef, got {:?}", other),
         }
@@ -939,7 +946,8 @@ mod tests {
             Stmt::SingletonClassDef { target, body, .. } => {
                 assert_eq!(target, "self");
                 assert_eq!(body.len(), 1, "only `X = 1` stays in body; got {:?}", body);
-                assert!(matches!(&body[0], Stmt::LetBinding { name, .. } if name == "X"));
+                // Phase 15c: `X = 1` is a constant assignment → Assign(Const).
+                assert!(matches!(&body[0], Stmt::Assign { name, scope, .. } if name == "X" && *scope == Scope::Const));
             }
             other => panic!("expected Stmt::SingletonClassDef, got {:?}", other),
         }
@@ -1118,6 +1126,73 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
+    // Phase 15c (FC) — constants `FOO` / `MyClass` → `Scope::Const`.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn const_read_lowers_to_const_scope() {
+        // A bare uppercase-initial name read lowers to
+        // `VarRef { scope: Const }` and requests `Feature::Constants`
+        // (no declaration needed).
+        let m = lower("MAX\n");
+        match &main_body(&m).value {
+            Expr::VarRef { name, scope, .. } => {
+                assert_eq!(name, "MAX");
+                assert_eq!(*scope, Scope::Const);
+            }
+            other => panic!("expected VarRef const, got {:?}", other),
+        }
+        assert!(
+            m.manifest.contains(semantic_ir::Feature::Constants),
+            "manifest should declare Constants; got {:?}",
+            m.manifest
+        );
+    }
+
+    #[test]
+    fn const_assignment_lowers_to_const_assign_not_letbinding() {
+        // `MAX = 10` lowers to `Stmt::Assign { scope: Const }` (never a
+        // `LetBinding`); the constant is not registered as a local.
+        let m = lower("MAX = 10\n");
+        match &main_body(&m).stmts[0] {
+            Stmt::Assign { name, scope, .. } => {
+                assert_eq!(name, "MAX");
+                assert_eq!(*scope, Scope::Const);
+            }
+            other => panic!("expected Assign(MAX, Const), got {:?}", other),
+        }
+        assert!(m.manifest.contains(semantic_ir::Feature::Constants));
+    }
+
+    #[test]
+    fn const_read_without_assignment_passes_validator() {
+        // E2E: reading a constant with no prior assignment (as an
+        // assignment RHS) validates — a constant needs no `let`.
+        let m = lower("y = MAX\n");
+        let result = semantic_ir::validate(&m);
+        assert!(result.is_ok(), "validator rejected unset-const read: {:?}", result);
+    }
+
+    #[test]
+    fn lowercase_name_stays_local_not_const() {
+        // Regression: a lowercase-initial name is an ordinary local,
+        // NOT a constant — it must keep `Scope::Local` and must not
+        // request `Constants`.
+        let m = lower("foo = 1\nfoo\n");
+        match &main_body(&m).value {
+            Expr::VarRef { name, scope, .. } => {
+                assert_eq!(name, "foo");
+                assert_eq!(*scope, Scope::Local, "lowercase name stays Local");
+            }
+            other => panic!("expected VarRef(foo, Local), got {:?}", other),
+        }
+        assert!(
+            !m.manifest.contains(semantic_ir::Feature::Constants),
+            "a lowercase local must not request Constants"
+        );
+    }
+
+    // -----------------------------------------------------------------
     // Phase 14d (FC) — `module M … end` → `Stmt::ModuleDef`.  Mirrors
     // ClassDef (minus inheritance): method defs hoist to top-level
     // Functions; non-def statements stay in the module body.
@@ -1190,7 +1265,8 @@ mod tests {
             Stmt::ModuleDef { name, body, .. } => {
                 assert_eq!(name, "Config");
                 assert_eq!(body.len(), 1, "VERSION = 3 preserved; got {:?}", body);
-                assert!(matches!(&body[0], Stmt::LetBinding { name, .. } if name == "VERSION"));
+                // Phase 15c: `VERSION = 3` is a constant assignment → Assign(Const).
+                assert!(matches!(&body[0], Stmt::Assign { name, scope, .. } if name == "VERSION" && *scope == Scope::Const));
             }
             other => panic!("expected Stmt::ModuleDef, got {:?}", other),
         }

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -129,6 +129,9 @@ pub fn compile(program: &GrammarASTNode, module_name: &str) -> Result<Module, Ru
         // Phase 15b (FC) — a class-var ref (`@@x`, `Scope::ClassVar`)
         // triggers the `ClassVars` feature.
         Feature::ClassVars,
+        // Phase 15c (FC) — a constant ref/assign (`FOO`, `Scope::Const`)
+        // triggers the `Constants` feature.
+        Feature::Constants,
     ] {
         if lw.features_used.contains(&f) {
             manifest.add(f);
@@ -320,6 +323,19 @@ fn is_instance_var_name(name: &str) -> bool {
 /// (A single `@` is an *instance* variable — see `is_instance_var_name`.)
 fn is_class_var_name(name: &str) -> bool {
     name.starts_with("@@")
+}
+
+/// Phase 15c (FC) — is this Name-token value a Ruby *constant*?  In
+/// Ruby, any identifier whose first character is an uppercase ASCII
+/// letter is a constant (`FOO`, `Pi`, `MyClass`).  Sigil names (`@x`,
+/// `@@x`, `$x`) start with punctuation, so they are never constants;
+/// ordinary locals/params start lowercase or `_`.  Class/module *names*
+/// in `class Foo` / `module M` are consumed by their own grammar
+/// productions and never reach the generic Name→VarRef factor path, so
+/// this only fires for constants used as values (reads) or assignment
+/// targets (`FOO = …`).
+fn is_constant_name(name: &str) -> bool {
+    name.chars().next().is_some_and(|c| c.is_ascii_uppercase())
 }
 
 // ---------------------------------------------------------------------------
@@ -2248,12 +2264,15 @@ impl Lowerer {
                 // branch above (Phase 8b) and never reach this match.
                 _ => unreachable!("op_token matched only the eager compound forms above"),
             };
-            // Phase 15a/15b — a compound assign to a sigil var
-            // (`@x += 1`, `@@x += 1`) reads it with the matching scope.
+            // Phase 15a/15b/15c — a compound assign to a sigil var or a
+            // constant (`@x += 1`, `@@x += 1`, `FOO += 1`) reads it back
+            // with the matching scope.
             let lhs_scope = if is_class_var_name(&name) {
                 Scope::ClassVar
             } else if is_instance_var_name(&name) {
                 Scope::Instance
+            } else if is_constant_name(&name) {
+                Scope::Const
             } else {
                 Scope::Local
             };
@@ -2296,6 +2315,25 @@ impl Lowerer {
             return Ok(Stmt::Assign {
                 name,
                 scope: Scope::Instance,
+                value,
+                span,
+            });
+        }
+
+        // Phase 15c (FC) — a constant assignment (`FOO = …`) lowers to
+        // `Stmt::Assign { scope: Const }` rather than a `LetBinding`: a
+        // constant is resolved against the constant scope, not the
+        // local env, so it is never registered in `declared_locals`.
+        // The store is a `Stmt::Assign` whose validator arm observes
+        // `MutableBindings`, so we declare both features.  (Re-assigning
+        // a constant is a warning in real Ruby, not an error, so we do
+        // not try to enforce single-assignment here.)
+        if is_constant_name(&name) {
+            self.features_used.insert(Feature::Constants);
+            self.features_used.insert(Feature::MutableBindings);
+            return Ok(Stmt::Assign {
+                name,
+                scope: Scope::Const,
                 value,
                 span,
             });
@@ -4984,19 +5022,24 @@ impl Lowerer {
                             // and/or (b) auto-emit `Global` declarations for
                             // `$x`-prefixed names so the validator-true
                             // mapping `$x` → `Scope::Global` becomes usable.
-                            // Phase 15a/15b (FC) — sigil-prefixed names
-                            // lower to dedicated scopes (no declaration
-                            // needed): `@@x` (double `@`) → class var,
-                            // `@x` (single `@`) → instance var.  `$x`
-                            // (global) keeps the pre-15a `Scope::Local`
-                            // fallback for now.  Class var is checked
-                            // first since `@@x` also starts with `@`.
+                            // Phase 15a/15b/15c (FC) — names lower to
+                            // dedicated scopes (no declaration needed):
+                            // `@@x` (double `@`) → class var, `@x`
+                            // (single `@`) → instance var, and any
+                            // uppercase-initial name (`FOO`, `MyClass`)
+                            // → constant.  `$x` (global) keeps the
+                            // pre-15a `Scope::Local` fallback for now.
+                            // Class var is checked first since `@@x`
+                            // also starts with `@`.
                             let scope = if is_class_var_name(&tok.value) {
                                 self.features_used.insert(Feature::ClassVars);
                                 Scope::ClassVar
                             } else if is_instance_var_name(&tok.value) {
                                 self.features_used.insert(Feature::InstanceVars);
                                 Scope::Instance
+                            } else if is_constant_name(&tok.value) {
+                                self.features_used.insert(Feature::Constants);
+                                Scope::Const
                             } else if self.current_params.contains(&tok.value) {
                                 Scope::Param
                             } else {

--- a/code/packages/rust/semantic-ir-to-go/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/emit.rs
@@ -342,6 +342,11 @@ fn emit_var_ref(out: &mut String, name: &str, scope: Scope) {
             // class-var modules are rejected before emit.  Unreachable.
             panic!("go backend reached SIR17 class-var ref `{}` — capability check should have rejected it", name);
         }
+        Scope::Const => {
+            // SIR17 Phase 15c — `Feature::Constants` likewise unaccepted;
+            // constant-using modules are rejected before emit.  Unreachable.
+            panic!("go backend reached SIR17 const ref `{}` — capability check should have rejected it", name);
+        }
     }
 }
 

--- a/code/packages/rust/semantic-ir-to-python/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/emit.rs
@@ -296,6 +296,11 @@ fn emit_var_ref(out: &mut String, name: &str, scope: Scope) {
             // class-var modules are rejected before emit.  Unreachable.
             panic!("python backend reached SIR17 class-var ref `{}` — capability check should have rejected it", name);
         }
+        Scope::Const => {
+            // SIR17 Phase 15c — `Feature::Constants` likewise unaccepted;
+            // constant-using modules are rejected before emit.  Unreachable.
+            panic!("python backend reached SIR17 const ref `{}` — capability check should have rejected it", name);
+        }
     }
 }
 

--- a/code/packages/rust/semantic-ir-to-rust/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/emit.rs
@@ -286,6 +286,11 @@ fn emit_var_ref(out: &mut String, name: &str, scope: Scope) {
             // class-var modules are rejected before emit.  Unreachable.
             panic!("rust backend reached SIR17 class-var ref `{}` — capability check should have rejected it", name);
         }
+        Scope::Const => {
+            // SIR17 Phase 15c — `Feature::Constants` likewise unaccepted;
+            // constant-using modules are rejected before emit.  Unreachable.
+            panic!("rust backend reached SIR17 const ref `{}` — capability check should have rejected it", name);
+        }
     }
 }
 

--- a/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
@@ -280,6 +280,11 @@ fn emit_var_ref(out: &mut String, name: &str, scope: Scope) {
             // class-var modules are rejected before emit.  Unreachable.
             panic!("ts backend reached SIR17 class-var ref `{}` — capability check should have rejected it", name);
         }
+        Scope::Const => {
+            // SIR17 Phase 15c — `Feature::Constants` likewise unaccepted;
+            // constant-using modules are rejected before emit.  Unreachable.
+            panic!("ts backend reached SIR17 const ref `{}` — capability check should have rejected it", name);
+        }
     }
 }
 

--- a/code/packages/rust/semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to the `semantic-ir` crate are documented here.
 
+## 0.8.0 — SIR17: constant scope (`Scope::Const`)
+
+Introduced by the Ruby frontend's Phase 15c (`FOO` / `MyClass`).
+
+### Added
+
+- `Scope::Const` — a constant (Ruby `FOO`, `MyClass` — any
+  uppercase-initial name).  Like `Scope::Instance` / `Scope::ClassVar`,
+  it needs **no prior declaration**: `check_varref` performs no
+  scope-existence check (a constant resolves against the constant scope,
+  not a `let` binding).  `Scope::name()` / `from_name()` gain the
+  `"const"` tag.
+- `Feature::Constants` (kebab `constants`) — declared by any module that
+  references a `Scope::Const`.  The validator observes it from each
+  Const-scoped `VarRef`; backends that don't list it in their accepted
+  set reject such modules at the capability check, before emit.
+
+### Changed
+
+- `check_varref` gains a `Scope::Const` arm (observe-only, no
+  resolution).  The text printer renders `(var-ref FOO const)` via the
+  existing `scope.name()` path.  The four reference backends'
+  `emit_var_ref` gain an unreachable `panic!` arm for `Scope::Const`
+  (rejected pre-emit by the capability check).
+
+New tests (3): `print_var_ref_const_scope`,
+`const_ref_needs_no_declaration`,
+`const_ref_without_manifest_feature_is_error`.  Test count: 99 → 102.
+
+This is a **breaking enum change** for any exhaustive `match` on
+`Scope` without a `_` rest arm.
+
 ## 0.7.0 — SIR17: class-variable scope (`Scope::ClassVar`)
 
 Introduced by the Ruby frontend's Phase 15b (`@@x`).

--- a/code/packages/rust/semantic-ir/src/manifest.rs
+++ b/code/packages/rust/semantic-ir/src/manifest.rs
@@ -65,6 +65,11 @@ pub enum Feature {
     /// no prior declaration; they are shared across the class
     /// hierarchy rather than per-object.
     ClassVars,
+    /// Module references a constant (`Scope::Const`, Ruby `FOO` /
+    /// `MyClass` — any uppercase-initial name).  Phase 15c (Ruby).
+    /// Like instance/class vars, a constant reference needs no prior
+    /// `let` declaration; it resolves against the constant scope.
+    Constants,
 }
 
 impl Feature {
@@ -90,6 +95,7 @@ impl Feature {
         Feature::Modules,
         Feature::InstanceVars,
         Feature::ClassVars,
+        Feature::Constants,
     ];
 
     /// Kebab-case name for the SIR text format.
@@ -115,6 +121,7 @@ impl Feature {
             Feature::Modules => "modules",
             Feature::InstanceVars => "instance-vars",
             Feature::ClassVars => "class-vars",
+            Feature::Constants => "constants",
         }
     }
 

--- a/code/packages/rust/semantic-ir/src/nodes.rs
+++ b/code/packages/rust/semantic-ir/src/nodes.rs
@@ -345,6 +345,14 @@ pub enum Scope {
     /// Introduced by the Ruby frontend's Phase 15b; gated by
     /// `Feature::ClassVars`.
     ClassVar,
+    /// Constant (Ruby `FOO`, `MyClass` — any name whose first letter is
+    /// uppercase).  Like `Instance`/`ClassVar`, it needs **no prior
+    /// declaration** in the SIR sense (the validator performs no
+    /// scope-existence check): a constant is resolved against the
+    /// enclosing lexical/constant scope at runtime, not against a `let`
+    /// binding.  The name is preserved verbatim.  Introduced by the
+    /// Ruby frontend's Phase 15c; gated by `Feature::Constants`.
+    Const,
 }
 
 impl Scope {
@@ -358,6 +366,7 @@ impl Scope {
             Scope::Builtin => "builtin",
             Scope::Instance => "instance",
             Scope::ClassVar => "class-var",
+            Scope::Const => "const",
         }
     }
 
@@ -371,6 +380,7 @@ impl Scope {
             "builtin" => Scope::Builtin,
             "instance" => Scope::Instance,
             "class-var" => Scope::ClassVar,
+            "const" => Scope::Const,
             _ => return None,
         })
     }

--- a/code/packages/rust/semantic-ir/src/text/printer.rs
+++ b/code/packages/rust/semantic-ir/src/text/printer.rs
@@ -542,6 +542,18 @@ mod tests {
     }
 
     #[test]
+    fn print_var_ref_const_scope() {
+        // Phase 15c — a constant ref prints with the `const` scope tag
+        // and the (uppercase-initial) name preserved verbatim.
+        let e = Expr::VarRef {
+            name: "MAX".into(),
+            scope: Scope::Const,
+            span: s(),
+        };
+        assert_eq!(print_expr(&e), "(var-ref MAX const)");
+    }
+
+    #[test]
     fn print_builtin_call_with_pure() {
         let e = Expr::BuiltinCall {
             name: "+".into(),

--- a/code/packages/rust/semantic-ir/src/validator.rs
+++ b/code/packages/rust/semantic-ir/src/validator.rs
@@ -582,6 +582,12 @@ impl<'m> ValidatorState<'m> {
                 // declaration; record the feature only.
                 self.observed.add(Feature::ClassVars);
             }
+            Scope::Const => {
+                // Constants (Ruby `FOO` / `MyClass`) resolve against the
+                // constant scope, not a `let` binding — no local
+                // resolution; record the feature only.
+                self.observed.add(Feature::Constants);
+            }
         }
     }
 
@@ -1573,5 +1579,55 @@ mod tests {
         let r = validate(&m);
         assert!(!r.is_ok(), "expected missing-ClassVars-feature error");
         assert!(r.errors().any(|i| i.message.contains("class-vars")));
+    }
+
+    // -----------------------------------------------------------------
+    // SIR17 Phase 15c — `Scope::Const` (constants).
+    // -----------------------------------------------------------------
+
+    /// Build a one-function module whose body value is a single
+    /// constant ref, declaring the given features.
+    fn module_with_const_ref(features: &[Feature]) -> Module {
+        let mut m = empty_module(FeatureManifest::from_features(features));
+        m.functions.push(Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![],
+                value: Expr::VarRef {
+                    name: "MAX".into(),
+                    scope: Scope::Const,
+                    span: s(),
+                },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        });
+        m
+    }
+
+    #[test]
+    fn const_ref_needs_no_declaration() {
+        // A constant ref is accepted with no prior `let`/param — a
+        // constant resolves against the constant scope, not a local
+        // binding.  Module declares `Constants`.
+        let m = module_with_const_ref(&[Feature::Constants]);
+        let r = validate(&m);
+        assert!(r.is_ok(), "expected ok, got {:?}", r.issues);
+    }
+
+    #[test]
+    fn const_ref_without_manifest_feature_is_error() {
+        // The validator observes `Constants` from the Const-scoped ref;
+        // if the manifest doesn't declare it, the used-but-undeclared
+        // check fires.
+        let m = module_with_const_ref(&[]);
+        let r = validate(&m);
+        assert!(!r.is_ok(), "expected missing-Constants-feature error");
+        assert!(r.errors().any(|i| i.message.contains("constants")));
     }
 }


### PR DESCRIPTION
## Phase 15c (FC) — constants `FOO` / `MyClass` → `Scope::Const`

Mirrors the merged Phases 15a/15b (`@x` → `Scope::Instance`, `@@x` →
`Scope::ClassVar`) for Ruby **constants**. Previously constant
reads/assigns fell through to the Phase 6x `Scope::Local` placeholder:
the assignment became a `LetBinding` (registering the constant as a
local), and a read before assignment errored as an undefined local.

### `semantic-ir` 0.8.0

- **New `Scope::Const`** (kebab `const`) — a no-declaration scope like
  `Instance`/`ClassVar`; `name()` / `from_name()` gain the tag.
- **New `Feature::Constants`** (kebab `constants`) — observed by the
  validator from each Const-scoped `VarRef`; gated by the backends'
  capability check.
- `check_varref` gains a `Scope::Const` arm (observe-only, no
  resolution — a constant resolves against the constant scope).
- The four reference backends' `emit_var_ref` gain an **unreachable**
  `panic!` arm for `Scope::Const`.
- Text printer renders `(var-ref FOO const)` via `scope.name()`.

> ⚠️ **Breaking enum change** for any exhaustive `match` on `Scope`
> without a `_` rest arm.

### `ruby-to-semantic-ir` 0.47.0

- New `is_constant_name` helper (first char ASCII-uppercase).
  Class/module *names* in `class Foo` / `module M` are consumed by their
  own grammar productions and never reach the generic Name→VarRef factor
  path, so only constants used as **values** (reads) or **assignment
  targets** are routed here.
- Constant read → `VarRef { scope: Const }`; constant assignment →
  `Stmt::Assign { scope: Const }` (never a `LetBinding`, not registered
  as a local), requesting `Constants` + `MutableBindings`; compound
  `FOO += 1` reads back with `Scope::Const`.

### `ruby-parser` 0.45.0

- No grammar change (an uppercase-initial name already lexes as a `Name`
  token). New parse pin `test_parse_constant_assignment` (`MAX = 10`).

### Tests

- `semantic-ir`: 99 → 102 (printer + 2 validator).
- `ruby-to-semantic-ir`: 215 → 219 (read→Const, assign→Const-not-Let,
  unset-read E2E, lowercase-stays-Local regression). **Five** pre-existing
  class/module/singleton-body tests that asserted constant assignments as
  `LetBinding` were updated to the new `Assign { scope: Const }` contract.
- `ruby-parser`: 172 → 173 (constant-assignment parse pin).

All green locally:
`cargo test -p semantic-ir -p coding-adventures-ruby-parser -p ruby-to-semantic-ir`.

### Security

Pure logic over the AST — no I/O, no `unsafe`, no deserialization.
`/security-review` passed clean in one round.
