### PR TITLE
feat(closurec): --correlation_vector_summary_only (CLOC11.76)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.39.0] - 2026-05-30
+
+### Added — CLOC11.76: `--correlation_vector_summary_only` (pure analysis mode)
+
+Boolean flag (default false). When on, the run **skips every output write**: no JS file (or stdout), no source map, no manifest. The CV log is still computed in memory, so `--correlation_vector_summary` can still print real counts.
+
+Pairs naturally with `--correlation_vector_format NONE` to skip the CV sidecar too — a pure-analysis invocation that does no disk writes whatsoever. With both set, the only externally observable output is the summary line on stdout (or stderr under CLOC11.75).
+
+Use case: `closurec --correlation_vector --correlation_vector_summary --correlation_vector_summary_only` answers "what would the CV trace look like" without rebuilding artifacts.
+
+### Implementation
+
+- `SpecialModesConfig` gains `correlation_vector_summary_only: bool`.
+- Three call sites in `run_compiler` are gated on `!summary_only`: the JS output write, the source map write, and the manifest write. The matching `js_output_file` / `source_map_output` / `manifest_output` CV records are also skipped (they describe writes that didn't happen).
+- The CV sidecar write block (Step 7) is unchanged — `--correlation_vector_format NONE` is the right way to skip it, summary_only doesn't reach into that policy.
+- Default false → byte-identical to CLOC11.75.
+
+### Changed
+
+- `wire.rs`: `read_special_modes` pulls the new bool.
+- Versions: `Cargo.toml` `0.38.0` → `0.39.0`, `cli.spec.json` `0.38.0` → `0.39.0`.
+
 ## [0.38.0] - 2026-05-30
 
 ### Added — CLOC11.75: `--correlation_vector_summary_stderr`

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.38.0"
+version = "0.39.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },
@@ -105,6 +105,7 @@
     { "id": "correlation_vector_summary", "long": "correlation_vector_summary", "type": "boolean", "default": false, "description": "Print a one-line summary of the correlation-vector trace to stdout after the sidecar is written (or skipped under --correlation_vector_format NONE). Format: `cv sidecar: <path>: N entries, M contributions, T tombstones, pass_order=[a,b,c]`. Counts reflect post-filter state. Useful for build pipelines that don't want to parse the JSON to see if anything interesting happened (CLOC11.73)." },
     { "id": "correlation_vector_summary_format", "long": "correlation_vector_summary_format", "type": "enum", "enum_values": ["TEXT", "JSON", "KV"], "default": "TEXT", "description": "Format for the --correlation_vector_summary stdout line. TEXT (default) = the existing human-readable line. JSON = single-line `{\"cv_sidecar\": {...}}` for machine consumers. KV = space-separated `cv_sidecar.entries=N cv_sidecar.contributions=M ...` for ad-hoc shell parsing. Ignored unless --correlation_vector_summary is also set (CLOC11.74)." },
     { "id": "correlation_vector_summary_stderr", "long": "correlation_vector_summary_stderr", "type": "boolean", "default": false, "description": "Route the --correlation_vector_summary line to stderr instead of stdout. Useful when stdout is the actual JS output (no --js_output_file) and you don't want the summary to corrupt it. Default off preserves the CLOC11.73 stdout-bound behaviour (CLOC11.75)." },
+    { "id": "correlation_vector_summary_only", "long": "correlation_vector_summary_only", "type": "boolean", "default": false, "description": "Skip all output writes (JS, source map, manifest) and only emit the CV summary. Useful for `closurec --print-cv-summary` style invocations that just want the trace counts. Pair with --correlation_vector_format NONE to skip the sidecar too — pure analysis mode, no disk writes at all. Default off preserves normal compile output (CLOC11.76)." },
     { "id": "instrument_for_coverage_option", "long": "instrument_for_coverage_option", "type": "enum", "enum_values": ["NONE", "LINE", "BRANCH", "PRODUCTION"], "default": "NONE", "description": "Enable code instrumentation for coverage analysis." },
     { "id": "production_instrumentation_array_name", "long": "production_instrumentation_array_name", "type": "string", "default": "", "description": "Global array name used by production instrumentation." },
     { "id": "chunk_output_type", "long": "chunk_output_type", "type": "enum", "enum_values": ["GLOBAL_NAMESPACE", "ES_MODULES"], "default": "GLOBAL_NAMESPACE", "description": "Format for output chunks." },

--- a/code/programs/rust/closurec/src/config.rs
+++ b/code/programs/rust/closurec/src/config.rs
@@ -643,6 +643,23 @@ pub struct SpecialModesConfig {
     /// behaviour byte-for-byte. Only consulted when
     /// `correlation_vector_summary` is also true.
     pub correlation_vector_summary_stderr: bool,
+    /// CLOC11.76: skip all output writes (JS, source map,
+    /// manifest) and only emit the CV summary. Useful for
+    /// `closurec --print-cv-summary` style invocations that
+    /// just want the trace counts without producing build
+    /// artifacts.
+    ///
+    /// Pairs naturally with
+    /// `--correlation_vector_format NONE` to skip the
+    /// sidecar too — pure analysis mode, no disk writes at
+    /// all. The CV log is still computed in memory (so the
+    /// summary counts are real).
+    ///
+    /// Default `false` preserves normal compile output.
+    /// Independent of `correlation_vector`: if you set this
+    /// without `--correlation_vector`, you get no writes
+    /// and no summary — effectively a no-op pipeline run.
+    pub correlation_vector_summary_only: bool,
 }
 
 /// CLOC11.74 — render style for the `--correlation_vector_summary`

--- a/code/programs/rust/closurec/src/run.rs
+++ b/code/programs/rust/closurec/src/run.rs
@@ -1071,20 +1071,30 @@ pub fn run_compiler(config: &CompilerConfig) -> Result<CompilerOutput, CompilerE
     // None arm moves `encoded` into stdout_text; without the
     // pre-capture we'd see a borrow-of-moved error.
     let encoded_byte_len = encoded.len();
-    let mut result = match &config.io.js_output_file {
-        Some(path) => {
-            write_output_file(path, &encoded)?;
-            CompilerOutput {
-                stdout_text: String::new(),
-                stderr_text: String::new(),
-                wrote_files: vec![path.clone()],
+    // CLOC11.76 — when --correlation_vector_summary_only is
+    // set, skip the JS write entirely. The CV log still
+    // accumulates per-file / combined / post-combine
+    // records; we just don't produce any build artifacts.
+    // The js_output_file CV record below is also skipped
+    // (it would describe a write that never happened).
+    let mut result = if config.special_modes.correlation_vector_summary_only {
+        CompilerOutput::default()
+    } else {
+        match &config.io.js_output_file {
+            Some(path) => {
+                write_output_file(path, &encoded)?;
+                CompilerOutput {
+                    stdout_text: String::new(),
+                    stderr_text: String::new(),
+                    wrote_files: vec![path.clone()],
+                }
             }
+            None => CompilerOutput {
+                stdout_text: encoded,
+                stderr_text: String::new(),
+                wrote_files: Vec::new(),
+            },
         }
-        None => CompilerOutput {
-            stdout_text: encoded,
-            stderr_text: String::new(),
-            wrote_files: Vec::new(),
-        },
     };
 
     // Step 5 (CLOC11.42): source map write.
@@ -1095,6 +1105,11 @@ pub fn run_compiler(config: &CompilerConfig) -> Result<CompilerOutput, CompilerE
     // entry as parent. Contributes a `wrote` record with the
     // path + byte_len so a CV trace consumer can match an output
     // file back to its substrate.
+    //
+    // CLOC11.76: skip this CV record under summary_only — the
+    // write never happened, so the trace should not pretend
+    // there's a file on disk.
+    if !config.special_modes.correlation_vector_summary_only {
     if let Some(parent_id) = &combined_cv_id {
         if let Some(js_path) = &config.io.js_output_file {
             let mut origin_meta = std::collections::HashMap::new();
@@ -1126,8 +1141,12 @@ pub fn run_compiler(config: &CompilerConfig) -> Result<CompilerOutput, CompilerE
             );
         }
     }
+    } // end CLOC11.76 summary_only gate around js CV record
 
-    if !config.source_map.path_template.is_empty() {
+    // CLOC11.76: source map write also skipped under
+    // summary_only.
+    if !config.special_modes.correlation_vector_summary_only
+        && !config.source_map.path_template.is_empty() {
         let map_path = std::path::PathBuf::from(&config.source_map.path_template);
         let map_body = crate::source_map::format_minimal_v3(
             config.io.js_output_file.as_deref(),
@@ -1186,6 +1205,8 @@ pub fn run_compiler(config: &CompilerConfig) -> Result<CompilerOutput, CompilerE
     //
     // Empty inputs (banner mode) produce an empty manifest file
     // — still valid, still useful as a "compilation ran" marker.
+    // CLOC11.76: manifest write also skipped under summary_only.
+    if !config.special_modes.correlation_vector_summary_only {
     if let Some(manifest_path) = &config.chunks.output_manifest_file {
         let body = format_manifest(&inputs);
         write_output_file(manifest_path, &body)?;
@@ -1235,6 +1256,7 @@ pub fn run_compiler(config: &CompilerConfig) -> Result<CompilerOutput, CompilerE
             );
         }
     }
+    } // end CLOC11.76 summary_only gate around manifest write
 
     // Step 7 (CLOC11.60): write the correlation-vector trace as
     // a JSON sidecar file when `--correlation_vector` was set.
@@ -4513,6 +4535,113 @@ mod tests {
             out.stderr_text.is_empty(),
             "expected empty stderr_text by default, got: {:?}",
             out.stderr_text
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    // ------------------------------------------------------------------
+    // CLOC11.76 — --correlation_vector_summary_only
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn correlation_vector_summary_only_skips_js_and_map_and_manifest() {
+        // summary_only=true + format=NONE: no JS file on disk,
+        // no source map file, no manifest file, no CV sidecar.
+        // wrote_files should be empty. Summary still emitted.
+        let dir =
+            std::env::temp_dir().join("closurec_cloc11_76_summary_only");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("create dir");
+        let in_path = dir.join("a.js");
+        fs::write(&in_path, "var x = 1;").expect("write");
+        let out_path = dir.join("out.js");
+        let map_path = dir.join("out.js.map");
+        let manifest_path = dir.join("manifest.txt");
+        let cfg = CompilerConfig {
+            io: IoConfig {
+                js_patterns: vec![in_path.to_string_lossy().to_string()],
+                js_output_file: Some(out_path.clone()),
+                ..Default::default()
+            },
+            source_map: crate::config::SourceMapConfig {
+                path_template: map_path.to_string_lossy().to_string(),
+                ..Default::default()
+            },
+            chunks: crate::config::ChunksConfig {
+                output_manifest_file: Some(manifest_path.clone()),
+                ..Default::default()
+            },
+            special_modes: crate::config::SpecialModesConfig {
+                correlation_vector: true,
+                correlation_vector_summary: true,
+                correlation_vector_summary_only: true,
+                correlation_vector_format:
+                    crate::config::CorrelationVectorFormat::None,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let out = run_compiler(&cfg).expect("ok");
+        // No files written anywhere.
+        assert!(
+            !out_path.exists(),
+            "summary_only should skip JS write, found file at {:?}",
+            out_path
+        );
+        assert!(
+            !map_path.exists(),
+            "summary_only should skip source map, found file at {:?}",
+            map_path
+        );
+        assert!(
+            !manifest_path.exists(),
+            "summary_only should skip manifest, found file at {:?}",
+            manifest_path
+        );
+        assert!(
+            out.wrote_files.is_empty(),
+            "summary_only should produce empty wrote_files, got: {:?}",
+            out.wrote_files
+        );
+        // Summary line still appears.
+        assert!(
+            out.stdout_text.contains("cv sidecar:"),
+            "expected summary line under summary_only, got: {:?}",
+            out.stdout_text
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn correlation_vector_summary_only_off_writes_outputs_normally() {
+        // Default (summary_only=false): JS file is written
+        // even when summary is on. Tests the
+        // byte-for-byte-unchanged guarantee.
+        let dir = std::env::temp_dir().join("closurec_cloc11_76_only_off");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("create dir");
+        let in_path = dir.join("a.js");
+        fs::write(&in_path, "var x = 1;").expect("write");
+        let out_path = dir.join("out.js");
+        let cfg = CompilerConfig {
+            io: IoConfig {
+                js_patterns: vec![in_path.to_string_lossy().to_string()],
+                js_output_file: Some(out_path.clone()),
+                ..Default::default()
+            },
+            special_modes: crate::config::SpecialModesConfig {
+                correlation_vector: true,
+                correlation_vector_summary: true,
+                // correlation_vector_summary_only defaults to false
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let _ = run_compiler(&cfg).expect("ok");
+        assert!(
+            out_path.exists(),
+            "default summary_only=false should still write JS, got nothing at {:?}",
+            out_path
         );
         let _ = fs::remove_dir_all(&dir);
     }

--- a/code/programs/rust/closurec/src/wire.rs
+++ b/code/programs/rust/closurec/src/wire.rs
@@ -533,6 +533,10 @@ fn read_special_modes(p: &ParseResult) -> Result<SpecialModesConfig, ConfigError
             p,
             "correlation_vector_summary_stderr",
         )?,
+        correlation_vector_summary_only: get_bool(
+            p,
+            "correlation_vector_summary_only",
+        )?,
     })
 }
 

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.38.0
+Version: 0.39.0
 
 ## Flags
 
@@ -405,6 +405,10 @@ Format for the --correlation_vector_summary stdout line. TEXT (default) = the ex
 ### `--correlation_vector_summary_stderr` (boolean, default: false)
 
 Route the --correlation_vector_summary line to stderr instead of stdout. Useful when stdout is the actual JS output (no --js_output_file) and you don't want the summary to corrupt it. Default off preserves the CLOC11.73 stdout-bound behaviour (CLOC11.75).
+
+### `--correlation_vector_summary_only` (boolean, default: false)
+
+Skip all output writes (JS, source map, manifest) and only emit the CV summary. Useful for `closurec --print-cv-summary` style invocations that just want the trace counts. Pair with --correlation_vector_format NONE to skip the sidecar too — pure analysis mode, no disk writes at all. Default off preserves normal compile output (CLOC11.76).
 
 ### `--instrument_for_coverage_option` (enum, default: NONE)
 


### PR DESCRIPTION
## Summary

Boolean flag (default false). When on, the run **skips every output write** — no JS file (or stdout), no source map, no manifest. The CV log is still computed in memory, so `--correlation_vector_summary` still prints real counts.

Pairs naturally with `--correlation_vector_format NONE` to skip the CV sidecar too — pure analysis mode, no disk writes whatsoever.

```bash
closurec --correlation_vector \
         --correlation_vector_summary \
         --correlation_vector_summary_only \
         --correlation_vector_format NONE
```

answers "what would the CV trace look like" without rebuilding any artifacts.

## Implementation

- Three call sites in `run_compiler` gated on `!summary_only`: the JS output write, the source map write, and the manifest write. The matching `js_output_file` / `source_map_output` / `manifest_output` CV records are also skipped (they describe writes that didn't happen).
- The CV sidecar block is unchanged — `--correlation_vector_format NONE` is the right way to skip it; summary_only doesn't reach into that policy.

## Test plan
- [x] cargo build clean
- [x] 263 unit + 17 integration suites pass
- [x] New tests:
  - `correlation_vector_summary_only_skips_js_and_map_and_manifest` — summary_only + format=NONE → no files on disk; wrote_files empty; summary still emitted
  - `correlation_vector_summary_only_off_writes_outputs_normally` — default off → JS file still written
- [x] help-markdown fixture regenerated for 0.39.0

## Security review (inline)
- Default-off byte-identical to CLOC11.75.
- Skipping I/O strictly reduces attack surface — no new path construction, no new disk writes.
- CV record for `js_output_file` correctly suppressed under summary_only — sidecar can't claim a file exists when it doesn't.
- No unsafe, no new deps.

## Versions
- `Cargo.toml`: 0.38.0 → 0.39.0
- `cli.spec.json`: 0.38.0 → 0.39.0
- `CHANGELOG.md`: new `[0.39.0]` section

🤖 Generated with [Claude Code](https://claude.com/claude-code)