### PR TITLE
feat(closurec): --correlation_vector_summary_format enum (CLOC11.74)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.37.0] - 2026-05-30
+
+### Added — CLOC11.74: `--correlation_vector_summary_format` enum (TEXT | JSON | KV)
+
+Machine-readable rendering for the CLOC11.73 summary line. Lets CI/build pipelines consume the summary without regex-matching the human-readable text.
+
+- `TEXT` (default) — CLOC11.73 line: `cv sidecar: <path>: N entries, M contributions, T tombstones, pass_order=[a,b,c]`
+- `JSON` — single-line JSON object:
+  ```json
+  {"cv_sidecar":{"path":"<path>","skipped":false,"entries":N,"contributions":M,"tombstones":T,"pass_order":["a","b","c"]}}
+  ```
+  Under format=NONE: `"path": null, "skipped": true`.
+- `KV` — space-separated `key=value`:
+  ```
+  cv_sidecar.path="<path>" cv_sidecar.skipped=false cv_sidecar.entries=N cv_sidecar.contributions=M cv_sidecar.tombstones=T cv_sidecar.pass_order="a,b,c"
+  ```
+  Path and pass_order are quoted on the RHS via `serde_json::to_string` so shell tooling can split on whitespace safely.
+
+Flag is only consulted when `--correlation_vector_summary` is also on. With summary off, the format selector is dead.
+
+### Implementation
+
+- `compute_cv_summary` and `summary_line` gain a `summary_format: CorrelationVectorSummaryFormat` parameter. The count walk is unchanged; only the terminal rendering branches.
+- JSON and KV use `serde_json` for string escaping (paths can contain quotes, backslashes, control chars on weird filesystems — let serde handle it).
+- New public enum `CorrelationVectorSummaryFormat` with `#[default] = Text`.
+
+### Changed
+
+- `SpecialModesConfig` gains `correlation_vector_summary_format: CorrelationVectorSummaryFormat`.
+- `wire::read_special_modes` maps the string value to the enum; unknown / empty falls back to `Text`.
+- Versions: `Cargo.toml` `0.36.0` → `0.37.0`, `cli.spec.json` `0.36.0` → `0.37.0`.
+
 ## [0.36.0] - 2026-05-30
 
 ### Added — CLOC11.73: `--correlation_vector_summary` stdout one-liner

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.36.0"
+version = "0.37.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },
@@ -103,6 +103,7 @@
     { "id": "correlation_vector_filter_includes_origin", "long": "correlation_vector_filter_includes_origin", "type": "boolean", "default": false, "description": "When --correlation_vector_filter is set, also match entries by their origin.source (in addition to contribution.source). Lets `--correlation_vector_filter lex` keep the per-token CV entries whose Origin.source is \"lexer_token\". Default off preserves CLOC11.70 strict semantics (CLOC11.71)." },
     { "id": "correlation_vector_filter_invert", "long": "correlation_vector_filter_invert", "type": "boolean", "default": false, "description": "Invert the --correlation_vector_filter from an allowlist to a blocklist. With --correlation_vector_filter lex and --correlation_vector_filter_invert true, entries that DO match (i.e. carry a `lex` contribution and/or origin) are dropped; everything else is kept. Useful for \"everything except X\" filters where enumerating the allowlist is impractical (CLOC11.72)." },
     { "id": "correlation_vector_summary", "long": "correlation_vector_summary", "type": "boolean", "default": false, "description": "Print a one-line summary of the correlation-vector trace to stdout after the sidecar is written (or skipped under --correlation_vector_format NONE). Format: `cv sidecar: <path>: N entries, M contributions, T tombstones, pass_order=[a,b,c]`. Counts reflect post-filter state. Useful for build pipelines that don't want to parse the JSON to see if anything interesting happened (CLOC11.73)." },
+    { "id": "correlation_vector_summary_format", "long": "correlation_vector_summary_format", "type": "enum", "enum_values": ["TEXT", "JSON", "KV"], "default": "TEXT", "description": "Format for the --correlation_vector_summary stdout line. TEXT (default) = the existing human-readable line. JSON = single-line `{\"cv_sidecar\": {...}}` for machine consumers. KV = space-separated `cv_sidecar.entries=N cv_sidecar.contributions=M ...` for ad-hoc shell parsing. Ignored unless --correlation_vector_summary is also set (CLOC11.74)." },
     { "id": "instrument_for_coverage_option", "long": "instrument_for_coverage_option", "type": "enum", "enum_values": ["NONE", "LINE", "BRANCH", "PRODUCTION"], "default": "NONE", "description": "Enable code instrumentation for coverage analysis." },
     { "id": "production_instrumentation_array_name", "long": "production_instrumentation_array_name", "type": "string", "default": "", "description": "Global array name used by production instrumentation." },
     { "id": "chunk_output_type", "long": "chunk_output_type", "type": "enum", "enum_values": ["GLOBAL_NAMESPACE", "ES_MODULES"], "default": "GLOBAL_NAMESPACE", "description": "Format for output chunks." },

--- a/code/programs/rust/closurec/src/config.rs
+++ b/code/programs/rust/closurec/src/config.rs
@@ -617,6 +617,37 @@ pub struct SpecialModesConfig {
     ///
     /// Only consulted when `correlation_vector` is true.
     pub correlation_vector_summary: bool,
+    /// CLOC11.74: rendering style for the
+    /// `--correlation_vector_summary` line.
+    ///   - `Text` (default): human-readable one-line form
+    ///     introduced by CLOC11.73.
+    ///   - `Json`: single-line JSON object — `{"cv_sidecar":
+    ///     {"path": "...", "skipped": false, "entries": N,
+    ///     "contributions": M, "tombstones": T,
+    ///     "pass_order": [...]}}`. Machine consumers can
+    ///     parse without regex-matching the human line.
+    ///   - `Kv`: space-separated key=value pairs prefixed
+    ///     with `cv_sidecar.` — `cv_sidecar.path=... cv_sidecar.entries=N
+    ///     cv_sidecar.contributions=M ...`. For shell-tooling
+    ///     pipelines that grep/cut single fields.
+    ///
+    /// Only consulted when `correlation_vector_summary` is
+    /// also true. With summary off the format flag is dead.
+    pub correlation_vector_summary_format: CorrelationVectorSummaryFormat,
+}
+
+/// CLOC11.74 — render style for the `--correlation_vector_summary`
+/// line. Default `Text` (the CLOC11.73 form).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CorrelationVectorSummaryFormat {
+    /// Human-readable one-line summary (CLOC11.73 default).
+    #[default]
+    Text,
+    /// Single-line JSON object: `{"cv_sidecar": {...}}`.
+    Json,
+    /// Space-separated `key=value` pairs prefixed with
+    /// `cv_sidecar.`.
+    Kv,
 }
 
 /// CLOC11.69 — sidecar persistence format. Default is

--- a/code/programs/rust/closurec/src/run.rs
+++ b/code/programs/rust/closurec/src/run.rs
@@ -1301,6 +1301,7 @@ pub fn run_compiler(config: &CompilerConfig) -> Result<CompilerOutput, CompilerE
                 config.special_modes.correlation_vector_filter_includes_origin,
                 config.special_modes.correlation_vector_filter_invert,
                 cv_sidecar_written.as_deref(),
+                config.special_modes.correlation_vector_summary_format,
             );
             result.stdout_text.push_str(&summary);
         }
@@ -1333,6 +1334,7 @@ fn compute_cv_summary(
     filter_includes_origin: bool,
     filter_invert: bool,
     wrote_path: Option<&std::path::Path>,
+    summary_format: crate::config::CorrelationVectorSummaryFormat,
 ) -> String {
     // Build the same parsed-Value form the formatters use,
     // apply the same filter, then count.
@@ -1345,7 +1347,7 @@ fn compute_cv_summary(
             // Fallback to a stub summary; pass_order is
             // unknown but we still print zeros so the line
             // is well-formed.
-            return summary_line(wrote_path, 0, 0, 0, &[]);
+            return summary_line(wrote_path, 0, 0, 0, &[], summary_format);
         }
     };
     if !filter.is_empty() {
@@ -1394,6 +1396,7 @@ fn compute_cv_summary(
         contribution_count,
         tombstone_count,
         &pass_order,
+        summary_format,
     )
 }
 
@@ -1401,25 +1404,125 @@ fn compute_cv_summary(
 /// `\n`. Kept separate from `compute_cv_summary` so the
 /// formatting can be tested / changed without re-running the
 /// CV count walk.
+///
+/// CLOC11.74: dispatch on `summary_format` to produce one of
+/// three shapes:
+///   - `Text` (default): the CLOC11.73 human-readable form.
+///   - `Json`: single-line JSON object `{"cv_sidecar": {...}}`.
+///     `path` is `null` under `skipped=true`.
+///   - `Kv`: space-separated `key=value` pairs prefixed
+///     with `cv_sidecar.`. Values that may contain spaces
+///     (path; pass_order joined by `,`) are quoted on the
+///     RHS so shell tooling can `awk '{...}'`/`cut` safely.
 fn summary_line(
     wrote_path: Option<&std::path::Path>,
     entries: usize,
     contributions: usize,
     tombstones: usize,
     pass_order: &[String],
+    summary_format: crate::config::CorrelationVectorSummaryFormat,
 ) -> String {
-    let prefix = match wrote_path {
-        Some(p) => format!("cv sidecar: {}", p.display()),
-        None => "cv sidecar: skipped (format=NONE)".to_string(),
-    };
-    format!(
-        "{}: {} entries, {} contributions, {} tombstones, pass_order=[{}]\n",
-        prefix,
-        entries,
-        contributions,
-        tombstones,
-        pass_order.join(","),
-    )
+    use crate::config::CorrelationVectorSummaryFormat as F;
+    match summary_format {
+        F::Text => {
+            let prefix = match wrote_path {
+                Some(p) => format!("cv sidecar: {}", p.display()),
+                None => "cv sidecar: skipped (format=NONE)".to_string(),
+            };
+            format!(
+                "{}: {} entries, {} contributions, {} tombstones, pass_order=[{}]\n",
+                prefix,
+                entries,
+                contributions,
+                tombstones,
+                pass_order.join(","),
+            )
+        }
+        F::Json => {
+            // Build a serde_json::Map for the cv_sidecar
+            // payload so we don't have to hand-escape paths
+            // or pass_order entries. serde_json handles
+            // strings, quotes, nested objects safely.
+            let mut payload = serde_json::Map::new();
+            match wrote_path {
+                Some(p) => {
+                    payload.insert(
+                        "path".to_string(),
+                        serde_json::Value::String(p.display().to_string()),
+                    );
+                    payload.insert(
+                        "skipped".to_string(),
+                        serde_json::Value::Bool(false),
+                    );
+                }
+                None => {
+                    payload.insert(
+                        "path".to_string(),
+                        serde_json::Value::Null,
+                    );
+                    payload.insert(
+                        "skipped".to_string(),
+                        serde_json::Value::Bool(true),
+                    );
+                }
+            }
+            payload.insert(
+                "entries".to_string(),
+                serde_json::Value::Number((entries as u64).into()),
+            );
+            payload.insert(
+                "contributions".to_string(),
+                serde_json::Value::Number((contributions as u64).into()),
+            );
+            payload.insert(
+                "tombstones".to_string(),
+                serde_json::Value::Number((tombstones as u64).into()),
+            );
+            payload.insert(
+                "pass_order".to_string(),
+                serde_json::Value::Array(
+                    pass_order
+                        .iter()
+                        .map(|s| serde_json::Value::String(s.clone()))
+                        .collect(),
+                ),
+            );
+            let mut root = serde_json::Map::new();
+            root.insert(
+                "cv_sidecar".to_string(),
+                serde_json::Value::Object(payload),
+            );
+            let mut line = serde_json::to_string(&serde_json::Value::Object(root))
+                .unwrap_or_else(|_| "{\"cv_sidecar\":{}}".to_string());
+            line.push('\n');
+            line
+        }
+        F::Kv => {
+            // Quote path + pass_order on the RHS so callers
+            // can split on whitespace; the values themselves
+            // never contain a literal `"` in our pipeline,
+            // but we still let serde escape them defensively.
+            let path_val = match wrote_path {
+                Some(p) => p.display().to_string(),
+                None => String::new(),
+            };
+            let skipped_val = wrote_path.is_none();
+            let pass_order_joined = pass_order.join(",");
+            let path_quoted = serde_json::to_string(&path_val)
+                .unwrap_or_else(|_| "\"\"".to_string());
+            let pass_order_quoted = serde_json::to_string(&pass_order_joined)
+                .unwrap_or_else(|_| "\"\"".to_string());
+            format!(
+                "cv_sidecar.path={} cv_sidecar.skipped={} cv_sidecar.entries={} cv_sidecar.contributions={} cv_sidecar.tombstones={} cv_sidecar.pass_order={}\n",
+                path_quoted,
+                skipped_val,
+                entries,
+                contributions,
+                tombstones,
+                pass_order_quoted,
+            )
+        }
+    }
 }
 
 /// Serialize a `CVLog` to a JSON string for the
@@ -4175,6 +4278,140 @@ mod tests {
         assert!(
             !out.stdout_text.contains("cv sidecar:"),
             "expected no summary line under default flag, got: {:?}",
+            out.stdout_text
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    // ------------------------------------------------------------------
+    // CLOC11.74 — --correlation_vector_summary_format
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn correlation_vector_summary_format_json_emits_parseable_object() {
+        // JSON summary: stdout_text contains one line that
+        // parses as JSON and has the cv_sidecar object with
+        // expected fields.
+        let dir =
+            std::env::temp_dir().join("closurec_cloc11_74_summary_json");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("create dir");
+        let in_path = dir.join("a.js");
+        fs::write(&in_path, "var x = 1;").expect("write");
+        let out_path = dir.join("out.js");
+        let cfg = CompilerConfig {
+            io: IoConfig {
+                js_patterns: vec![in_path.to_string_lossy().to_string()],
+                js_output_file: Some(out_path.clone()),
+                ..Default::default()
+            },
+            special_modes: crate::config::SpecialModesConfig {
+                correlation_vector: true,
+                correlation_vector_summary: true,
+                correlation_vector_summary_format:
+                    crate::config::CorrelationVectorSummaryFormat::Json,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let out = run_compiler(&cfg).expect("ok");
+        let line = out.stdout_text.trim();
+        let parsed: serde_json::Value = serde_json::from_str(line)
+            .unwrap_or_else(|_| panic!("JSON summary did not parse: {line}"));
+        let cv = parsed
+            .get("cv_sidecar")
+            .and_then(|v| v.as_object())
+            .expect("cv_sidecar object missing");
+        assert_eq!(cv.get("skipped"), Some(&serde_json::Value::Bool(false)));
+        assert!(cv.get("path").and_then(|v| v.as_str()).is_some());
+        assert!(cv.get("entries").and_then(|v| v.as_u64()).is_some());
+        assert!(cv.get("contributions").and_then(|v| v.as_u64()).is_some());
+        assert!(cv.get("tombstones").and_then(|v| v.as_u64()).is_some());
+        assert!(cv.get("pass_order").and_then(|v| v.as_array()).is_some());
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn correlation_vector_summary_format_kv_emits_key_value_pairs() {
+        // KV summary: stdout contains the cv_sidecar.* keys
+        // with `=` separators; path and pass_order are quoted.
+        let dir =
+            std::env::temp_dir().join("closurec_cloc11_74_summary_kv");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("create dir");
+        let in_path = dir.join("a.js");
+        fs::write(&in_path, "var x = 1;").expect("write");
+        let out_path = dir.join("out.js");
+        let cfg = CompilerConfig {
+            io: IoConfig {
+                js_patterns: vec![in_path.to_string_lossy().to_string()],
+                js_output_file: Some(out_path.clone()),
+                ..Default::default()
+            },
+            special_modes: crate::config::SpecialModesConfig {
+                correlation_vector: true,
+                correlation_vector_summary: true,
+                correlation_vector_summary_format:
+                    crate::config::CorrelationVectorSummaryFormat::Kv,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let out = run_compiler(&cfg).expect("ok");
+        let line = out.stdout_text.trim();
+        assert!(
+            line.contains("cv_sidecar.path=\""),
+            "expected quoted cv_sidecar.path=\"...\" in KV summary, got: {line}"
+        );
+        assert!(
+            line.contains("cv_sidecar.skipped=false"),
+            "expected cv_sidecar.skipped=false in KV summary, got: {line}"
+        );
+        assert!(
+            line.contains("cv_sidecar.entries="),
+            "expected cv_sidecar.entries= in KV summary, got: {line}"
+        );
+        assert!(
+            line.contains("cv_sidecar.pass_order=\""),
+            "expected quoted cv_sidecar.pass_order=\"...\" in KV summary, got: {line}"
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn correlation_vector_summary_format_text_remains_default() {
+        // No format flag set → CLOC11.73 text line, byte-
+        // for-byte unchanged.
+        let dir =
+            std::env::temp_dir().join("closurec_cloc11_74_summary_default");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("create dir");
+        let in_path = dir.join("a.js");
+        fs::write(&in_path, "var x = 1;").expect("write");
+        let out_path = dir.join("out.js");
+        let cfg = CompilerConfig {
+            io: IoConfig {
+                js_patterns: vec![in_path.to_string_lossy().to_string()],
+                js_output_file: Some(out_path.clone()),
+                ..Default::default()
+            },
+            special_modes: crate::config::SpecialModesConfig {
+                correlation_vector: true,
+                correlation_vector_summary: true,
+                // summary_format defaults to Text
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let out = run_compiler(&cfg).expect("ok");
+        assert!(
+            out.stdout_text.starts_with("cv sidecar:"),
+            "expected text prefix `cv sidecar:`, got: {:?}",
+            out.stdout_text
+        );
+        assert!(
+            !out.stdout_text.contains("{\"cv_sidecar\""),
+            "text default should not emit JSON, got: {:?}",
             out.stdout_text
         );
         let _ = fs::remove_dir_all(&dir);

--- a/code/programs/rust/closurec/src/wire.rs
+++ b/code/programs/rust/closurec/src/wire.rs
@@ -518,6 +518,17 @@ fn read_special_modes(p: &ParseResult) -> Result<SpecialModesConfig, ConfigError
             "correlation_vector_filter_invert",
         )?,
         correlation_vector_summary: get_bool(p, "correlation_vector_summary")?,
+        correlation_vector_summary_format: match get_str(
+            p,
+            "correlation_vector_summary_format",
+        )?
+        .as_deref()
+        {
+            Some("JSON") => crate::config::CorrelationVectorSummaryFormat::Json,
+            Some("KV") => crate::config::CorrelationVectorSummaryFormat::Kv,
+            // TEXT, empty, or absent → default
+            _ => crate::config::CorrelationVectorSummaryFormat::Text,
+        },
     })
 }
 

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.36.0
+Version: 0.37.0
 
 ## Flags
 
@@ -397,6 +397,10 @@ Invert the --correlation_vector_filter from an allowlist to a blocklist. With --
 ### `--correlation_vector_summary` (boolean, default: false)
 
 Print a one-line summary of the correlation-vector trace to stdout after the sidecar is written (or skipped under --correlation_vector_format NONE). Format: `cv sidecar: <path>: N entries, M contributions, T tombstones, pass_order=[a,b,c]`. Counts reflect post-filter state. Useful for build pipelines that don't want to parse the JSON to see if anything interesting happened (CLOC11.73).
+
+### `--correlation_vector_summary_format` (enum, default: TEXT)
+
+Format for the --correlation_vector_summary stdout line. TEXT (default) = the existing human-readable line. JSON = single-line `{"cv_sidecar": {...}}` for machine consumers. KV = space-separated `cv_sidecar.entries=N cv_sidecar.contributions=M ...` for ad-hoc shell parsing. Ignored unless --correlation_vector_summary is also set (CLOC11.74).
 
 ### `--instrument_for_coverage_option` (enum, default: NONE)
 


### PR DESCRIPTION
## Summary

Machine-readable rendering for the CLOC11.73 summary line. Lets CI/build pipelines consume the summary without regex-matching the human-readable text.

| Value | Output |
|---|---|
| `TEXT` (default) | CLOC11.73 line: `cv sidecar: <path>: N entries, M contributions, T tombstones, pass_order=[a,b,c]` |
| `JSON` | `{"cv_sidecar":{"path":"...","skipped":false,"entries":N,"contributions":M,"tombstones":T,"pass_order":["a","b","c"]}}` |
| `KV` | `cv_sidecar.path="..." cv_sidecar.skipped=false cv_sidecar.entries=N cv_sidecar.contributions=M cv_sidecar.tombstones=T cv_sidecar.pass_order="a,b,c"` |

Under `--correlation_vector_format NONE`: `path` is `null` (JSON) or empty `""` (KV); `skipped` is `true`.

Flag is only consulted when `--correlation_vector_summary` is also on.

## Implementation

- `compute_cv_summary` and `summary_line` gain a `summary_format` param. Count walk unchanged; only terminal rendering branches.
- JSON and KV use `serde_json::to_string` for string escaping — paths/pass_order entries that contain quotes/backslashes/control chars are safely escaped.
- New public enum `CorrelationVectorSummaryFormat` with `#[default] = Text`.

## Test plan
- [x] cargo build clean
- [x] 259 unit + 17 integration suites pass
- [x] New tests:
  - `correlation_vector_summary_format_json_emits_parseable_object` — JSON parses, has cv_sidecar fields with expected types
  - `correlation_vector_summary_format_kv_emits_key_value_pairs` — KV has quoted path, bare bool, key=value separators
  - `correlation_vector_summary_format_text_remains_default` — no flag set → CLOC11.73 line preserved
- [x] help-markdown fixture regenerated for 0.37.0

## Security review (inline)
- Default TEXT = CLOC11.73 byte-identical.
- JSON/KV use `serde_json::to_string` for path + pass_order escaping; no manual concat into JSON or KV.
- KV quoting via `to_string` makes shell tooling safe to split on whitespace.
- No unsafe, no new deps.

## Versions
- `Cargo.toml`: 0.36.0 → 0.37.0
- `cli.spec.json`: 0.36.0 → 0.37.0
- `CHANGELOG.md`: new `[0.37.0]` section

🤖 Generated with [Claude Code](https://claude.com/claude-code)