### PR TITLE
feat(ruby-fc): Phase 15d — scope-resolution operator Foo::Bar

### DIFF
--- a/code/grammars/ruby.grammar
+++ b/code/grammars/ruby.grammar
@@ -327,6 +327,14 @@ rightward_assignment = expression "=>" NAME ;
 # deliberately out of scope for this chunk — they get their own phases.
 method_call  = ( NAME | KEYWORD ) LPAREN [ call_arg { COMMA call_arg } ] RPAREN { dot_call } ;
 dot_call     = "." ( NAME | KEYWORD ) [ LPAREN [ call_arg { COMMA call_arg } ] RPAREN ] ;
+# Phase 15d (FC) — scope-resolution operator `Foo::Bar` (and chains
+# `A::B::C`).  The lexer emits `::` as a `Colon` token whose VALUE is
+# "::", so the grammar literal `"::"` matches it by value.  A
+# `scope_resolution` postfix mirrors `dot_call`: it captures one `::Name`
+# step and is appended to `factor`'s postfix alternation so a constant
+# path parses as `((Foo)::Bar)::Baz`.  The lowerer folds each step into a
+# qualified `Scope::Const` name.
+scope_resolution = "::" ( NAME | KEYWORD ) ;
 # Phase 6s — splat call arguments.  `f(*arr)` and `f(**hsh)` (and the
 # mixed form `f(1, *arr, **hsh, named: x)`) flow through here.  The
 # optional `[ "*" | "**" ]` prefix sits inside a single call_arg slot,
@@ -458,7 +466,7 @@ term         = factor { ( STAR | SLASH ) factor } ;
 # leaving `(1).bar` unconsumed.  When no parens follow the name, the
 # method_call alternative fails (requires LPAREN) and we fall through to
 # the bare-NAME branch.
-factor       = ( lambda_literal | method_call | NUMBER | STRING | NAME | KEYWORD | symbol_literal | array_literal | hash_literal | LPAREN expression RPAREN | unary_minus ) { dot_call } ;
+factor       = ( lambda_literal | method_call | NUMBER | STRING | NAME | KEYWORD | symbol_literal | array_literal | hash_literal | LPAREN expression RPAREN | unary_minus ) { dot_call | scope_resolution } ;
 # Phase 6w — arrow-lambda literal `->(params){body}` / `->{body}`.
 #
 # Ruby 1.9+ shorthand for creating a `Proc`/`Lambda`.  The parameter
@@ -479,7 +487,13 @@ factor       = ( lambda_literal | method_call | NUMBER | STRING | NAME | KEYWORD
 # downstream emitters a single closure-construction shape.
 lambda_literal = "->" [ LPAREN [ params ] RPAREN ] block ;
 unary_minus  = MINUS factor ;
-symbol_literal = COLON ( NAME | KEYWORD | STRING ) ;
+# Phase 15d (FC) — the colon is matched by the literal ":" (by VALUE)
+# rather than the COLON token reference (by TYPE).  The lexer emits both
+# `:` and `::` as `Colon`-typed tokens distinguished only by value, so a
+# by-type match would let `symbol_literal` swallow the `::` of a
+# scope-resolution (`Foo::Bar`).  Matching the literal ":" keeps symbols
+# to the single-colon form and frees `::` for `scope_resolution`.
+symbol_literal = ":" ( NAME | KEYWORD | STRING ) ;
 array_literal = LBRACKET [ expression { COMMA expression } ] RBRACKET ;
 hash_literal = LBRACE [ hash_entry { COMMA hash_entry } ] RBRACE ;
 hash_entry   = NAME COLON expression | NAME COLON | expression "=>" expression ;

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.46.0] - 2026-05-30
+
+### Added (Phase 15d (FC) — scope-resolution operator `Foo::Bar`)
+
+The grammar gains a `scope_resolution` postfix so constant paths parse:
+
+- New rule `scope_resolution = "::" ( NAME | KEYWORD ) ;`, appended to
+  `factor`'s postfix alternation (`{ dot_call | scope_resolution }`), so
+  `Foo::Bar` parses as `(Foo)::Bar` and `A::B::C` as a chain of two
+  `::` steps.  The `::` literal matches by VALUE (the lexer emits `::`
+  as a `Colon`-typed token whose value is `"::"`).
+- **Disambiguation fix**: `symbol_literal` previously matched the
+  `COLON` token by TYPE, which let it swallow the `::` of a scope
+  resolution (so `Foo::Bar` mis-parsed as `Foo(:Bar)`).  It now matches
+  the literal `":"` (by value), keeping symbols to the single-colon form
+  and freeing `::` for `scope_resolution`.  All existing symbol tests
+  still pass (a lone `:` lexes as `Colon` value `":"`).
+
+New parse pins (+3): `test_parse_scope_resolution_foo_bar`,
+`test_parse_scope_resolution_chain` (`A::B::C` → two steps),
+`test_parse_scope_resolution_then_dot_call` (`Foo::Bar.baz` mixes both
+postfix kinds).  Test count: 173 → 176 (+3).
+
 ## [0.45.0] - 2026-05-30
 
 ### Added (Phase 15c (FC) — constants `FOO` / `MyClass`)

--- a/code/packages/rust/ruby-parser/src/_grammar.rs
+++ b/code/packages/rust/ruby-parser/src/_grammar.rs
@@ -643,6 +643,17 @@ pub fn parser_grammar() -> ParserGrammar {
             line_number: 329,
         },
         GrammarRule {
+            name: r#"scope_resolution"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"::"#.to_string() },
+                GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                        GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"KEYWORD"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 337,
+        },
+        GrammarRule {
             name: r#"call_arg"#.to_string(),
             body: GrammarElement::Sequence { elements: vec![
                 GrammarElement::Optional { element: Box::new(GrammarElement::Alternation { choices: vec![
@@ -651,7 +662,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 336,
+            line_number: 344,
         },
         GrammarRule {
             name: r#"method_call_no_paren"#.to_string(),
@@ -666,17 +677,17 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 350,
+            line_number: 358,
         },
         GrammarRule {
             name: r#"expression_stmt"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"expression"#.to_string() },
-            line_number: 351,
+            line_number: 359,
         },
         GrammarRule {
             name: r#"expression"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"ternary"#.to_string() },
-            line_number: 437,
+            line_number: 445,
         },
         GrammarRule {
             name: r#"ternary"#.to_string(),
@@ -689,7 +700,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 438,
+            line_number: 446,
         },
         GrammarRule {
             name: r#"range"#.to_string(),
@@ -703,7 +714,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_or"#.to_string() },
                     ] }) },
             ] },
-            line_number: 439,
+            line_number: 447,
         },
         GrammarRule {
             name: r#"logical_or"#.to_string(),
@@ -717,7 +728,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_and"#.to_string() },
                     ] }) },
             ] },
-            line_number: 440,
+            line_number: 448,
         },
         GrammarRule {
             name: r#"logical_and"#.to_string(),
@@ -731,7 +742,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_not"#.to_string() },
                     ] }) },
             ] },
-            line_number: 441,
+            line_number: 449,
         },
         GrammarRule {
             name: r#"logical_not"#.to_string(),
@@ -742,7 +753,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) }) },
                 GrammarElement::RuleReference { name: r#"comparison"#.to_string() },
             ] },
-            line_number: 448,
+            line_number: 456,
         },
         GrammarRule {
             name: r#"comparison"#.to_string(),
@@ -760,7 +771,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"sum"#.to_string() },
                     ] }) },
             ] },
-            line_number: 449,
+            line_number: 457,
         },
         GrammarRule {
             name: r#"sum"#.to_string(),
@@ -774,7 +785,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term"#.to_string() },
                     ] }) },
             ] },
-            line_number: 450,
+            line_number: 458,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -788,7 +799,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"factor"#.to_string() },
                     ] }) },
             ] },
-            line_number: 451,
+            line_number: 459,
         },
         GrammarRule {
             name: r#"factor"#.to_string(),
@@ -810,9 +821,12 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] },
                         GrammarElement::RuleReference { name: r#"unary_minus"#.to_string() },
                     ] }) },
-                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"dot_call"#.to_string() }) },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Alternation { choices: vec![
+                        GrammarElement::RuleReference { name: r#"dot_call"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"scope_resolution"#.to_string() },
+                    ] }) },
             ] },
-            line_number: 461,
+            line_number: 469,
         },
         GrammarRule {
             name: r#"lambda_literal"#.to_string(),
@@ -825,7 +839,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"block"#.to_string() },
             ] },
-            line_number: 480,
+            line_number: 488,
         },
         GrammarRule {
             name: r#"unary_minus"#.to_string(),
@@ -833,19 +847,19 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"factor"#.to_string() },
             ] },
-            line_number: 481,
+            line_number: 489,
         },
         GrammarRule {
             name: r#"symbol_literal"#.to_string(),
             body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
+                GrammarElement::Literal { value: r#":"#.to_string() },
                 GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
                         GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
                         GrammarElement::TokenReference { name: r#"KEYWORD"#.to_string() },
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 482,
+            line_number: 496,
         },
         GrammarRule {
             name: r#"array_literal"#.to_string(),
@@ -860,7 +874,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 483,
+            line_number: 497,
         },
         GrammarRule {
             name: r#"hash_literal"#.to_string(),
@@ -875,7 +889,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 484,
+            line_number: 498,
         },
         GrammarRule {
             name: r#"hash_entry"#.to_string(),
@@ -895,7 +909,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                 ] },
             ] },
-            line_number: 485,
+            line_number: 499,
         },
     ],
         version: 1,

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -905,6 +905,56 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_parse_scope_resolution_foo_bar() {
+        // `Foo::Bar` parses with a `scope_resolution` postfix node
+        // carrying the `::` operator token and the `Bar` Name.
+        let ast = parse_ruby("Foo::Bar");
+        let sr = find_descendant(&ast, "scope_resolution")
+            .expect("expected scope_resolution node");
+        assert!(
+            body_has_token_value(sr, "::"),
+            "scope_resolution should carry the `::` operator token"
+        );
+        assert!(
+            body_has_token_value(sr, "Bar"),
+            "scope_resolution should carry the `Bar` Name token"
+        );
+    }
+
+    #[test]
+    fn test_parse_scope_resolution_chain() {
+        // `A::B::C` parses as a chain of TWO `scope_resolution` steps.
+        let ast = parse_ruby("A::B::C");
+        let factor = find_descendant(&ast, "factor")
+            .expect("expected factor node");
+        let steps = factor
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "scope_resolution"))
+            .count();
+        assert_eq!(steps, 2, "A::B::C has two `::` steps; got {}", steps);
+    }
+
+    #[test]
+    fn test_parse_scope_resolution_then_dot_call() {
+        // `Foo::Bar.baz` mixes a `::` step and a `.` step under the same
+        // factor postfix — both node kinds coexist.
+        let ast = parse_ruby("Foo::Bar.baz");
+        let factor = find_descendant(&ast, "factor")
+            .expect("expected factor node");
+        assert!(
+            factor.children.iter().any(|c|
+                matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "scope_resolution")),
+            "expected a scope_resolution step"
+        );
+        assert!(
+            factor.children.iter().any(|c|
+                matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "dot_call")),
+            "expected a dot_call step"
+        );
+    }
+
     // -----------------------------------------------------------------------
     // Phase 6g — blocks `do … end` and brace-blocks `method { … }`
     // -----------------------------------------------------------------------

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.48.0] - 2026-05-30
+
+### Added (Phase 15d (FC) — scoped lookup `Foo::Bar`)
+
+Ruby's scope-resolution operator now lowers.  A scoped constant lookup
+is, semantically, a single constant resolved against a namespace, so it
+reuses the Phase 15c `Scope::Const` machinery (no new SIR node):
+
+- `apply_dot_chain` now also folds `scope_resolution` postfix steps.
+- New `fold_one_scope_resolution`: `Foo::Bar` folds into a single
+  `VarRef { scope: Const, name: "Foo::Bar" }`, and `A::B::C` collapses
+  to `VarRef { Const, "A::B::C" }`.  Each step requests
+  `Feature::Constants`.
+- A non-constant base (`expr::Bar`, uncommon) is preserved structurally
+  via a `BuiltinCall("__scope__", [base, StrLit(name)])` marker so no
+  structure is silently dropped.
+
+New tests (+3): `scope_resolution_lowers_to_qualified_const`,
+`scope_resolution_chain_lowers_to_full_path`,
+`scope_resolution_passes_sir_validator` (E2E).  Test count: 219 → 222
+(+3).
+
 ## [0.47.0] - 2026-05-30
 
 ### Changed (Phase 15c (FC) — constants `FOO` / `MyClass`)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -1193,6 +1193,52 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
+    // Phase 15d (FC) — scoped lookup `Foo::Bar` → qualified `Scope::Const`.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn scope_resolution_lowers_to_qualified_const() {
+        // `Foo::Bar` folds into a single `VarRef { scope: Const }` whose
+        // name is the qualified path `"Foo::Bar"`, and requests
+        // `Feature::Constants`.
+        let m = lower("Foo::Bar\n");
+        match &main_body(&m).value {
+            Expr::VarRef { name, scope, .. } => {
+                assert_eq!(name, "Foo::Bar", "qualified constant path preserved");
+                assert_eq!(*scope, Scope::Const);
+            }
+            other => panic!("expected VarRef(Foo::Bar, Const), got {:?}", other),
+        }
+        assert!(
+            m.manifest.contains(semantic_ir::Feature::Constants),
+            "manifest should declare Constants; got {:?}",
+            m.manifest
+        );
+    }
+
+    #[test]
+    fn scope_resolution_chain_lowers_to_full_path() {
+        // `A::B::C` collapses to `VarRef { Const, "A::B::C" }`.
+        let m = lower("A::B::C\n");
+        match &main_body(&m).value {
+            Expr::VarRef { name, scope, .. } => {
+                assert_eq!(name, "A::B::C");
+                assert_eq!(*scope, Scope::Const);
+            }
+            other => panic!("expected VarRef(A::B::C, Const), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn scope_resolution_passes_sir_validator() {
+        // E2E: a scoped constant lookup (as an assignment RHS) validates —
+        // a constant needs no prior `let`.
+        let m = lower("y = Foo::Bar\n");
+        let result = semantic_ir::validate(&m);
+        assert!(result.is_ok(), "validator rejected scoped const: {:?}", result);
+    }
+
+    // -----------------------------------------------------------------
     // Phase 14d (FC) — `module M … end` → `Stmt::ModuleDef`.  Mirrors
     // ClassDef (minus inheritance): method defs hoist to top-level
     // Functions; non-def statements stay in the module body.

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -5129,10 +5129,61 @@ impl Lowerer {
             if let ASTNodeOrToken::Node(sub) = child {
                 if sub.rule_name == "dot_call" {
                     recv = self.fold_one_dot_call(recv, sub)?;
+                } else if sub.rule_name == "scope_resolution" {
+                    // Phase 15d (FC) — `::Name` step.
+                    recv = self.fold_one_scope_resolution(recv, sub)?;
                 }
             }
         }
         Ok(recv)
+    }
+
+    /// Lower a single `scope_resolution` step (`::Name`).  Grammar shape
+    /// (Phase 15d):
+    ///     scope_resolution = "::" ( NAME | KEYWORD ) ;
+    ///
+    /// A scoped constant lookup `Foo::Bar` is, semantically, a single
+    /// constant resolved against a namespace.  The common case — a
+    /// constant path whose base is itself a `Scope::Const` ref — folds
+    /// into one qualified-name `Scope::Const` ref (`"Foo::Bar"`), so
+    /// `A::B::C` collapses to `VarRef { scope: Const, name: "A::B::C" }`.
+    /// A non-constant base (`expr::Bar`, uncommon) is preserved
+    /// structurally via a `__scope__` BuiltinCall marker so no structure
+    /// is silently dropped.  Either way `Feature::Constants` is
+    /// requested (the result is a constant reference).
+    fn fold_one_scope_resolution(
+        &mut self,
+        base: Expr,
+        sr_node: &GrammarASTNode,
+    ) -> Result<Expr, RubyLowerError> {
+        let (rhs_name, rhs_span) = self.expect_first_name_token(sr_node)?;
+        self.features_used.insert(Feature::Constants);
+        match base {
+            Expr::VarRef { name, scope: Scope::Const, span } => Ok(Expr::VarRef {
+                name: format!("{name}::{rhs_name}"),
+                scope: Scope::Const,
+                span,
+            }),
+            other => {
+                // Fallback: `expr::Bar` where the base is not a bare
+                // constant.  Keep the step explicit; the synthetic
+                // StrLit triggers the Strings feature.
+                self.features_used.insert(Feature::Strings);
+                let span = self.span_of(sr_node);
+                Ok(Expr::BuiltinCall {
+                    name: "__scope__".to_string(),
+                    args: vec![
+                        other,
+                        Expr::StrLit {
+                            value: rhs_name,
+                            span: rhs_span,
+                        },
+                    ],
+                    effects: EffectSet::PURE,
+                    span,
+                })
+            }
+        }
     }
 
     /// Lower a single `dot_call` step.  Grammar shape (Phase 6s):


### PR DESCRIPTION
## Phase 15d (FC) — scope-resolution operator `Foo::Bar`

Ruby's `::` scoped constant lookup now parses and lowers. A scoped
constant is semantically a single constant resolved against a namespace,
so it **reuses the Phase 15c `Scope::Const` machinery** — no new SIR
node, no backend/validator/`semantic-ir` change.

### `ruby-parser` 0.46.0 (grammar)

- New rule `scope_resolution = "::" ( NAME | KEYWORD ) ;`, appended to
  `factor`'s postfix alternation (`{ dot_call | scope_resolution }`), so
  `Foo::Bar` parses as `(Foo)::Bar` and `A::B::C` as a chain of two `::`
  steps. The `::` literal matches by **value** (the lexer emits `::` as
  a `Colon`-typed token whose value is `"::"`).
- **Disambiguation fix**: `symbol_literal` matched the `COLON` token by
  **type**, which let it swallow the `::` of a scope resolution (so
  `Foo::Bar` mis-parsed as `Foo(:Bar)`). It now matches the literal
  `":"` by value, keeping symbols to the single-colon form and freeing
  `::`. A lone `:` still lexes as `Colon` value `":"`, so all existing
  symbol tests pass.
- Regenerated `_grammar.rs`.
- New parse pins (+3): `test_parse_scope_resolution_foo_bar`,
  `test_parse_scope_resolution_chain` (`A::B::C` → two steps),
  `test_parse_scope_resolution_then_dot_call` (`Foo::Bar.baz` mixes both
  postfix kinds). 173 → 176.

### `ruby-to-semantic-ir` 0.48.0 (lowering)

- `apply_dot_chain` now also folds `scope_resolution` steps.
- New `fold_one_scope_resolution`: `Foo::Bar` →
  `VarRef { scope: Const, name: "Foo::Bar" }`; `A::B::C` →
  `VarRef { Const, "A::B::C" }`; each step requests `Feature::Constants`.
- A non-constant base (`expr::Bar`, uncommon) is preserved structurally
  via a `BuiltinCall("__scope__", [base, StrLit(name)])` marker so no
  structure is silently dropped.
- New tests (+3): qualified-const, chain-full-path, validator E2E.
  219 → 222.

### Verification

All green locally:
`cargo test -p coding-adventures-ruby-lexer -p coding-adventures-ruby-parser -p ruby-to-semantic-ir`
(lexer 173, parser 176, lowerer 222).

### Security

Pure logic over the AST — no I/O, no `unsafe`, no deserialization.
`/security-review` passed clean in one round.
