### PR TITLE
feat(closurec): --correlation_vector_summary_stderr (CLOC11.75)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.38.0] - 2026-05-30
+
+### Added — CLOC11.75: `--correlation_vector_summary_stderr`
+
+Boolean flag (default false). When on, the `--correlation_vector_summary` line is routed to `stderr_text` instead of `stdout_text`. Useful when stdout carries the actual JS payload (no `--js_output_file`) — without this flag, the summary line would corrupt the JS that downstream tooling pipes into.
+
+### Changed
+
+- `CompilerOutput` gains `stderr_text: String` (default empty). Existing callers ignoring stderr see no behavior change; tests can assert on routing without grepping file descriptors.
+- `parse_and_run`'s contract is now: returns `(stdout_text + stderr_text, ExitCode)` for back-compat with existing callers. A new `parse_and_run_with_streams` returns `(stdout, stderr, ExitCode)` separately; `main()` calls the streaming variant and writes stderr via `eprint!`.
+- `SpecialModesConfig` gains `correlation_vector_summary_stderr: bool`.
+- Versions: `Cargo.toml` `0.37.0` → `0.38.0`, `cli.spec.json` `0.37.0` → `0.38.0`.
+
+### Implementation note
+
+Why split the CompilerOutput rather than threading an `io::Write`: keeping run_compiler pure (no I/O, returns a value) preserves the existing test ergonomics — tests inspect the returned struct. The cost is one extra `String` field that's empty on the common path.
+
 ## [0.37.0] - 2026-05-30
 
 ### Added — CLOC11.74: `--correlation_vector_summary_format` enum (TEXT | JSON | KV)

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.37.0"
+version = "0.38.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },
@@ -104,6 +104,7 @@
     { "id": "correlation_vector_filter_invert", "long": "correlation_vector_filter_invert", "type": "boolean", "default": false, "description": "Invert the --correlation_vector_filter from an allowlist to a blocklist. With --correlation_vector_filter lex and --correlation_vector_filter_invert true, entries that DO match (i.e. carry a `lex` contribution and/or origin) are dropped; everything else is kept. Useful for \"everything except X\" filters where enumerating the allowlist is impractical (CLOC11.72)." },
     { "id": "correlation_vector_summary", "long": "correlation_vector_summary", "type": "boolean", "default": false, "description": "Print a one-line summary of the correlation-vector trace to stdout after the sidecar is written (or skipped under --correlation_vector_format NONE). Format: `cv sidecar: <path>: N entries, M contributions, T tombstones, pass_order=[a,b,c]`. Counts reflect post-filter state. Useful for build pipelines that don't want to parse the JSON to see if anything interesting happened (CLOC11.73)." },
     { "id": "correlation_vector_summary_format", "long": "correlation_vector_summary_format", "type": "enum", "enum_values": ["TEXT", "JSON", "KV"], "default": "TEXT", "description": "Format for the --correlation_vector_summary stdout line. TEXT (default) = the existing human-readable line. JSON = single-line `{\"cv_sidecar\": {...}}` for machine consumers. KV = space-separated `cv_sidecar.entries=N cv_sidecar.contributions=M ...` for ad-hoc shell parsing. Ignored unless --correlation_vector_summary is also set (CLOC11.74)." },
+    { "id": "correlation_vector_summary_stderr", "long": "correlation_vector_summary_stderr", "type": "boolean", "default": false, "description": "Route the --correlation_vector_summary line to stderr instead of stdout. Useful when stdout is the actual JS output (no --js_output_file) and you don't want the summary to corrupt it. Default off preserves the CLOC11.73 stdout-bound behaviour (CLOC11.75)." },
     { "id": "instrument_for_coverage_option", "long": "instrument_for_coverage_option", "type": "enum", "enum_values": ["NONE", "LINE", "BRANCH", "PRODUCTION"], "default": "NONE", "description": "Enable code instrumentation for coverage analysis." },
     { "id": "production_instrumentation_array_name", "long": "production_instrumentation_array_name", "type": "string", "default": "", "description": "Global array name used by production instrumentation." },
     { "id": "chunk_output_type", "long": "chunk_output_type", "type": "enum", "enum_values": ["GLOBAL_NAMESPACE", "ES_MODULES"], "default": "GLOBAL_NAMESPACE", "description": "Format for output chunks." },

--- a/code/programs/rust/closurec/src/config.rs
+++ b/code/programs/rust/closurec/src/config.rs
@@ -634,6 +634,15 @@ pub struct SpecialModesConfig {
     /// Only consulted when `correlation_vector_summary` is
     /// also true. With summary off the format flag is dead.
     pub correlation_vector_summary_format: CorrelationVectorSummaryFormat,
+    /// CLOC11.75: route the summary line to `stderr_text`
+    /// instead of `stdout_text`. Useful when stdout carries
+    /// the actual JS payload (no `--js_output_file`) and you
+    /// don't want a `cv sidecar: ...` line corrupting it.
+    ///
+    /// Default `false` preserves CLOC11.73's stdout-bound
+    /// behaviour byte-for-byte. Only consulted when
+    /// `correlation_vector_summary` is also true.
+    pub correlation_vector_summary_stderr: bool,
 }
 
 /// CLOC11.74 — render style for the `--correlation_vector_summary`

--- a/code/programs/rust/closurec/src/main.rs
+++ b/code/programs/rust/closurec/src/main.rs
@@ -102,6 +102,28 @@ const CLI_SPEC_JSON: &str = include_str!("../cli.spec.json");
 /// `3` for compilation error, `4` for IO error once those paths
 /// actually exist. Stick with 0/1 for now.
 pub fn parse_and_run(args: &[String]) -> (String, ExitCode) {
+    let (stdout, stderr, code) = parse_and_run_with_streams(args);
+    // Back-compat shim: combine stdout + stderr into a single
+    // string for callers that don't care about routing. Tests
+    // that need to assert on stderr separately call
+    // `parse_and_run_with_streams` directly.
+    let mut combined = stdout;
+    combined.push_str(&stderr);
+    (combined, code)
+}
+
+/// CLOC11.75 — version of `parse_and_run` that splits the
+/// output into stdout-bound and stderr-bound text. `main`
+/// uses this to route the CV summary line to stderr when
+/// `--correlation_vector_summary_stderr` is set, without
+/// corrupting an stdout-bound JS payload.
+///
+/// All call sites other than `main` and the CLOC11.75 tests
+/// can keep using `parse_and_run` — its return value
+/// (stdout + stderr concatenated, plus exit code) is the
+/// same byte-for-byte as before for runs without
+/// `--correlation_vector_summary_stderr`.
+pub fn parse_and_run_with_streams(args: &[String]) -> (String, String, ExitCode) {
     // Step 1: load the spec. This is cheap (serde_json parses the
     // ~9 KB spec in microseconds) and runs once per invocation.
     // We could lazy_static it for repeated CLI loops, but the
@@ -114,6 +136,7 @@ pub fn parse_and_run(args: &[String]) -> (String, ExitCode) {
             // of reporting it.
             return (
                 format!("internal error: cli.spec.json failed to load: {}\n", e),
+                String::new(),
                 ExitCode::from(70), // EX_SOFTWARE per sysexits.h
             );
         }
@@ -144,7 +167,7 @@ pub fn parse_and_run(args: &[String]) -> (String, ExitCode) {
             // typed CompilerConfig.
             let cfg = match wire::config_from_parsed(&result) {
                 Ok(c) => c,
-                Err(e) => return (format!("{e}\n"), ExitCode::from(1)),
+                Err(e) => return (format!("{e}\n"), String::new(), ExitCode::from(1)),
             };
 
             // Step 3.5 (CLOC11.54): --help_markdown short-circuit.
@@ -158,6 +181,7 @@ pub fn parse_and_run(args: &[String]) -> (String, ExitCode) {
             if cfg.special_modes.help_markdown {
                 return (
                     help_markdown::format_help_markdown(&spec_for_help_md),
+                    String::new(),
                     ExitCode::SUCCESS,
                 );
             }
@@ -173,12 +197,12 @@ pub fn parse_and_run(args: &[String]) -> (String, ExitCode) {
                 Ok(out) => {
                     // Closure exits 0 on success regardless of
                     // whether output went to stdout or to a file.
-                    (out.stdout_text, ExitCode::SUCCESS)
+                    (out.stdout_text, out.stderr_text, ExitCode::SUCCESS)
                 }
-                Err(e) => (format!("{e}\n"), ExitCode::from(2)),
+                Err(e) => (format!("{e}\n"), String::new(), ExitCode::from(2)),
             }
         }
-        Ok(ParserOutput::Help(h)) => (h.text, ExitCode::SUCCESS),
+        Ok(ParserOutput::Help(h)) => (h.text, String::new(), ExitCode::SUCCESS),
         Ok(ParserOutput::Version(v)) => {
             // CLOC11.55: emit a CC-compat banner.
             //
@@ -205,6 +229,7 @@ pub fn parse_and_run(args: &[String]) -> (String, ExitCode) {
                     "Closure Compiler (closurec — drop-in replacement, https://github.com/adhithyan15/coding-adventures)\nVersion: {}\n",
                     v.version
                 ),
+                String::new(),
                 ExitCode::SUCCESS,
             )
         }
@@ -212,7 +237,7 @@ pub fn parse_and_run(args: &[String]) -> (String, ExitCode) {
             // cli-builder's Display for CliBuilderError already
             // formats nicely (multi-line if there are multiple
             // errors, with "did you mean?" suggestions).
-            (format!("{}\n", e), ExitCode::from(1))
+            (format!("{}\n", e), String::new(), ExitCode::from(1))
         }
     }
 }
@@ -225,8 +250,16 @@ pub fn parse_and_run(args: &[String]) -> (String, ExitCode) {
 /// the spec.
 fn main() -> ExitCode {
     let args: Vec<String> = std::env::args().skip(1).collect();
-    let (text, code) = parse_and_run(&args);
-    print!("{}", text);
+    // CLOC11.75 — use the streaming variant so the CV summary
+    // line can land on stderr when
+    // `--correlation_vector_summary_stderr` is set; without
+    // that flag stderr_text is always empty and main behaves
+    // identically to pre-CLOC11.75.
+    let (stdout, stderr, code) = parse_and_run_with_streams(&args);
+    print!("{}", stdout);
+    if !stderr.is_empty() {
+        eprint!("{}", stderr);
+    }
     code
 }
 

--- a/code/programs/rust/closurec/src/run.rs
+++ b/code/programs/rust/closurec/src/run.rs
@@ -40,10 +40,15 @@ use std::path::{Path, PathBuf};
 /// `stdout_text` is what should be printed (empty if `--js_output_file`
 /// captured all output). `wrote_files` lists every path actually
 /// written, so tests can assert on disk effects without reading
-/// each file.
+/// each file. `stderr_text` (CLOC11.75) is content the caller
+/// should print to stderr — used today for the CV summary
+/// when `--correlation_vector_summary_stderr` is set so the
+/// summary doesn't corrupt a stdout-bound JS payload. Default
+/// empty; tests can assert on routing without grepping fds.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct CompilerOutput {
     pub stdout_text: String,
+    pub stderr_text: String,
     pub wrote_files: Vec<PathBuf>,
 }
 
@@ -364,6 +369,7 @@ pub fn run_compiler(config: &CompilerConfig) -> Result<CompilerOutput, CompilerE
     if config.io.js_patterns.is_empty() {
         return Ok(CompilerOutput {
             stdout_text: "closurec v0.1.0 - identity pipeline\n".to_string(),
+            stderr_text: String::new(),
             wrote_files: Vec::new(),
         });
     }
@@ -430,6 +436,7 @@ pub fn run_compiler(config: &CompilerConfig) -> Result<CompilerOutput, CompilerE
         }
         return Ok(CompilerOutput {
             stdout_text: dump,
+            stderr_text: String::new(),
             wrote_files: Vec::new(),
         });
     }
@@ -471,6 +478,7 @@ pub fn run_compiler(config: &CompilerConfig) -> Result<CompilerOutput, CompilerE
         };
         return Ok(CompilerOutput {
             stdout_text: dump,
+            stderr_text: String::new(),
             wrote_files: Vec::new(),
         });
     }
@@ -880,6 +888,7 @@ pub fn run_compiler(config: &CompilerConfig) -> Result<CompilerOutput, CompilerE
     if config.compilation.checks_only {
         return Ok(CompilerOutput {
             stdout_text: String::new(),
+            stderr_text: String::new(),
             wrote_files: Vec::new(),
         });
     }
@@ -1067,11 +1076,13 @@ pub fn run_compiler(config: &CompilerConfig) -> Result<CompilerOutput, CompilerE
             write_output_file(path, &encoded)?;
             CompilerOutput {
                 stdout_text: String::new(),
+                stderr_text: String::new(),
                 wrote_files: vec![path.clone()],
             }
         }
         None => CompilerOutput {
             stdout_text: encoded,
+            stderr_text: String::new(),
             wrote_files: Vec::new(),
         },
     };
@@ -1303,12 +1314,19 @@ pub fn run_compiler(config: &CompilerConfig) -> Result<CompilerOutput, CompilerE
                 cv_sidecar_written.as_deref(),
                 config.special_modes.correlation_vector_summary_format,
             );
-            result.stdout_text.push_str(&summary);
+            // CLOC11.75 — route to stderr_text when the
+            // stderr flag is on; default stays on stdout.
+            if config.special_modes.correlation_vector_summary_stderr {
+                result.stderr_text.push_str(&summary);
+            } else {
+                result.stdout_text.push_str(&summary);
+            }
         }
     }
 
     Ok(CompilerOutput {
         stdout_text: result.stdout_text,
+        stderr_text: result.stderr_text,
         wrote_files,
     })
 }
@@ -4413,6 +4431,88 @@ mod tests {
             !out.stdout_text.contains("{\"cv_sidecar\""),
             "text default should not emit JSON, got: {:?}",
             out.stdout_text
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    // ------------------------------------------------------------------
+    // CLOC11.75 — --correlation_vector_summary_stderr
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn correlation_vector_summary_stderr_routes_to_stderr_text() {
+        // With the stderr flag on, the summary line should
+        // appear in stderr_text and NOT in stdout_text.
+        let dir =
+            std::env::temp_dir().join("closurec_cloc11_75_stderr_on");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("create dir");
+        let in_path = dir.join("a.js");
+        fs::write(&in_path, "var x = 1;").expect("write");
+        let out_path = dir.join("out.js");
+        let cfg = CompilerConfig {
+            io: IoConfig {
+                js_patterns: vec![in_path.to_string_lossy().to_string()],
+                js_output_file: Some(out_path.clone()),
+                ..Default::default()
+            },
+            special_modes: crate::config::SpecialModesConfig {
+                correlation_vector: true,
+                correlation_vector_summary: true,
+                correlation_vector_summary_stderr: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let out = run_compiler(&cfg).expect("ok");
+        assert!(
+            out.stderr_text.contains("cv sidecar:"),
+            "expected summary on stderr_text, got: {:?}",
+            out.stderr_text
+        );
+        assert!(
+            !out.stdout_text.contains("cv sidecar:"),
+            "expected NO summary on stdout_text under stderr flag, got: {:?}",
+            out.stdout_text
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn correlation_vector_summary_stderr_off_remains_on_stdout() {
+        // Default: stderr flag off → summary stays on stdout
+        // (CLOC11.73 behaviour). stderr_text is empty.
+        let dir =
+            std::env::temp_dir().join("closurec_cloc11_75_stderr_off");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("create dir");
+        let in_path = dir.join("a.js");
+        fs::write(&in_path, "var x = 1;").expect("write");
+        let out_path = dir.join("out.js");
+        let cfg = CompilerConfig {
+            io: IoConfig {
+                js_patterns: vec![in_path.to_string_lossy().to_string()],
+                js_output_file: Some(out_path.clone()),
+                ..Default::default()
+            },
+            special_modes: crate::config::SpecialModesConfig {
+                correlation_vector: true,
+                correlation_vector_summary: true,
+                // correlation_vector_summary_stderr defaults to false
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let out = run_compiler(&cfg).expect("ok");
+        assert!(
+            out.stdout_text.contains("cv sidecar:"),
+            "expected summary on stdout_text by default, got: {:?}",
+            out.stdout_text
+        );
+        assert!(
+            out.stderr_text.is_empty(),
+            "expected empty stderr_text by default, got: {:?}",
+            out.stderr_text
         );
         let _ = fs::remove_dir_all(&dir);
     }

--- a/code/programs/rust/closurec/src/wire.rs
+++ b/code/programs/rust/closurec/src/wire.rs
@@ -529,6 +529,10 @@ fn read_special_modes(p: &ParseResult) -> Result<SpecialModesConfig, ConfigError
             // TEXT, empty, or absent → default
             _ => crate::config::CorrelationVectorSummaryFormat::Text,
         },
+        correlation_vector_summary_stderr: get_bool(
+            p,
+            "correlation_vector_summary_stderr",
+        )?,
     })
 }
 

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.37.0
+Version: 0.38.0
 
 ## Flags
 
@@ -401,6 +401,10 @@ Print a one-line summary of the correlation-vector trace to stdout after the sid
 ### `--correlation_vector_summary_format` (enum, default: TEXT)
 
 Format for the --correlation_vector_summary stdout line. TEXT (default) = the existing human-readable line. JSON = single-line `{"cv_sidecar": {...}}` for machine consumers. KV = space-separated `cv_sidecar.entries=N cv_sidecar.contributions=M ...` for ad-hoc shell parsing. Ignored unless --correlation_vector_summary is also set (CLOC11.74).
+
+### `--correlation_vector_summary_stderr` (boolean, default: false)
+
+Route the --correlation_vector_summary line to stderr instead of stdout. Useful when stdout is the actual JS output (no --js_output_file) and you don't want the summary to corrupt it. Default off preserves the CLOC11.73 stdout-bound behaviour (CLOC11.75).
 
 ### `--instrument_for_coverage_option` (enum, default: NONE)
 


### PR DESCRIPTION
## Summary

Boolean flag (default false). When on, the `--correlation_vector_summary` line is routed to `stderr_text` instead of `stdout_text`. Useful when stdout carries the actual JS payload (no `--js_output_file`) — without this flag, the summary line would corrupt the JS that downstream tooling pipes into.

Default off → byte-identical to CLOC11.74 (stderr_text empty, summary still flows to stdout).

## Implementation

- `CompilerOutput` gains `stderr_text: String` (default empty). All run.rs return sites populate it; existing callers ignoring stderr see no behavior change.
- `parse_and_run` keeps its `(String, ExitCode)` shape via a back-compat shim that concatenates `stdout_text + stderr_text`. All 16+ existing tests pass without modification.
- New `parse_and_run_with_streams(args) -> (String, String, ExitCode)` returns the two streams separately.
- `main()` calls `parse_and_run_with_streams` and routes via `print!()`/`eprint!()` (only when stderr non-empty).

## Test plan
- [x] cargo build clean
- [x] 261 unit + 17 integration suites pass (16 existing parse_and_run tests + 2 new CLOC11.75 tests)
- [x] New tests:
  - `correlation_vector_summary_stderr_routes_to_stderr_text` — flag on → `cv sidecar:` on stderr_text, NOT stdout_text
  - `correlation_vector_summary_stderr_off_remains_on_stdout` — default off → stdout, stderr_text empty
- [x] help-markdown fixture regenerated for 0.38.0

## Security review (inline)
- Default-off byte-identical to CLOC11.74.
- `parse_and_run` shim preserves all existing test assertions.
- `eprint!("{}", stderr)` uses `{}` placeholder — value is data, no format-string interpretation.
- No unsafe, no new deps.

## Versions
- `Cargo.toml`: 0.37.0 → 0.38.0
- `cli.spec.json`: 0.37.0 → 0.38.0
- `CHANGELOG.md`: new `[0.38.0]` section

🤖 Generated with [Claude Code](https://claude.com/claude-code)