### PR TITLE
feat(ruby-fc): Phase 16d — raise / raise Foo / raise Foo, "msg"

### DIFF
--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.49.0] - 2026-05-30
+
+### Added (Phase 16d (FC) — `raise` / `raise Foo` / `raise Foo, "msg"`)
+
+No grammar change — `raise` is not a keyword; `raise Foo, "msg"` parses
+as a paren-less method call (`method_call_no_paren`) and bare `raise` as
+an expression.  Phase 16d adds a parse pin:
+
+- `test_parse_raise_with_class_and_message` — `raise Foo, "boom"` parses
+  as a `method_call_no_paren` carrying the `raise` head and both args.
+
+Test count: 179 → 180 (+1).
+
 ## [0.48.0] - 2026-05-30
 
 ### Added (Phase 16c (FC) — `ensure` clause coverage)

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -2529,6 +2529,17 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_raise_with_class_and_message() {
+        // Phase 16d — `raise Foo, "boom"` parses as a paren-less method
+        // call carrying the `raise` head Name and both arguments.
+        let ast = parse_ruby("raise Foo, \"boom\"");
+        let mc = find_descendant(&ast, "method_call_no_paren")
+            .expect("expected method_call_no_paren");
+        assert!(body_has_token_value(mc, "raise"), "expected `raise` head token");
+        assert!(tree_has_token_value(mc, "Foo"), "expected exception class `Foo`");
+    }
+
+    #[test]
     fn test_parse_case_single_when() {
         // Smallest form: one when clause, no else.
         let ast = parse_ruby("case x\nwhen 1\n  y = 1\nend");

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.52.0] - 2026-05-30
+
+### Added (Phase 16d (FC) — `raise` / `raise Foo` / `raise Foo, "msg"`)
+
+`raise` lowers to `BuiltinCall("raise", args)` tagged `MayThrow` +
+`Divergent` (it is an expression-position construct, so it stays a
+builtin rather than a `Stmt`).  Phase 16d completes and hardens this:
+
+- **Bare `raise`** (re-raise the current exception) previously lowered
+  to a plain `VarRef("raise", Local)` — losing the throw/divergent
+  effects.  It now lowers to `BuiltinCall("raise", [])` in the factor
+  path, unless `raise` is shadowed by a local binding.
+- A `raise`-using module now requests `Feature::Exceptions` (both the
+  bare-`raise` factor path and the `raise Foo` / `raise Foo, "msg"`
+  method-call path), aligning the manifest with begin/rescue (Phase 16a).
+- `raise Foo` / `raise Foo, "msg"` already lowered to
+  `BuiltinCall("raise", [Foo, …])` via the method-call path (unchanged).
+
+New tests (+4): bare-raise → builtin with MayThrow+Divergent+Exceptions;
+`raise Foo` → one Const arg; `raise Foo, "msg"` → class + message args;
+validator E2E.  Test count: 229 → 233 (+4).
+
 ## [0.51.0] - 2026-05-30
 
 ### Added (Phase 16c (FC) — `ensure` clause coverage)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -3709,6 +3709,65 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
+    // Phase 16d (FC) — `raise` / `raise Foo` / `raise Foo, "msg"`.
+    // -----------------------------------------------------------------
+
+    /// Extract the head `BuiltinCall` from `main`'s trailing block value
+    /// (a lone trailing expression lowers to the block `value`, not a
+    /// statement).
+    fn raise_builtin(m: &semantic_ir::Module) -> (&str, &[Expr], semantic_ir::EffectSet) {
+        match &main_body(m).value {
+            Expr::BuiltinCall { name, args, effects, .. } => {
+                (name.as_str(), args.as_slice(), *effects)
+            }
+            other => panic!("expected BuiltinCall(raise), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn raise_bare_lowers_to_builtin_with_throw_divergent() {
+        // A bare `raise` (re-raise) lowers to `BuiltinCall("raise", [])`
+        // tagged MayThrow + Divergent, and requests `Feature::Exceptions`.
+        let m = lower("raise\n");
+        let (name, args, effects) = raise_builtin(&m);
+        assert_eq!(name, "raise");
+        assert!(args.is_empty(), "bare raise has no args; got {:?}", args);
+        assert!(effects.contains(Effect::MayThrow), "raise is MayThrow");
+        assert!(effects.contains(Effect::Divergent), "raise is Divergent");
+        assert!(m.manifest.contains(semantic_ir::Feature::Exceptions));
+    }
+
+    #[test]
+    fn raise_with_class_lowers_to_builtin() {
+        // `raise Foo` → `BuiltinCall("raise", [VarRef(Foo, Const)])`.
+        let m = lower("raise Foo\n");
+        let (name, args, _effects) = raise_builtin(&m);
+        assert_eq!(name, "raise");
+        assert_eq!(args.len(), 1, "one exception-class arg; got {:?}", args);
+        assert!(matches!(&args[0], Expr::VarRef { name, scope, .. } if name == "Foo" && *scope == Scope::Const));
+        assert!(m.manifest.contains(semantic_ir::Feature::Exceptions));
+    }
+
+    #[test]
+    fn raise_with_class_and_message_lowers_to_builtin() {
+        // `raise Foo, "boom"` → `BuiltinCall("raise", [Foo, StrLit])`.
+        let m = lower("raise Foo, \"boom\"\n");
+        let (name, args, _effects) = raise_builtin(&m);
+        assert_eq!(name, "raise");
+        assert_eq!(args.len(), 2, "class + message args; got {:?}", args);
+        assert!(matches!(&args[0], Expr::VarRef { name, .. } if name == "Foo"));
+        assert!(matches!(&args[1], Expr::StrLit { value, .. } if value == "boom"));
+    }
+
+    #[test]
+    fn raise_passes_sir_validator() {
+        // E2E: `raise Foo, "boom"` validates end-to-end.
+        let m = lower("raise Foo, \"boom\"\n");
+        let result = semantic_ir::validate(&m);
+        assert!(result.is_ok(), "validator rejected raise: {:?}", result);
+    }
+
+    // -----------------------------------------------------------------
     // Phase 6u — `case … when … else … end`
     // -----------------------------------------------------------------
     //

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -3281,6 +3281,12 @@ impl Lowerer {
         };
 
         let span = self.span_of(node);
+        // Phase 16d (FC) — `raise Foo` / `raise Foo, "msg"` is exception
+        // machinery; a module that uses it requests `Feature::Exceptions`
+        // (aligning the manifest with begin/rescue from Phase 16a).
+        if callee == "raise" {
+            self.features_used.insert(Feature::Exceptions);
+        }
         let head: Expr = if let Some(effects) = ruby_builtin_effects(&callee) {
             Expr::BuiltinCall {
                 name: callee,
@@ -4977,6 +4983,27 @@ impl Lowerer {
                             );
                         }
                         TokenType::Name => {
+                            // Phase 16d (FC) — a bare `raise` (no args:
+                            // re-raise the current exception) lowers to
+                            // the same `BuiltinCall("raise")` as
+                            // `raise Foo` — `MayThrow` + `Divergent` —
+                            // rather than a plain local read, and
+                            // requests `Feature::Exceptions`.  A `raise`
+                            // shadowed by a local binding (`raise = 1`)
+                            // keeps the local.
+                            if tok.value == "raise"
+                                && !self.declared_locals.contains("raise")
+                            {
+                                self.features_used.insert(Feature::Exceptions);
+                                return Ok(Expr::BuiltinCall {
+                                    name: "raise".to_string(),
+                                    args: vec![],
+                                    effects: EffectSet::PURE
+                                        .with(Effect::MayThrow)
+                                        .with(Effect::Divergent),
+                                    span,
+                                });
+                            }
                             // Inside a function body, parameter
                             // names lex as `VarRef` with
                             // `Scope::Param` so the SIR validator


### PR DESCRIPTION
## Phase 16d (FC) — `raise` / `raise Foo` / `raise Foo, "msg"`

`raise` lowers to `BuiltinCall("raise", args)` tagged `MayThrow` +
`Divergent`. It is an **expression-position** construct in Ruby
(`x.save or raise`), so it stays a builtin rather than a `Stmt`. **No
grammar change** (`raise` is not a keyword) and **no new SIR node**
(`Feature::Exceptions` already exists from 16a).

### `ruby-to-semantic-ir` 0.52.0

- **Bare `raise`** (re-raise the current exception) previously lowered to
  a plain `VarRef("raise", Local)` — losing the throw/divergent effects.
  It now lowers to `BuiltinCall("raise", [])` in the factor path, unless
  `raise` is shadowed by a local binding (`raise = 1`).
- A `raise`-using module now requests `Feature::Exceptions` (both the
  bare-`raise` factor path and the `raise Foo` / `raise Foo, "msg"`
  method-call path), aligning the manifest with begin/rescue (Phase 16a).
- `raise Foo` / `raise Foo, "msg"` already lowered to
  `BuiltinCall("raise", [Foo, …])` via the method-call path (unchanged).
- New tests (+4): bare-raise → builtin with MayThrow+Divergent+Exceptions;
  `raise Foo` → one Const arg; `raise Foo, "msg"` → class + message args;
  validator E2E. 229 → 233.

### `ruby-parser` 0.49.0

- New parse pin `test_parse_raise_with_class_and_message` (`raise Foo,
  "boom"` parses as `method_call_no_paren` with the `raise` head).
  179 → 180.

### Verification

All green locally:
`cargo test -p coding-adventures-ruby-lexer -p coding-adventures-ruby-parser -p ruby-to-semantic-ir`
(parser 180, lowerer 233).

### Security

Pure logic over the AST/IR — the new code is an O(1) string compare plus
a HashSet membership check; no I/O, no `unsafe`, no recursion.
`/security-review` passed clean in one round.
