### PR TITLE
feat(ruby-fc): Phase 16b — typed / multi-type / multi-clause rescue

### DIFF
--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.47.0] - 2026-05-30
+
+### Added (Phase 16b (FC) — typed / multi-type / multi-clause rescue)
+
+No grammar change — the `rescue_clause` /  `exception_list` rules
+(`rescue ExceptionType[, OtherType] => var`) already parse these forms
+(Phase 6v).  Phase 16b adds parse pins for the typed and multi-clause
+shapes that the Phase 16a `Stmt::TryCatch` lowering relies on:
+
+- `test_parse_begin_multi_type_rescue` — `rescue Foo, Bar => e` parses
+  with an `exception_list` carrying both class Name tokens plus the `=>`
+  binding.
+- `test_parse_begin_multiple_rescue_clauses` — two `rescue` clauses
+  parse as two distinct `rescue_clause` nodes under the begin_statement.
+
+Test count: 176 → 178 (+2).
+
 ## [0.46.0] - 2026-05-30
 
 ### Added (Phase 15d (FC) — scope-resolution operator `Foo::Bar`)

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -2440,6 +2440,46 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_begin_multi_type_rescue() {
+        // Phase 16b — `rescue Foo, Bar => e` parses with an
+        // `exception_list` carrying BOTH class Name tokens.
+        let ast = parse_ruby(
+            "begin\n  x = 1\nrescue Foo, Bar => e\n  y = 2\nend",
+        );
+        let rc = find_descendant(&ast, "rescue_clause")
+            .expect("expected rescue_clause");
+        let el = find_descendant(rc, "exception_list")
+            .expect("expected exception_list");
+        assert!(tree_has_token_value(el, "Foo"), "expected `Foo` exception type");
+        assert!(tree_has_token_value(el, "Bar"), "expected `Bar` exception type");
+        assert!(tree_has_token_value(rc, "=>"), "expected `=>` token");
+        assert!(tree_has_token_value(rc, "e"), "expected binding `e`");
+    }
+
+    #[test]
+    fn test_parse_begin_multiple_rescue_clauses() {
+        // Phase 16b — two `rescue` clauses parse as two distinct
+        // `rescue_clause` nodes under the begin_statement.
+        let ast = parse_ruby(concat!(
+            "begin\n",
+            "  x = 1\n",
+            "rescue TypeError => e\n",
+            "  y = 2\n",
+            "rescue NameError => f\n",
+            "  z = 3\n",
+            "end",
+        ));
+        let b = find_descendant(&ast, "begin_statement")
+            .expect("expected begin_statement node");
+        let clause_count = b
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "rescue_clause"))
+            .count();
+        assert_eq!(clause_count, 2, "expected two rescue_clause nodes; got {}", clause_count);
+    }
+
+    #[test]
     fn test_parse_begin_with_ensure() {
         let ast = parse_ruby("begin\n  x = 1\nensure\n  cleanup = 1\nend");
         let b = find_descendant(&ast, "begin_statement")

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.50.0] - 2026-05-30
+
+### Added (Phase 16b (FC) — typed / multi-type / multi-clause rescue)
+
+Hardening of the Phase 16a `Stmt::TryCatch` lowering — no code change,
+the 16a `RescueClause` plumbing already handles these forms.  Phase 16b
+locks the behaviour in with dedicated tests:
+
+- `rescue_multi_type_lowers_all_exception_types` — `rescue Foo, Bar => e`
+  lowers to one `RescueClause` whose `exception_types` lists both classes
+  in source order, with binding `e`.
+- `multiple_rescue_clauses_lower_to_separate_clauses` — two `rescue`
+  clauses lower to two `RescueClause`s, each with its own exception type
+  and binding, in source order.
+- `multi_clause_rescue_passes_sir_validator` (E2E) — each clause's
+  binding resolves inside its own body, confirming per-clause scope.
+
+Test count: 223 → 226 (+3).
+
 ## [0.49.0] - 2026-05-30
 
 ### Changed (Phase 16a (FC) — `begin/rescue/ensure/end` → `Stmt::TryCatch`)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -3599,6 +3599,73 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
+    // Phase 16b (FC) — typed / multi-type / multi-clause rescue.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn rescue_multi_type_lowers_all_exception_types() {
+        // `rescue Foo, Bar => e` → one RescueClause whose exception_types
+        // lists BOTH classes, in source order.
+        let m = lower("begin\n  x = 1\nrescue Foo, Bar => e\n  y = 2\nend\n");
+        let b = main_body(&m);
+        match &b.stmts[0] {
+            Stmt::TryCatch { rescues, .. } => {
+                assert_eq!(rescues.len(), 1);
+                assert_eq!(
+                    rescues[0].exception_types,
+                    vec!["Foo".to_string(), "Bar".to_string()],
+                    "both exception classes preserved in order"
+                );
+                assert_eq!(rescues[0].binding.as_deref(), Some("e"));
+            }
+            other => panic!("expected Stmt::TryCatch, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn multiple_rescue_clauses_lower_to_separate_clauses() {
+        // Two `rescue` clauses → two RescueClauses, each with its own
+        // exception type and binding, in source order.
+        let m = lower(concat!(
+            "begin\n",
+            "  x = 1\n",
+            "rescue TypeError => e\n",
+            "  y = 2\n",
+            "rescue NameError => f\n",
+            "  z = 3\n",
+            "end\n",
+        ));
+        let b = main_body(&m);
+        match &b.stmts[0] {
+            Stmt::TryCatch { rescues, .. } => {
+                assert_eq!(rescues.len(), 2, "two rescue clauses");
+                assert_eq!(rescues[0].exception_types, vec!["TypeError".to_string()]);
+                assert_eq!(rescues[0].binding.as_deref(), Some("e"));
+                assert_eq!(rescues[1].exception_types, vec!["NameError".to_string()]);
+                assert_eq!(rescues[1].binding.as_deref(), Some("f"));
+            }
+            other => panic!("expected Stmt::TryCatch, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn multi_clause_rescue_passes_sir_validator() {
+        // E2E: a begin with two typed rescue clauses (each binding used in
+        // its own body) validates, confirming per-clause binding scope.
+        let m = lower(concat!(
+            "begin\n",
+            "  x = 1\n",
+            "rescue TypeError => e\n",
+            "  y = e\n",
+            "rescue NameError => f\n",
+            "  z = f\n",
+            "end\n",
+        ));
+        let result = semantic_ir::validate(&m);
+        assert!(result.is_ok(), "validator rejected multi-clause rescue: {:?}", result);
+    }
+
+    // -----------------------------------------------------------------
     // Phase 6u — `case … when … else … end`
     // -----------------------------------------------------------------
     //


### PR DESCRIPTION
## Phase 16b (FC) — typed / multi-type / multi-clause rescue

Hardening of the Phase 16a `Stmt::TryCatch` lowering. The 16a
`RescueClause` plumbing already handles the typed (`rescue Foo => e`),
multi-type (`rescue Foo, Bar => e`), and multiple-clause begin forms —
this phase **locks that behaviour in with dedicated tests**. No grammar
change (these forms parse since Phase 6v) and **no lowerer/SIR code
change**.

### `ruby-parser` 0.47.0

- `test_parse_begin_multi_type_rescue` — `rescue Foo, Bar => e` parses
  with an `exception_list` carrying both class Name tokens plus the `=>`
  binding.
- `test_parse_begin_multiple_rescue_clauses` — two `rescue` clauses parse
  as two distinct `rescue_clause` nodes. 176 → 178.

### `ruby-to-semantic-ir` 0.50.0

- `rescue_multi_type_lowers_all_exception_types` — `rescue Foo, Bar => e`
  → one `RescueClause` with `exception_types == ["Foo", "Bar"]` (source
  order) and binding `e`.
- `multiple_rescue_clauses_lower_to_separate_clauses` — two clauses → two
  `RescueClause`s, each with its own type + binding.
- `multi_clause_rescue_passes_sir_validator` (E2E) — each clause's
  binding resolves inside its own body, confirming per-clause scope.
  223 → 226.

### Note

Bare typed rescue **without** a binding (`rescue Foo`) remains deferred —
a documented PEG ambiguity with a NAME-led body statement (e.g.
`rescue x = 2`). The workaround is `rescue Foo => _`.

### Verification

All green locally:
`cargo test -p coding-adventures-ruby-lexer -p coding-adventures-ruby-parser -p ruby-to-semantic-ir`
(parser 178, lowerer 226).

### Security

Test-only change — no production code touched. `/security-review` passed
clean in one round.
