### PR TITLE
feat(ruby-fc): Phase 16a — begin/rescue/ensure/end → Stmt::TryCatch

### DIFF
--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.49.0] - 2026-05-30
+
+### Changed (Phase 16a (FC) — `begin/rescue/ensure/end` → `Stmt::TryCatch`)
+
+`begin/rescue/ensure/end` now lowers to the first-class
+`Stmt::TryCatch` (semantic-ir 0.9.0) instead of the Phase 6v inline
+`__rescue_marker__` / `__ensure_marker__` placeholder builtins:
+
+- `lower_begin_statement` builds a single `Stmt::TryCatch { body,
+  rescues, ensure_body }`.  The try body and each clause body are lowered
+  with the existing `lower_statement_inner_multi` collector.
+- Each `rescue_clause` becomes a `RescueClause` carrying its exception
+  class names (`Vec<String>`), the optional `=> e` binding, and its body.
+  A bare `rescue` yields an empty `exception_types`.
+- The optional `ensure_clause` becomes `ensure_body: Some(..)`.
+- Emitting a `TryCatch` requests `Feature::Exceptions` (no longer the
+  ad-hoc `Effect::MayThrow`-tagged marker builtins).
+- No grammar change — `begin_statement` already parsed (Phase 6v).
+
+The four pre-existing Phase 6v tests were rewritten from
+marker-assertions to the `TryCatch` contract
+(`begin_without_rescue_lowers_body_inline`,
+`begin_with_rescue_lowers_to_rescue_clause`,
+`begin_with_ensure_lowers_to_ensure_body`,
+`begin_with_rescue_and_ensure_lowers_to_full_trycatch`), plus a new
+validator E2E (`begin_rescue_passes_sir_validator`).  Test count:
+222 → 223 (+1).
+
 ## [0.48.0] - 2026-05-30
 
 ### Added (Phase 15d (FC) — scoped lookup `Foo::Bar`)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -3496,67 +3496,69 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
-    // Phase 6v — `begin … rescue … ensure … end`
+    // Phase 6v / 16a — `begin … rescue … ensure … end`
     // -----------------------------------------------------------------
     //
-    // SIR has no try/catch primitive.  v0 lowering is lossy: body,
-    // rescue, and ensure stmts emit inline with marker BuiltinCalls
-    // (`__rescue_marker__`, `__ensure_marker__`) bracketing the
-    // rescue/ensure sections.
+    // Phase 16a (FC): `begin/rescue/ensure/end` lowers to a first-class
+    // `Stmt::TryCatch` (replacing the Phase 6v inline
+    // `__rescue_marker__`/`__ensure_marker__` placeholder builtins).
 
     #[test]
     fn begin_without_rescue_lowers_body_inline() {
-        // `begin x = 1 end` → just LetBinding(x, 1).  No markers.
+        // `begin x = 1 end` → TryCatch with just the body, no rescues/ensure.
         let m = lower("begin\n  x = 1\nend\n");
         let b = main_body(&m);
         assert_eq!(b.stmts.len(), 1);
-        assert!(matches!(&b.stmts[0], Stmt::LetBinding { name, .. } if name == "x"));
+        match &b.stmts[0] {
+            Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+                assert_eq!(body.len(), 1);
+                assert!(matches!(&body[0], Stmt::LetBinding { name, .. } if name == "x"));
+                assert!(rescues.is_empty(), "no rescue clauses");
+                assert!(ensure_body.is_none(), "no ensure clause");
+            }
+            other => panic!("expected Stmt::TryCatch, got {:?}", other),
+        }
+        assert!(m.manifest.contains(semantic_ir::Feature::Exceptions));
     }
 
     #[test]
-    fn begin_with_rescue_emits_rescue_marker() {
+    fn begin_with_rescue_lowers_to_rescue_clause() {
         let m = lower(
             "begin\n  x = 1\nrescue StandardError => e\n  y = 2\nend\n",
         );
         let b = main_body(&m);
-        // Stmts: LetBinding(x,1), ExprStmt(BuiltinCall(__rescue_marker__, ["StandardError", "e"])), LetBinding(y,2).
-        assert_eq!(b.stmts.len(), 3);
-        let marker = match &b.stmts[1] {
-            Stmt::ExprStmt { expr, .. } => expr,
-            other => panic!("expected ExprStmt(rescue marker), got {:?}", other),
-        };
-        match marker {
-            Expr::BuiltinCall { name, args, .. } => {
-                assert_eq!(name, "__rescue_marker__");
-                assert_eq!(args.len(), 2);
-                assert!(
-                    matches!(&args[0], Expr::StrLit { value, .. } if value == "StandardError")
-                );
-                assert!(
-                    matches!(&args[1], Expr::StrLit { value, .. } if value == "e")
-                );
+        match &b.stmts[0] {
+            Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+                assert!(matches!(&body[0], Stmt::LetBinding { name, .. } if name == "x"));
+                assert_eq!(rescues.len(), 1);
+                let r = &rescues[0];
+                assert_eq!(r.exception_types, vec!["StandardError".to_string()]);
+                assert_eq!(r.binding.as_deref(), Some("e"));
+                assert!(matches!(&r.body[0], Stmt::LetBinding { name, .. } if name == "y"));
+                assert!(ensure_body.is_none());
             }
-            other => panic!("expected __rescue_marker__ builtin, got {:?}", other),
+            other => panic!("expected Stmt::TryCatch, got {:?}", other),
+        }
+        assert!(m.manifest.contains(semantic_ir::Feature::Exceptions));
+    }
+
+    #[test]
+    fn begin_with_ensure_lowers_to_ensure_body() {
+        let m = lower("begin\n  x = 1\nensure\n  y = 2\nend\n");
+        let b = main_body(&m);
+        match &b.stmts[0] {
+            Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+                assert!(matches!(&body[0], Stmt::LetBinding { name, .. } if name == "x"));
+                assert!(rescues.is_empty());
+                let ens = ensure_body.as_ref().expect("ensure body present");
+                assert!(matches!(&ens[0], Stmt::LetBinding { name, .. } if name == "y"));
+            }
+            other => panic!("expected Stmt::TryCatch, got {:?}", other),
         }
     }
 
     #[test]
-    fn begin_with_ensure_emits_ensure_marker() {
-        let m = lower("begin\n  x = 1\nensure\n  y = 2\nend\n");
-        let b = main_body(&m);
-        // Stmts: LetBinding(x,1), ExprStmt(BuiltinCall(__ensure_marker__, [])), LetBinding(y,2).
-        assert_eq!(b.stmts.len(), 3);
-        assert!(matches!(
-            &b.stmts[1],
-            Stmt::ExprStmt {
-                expr: Expr::BuiltinCall { name, args, .. },
-                ..
-            } if name == "__ensure_marker__" && args.is_empty()
-        ));
-    }
-
-    #[test]
-    fn begin_with_rescue_and_ensure_emits_both_markers_in_order() {
+    fn begin_with_rescue_and_ensure_lowers_to_full_trycatch() {
         let m = lower(concat!(
             "begin\n",
             "  x = 1\n",
@@ -3567,27 +3569,33 @@ mod tests {
             "end\n",
         ));
         let b = main_body(&m);
-        // Stmts in order:
-        //   0: LetBinding(x, 1)
-        //   1: ExprStmt(__rescue_marker__("StandardError", "e"))
-        //   2: LetBinding(y, 2)
-        //   3: ExprStmt(__ensure_marker__())
-        //   4: LetBinding(z, 3)
-        assert_eq!(b.stmts.len(), 5);
-        assert!(matches!(
-            &b.stmts[1],
-            Stmt::ExprStmt {
-                expr: Expr::BuiltinCall { name, .. },
-                ..
-            } if name == "__rescue_marker__"
+        match &b.stmts[0] {
+            Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+                assert!(matches!(&body[0], Stmt::LetBinding { name, .. } if name == "x"));
+                assert_eq!(rescues.len(), 1);
+                assert!(matches!(&rescues[0].body[0], Stmt::LetBinding { name, .. } if name == "y"));
+                let ens = ensure_body.as_ref().expect("ensure present");
+                assert!(matches!(&ens[0], Stmt::LetBinding { name, .. } if name == "z"));
+            }
+            other => panic!("expected Stmt::TryCatch, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn begin_rescue_passes_sir_validator() {
+        // E2E: a begin/rescue/ensure program validates end-to-end, and
+        // the exception binding `e` is usable inside the rescue body.
+        let m = lower(concat!(
+            "begin\n",
+            "  x = 1\n",
+            "rescue StandardError => e\n",
+            "  y = e\n",
+            "ensure\n",
+            "  z = 3\n",
+            "end\n",
         ));
-        assert!(matches!(
-            &b.stmts[3],
-            Stmt::ExprStmt {
-                expr: Expr::BuiltinCall { name, .. },
-                ..
-            } if name == "__ensure_marker__"
-        ));
+        let result = semantic_ir::validate(&m);
+        assert!(result.is_ok(), "validator rejected begin/rescue: {:?}", result);
     }
 
     // -----------------------------------------------------------------

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -14,7 +14,7 @@ use lexer::token::{Token, TokenType};
 use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
 use semantic_ir::{
     Block, Effect, EffectSet, ExportName, Expr, Feature, FeatureManifest, Function, Metadata,
-    Module, Param, Scope, Span, Stmt,
+    Module, Param, RescueClause, Scope, Span, Stmt,
 };
 
 /// A failure encountered during Ruby → SIR lowering.
@@ -132,6 +132,9 @@ pub fn compile(program: &GrammarASTNode, module_name: &str) -> Result<Module, Ru
         // Phase 15c (FC) — a constant ref/assign (`FOO`, `Scope::Const`)
         // triggers the `Constants` feature.
         Feature::Constants,
+        // Phase 16a (FC) — `begin/rescue/ensure/end` (`Stmt::TryCatch`)
+        // triggers the `Exceptions` feature.
+        Feature::Exceptions,
     ] {
         if lw.features_used.contains(&f) {
             manifest.add(f);
@@ -300,6 +303,30 @@ fn block_references_any_name(block: &Block, names: &HashSet<String>) -> bool {
                         span: inner.span().clone(),
                     };
                     if block_references_any_name(&synthetic, names) {
+                        return true;
+                    }
+                }
+            }
+            Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+                // Exception handling (Phase 16a): the try body, each
+                // rescue body, and the optional ensure body are all
+                // `Vec<Stmt>`.  Recurse over every contained statement via
+                // a synthetic wrapper Block, mirroring the class arm.
+                let scan = |stmts: &[Stmt]| -> bool {
+                    stmts.iter().any(|inner| {
+                        let synthetic = Block {
+                            stmts: vec![inner.clone()],
+                            value: Expr::NilLit { span: inner.span().clone() },
+                            span: inner.span().clone(),
+                        };
+                        block_references_any_name(&synthetic, names)
+                    })
+                };
+                if scan(body) || rescues.iter().any(|r| scan(&r.body)) {
+                    return true;
+                }
+                if let Some(ens) = ensure_body {
+                    if scan(ens) {
                         return true;
                     }
                 }
@@ -3048,10 +3075,10 @@ impl Lowerer {
     }
 
     // -------------------------------------------------------------------
-    // Phase 6v — `begin … rescue … ensure … end`
+    // Phase 6v / 16a — `begin … rescue … ensure … end`
     // -------------------------------------------------------------------
 
-    /// Lower a `begin_statement` node to a sequence of SIR statements.
+    /// Lower a `begin_statement` node to a single `Stmt::TryCatch`.
     ///
     /// Grammar shape (per `ruby.grammar`):
     /// ```text
@@ -3066,10 +3093,11 @@ impl Lowerer {
     /// ensure_clause   = "ensure" { !"end" statement } ;
     /// ```
     ///
-    /// **v0 lossy lowering** — SIR has no exception-handling primitive.
-    /// We lower body, rescue, and ensure blocks INLINE (concatenated)
-    /// with synthetic `BuiltinCall` markers bracketing each rescue and
-    /// ensure section so downstream emitters can detect the form:
+    /// **Phase 16a (FC)** — the body, each `rescue_clause`, and the
+    /// optional `ensure_clause` lower into a first-class
+    /// `Stmt::TryCatch { body, rescues, ensure_body }` (semantic-ir
+    /// 0.9.0), replacing the Phase 6v inline `__rescue_marker__` /
+    /// `__ensure_marker__` placeholder builtins:
     ///
     /// ```text
     /// begin
@@ -3081,58 +3109,62 @@ impl Lowerer {
     /// end
     /// ```
     ///
-    /// → SIR sequence:
+    /// →
     ///
     /// ```text
-    /// body_stmts...
-    /// ExprStmt(BuiltinCall("__rescue_marker__", [
-    ///     StrLit("StandardError,IOError"),
-    ///     StrLit("e"),
-    /// ]))
-    /// rescue_stmts...
-    /// ExprStmt(BuiltinCall("__ensure_marker__", []))
-    /// ensure_stmts...
+    /// TryCatch {
+    ///   body:    [body_stmts…],
+    ///   rescues: [RescueClause {
+    ///       exception_types: ["StandardError", "IOError"],
+    ///       binding: Some("e"),
+    ///       body: [rescue_stmts…],
+    ///   }],
+    ///   ensure_body: Some([ensure_stmts…]),
+    /// }
     /// ```
     ///
-    /// Semantics: the body always runs.  Without a real try/catch
-    /// primitive, the rescue body is unreachable in the SIR model
-    /// (exceptions can't propagate through SIR's effect lattice in
-    /// v0).  The ensure body runs unconditionally after the rescue
-    /// section (same effect as a plain sequence under "no exception"
-    /// semantics).  Downstream emitters that target languages with
-    /// real exceptions can re-stitch the form via the marker
-    /// `BuiltinCall`s; this is documented as a deferred limitation.
-    ///
-    /// `__rescue_marker__` and `__ensure_marker__` carry the
-    /// `Effect::MayThrow` tag so the validator allows exception-aware
-    /// programs without forcing the user to declare extra features.
+    /// Emitting it requests `Feature::Exceptions`.  The function returns
+    /// a one-element `Vec<Stmt>` (the `TryCatch`) so its call site — which
+    /// flattens statement lists — stays uniform with the other
+    /// multi-statement lowerings.
     fn lower_begin_statement(
         &mut self,
         node: &GrammarASTNode,
     ) -> Result<Vec<Stmt>, RubyLowerError> {
-        let mut out: Vec<Stmt> = Vec::new();
+        // Phase 16a (FC): `begin/rescue/ensure/end` now lowers to a
+        // first-class `Stmt::TryCatch` (replacing the Phase 6v inline
+        // `__rescue_marker__`/`__ensure_marker__` placeholder builtins).
         let outer_span = self.span_of(node);
+        self.features_used.insert(Feature::Exceptions);
 
-        // 1. Lower the body statements (direct `statement` children of
-        //    `begin_statement`).  The grammar's negative-lookahead
-        //    repetition stops collection at the first rescue/ensure/end,
-        //    so direct `statement` children are exactly the body.
-        for child in &node.children {
-            if let ASTNodeOrToken::Node(n) = child {
-                if n.rule_name == "statement" {
-                    if let Some(inner) = self.first_node_child(n) {
-                        out.extend(self.lower_statement_inner_multi(inner)?);
+        // Helper: lower the direct `statement` children of a node into a
+        // flat `Vec<Stmt>` (the negative-lookahead grammar repetition
+        // ensures these are exactly the relevant block's statements).
+        let lower_body = |this: &mut Self, n: &GrammarASTNode| -> Result<Vec<Stmt>, RubyLowerError> {
+            let mut body = Vec::new();
+            for cc in &n.children {
+                if let ASTNodeOrToken::Node(nn) = cc {
+                    if nn.rule_name == "statement" {
+                        if let Some(inner) = this.first_node_child(nn) {
+                            body.extend(this.lower_statement_inner_multi(inner)?);
+                        }
                     }
                 }
             }
-        }
+            Ok(body)
+        };
 
-        // 2. Process each rescue_clause in order.
+        // 1. The try body: direct `statement` children of `begin_statement`.
+        let body = lower_body(self, node)?;
+
+        // 2. Each rescue_clause, in source order.
+        let mut rescues: Vec<RescueClause> = Vec::new();
         for child in &node.children {
             if let ASTNodeOrToken::Node(n) = child {
                 if n.rule_name == "rescue_clause" {
-                    // Collect the exception type list (if present).
-                    let exc_list = n
+                    // Exception class names (`rescue Foo, Bar`) — the
+                    // `exception_list` node holds them as Name tokens.
+                    let exception_types: Vec<String> = n
                         .children
                         .iter()
                         .find_map(|c| match c {
@@ -3150,103 +3182,57 @@ impl Lowerer {
                                     ASTNodeOrToken::Token(t)
                                         if t.type_ == TokenType::Name =>
                                     {
-                                        Some(t.value.as_str())
+                                        Some(t.value.clone())
                                     }
                                     _ => None,
                                 })
                                 .collect::<Vec<_>>()
-                                .join(",")
                         })
                         .unwrap_or_default();
-                    // Find the exception variable name (after `=>`).
-                    // The grammar `[ "=>" NAME ]` puts both inside the
-                    // rescue_clause's direct token children.  Walk to
-                    // find the `=>` token, then take the next Name.
-                    let var_name: String = {
+                    // Optional binding (`=> e`): the Name token after the
+                    // `=>` token among the clause's direct children.
+                    let binding: Option<String> = {
                         let mut saw_arrow = false;
                         let mut found: Option<String> = None;
                         for cc in &n.children {
                             if let ASTNodeOrToken::Token(t) = cc {
                                 if t.value == "=>" {
                                     saw_arrow = true;
-                                } else if saw_arrow
-                                    && t.type_ == TokenType::Name
-                                {
+                                } else if saw_arrow && t.type_ == TokenType::Name {
                                     found = Some(t.value.clone());
                                     break;
                                 }
                             }
                         }
-                        found.unwrap_or_default()
+                        found
                     };
-                    // Emit the marker.
-                    out.push(Stmt::ExprStmt {
-                        expr: Expr::BuiltinCall {
-                            name: "__rescue_marker__".to_string(),
-                            args: vec![
-                                Expr::StrLit {
-                                    value: exc_list,
-                                    span: outer_span.clone(),
-                                },
-                                Expr::StrLit {
-                                    value: var_name,
-                                    span: outer_span.clone(),
-                                },
-                            ],
-                            effects: EffectSet::PURE.with(Effect::MayThrow),
-                            span: outer_span.clone(),
-                        },
-                        span: outer_span.clone(),
+                    let rescue_body = lower_body(self, n)?;
+                    rescues.push(RescueClause {
+                        exception_types,
+                        binding,
+                        body: rescue_body,
+                        span: self.span_of(n),
                     });
-                    // Strings feature is required because we emit StrLits.
-                    self.features_used.insert(Feature::Strings);
-                    // Lower the rescue body's statements inline.
-                    for cc in &n.children {
-                        if let ASTNodeOrToken::Node(nn) = cc {
-                            if nn.rule_name == "statement" {
-                                if let Some(inner) = self.first_node_child(nn)
-                                {
-                                    out.extend(
-                                        self.lower_statement_inner_multi(inner)?,
-                                    );
-                                }
-                            }
-                        }
-                    }
                 }
             }
         }
 
-        // 3. Process the optional ensure_clause.
+        // 3. Optional ensure_clause.
+        let mut ensure_body: Option<Vec<Stmt>> = None;
         for child in &node.children {
             if let ASTNodeOrToken::Node(n) = child {
                 if n.rule_name == "ensure_clause" {
-                    out.push(Stmt::ExprStmt {
-                        expr: Expr::BuiltinCall {
-                            name: "__ensure_marker__".to_string(),
-                            args: vec![],
-                            effects: EffectSet::PURE.with(Effect::MayThrow),
-                            span: outer_span.clone(),
-                        },
-                        span: outer_span.clone(),
-                    });
-                    for cc in &n.children {
-                        if let ASTNodeOrToken::Node(nn) = cc {
-                            if nn.rule_name == "statement" {
-                                if let Some(inner) = self.first_node_child(nn)
-                                {
-                                    out.extend(
-                                        self.lower_statement_inner_multi(inner)?,
-                                    );
-                                }
-                            }
-                        }
-                    }
+                    ensure_body = Some(lower_body(self, n)?);
                 }
             }
         }
 
-        Ok(out)
+        Ok(vec![Stmt::TryCatch {
+            body,
+            rescues,
+            ensure_body,
+            span: outer_span,
+        }])
     }
 
     // -------------------------------------------------------------------

--- a/code/packages/rust/semantic-ir-to-go/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/emit.rs
@@ -197,6 +197,12 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
         Stmt::SingletonClassDef { span, .. } => {
             panic!("go backend reached SIR17 singleton-class-def statement at {} — capability check should have rejected it", span);
         }
+        // SIR17 (exceptions) — `Feature::Exceptions` is not accepted by
+        // this backend, so a try/catch-using module is rejected by the
+        // capability check before emit.  Unreachable.
+        Stmt::TryCatch { span, .. } => {
+            panic!("go backend reached SIR17 try-catch statement at {} — capability check should have rejected it", span);
+        }
     }
 }
 

--- a/code/packages/rust/semantic-ir-to-python/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/emit.rs
@@ -185,6 +185,9 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
         Stmt::SingletonClassDef { span, .. } => {
             panic!("python backend reached SIR17 singleton-class-def statement at {} — capability check should have rejected it", span);
         }
+        Stmt::TryCatch { span, .. } => {
+            panic!("python backend reached SIR17 try-catch statement at {} — capability check should have rejected it", span);
+        }
     }
 }
 
@@ -406,6 +409,9 @@ fn emit_block_as_expr(out: &mut String, b: &Block, indent: usize) {
             }
             Stmt::SingletonClassDef { span, .. } => {
                 panic!("python backend (walrus path) reached SIR17 singleton-class-def statement at {} — capability check should have rejected it", span);
+            }
+            Stmt::TryCatch { span, .. } => {
+                panic!("python backend (walrus path) reached SIR17 try-catch statement at {} — capability check should have rejected it", span);
             }
         }
     }

--- a/code/packages/rust/semantic-ir-to-rust/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/emit.rs
@@ -192,6 +192,9 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
         Stmt::SingletonClassDef { span, .. } => {
             panic!("rust backend reached SIR17 singleton-class-def statement at {} — capability check should have rejected it", span);
         }
+        Stmt::TryCatch { span, .. } => {
+            panic!("rust backend reached SIR17 try-catch statement at {} — capability check should have rejected it", span);
+        }
     }
 }
 
@@ -541,6 +544,9 @@ fn emit_stmt_inline(out: &mut String, s: &Stmt, indent: usize) {
         }
         Stmt::SingletonClassDef { span, .. } => {
             panic!("rust backend (inline) reached SIR17 singleton-class-def statement at {} — capability check should have rejected it", span);
+        }
+        Stmt::TryCatch { span, .. } => {
+            panic!("rust backend (inline) reached SIR17 try-catch statement at {} — capability check should have rejected it", span);
         }
     }
 }

--- a/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
@@ -169,6 +169,9 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
         Stmt::SingletonClassDef { span, .. } => {
             panic!("ts backend reached SIR17 singleton-class-def statement at {} — capability check should have rejected it", span);
         }
+        Stmt::TryCatch { span, .. } => {
+            panic!("ts backend reached SIR17 try-catch statement at {} — capability check should have rejected it", span);
+        }
     }
 }
 

--- a/code/packages/rust/semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 All notable changes to the `semantic-ir` crate are documented here.
 
+## 0.9.0 — SIR17: structured exception handling (`Stmt::TryCatch`)
+
+Introduced by the Ruby frontend's Phase 16a (`begin/rescue/ensure/end`).
+
+### Added
+
+- `Stmt::TryCatch { body, rescues, ensure_body, span }` — a first-class
+  exception-handling statement that replaces the earlier
+  `__rescue_marker__` / `__ensure_marker__` inline `BuiltinCall`
+  placeholders.  `body` and `ensure_body` are bare statement lists (like
+  `ClassDef.body`); `ensure_body` is `Option`al.
+- `RescueClause { exception_types, binding, body, span }` — one `rescue`
+  clause.  `exception_types` is a list of advisory class names (empty =
+  bare catch-all, not resolved by the validator); `binding` is the
+  optional `=> e` exception variable, in scope as a `Scope::Local`
+  within that clause's `body` only.
+- `Feature::Exceptions` (kebab `exceptions`) — declared by any module
+  containing a `TryCatch`.  Backends that don't accept it reject the
+  module at the capability check before emit.
+
+### Changed
+
+- `Stmt::span()`, the walker, the validator (`check_stmt_seq`), the text
+  printer (`(try-catch … (rescue (types …) (bind …) …) (ensure …))`),
+  `backend::walk_intrinsics_in_stmt`, and all four reference backends'
+  statement-emit match gain a `Stmt::TryCatch` arm.  The validator walks
+  the body, each rescue body (with the binding introduced as a local),
+  and the ensure body in fresh local-env scopes; the backend arms are
+  unreachable `panic!`s (rejected pre-emit by the capability check).
+
+New tests (4): `print_try_catch_with_rescue_and_ensure`,
+`try_catch_validates_and_binding_is_in_scope`,
+`try_catch_without_manifest_feature_is_error`,
+`try_catch_binding_does_not_leak_past_rescue`.  Test count: 102 → 106.
+
+This is a **breaking enum change** for any exhaustive `match` on `Stmt`
+without a `_` rest arm.
+
 ## 0.8.0 — SIR17: constant scope (`Scope::Const`)
 
 Introduced by the Ruby frontend's Phase 15c (`FOO` / `MyClass`).

--- a/code/packages/rust/semantic-ir/src/backend.rs
+++ b/code/packages/rust/semantic-ir/src/backend.rs
@@ -242,6 +242,23 @@ where
                 walk_intrinsics_in_stmt(s, f, depth + 1);
             }
         }
+        Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+            // Recurse into the try body, each rescue body, and the
+            // optional ensure body (Ruby Phase 16a).
+            for s in body {
+                walk_intrinsics_in_stmt(s, f, depth + 1);
+            }
+            for r in rescues {
+                for s in &r.body {
+                    walk_intrinsics_in_stmt(s, f, depth + 1);
+                }
+            }
+            if let Some(ens) = ensure_body {
+                for s in ens {
+                    walk_intrinsics_in_stmt(s, f, depth + 1);
+                }
+            }
+        }
     }
 }
 

--- a/code/packages/rust/semantic-ir/src/lib.rs
+++ b/code/packages/rust/semantic-ir/src/lib.rs
@@ -66,7 +66,7 @@ pub use manifest::{Feature, FeatureManifest};
 pub use metadata::{Metadata, CURRENT_SIR_VERSION};
 pub use nodes::{
     Block, Capture, CaptureValue, ExportName, Expr, Function, Global, Import, ImportName, Module,
-    Param, Scope, Stmt,
+    Param, RescueClause, Scope, Stmt,
 };
 pub use span::Span;
 pub use text::{print_block, print_expr, print_function, print_module};

--- a/code/packages/rust/semantic-ir/src/manifest.rs
+++ b/code/packages/rust/semantic-ir/src/manifest.rs
@@ -70,6 +70,11 @@ pub enum Feature {
     /// Like instance/class vars, a constant reference needs no prior
     /// `let` declaration; it resolves against the constant scope.
     Constants,
+    /// Module uses structured exception handling (`Stmt::TryCatch`,
+    /// Ruby `begin/rescue/ensure/end`).  Phase 16a (Ruby).  Replaces the
+    /// earlier `__rescue_marker__`/`__ensure_marker__` placeholder
+    /// builtins with a first-class node.
+    Exceptions,
 }
 
 impl Feature {
@@ -96,6 +101,7 @@ impl Feature {
         Feature::InstanceVars,
         Feature::ClassVars,
         Feature::Constants,
+        Feature::Exceptions,
     ];
 
     /// Kebab-case name for the SIR text format.
@@ -122,6 +128,7 @@ impl Feature {
             Feature::InstanceVars => "instance-vars",
             Feature::ClassVars => "class-vars",
             Feature::Constants => "constants",
+            Feature::Exceptions => "exceptions",
         }
     }
 

--- a/code/packages/rust/semantic-ir/src/nodes.rs
+++ b/code/packages/rust/semantic-ir/src/nodes.rs
@@ -158,6 +158,28 @@ pub struct Block {
     pub span: Span,
 }
 
+/// One `rescue` clause of a [`Stmt::TryCatch`] (SIR17, Ruby Phase 16a).
+///
+/// A `begin … rescue … end` may carry several `rescue` clauses, each
+/// matching a (possibly empty) set of exception classes and optionally
+/// binding the caught exception to a local.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RescueClause {
+    /// Exception class names this clause matches (`rescue Foo, Bar`).
+    /// **Empty** means a bare `rescue` (catch-all).  These are advisory
+    /// names only: SIR v0 has no exception-class symbol table, so the
+    /// validator does not resolve them (mirroring `ClassDef.superclass`).
+    pub exception_types: Vec<String>,
+    /// Optional binding for the caught exception (`rescue … => e`).
+    /// When `Some`, the name is in scope as a `Scope::Local` within
+    /// `body` only.
+    pub binding: Option<String>,
+    /// The clause body, a bare statement list (no trailing value slot,
+    /// like `ClassDef.body`).
+    pub body: Vec<Stmt>,
+    pub span: Span,
+}
+
 /// Statement kinds.
 ///
 /// SIR v0 had only `LetBinding`, `LetStarBinding`, and `ExprStmt`.
@@ -296,6 +318,27 @@ pub enum Stmt {
         body: Vec<Stmt>,
         span: Span,
     },
+
+    // ── SIR17: exception handling ──────────────────────────────────
+    /// `begin; body; rescue …; ensure …; end` — structured exception
+    /// handling.  Introduced by the Ruby frontend's Phase 16a, which
+    /// replaces the earlier `__rescue_marker__` / `__ensure_marker__`
+    /// inline `BuiltinCall` placeholders with this first-class node.
+    ///
+    /// - `body` runs first (a bare statement list, like `ClassDef.body`).
+    /// - `rescues` are tried in order if `body` raises; each
+    ///   [`RescueClause`] matches a set of exception classes and may
+    ///   bind the exception.
+    /// - `ensure_body`, when `Some`, runs unconditionally afterwards.
+    ///
+    /// Gated by `Feature::Exceptions`; backends that don't accept it
+    /// reject the module at the capability check before emit.
+    TryCatch {
+        body: Vec<Stmt>,
+        rescues: Vec<RescueClause>,
+        ensure_body: Option<Vec<Stmt>>,
+        span: Span,
+    },
 }
 
 impl Stmt {
@@ -313,6 +356,7 @@ impl Stmt {
             Stmt::ClassDef { span, .. } => span,
             Stmt::ModuleDef { span, .. } => span,
             Stmt::SingletonClassDef { span, .. } => span,
+            Stmt::TryCatch { span, .. } => span,
         }
     }
 }

--- a/code/packages/rust/semantic-ir/src/text/printer.rs
+++ b/code/packages/rust/semantic-ir/src/text/printer.rs
@@ -261,6 +261,39 @@ fn print_stmt(out: &mut String, s: &Stmt, indent: usize, depth: usize) {
             }
             out.push(')');
         }
+        Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+            // `(try-catch <body…> (rescue …) … (ensure …))` — exception
+            // handling (Ruby Phase 16a).  Each clause prints on its own
+            // indented line.
+            out.push_str("(try-catch");
+            for inner in body {
+                let _ = write!(out, "\n{}  ", " ".repeat(indent));
+                print_stmt(out, inner, indent + 2, depth + 1);
+            }
+            for r in rescues {
+                let _ = write!(out, "\n{}  (rescue", " ".repeat(indent));
+                if !r.exception_types.is_empty() {
+                    let _ = write!(out, " (types {})", r.exception_types.join(" "));
+                }
+                if let Some(bind) = &r.binding {
+                    let _ = write!(out, " (bind {})", bind);
+                }
+                for inner in &r.body {
+                    let _ = write!(out, "\n{}    ", " ".repeat(indent));
+                    print_stmt(out, inner, indent + 4, depth + 1);
+                }
+                out.push(')');
+            }
+            if let Some(ens) = ensure_body {
+                let _ = write!(out, "\n{}  (ensure", " ".repeat(indent));
+                for inner in ens {
+                    let _ = write!(out, "\n{}    ", " ".repeat(indent));
+                    print_stmt(out, inner, indent + 4, depth + 1);
+                }
+                out.push(')');
+            }
+            out.push(')');
+        }
     }
 }
 
@@ -870,5 +903,43 @@ mod tests {
             "expected `(class-def Foo (< Bar))` in output, got:\n{}",
             out
         );
+    }
+
+    #[test]
+    fn print_try_catch_with_rescue_and_ensure() {
+        // Ruby Phase 16a: `begin … rescue Foo => e … ensure … end` prints
+        // a `(try-catch …)` head with `(rescue (types …) (bind …) …)` and
+        // `(ensure …)` clauses.
+        let s_ = s();
+        let lb = |name: &str| Stmt::LetBinding {
+            name: name.into(),
+            sir_type: None,
+            value: Expr::IntLit { value: 1, span: s_.clone() },
+            span: s_.clone(),
+        };
+        let block = Block {
+            stmts: vec![Stmt::TryCatch {
+                body: vec![lb("x")],
+                rescues: vec![crate::nodes::RescueClause {
+                    exception_types: vec!["StandardError".into()],
+                    binding: Some("e".into()),
+                    body: vec![lb("y")],
+                    span: s_.clone(),
+                }],
+                ensure_body: Some(vec![lb("z")]),
+                span: s_.clone(),
+            }],
+            value: Expr::NilLit { span: s_.clone() },
+            span: s_,
+        };
+        let mut out = String::new();
+        print_block(&mut out, &block, 0);
+        assert!(out.contains("(try-catch"), "expected try-catch head, got:\n{}", out);
+        assert!(
+            out.contains("(rescue (types StandardError) (bind e)"),
+            "expected rescue clause, got:\n{}",
+            out
+        );
+        assert!(out.contains("(ensure"), "expected ensure clause, got:\n{}", out);
     }
 }

--- a/code/packages/rust/semantic-ir/src/validator.rs
+++ b/code/packages/rust/semantic-ir/src/validator.rs
@@ -409,6 +409,37 @@ impl<'m> ValidatorState<'m> {
                     env.rewind(singleton_mark);
                     i += 1;
                 }
+                Stmt::TryCatch { body, rescues, ensure_body, span } => {
+                    // Structured exception handling (Ruby Phase 16a).
+                    // Mark Feature::Exceptions, then depth-guard and walk
+                    // each block in a fresh local-env scope so block-local
+                    // names don't leak into the surrounding stream.  A
+                    // rescue's exception binding (`=> e`) is in scope for
+                    // that clause's body only.  Exception class names are
+                    // advisory (no symbol table), so they are not resolved.
+                    self.observed.add(Feature::Exceptions);
+                    if self.check_depth(depth, span) {
+                        i += 1;
+                        continue;
+                    }
+                    let body_mark = env.mark();
+                    self.check_stmt_seq(body, env, depth + 1);
+                    env.rewind(body_mark);
+                    for r in rescues {
+                        let rescue_mark = env.mark();
+                        if let Some(bind) = &r.binding {
+                            env.add_local(bind.clone());
+                        }
+                        self.check_stmt_seq(&r.body, env, depth + 1);
+                        env.rewind(rescue_mark);
+                    }
+                    if let Some(ens) = ensure_body {
+                        let ensure_mark = env.mark();
+                        self.check_stmt_seq(ens, env, depth + 1);
+                        env.rewind(ensure_mark);
+                    }
+                    i += 1;
+                }
             }
         }
     }
@@ -1629,5 +1660,110 @@ mod tests {
         let r = validate(&m);
         assert!(!r.is_ok(), "expected missing-Constants-feature error");
         assert!(r.errors().any(|i| i.message.contains("constants")));
+    }
+
+    // -----------------------------------------------------------------
+    // SIR17 Phase 16a — `Stmt::TryCatch` (exception handling).
+    // -----------------------------------------------------------------
+
+    /// Build a one-function module whose body is a single `TryCatch`
+    /// (`begin; let _t=1; rescue Foo => e; let _r=e; ensure; let _e=1;
+    /// end`), declaring the given features.  The rescue body references
+    /// the bound exception `e`, exercising the binding's scope.
+    fn module_with_try_catch(features: &[Feature]) -> Module {
+        let mut m = empty_module(FeatureManifest::from_features(features));
+        let lb = |name: &str, value: Expr| Stmt::LetBinding {
+            name: name.into(),
+            sir_type: None,
+            value,
+            span: s(),
+        };
+        m.functions.push(Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![Stmt::TryCatch {
+                    body: vec![lb("_t", Expr::IntLit { value: 1, span: s() })],
+                    rescues: vec![RescueClause {
+                        exception_types: vec!["Foo".into()],
+                        binding: Some("e".into()),
+                        // The rescue body reads the bound `e` — must resolve.
+                        body: vec![lb(
+                            "_r",
+                            Expr::VarRef { name: "e".into(), scope: Scope::Local, span: s() },
+                        )],
+                        span: s(),
+                    }],
+                    ensure_body: Some(vec![lb("_e", Expr::IntLit { value: 1, span: s() })]),
+                    span: s(),
+                }],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        });
+        m
+    }
+
+    #[test]
+    fn try_catch_validates_and_binding_is_in_scope() {
+        // A try/catch validates when the manifest declares `Exceptions`,
+        // and the rescue binding `e` resolves inside the rescue body.
+        let m = module_with_try_catch(&[Feature::Exceptions]);
+        let r = validate(&m);
+        assert!(r.is_ok(), "expected ok, got {:?}", r.issues);
+    }
+
+    #[test]
+    fn try_catch_without_manifest_feature_is_error() {
+        // The validator observes `Exceptions` from the TryCatch; if the
+        // manifest doesn't declare it, the used-but-undeclared check fires.
+        let m = module_with_try_catch(&[]);
+        let r = validate(&m);
+        assert!(!r.is_ok(), "expected missing-Exceptions-feature error");
+        assert!(r.errors().any(|i| i.message.contains("exceptions")));
+    }
+
+    #[test]
+    fn try_catch_binding_does_not_leak_past_rescue() {
+        // The rescue binding `e` is scoped to its clause body only — a
+        // reference to `e` in the ensure body is undefined.
+        let mut m = empty_module(FeatureManifest::from_features(&[Feature::Exceptions]));
+        m.functions.push(Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![Stmt::TryCatch {
+                    body: vec![],
+                    rescues: vec![RescueClause {
+                        exception_types: vec![],
+                        binding: Some("e".into()),
+                        body: vec![],
+                        span: s(),
+                    }],
+                    // ensure references `e` — out of scope → error.
+                    ensure_body: Some(vec![Stmt::LetBinding {
+                        name: "_x".into(),
+                        sir_type: None,
+                        value: Expr::VarRef { name: "e".into(), scope: Scope::Local, span: s() },
+                        span: s(),
+                    }]),
+                    span: s(),
+                }],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        });
+        let r = validate(&m);
+        assert!(!r.is_ok(), "expected `e` out-of-scope error in ensure body");
     }
 }

--- a/code/packages/rust/semantic-ir/src/walker.rs
+++ b/code/packages/rust/semantic-ir/src/walker.rs
@@ -143,6 +143,24 @@ pub fn walk_stmt_default<V: Visitor>(v: &mut V, s: &Stmt) {
                 v.visit_stmt(stmt);
             }
         }
+        Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+            // Exception handling (Ruby Phase 16a): recurse into the try
+            // body, each rescue clause's body, and the optional ensure
+            // body, so visitors see every nested statement.
+            for stmt in body {
+                v.visit_stmt(stmt);
+            }
+            for r in rescues {
+                for stmt in &r.body {
+                    v.visit_stmt(stmt);
+                }
+            }
+            if let Some(ens) = ensure_body {
+                for stmt in ens {
+                    v.visit_stmt(stmt);
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Phase 16a (FC) — `begin/rescue/ensure/end` → `Stmt::TryCatch`

Replaces the Phase 6v inline `__rescue_marker__` / `__ensure_marker__`
placeholder builtins with a **first-class `Stmt::TryCatch`** node. This
is the first Tier-1 exception-handling phase. **No grammar change** —
`begin_statement` has parsed since Phase 6v.

### `semantic-ir` 0.9.0 (new SIR node + feature)

- **`Stmt::TryCatch { body, rescues, ensure_body, span }`** — `body` and
  `ensure_body` are bare statement lists (like `ClassDef.body`);
  `ensure_body` is `Option`al.
- **`RescueClause { exception_types, binding, body, span }`** — one
  `rescue` clause. `exception_types` is a list of advisory class names
  (empty = bare catch-all, not resolved by the validator); `binding` is
  the optional `=> e` variable, in scope as a `Scope::Local` within that
  clause's `body` only.
- **`Feature::Exceptions`** (kebab `exceptions`) — backends that don't
  accept it reject the module at the capability check before emit.
- Wired through every `Stmt` match site: `span()`, walker, validator
  (`check_stmt_seq`), printer
  (`(try-catch … (rescue (types …) (bind …) …) (ensure …))`),
  `backend::walk_intrinsics_in_stmt`, and all four reference backends'
  emit (unreachable `panic!`, gated by capability check). The validator
  walks the body, each rescue body (binding introduced as a local), and
  the ensure body in fresh local-env scopes.
- New tests (+4): printer + 3 validator (validate + binding-scope,
  missing-feature error, binding-does-not-leak-past-rescue). 102 → 106.

> ⚠️ **Breaking enum change** for any exhaustive `match` on `Stmt`
> without a `_` rest arm.

### `ruby-to-semantic-ir` 0.49.0 (lowering)

- `lower_begin_statement` now builds a single `Stmt::TryCatch` (extracting
  exception class names, the `=> e` binding, and each clause body),
  requesting `Feature::Exceptions` — no more `Effect::MayThrow`-tagged
  marker builtins.
- `block_references_any_name` gains a `TryCatch` arm.
- The four Phase 6v marker tests were rewritten to the `TryCatch`
  contract, plus a new validator E2E (`begin_rescue_passes_sir_validator`).
  222 → 223.

### Verification

All green locally:
`cargo test -p semantic-ir -p coding-adventures-ruby-parser -p ruby-to-semantic-ir`
(semantic-ir 106, parser 176, lowerer 223).

### Security

Pure logic over the AST/IR — no I/O, no `unsafe`, no deserialization;
recursion is depth-guarded at the validator/printer/backend. The
`/security-review` sub-agent passed clean in one round.
