### PR TITLE
feat(ruby-fc): Phase 16c — ensure clause coverage / hardening

### DIFF
--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.48.0] - 2026-05-30
+
+### Added (Phase 16c (FC) — `ensure` clause coverage)
+
+No grammar change — the `ensure_clause` rule already parses (Phase 6v),
+and the Phase 16a `Stmt::TryCatch.ensure_body` lowering consumes it.
+Phase 16c adds a parse pin for the multi-statement ensure body:
+
+- `test_parse_begin_ensure_multiple_statements` — an `ensure` clause with
+  several statements collects them all under the `ensure_clause` node.
+
+(Ensure-only and rescue+ensure shapes are already covered by
+`test_parse_begin_with_ensure` / `test_parse_begin_with_rescue_and_ensure`.)
+Test count: 178 → 179 (+1).
+
 ## [0.47.0] - 2026-05-30
 
 ### Added (Phase 16b (FC) — typed / multi-type / multi-clause rescue)

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -2511,6 +2511,24 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_begin_ensure_multiple_statements() {
+        // Phase 16c — an ensure clause with several statements collects
+        // them all under the `ensure_clause` node (negative-lookahead
+        // repetition stops at `end`).
+        let ast = parse_ruby(
+            "begin\n  x = 1\nensure\n  a = 1\n  b = 2\nend",
+        );
+        let ec = find_descendant(&ast, "ensure_clause")
+            .expect("expected ensure_clause");
+        let stmt_count = ec
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "statement"))
+            .count();
+        assert_eq!(stmt_count, 2, "expected 2 ensure-body statements; got {stmt_count}");
+    }
+
+    #[test]
     fn test_parse_case_single_when() {
         // Smallest form: one when clause, no else.
         let ast = parse_ruby("case x\nwhen 1\n  y = 1\nend");

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.51.0] - 2026-05-30
+
+### Added (Phase 16c (FC) — `ensure` clause coverage)
+
+Hardening of the Phase 16a `Stmt::TryCatch.ensure_body` lowering — no
+code change.  Phase 16c locks the ensure-clause behaviour in with tests
+that 16a didn't cover:
+
+- `ensure_only_lowers_with_no_rescues` — `begin … ensure … end` (no
+  rescue) lowers to a `TryCatch` with empty `rescues` and a populated
+  `ensure_body`, requesting `Feature::Exceptions`.
+- `ensure_body_preserves_statement_order` — a multi-statement ensure
+  body keeps its statements in source order.
+- `ensure_only_passes_sir_validator` (E2E) — an ensure-only begin
+  validates end-to-end (no rescue path).
+
+Test count: 226 → 229 (+3).
+
 ## [0.50.0] - 2026-05-30
 
 ### Added (Phase 16b (FC) — typed / multi-type / multi-clause rescue)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -3666,6 +3666,49 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
+    // Phase 16c (FC) — ensure clause coverage / hardening.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn ensure_only_lowers_with_no_rescues() {
+        // `begin … ensure … end` (no rescue) → TryCatch with an empty
+        // `rescues` and a populated `ensure_body`; requests Exceptions.
+        let m = lower("begin\n  x = 1\nensure\n  y = 2\nend\n");
+        match &main_body(&m).stmts[0] {
+            Stmt::TryCatch { rescues, ensure_body, .. } => {
+                assert!(rescues.is_empty(), "ensure-only has no rescue clauses");
+                let ens = ensure_body.as_ref().expect("ensure body present");
+                assert!(matches!(&ens[0], Stmt::LetBinding { name, .. } if name == "y"));
+            }
+            other => panic!("expected Stmt::TryCatch, got {:?}", other),
+        }
+        assert!(m.manifest.contains(semantic_ir::Feature::Exceptions));
+    }
+
+    #[test]
+    fn ensure_body_preserves_statement_order() {
+        // The ensure body keeps its statements in source order.
+        let m = lower("begin\n  x = 1\nensure\n  a = 1\n  b = 2\nend\n");
+        match &main_body(&m).stmts[0] {
+            Stmt::TryCatch { ensure_body, .. } => {
+                let ens = ensure_body.as_ref().expect("ensure body present");
+                assert_eq!(ens.len(), 2, "both ensure stmts preserved; got {:?}", ens);
+                assert!(matches!(&ens[0], Stmt::LetBinding { name, .. } if name == "a"));
+                assert!(matches!(&ens[1], Stmt::LetBinding { name, .. } if name == "b"));
+            }
+            other => panic!("expected Stmt::TryCatch, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn ensure_only_passes_sir_validator() {
+        // E2E: an ensure-only begin (no rescue) validates end-to-end.
+        let m = lower("begin\n  x = 1\nensure\n  y = 2\nend\n");
+        let result = semantic_ir::validate(&m);
+        assert!(result.is_ok(), "validator rejected ensure-only begin: {:?}", result);
+    }
+
+    // -----------------------------------------------------------------
     // Phase 6u — `case … when … else … end`
     // -----------------------------------------------------------------
     //


### PR DESCRIPTION
## Phase 16c (FC) — `ensure` clause coverage / hardening

Hardening of the Phase 16a `Stmt::TryCatch.ensure_body` lowering. The
`ensure_body` already lands in `TryCatch` from 16a — this phase **locks
the ensure-clause behaviour in with tests 16a didn't cover**. **No
grammar change** (`ensure_clause` parses since Phase 6v) and **no
lowerer/SIR code change**.

### `ruby-parser` 0.48.0

- `test_parse_begin_ensure_multiple_statements` — an `ensure` clause with
  several statements collects them all under the `ensure_clause` node.
  178 → 179.

### `ruby-to-semantic-ir` 0.51.0

- `ensure_only_lowers_with_no_rescues` — `begin … ensure … end` (no
  rescue) → `TryCatch` with empty `rescues` + populated `ensure_body`,
  requesting `Feature::Exceptions`.
- `ensure_body_preserves_statement_order` — a multi-statement ensure body
  keeps source order.
- `ensure_only_passes_sir_validator` (E2E) — ensure-only begin validates
  end-to-end (no rescue path). 226 → 229.

### Verification

All green locally:
`cargo test -p coding-adventures-ruby-lexer -p coding-adventures-ruby-parser -p ruby-to-semantic-ir`
(parser 179, lowerer 229).

### Security

Test-only change — no production code touched. `/security-review` passed
clean in one round.
