### PR TITLE
feat(ruby-fc): Phase 16e — method-level rescue/ensure (def … rescue … end)

### DIFF
--- a/code/grammars/ruby.grammar
+++ b/code/grammars/ruby.grammar
@@ -106,7 +106,13 @@ mlhs_target  = [ "*" ] NAME ;
 # token.  This split sidesteps the grammar's newline-insensitive default
 # mode (modifier syntax is intrinsically a same-line construct in Ruby).
 modifier_statement = ( assignment | method_call_no_paren | method_call | expression_stmt ) ( "if_modifier" | "unless_modifier" | "while_modifier" | "until_modifier" ) expression ;
-def_statement = "def" NAME [ LPAREN [ params ] RPAREN ] { !"end" statement } "end" ;
+# Phase 16e (FC) — method-level rescue/ensure: a `def` body may carry
+# trailing `rescue`/`ensure` clauses WITHOUT an explicit `begin` (the
+# whole method body is the protected region).  The body repetition gets
+# the same `!"rescue" !"ensure"` negative-lookahead as begin_statement so
+# it stops at the first clause; the lowerer wraps the body + clauses in a
+# `Stmt::TryCatch` (Phase 16a) when any clause is present.
+def_statement = "def" NAME [ LPAREN [ params ] RPAREN ] { !"rescue" !"ensure" !"end" statement } { rescue_clause } [ ensure_clause ] "end" ;
 # Phase 7c — Ruby 3.0 endless method definition: `def foo = expr` and
 # `def foo(x, y) = expr`.  No `end`, no block body — just a single
 # expression after the `=`.  Placed BEFORE `def_statement` in the

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.50.0] - 2026-05-30
+
+### Added (Phase 16e (FC) — method-level rescue/ensure)
+
+`def_statement` now accepts trailing `rescue`/`ensure` clauses WITHOUT an
+explicit `begin` — the whole method body is the protected region:
+
+- `def_statement = "def" NAME [ LPAREN [ params ] RPAREN ]
+  { !"rescue" !"ensure" !"end" statement } { rescue_clause }
+  [ ensure_clause ] "end" ;` — the body repetition gains the same
+  `!"rescue" !"ensure"` negative-lookahead as `begin_statement`, then the
+  shared `rescue_clause` / `ensure_clause` rules.
+- Regenerated `_grammar.rs`.
+
+New parse pins (+3): `test_parse_def_with_method_level_rescue`,
+`test_parse_def_with_method_level_ensure`,
+`test_parse_def_with_typed_rescue_and_ensure`.  Test count: 180 → 183.
+
 ## [0.49.0] - 2026-05-30
 
 ### Added (Phase 16d (FC) — `raise` / `raise Foo` / `raise Foo, "msg"`)

--- a/code/packages/rust/ruby-parser/src/_grammar.rs
+++ b/code/packages/rust/ruby-parser/src/_grammar.rs
@@ -100,12 +100,16 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                     ] }) },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"rescue"#.to_string() }) },
+                        GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"ensure"#.to_string() }) },
                         GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"end"#.to_string() }) },
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"rescue_clause"#.to_string() }) },
+                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"ensure_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 109,
+            line_number: 115,
         },
         GrammarRule {
             name: r#"endless_def_statement"#.to_string(),
@@ -120,7 +124,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 115,
+            line_number: 121,
         },
         GrammarRule {
             name: r#"class_statement"#.to_string(),
@@ -149,7 +153,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::Literal { value: r#"end"#.to_string() },
                 ] },
             ] },
-            line_number: 136,
+            line_number: 142,
         },
         GrammarRule {
             name: r#"singleton_receiver"#.to_string(),
@@ -157,7 +161,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"self"#.to_string() },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
             ] },
-            line_number: 138,
+            line_number: 144,
         },
         GrammarRule {
             name: r#"module_statement"#.to_string(),
@@ -170,7 +174,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 139,
+            line_number: 145,
         },
         GrammarRule {
             name: r#"method_with_block"#.to_string(),
@@ -192,7 +196,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"block"#.to_string() },
             ] },
-            line_number: 141,
+            line_number: 147,
         },
         GrammarRule {
             name: r#"block"#.to_string(),
@@ -200,7 +204,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"do_block"#.to_string() },
                 GrammarElement::RuleReference { name: r#"brace_block"#.to_string() },
             ] },
-            line_number: 142,
+            line_number: 148,
         },
         GrammarRule {
             name: r#"do_block"#.to_string(),
@@ -213,7 +217,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 143,
+            line_number: 149,
         },
         GrammarRule {
             name: r#"brace_block"#.to_string(),
@@ -223,7 +227,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"statement"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 144,
+            line_number: 150,
         },
         GrammarRule {
             name: r#"block_params"#.to_string(),
@@ -236,7 +240,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"|"#.to_string() },
             ] },
-            line_number: 145,
+            line_number: 151,
         },
         GrammarRule {
             name: r#"return_statement"#.to_string(),
@@ -244,7 +248,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"return"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"expression"#.to_string() }) },
             ] },
-            line_number: 147,
+            line_number: 153,
         },
         GrammarRule {
             name: r#"break_statement"#.to_string(),
@@ -252,7 +256,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"break"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"expression"#.to_string() }) },
             ] },
-            line_number: 148,
+            line_number: 154,
         },
         GrammarRule {
             name: r#"next_statement"#.to_string(),
@@ -260,7 +264,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"next"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"expression"#.to_string() }) },
             ] },
-            line_number: 149,
+            line_number: 155,
         },
         GrammarRule {
             name: r#"yield_statement"#.to_string(),
@@ -268,7 +272,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"yield"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"yield_args"#.to_string() }) },
             ] },
-            line_number: 171,
+            line_number: 177,
         },
         GrammarRule {
             name: r#"yield_args"#.to_string(),
@@ -292,7 +296,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) },
                 ] },
             ] },
-            line_number: 172,
+            line_number: 178,
         },
         GrammarRule {
             name: r#"params"#.to_string(),
@@ -303,7 +307,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"param"#.to_string() },
                     ] }) },
             ] },
-            line_number: 187,
+            line_number: 193,
         },
         GrammarRule {
             name: r#"param"#.to_string(),
@@ -314,7 +318,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
             ] },
-            line_number: 188,
+            line_number: 194,
         },
         GrammarRule {
             name: r#"if_statement"#.to_string(),
@@ -331,7 +335,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 189,
+            line_number: 195,
         },
         GrammarRule {
             name: r#"elsif_clause"#.to_string(),
@@ -345,7 +349,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 190,
+            line_number: 196,
         },
         GrammarRule {
             name: r#"else_clause"#.to_string(),
@@ -356,7 +360,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 191,
+            line_number: 197,
         },
         GrammarRule {
             name: r#"unless_statement"#.to_string(),
@@ -371,7 +375,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 192,
+            line_number: 198,
         },
         GrammarRule {
             name: r#"while_statement"#.to_string(),
@@ -384,7 +388,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 193,
+            line_number: 199,
         },
         GrammarRule {
             name: r#"until_statement"#.to_string(),
@@ -397,7 +401,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 194,
+            line_number: 200,
         },
         GrammarRule {
             name: r#"case_statement"#.to_string(),
@@ -411,7 +415,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 217,
+            line_number: 223,
         },
         GrammarRule {
             name: r#"when_clause"#.to_string(),
@@ -430,7 +434,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 218,
+            line_number: 224,
         },
         GrammarRule {
             name: r#"in_clause"#.to_string(),
@@ -445,7 +449,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 240,
+            line_number: 246,
         },
         GrammarRule {
             name: r#"pattern"#.to_string(),
@@ -455,7 +459,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"literal_pattern"#.to_string() },
                 GrammarElement::RuleReference { name: r#"binding_pattern"#.to_string() },
             ] },
-            line_number: 241,
+            line_number: 247,
         },
         GrammarRule {
             name: r#"literal_pattern"#.to_string(),
@@ -465,12 +469,12 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"symbol_literal"#.to_string() },
                 GrammarElement::TokenReference { name: r#"KEYWORD"#.to_string() },
             ] },
-            line_number: 242,
+            line_number: 248,
         },
         GrammarRule {
             name: r#"binding_pattern"#.to_string(),
             body: GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
-            line_number: 243,
+            line_number: 249,
         },
         GrammarRule {
             name: r#"array_pattern"#.to_string(),
@@ -485,7 +489,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 244,
+            line_number: 250,
         },
         GrammarRule {
             name: r#"hash_pattern"#.to_string(),
@@ -500,7 +504,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 245,
+            line_number: 251,
         },
         GrammarRule {
             name: r#"hash_pattern_pair"#.to_string(),
@@ -509,7 +513,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"pattern"#.to_string() }) },
             ] },
-            line_number: 246,
+            line_number: 252,
         },
         GrammarRule {
             name: r#"begin_statement"#.to_string(),
@@ -525,7 +529,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"ensure_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 267,
+            line_number: 273,
         },
         GrammarRule {
             name: r#"rescue_clause"#.to_string(),
@@ -543,7 +547,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 276,
+            line_number: 282,
         },
         GrammarRule {
             name: r#"exception_list"#.to_string(),
@@ -554,7 +558,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
                     ] }) },
             ] },
-            line_number: 277,
+            line_number: 283,
         },
         GrammarRule {
             name: r#"ensure_clause"#.to_string(),
@@ -565,7 +569,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 278,
+            line_number: 284,
         },
         GrammarRule {
             name: r#"assignment"#.to_string(),
@@ -589,7 +593,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 298,
+            line_number: 304,
         },
         GrammarRule {
             name: r#"rightward_assignment"#.to_string(),
@@ -598,7 +602,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"=>"#.to_string() },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
             ] },
-            line_number: 317,
+            line_number: 323,
         },
         GrammarRule {
             name: r#"method_call"#.to_string(),
@@ -618,7 +622,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"dot_call"#.to_string() }) },
             ] },
-            line_number: 328,
+            line_number: 334,
         },
         GrammarRule {
             name: r#"dot_call"#.to_string(),
@@ -640,7 +644,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                     ] }) },
             ] },
-            line_number: 329,
+            line_number: 335,
         },
         GrammarRule {
             name: r#"scope_resolution"#.to_string(),
@@ -651,7 +655,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"KEYWORD"#.to_string() },
                     ] }) },
             ] },
-            line_number: 337,
+            line_number: 343,
         },
         GrammarRule {
             name: r#"call_arg"#.to_string(),
@@ -662,7 +666,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 344,
+            line_number: 350,
         },
         GrammarRule {
             name: r#"method_call_no_paren"#.to_string(),
@@ -677,17 +681,17 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 358,
+            line_number: 364,
         },
         GrammarRule {
             name: r#"expression_stmt"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"expression"#.to_string() },
-            line_number: 359,
+            line_number: 365,
         },
         GrammarRule {
             name: r#"expression"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"ternary"#.to_string() },
-            line_number: 445,
+            line_number: 451,
         },
         GrammarRule {
             name: r#"ternary"#.to_string(),
@@ -700,7 +704,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 446,
+            line_number: 452,
         },
         GrammarRule {
             name: r#"range"#.to_string(),
@@ -714,7 +718,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_or"#.to_string() },
                     ] }) },
             ] },
-            line_number: 447,
+            line_number: 453,
         },
         GrammarRule {
             name: r#"logical_or"#.to_string(),
@@ -728,7 +732,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_and"#.to_string() },
                     ] }) },
             ] },
-            line_number: 448,
+            line_number: 454,
         },
         GrammarRule {
             name: r#"logical_and"#.to_string(),
@@ -742,7 +746,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_not"#.to_string() },
                     ] }) },
             ] },
-            line_number: 449,
+            line_number: 455,
         },
         GrammarRule {
             name: r#"logical_not"#.to_string(),
@@ -753,7 +757,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) }) },
                 GrammarElement::RuleReference { name: r#"comparison"#.to_string() },
             ] },
-            line_number: 456,
+            line_number: 462,
         },
         GrammarRule {
             name: r#"comparison"#.to_string(),
@@ -771,7 +775,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"sum"#.to_string() },
                     ] }) },
             ] },
-            line_number: 457,
+            line_number: 463,
         },
         GrammarRule {
             name: r#"sum"#.to_string(),
@@ -785,7 +789,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term"#.to_string() },
                     ] }) },
             ] },
-            line_number: 458,
+            line_number: 464,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -799,7 +803,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"factor"#.to_string() },
                     ] }) },
             ] },
-            line_number: 459,
+            line_number: 465,
         },
         GrammarRule {
             name: r#"factor"#.to_string(),
@@ -826,7 +830,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"scope_resolution"#.to_string() },
                     ] }) },
             ] },
-            line_number: 469,
+            line_number: 475,
         },
         GrammarRule {
             name: r#"lambda_literal"#.to_string(),
@@ -839,7 +843,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"block"#.to_string() },
             ] },
-            line_number: 488,
+            line_number: 494,
         },
         GrammarRule {
             name: r#"unary_minus"#.to_string(),
@@ -847,7 +851,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"factor"#.to_string() },
             ] },
-            line_number: 489,
+            line_number: 495,
         },
         GrammarRule {
             name: r#"symbol_literal"#.to_string(),
@@ -859,7 +863,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 496,
+            line_number: 502,
         },
         GrammarRule {
             name: r#"array_literal"#.to_string(),
@@ -874,7 +878,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 497,
+            line_number: 503,
         },
         GrammarRule {
             name: r#"hash_literal"#.to_string(),
@@ -889,7 +893,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 498,
+            line_number: 504,
         },
         GrammarRule {
             name: r#"hash_entry"#.to_string(),
@@ -909,7 +913,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                 ] },
             ] },
-            line_number: 499,
+            line_number: 505,
         },
     ],
         version: 1,

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -239,6 +239,40 @@ mod tests {
         assert!(find_def_statement(&ast).is_some());
     }
 
+    #[test]
+    fn test_parse_def_with_method_level_rescue() {
+        // Phase 16e — a `def` body may carry a trailing `rescue` clause
+        // without an explicit `begin`.
+        let ast = parse_ruby("def f\n  x = 1\nrescue\n  y = 2\nend");
+        let def = find_def_statement(&ast).expect("expected def_statement");
+        assert!(
+            find_descendant(def, "rescue_clause").is_some(),
+            "expected a rescue_clause under the def body"
+        );
+    }
+
+    #[test]
+    fn test_parse_def_with_method_level_ensure() {
+        // Phase 16e — a `def` body may carry a trailing `ensure` clause.
+        let ast = parse_ruby("def f\n  x = 1\nensure\n  y = 2\nend");
+        let def = find_def_statement(&ast).expect("expected def_statement");
+        assert!(
+            find_descendant(def, "ensure_clause").is_some(),
+            "expected an ensure_clause under the def body"
+        );
+    }
+
+    #[test]
+    fn test_parse_def_with_typed_rescue_and_ensure() {
+        // Phase 16e — full form: typed rescue + ensure on a method body.
+        let ast = parse_ruby(
+            "def f\n  x = 1\nrescue IOError => e\n  log = e\nensure\n  done = 1\nend",
+        );
+        let def = find_def_statement(&ast).expect("expected def_statement");
+        assert!(find_descendant(def, "rescue_clause").is_some(), "expected rescue_clause");
+        assert!(find_descendant(def, "ensure_clause").is_some(), "expected ensure_clause");
+    }
+
     // -----------------------------------------------------------------------
     // Phase 6b — `if … else … end` and `unless`
     // -----------------------------------------------------------------------

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.53.0] - 2026-05-30
+
+### Added (Phase 16e (FC) — method-level rescue/ensure)
+
+A `def` body carrying trailing `rescue`/`ensure` clauses (no explicit
+`begin`) now lowers so the **whole method body** is wrapped in a single
+`Stmt::TryCatch` (semantic-ir 0.9.0); the method's value becomes nil.
+
+- Refactored the Phase 16a `begin` lowering: the body / rescue / ensure
+  extraction is now shared via two helpers — `lower_flat_statements`
+  (direct `statement` children → flat `Vec<Stmt>`) and
+  `lower_rescue_ensure_clauses` (→ `(Vec<RescueClause>, Option<Vec<Stmt>>)`).
+  `lower_begin_statement` and `lower_def_statement` both call them.
+- `lower_def_statement` detects `rescue_clause` / `ensure_clause` children
+  and, when present, wraps the method body in a `TryCatch` (requesting
+  `Feature::Exceptions`); a plain `def` is unchanged (trailing expression
+  still becomes the method value).
+
+New tests (+4): rescue wraps body in TryCatch, ensure wraps body, plain
+def unchanged (regression), method-level rescue validator E2E.  Test
+count: 233 → 237.
+
 ## [0.52.0] - 2026-05-30
 
 ### Added (Phase 16d (FC) — `raise` / `raise Foo` / `raise Foo, "msg"`)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -3768,6 +3768,80 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
+    // Phase 16e (FC) — method-level rescue/ensure (def … rescue … end).
+    // -----------------------------------------------------------------
+
+    /// Find a hoisted top-level function by name.
+    fn func<'a>(m: &'a semantic_ir::Module, name: &str) -> &'a semantic_ir::Function {
+        m.functions
+            .iter()
+            .find(|f| f.name == name)
+            .unwrap_or_else(|| panic!("expected hoisted function `{}`", name))
+    }
+
+    #[test]
+    fn def_with_method_level_rescue_wraps_body_in_trycatch() {
+        // `def f; x = 1; rescue Foo => e; y = e; end` → the method body is
+        // a single `Stmt::TryCatch` (no explicit begin); the function
+        // value is nil.
+        let m = lower("def f\n  x = 1\nrescue Foo => e\n  y = e\nend\n");
+        let f = func(&m, "f");
+        assert_eq!(f.body.stmts.len(), 1, "method body is one TryCatch; got {:?}", f.body.stmts);
+        match &f.body.stmts[0] {
+            Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+                assert!(!body.is_empty(), "try body has the method statements");
+                assert_eq!(rescues.len(), 1);
+                assert_eq!(rescues[0].exception_types, vec!["Foo".to_string()]);
+                assert_eq!(rescues[0].binding.as_deref(), Some("e"));
+                assert!(ensure_body.is_none());
+            }
+            other => panic!("expected Stmt::TryCatch, got {:?}", other),
+        }
+        assert!(matches!(f.body.value, Expr::NilLit { .. }), "method value is nil");
+        assert!(m.manifest.contains(semantic_ir::Feature::Exceptions));
+    }
+
+    #[test]
+    fn def_with_method_level_ensure_wraps_body_in_trycatch() {
+        // `def f; x = 1; ensure; y = 2; end` → TryCatch with no rescues
+        // and a populated ensure body.
+        let m = lower("def f\n  x = 1\nensure\n  y = 2\nend\n");
+        let f = func(&m, "f");
+        match &f.body.stmts[0] {
+            Stmt::TryCatch { rescues, ensure_body, .. } => {
+                assert!(rescues.is_empty(), "ensure-only: no rescues");
+                assert!(ensure_body.is_some(), "ensure body present");
+            }
+            other => panic!("expected Stmt::TryCatch, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn def_without_rescue_keeps_plain_body() {
+        // Regression: a normal `def` (no rescue/ensure) is unchanged —
+        // no TryCatch wraps the body.
+        let m = lower("def f(n)\n  x = n + 1\nend\n");
+        let f = func(&m, "f");
+        assert!(
+            !f.body.stmts.iter().any(|s| matches!(s, Stmt::TryCatch { .. })),
+            "plain def must not produce a TryCatch"
+        );
+        assert!(
+            f.body.stmts.iter().any(|s| matches!(s, Stmt::LetBinding { name, .. } if name == "x")),
+            "plain def keeps its body statements; got {:?}", f.body.stmts
+        );
+    }
+
+    #[test]
+    fn method_level_rescue_passes_sir_validator() {
+        // E2E: a method-level rescue/ensure def (with the binding used in
+        // the rescue body) validates end-to-end.
+        let m = lower("def f\n  x = 1\nrescue StandardError => e\n  y = e\nensure\n  z = 1\nend\n");
+        let result = semantic_ir::validate(&m);
+        assert!(result.is_ok(), "validator rejected method-level rescue: {:?}", result);
+    }
+
+    // -----------------------------------------------------------------
     // Phase 6u — `case … when … else … end`
     // -----------------------------------------------------------------
     //

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -2042,52 +2042,78 @@ impl Lowerer {
             })
             .collect();
 
-        let mut stmts_out: Vec<Stmt> = Vec::new();
-        let mut value: Option<Expr> = None;
-        if body_stmts.is_empty() {
-            value = Some(Expr::NilLit {
-                span: self.span_of(node),
-            });
+        // Phase 16e (FC) — method-level rescue/ensure.  If the def body
+        // carries trailing `rescue`/`ensure` clauses (no explicit
+        // `begin`), the WHOLE method body is the protected region: wrap
+        // the body statements and the clauses in a single
+        // `Stmt::TryCatch` (the method's value is then nil).
+        let has_exception_clauses = node.children.iter().any(|c| {
+            matches!(c, ASTNodeOrToken::Node(n)
+                if n.rule_name == "rescue_clause" || n.rule_name == "ensure_clause")
+        });
+
+        let (stmts_out, value): (Vec<Stmt>, Expr) = if has_exception_clauses {
+            self.features_used.insert(Feature::Exceptions);
+            let try_body = self.lower_flat_statements(node)?;
+            let (rescues, ensure_body) = self.lower_rescue_ensure_clauses(node)?;
+            (
+                vec![Stmt::TryCatch {
+                    body: try_body,
+                    rescues,
+                    ensure_body,
+                    span: self.span_of(node),
+                }],
+                Expr::NilLit { span: self.span_of(node) },
+            )
         } else {
-            let last_idx = body_stmts.len() - 1;
-            for (i, s) in body_stmts.iter().enumerate() {
-                let inner = self.first_node_child(s).ok_or_else(|| {
-                    RubyLowerError {
-                        message: "statement node had no child rule".to_string(),
-                        line: s.start_line.unwrap_or(0),
-                        column: s.start_column.unwrap_or(0),
-                    }
-                })?;
-                let is_tail = i == last_idx;
-                let kind = inner.rule_name.as_str();
-                if is_tail && matches!(kind, "expression_stmt" | "method_call" | "method_call_no_paren") {
-                    let v = match kind {
-                        "expression_stmt" => {
-                            let expr_node =
-                                self.first_node_child(inner).ok_or_else(|| {
-                                    RubyLowerError {
-                                        message:
-                                            "expression_stmt had no expression child"
-                                                .to_string(),
-                                        line: inner.start_line.unwrap_or(0),
-                                        column: inner.start_column.unwrap_or(0),
-                                    }
-                                })?;
-                            self.lower_expression(expr_node)?
+            let mut stmts_out: Vec<Stmt> = Vec::new();
+            let mut value: Option<Expr> = None;
+            if body_stmts.is_empty() {
+                value = Some(Expr::NilLit {
+                    span: self.span_of(node),
+                });
+            } else {
+                let last_idx = body_stmts.len() - 1;
+                for (i, s) in body_stmts.iter().enumerate() {
+                    let inner = self.first_node_child(s).ok_or_else(|| {
+                        RubyLowerError {
+                            message: "statement node had no child rule".to_string(),
+                            line: s.start_line.unwrap_or(0),
+                            column: s.start_column.unwrap_or(0),
                         }
-                        "method_call" | "method_call_no_paren" => self.lower_method_call(inner)?,
-                        _ => unreachable!(),
-                    };
-                    value = Some(v);
-                } else {
-                    // Phase 6r — multi-stmt fan-out for `multi_assignment`.
-                    stmts_out.extend(self.lower_statement_inner_multi(inner)?);
+                    })?;
+                    let is_tail = i == last_idx;
+                    let kind = inner.rule_name.as_str();
+                    if is_tail && matches!(kind, "expression_stmt" | "method_call" | "method_call_no_paren") {
+                        let v = match kind {
+                            "expression_stmt" => {
+                                let expr_node =
+                                    self.first_node_child(inner).ok_or_else(|| {
+                                        RubyLowerError {
+                                            message:
+                                                "expression_stmt had no expression child"
+                                                    .to_string(),
+                                            line: inner.start_line.unwrap_or(0),
+                                            column: inner.start_column.unwrap_or(0),
+                                        }
+                                    })?;
+                                self.lower_expression(expr_node)?
+                            }
+                            "method_call" | "method_call_no_paren" => self.lower_method_call(inner)?,
+                            _ => unreachable!(),
+                        };
+                        value = Some(v);
+                    } else {
+                        // Phase 6r — multi-stmt fan-out for `multi_assignment`.
+                        stmts_out.extend(self.lower_statement_inner_multi(inner)?);
+                    }
                 }
             }
-        }
-        let value = value.unwrap_or(Expr::NilLit {
-            span: self.span_of(node),
-        });
+            (
+                stmts_out,
+                value.unwrap_or(Expr::NilLit { span: self.span_of(node) }),
+            )
+        };
 
         // Restore the outer scope's locals + params so the rest of
         // the program lowers correctly.
@@ -3131,33 +3157,55 @@ impl Lowerer {
         &mut self,
         node: &GrammarASTNode,
     ) -> Result<Vec<Stmt>, RubyLowerError> {
-        // Phase 16a (FC): `begin/rescue/ensure/end` now lowers to a
-        // first-class `Stmt::TryCatch` (replacing the Phase 6v inline
-        // `__rescue_marker__`/`__ensure_marker__` placeholder builtins).
+        // Phase 16a (FC): `begin/rescue/ensure/end` lowers to a
+        // first-class `Stmt::TryCatch`.  Phase 16e factored the body /
+        // rescue / ensure extraction into shared helpers so method-level
+        // rescue (`def … rescue … end`, no explicit `begin`) can reuse
+        // them.
         let outer_span = self.span_of(node);
         self.features_used.insert(Feature::Exceptions);
+        let body = self.lower_flat_statements(node)?;
+        let (rescues, ensure_body) = self.lower_rescue_ensure_clauses(node)?;
+        Ok(vec![Stmt::TryCatch {
+            body,
+            rescues,
+            ensure_body,
+            span: outer_span,
+        }])
+    }
 
-        // Helper: lower the direct `statement` children of a node into a
-        // flat `Vec<Stmt>` (the negative-lookahead grammar repetition
-        // ensures these are exactly the relevant block's statements).
-        let lower_body = |this: &mut Self, n: &GrammarASTNode| -> Result<Vec<Stmt>, RubyLowerError> {
-            let mut body = Vec::new();
-            for cc in &n.children {
-                if let ASTNodeOrToken::Node(nn) = cc {
-                    if nn.rule_name == "statement" {
-                        if let Some(inner) = this.first_node_child(nn) {
-                            body.extend(this.lower_statement_inner_multi(inner)?);
-                        }
+    /// Lower the direct `statement` children of `node` into a flat
+    /// `Vec<Stmt>` — no trailing-value extraction.  Used for
+    /// `Stmt::TryCatch` body / rescue / ensure blocks (Phase 16a/16e),
+    /// where the negative-lookahead grammar repetition guarantees the
+    /// direct `statement` children are exactly that block's statements.
+    fn lower_flat_statements(
+        &mut self,
+        node: &GrammarASTNode,
+    ) -> Result<Vec<Stmt>, RubyLowerError> {
+        let mut body = Vec::new();
+        for cc in &node.children {
+            if let ASTNodeOrToken::Node(nn) = cc {
+                if nn.rule_name == "statement" {
+                    if let Some(inner) = self.first_node_child(nn) {
+                        body.extend(self.lower_statement_inner_multi(inner)?);
                     }
                 }
             }
-            Ok(body)
-        };
+        }
+        Ok(body)
+    }
 
-        // 1. The try body: direct `statement` children of `begin_statement`.
-        let body = lower_body(self, node)?;
-
-        // 2. Each rescue_clause, in source order.
+    /// Scan `node`'s direct children for `rescue_clause` / `ensure_clause`
+    /// and build the `(rescues, ensure_body)` for a `Stmt::TryCatch`.
+    /// Shared by `begin … end` (Phase 16a) and method-level rescue on a
+    /// `def` body (Phase 16e).  Callers are responsible for requesting
+    /// `Feature::Exceptions`.
+    fn lower_rescue_ensure_clauses(
+        &mut self,
+        node: &GrammarASTNode,
+    ) -> Result<(Vec<RescueClause>, Option<Vec<Stmt>>), RubyLowerError> {
+        // Each rescue_clause, in source order.
         let mut rescues: Vec<RescueClause> = Vec::new();
         for child in &node.children {
             if let ASTNodeOrToken::Node(n) = child {
@@ -3206,7 +3254,7 @@ impl Lowerer {
                         }
                         found
                     };
-                    let rescue_body = lower_body(self, n)?;
+                    let rescue_body = self.lower_flat_statements(n)?;
                     rescues.push(RescueClause {
                         exception_types,
                         binding,
@@ -3217,22 +3265,17 @@ impl Lowerer {
             }
         }
 
-        // 3. Optional ensure_clause.
+        // Optional ensure_clause.
         let mut ensure_body: Option<Vec<Stmt>> = None;
         for child in &node.children {
             if let ASTNodeOrToken::Node(n) = child {
                 if n.rule_name == "ensure_clause" {
-                    ensure_body = Some(lower_body(self, n)?);
+                    ensure_body = Some(self.lower_flat_statements(n)?);
                 }
             }
         }
 
-        Ok(vec![Stmt::TryCatch {
-            body,
-            rescues,
-            ensure_body,
-            span: outer_span,
-        }])
+        Ok((rescues, ensure_body))
     }
 
     // -------------------------------------------------------------------


### PR DESCRIPTION
## Phase 16e (FC) — method-level rescue/ensure (`def … rescue … end`)

A Ruby `def` body may carry trailing `rescue`/`ensure` clauses **without
an explicit `begin`** — the whole method body is the protected region.
This is the **final Tier-1 exception-handling phase**. No new SIR node
(reuses `Stmt::TryCatch` / `Feature::Exceptions` from 16a).

### `ruby-parser` 0.50.0 (grammar)

- `def_statement` gains `{ !"rescue" !"ensure" !"end" statement }
  { rescue_clause } [ ensure_clause ]` before `"end"`, mirroring
  `begin_statement`. Regenerated `_grammar.rs`.
- New parse pins (+3): method-level rescue, ensure, typed rescue+ensure.
  180 → 183.

### `ruby-to-semantic-ir` 0.53.0 (lowering)

- Refactored the Phase-16a `begin` lowering into two **shared helpers** —
  `lower_flat_statements` (direct `statement` children → flat
  `Vec<Stmt>`) and `lower_rescue_ensure_clauses` (→
  `(Vec<RescueClause>, Option<Vec<Stmt>>)`) — used by both
  `lower_begin_statement` and `lower_def_statement`.
- `lower_def_statement` detects rescue/ensure clause children and, when
  present, wraps the whole method body in a single `Stmt::TryCatch`
  (requesting `Feature::Exceptions`); the method value becomes nil. A
  plain `def` is unchanged (trailing expression still becomes the value).
- New tests (+4): rescue wraps body, ensure wraps body, plain-def
  regression, method-level rescue validator E2E. 233 → 237.

### Verification

All green locally:
`cargo test -p coding-adventures-ruby-lexer -p coding-adventures-ruby-parser -p ruby-to-semantic-ir`
(lexer 173, parser 183, lowerer 237).

### Security

Pure AST/IR logic — no I/O, no `unsafe`; the lowerer change is a
structural refactor (byte-equivalent helper extraction) plus an
`if/else` wrap. `/security-review` passed clean in one round.
