### PR TITLE
feat(ruby-fc): Phase 10a — inclusive range `1..5` (coverage confirmation)

### DIFF
--- a/code/.pr-body-fc-10a.md
+++ b/code/.pr-body-fc-10a.md
@@ -1,0 +1,43 @@
+## Phase 10a (FC) — inclusive range `1..5` (coverage confirmation)
+
+Inclusive ranges (`1..5`) were first implemented in **Phase 6n**:
+
+- Grammar: `range = logical_or [ ( "..." | ".." ) logical_or ]`, with
+  the lexer's `fuse_range_ops` folding two adjacent `Dot` tokens into a
+  single `Name("..")`.
+- Lowering: `BuiltinCall("range", [start, end, BoolLit(exclusive)])` —
+  the third arg is the exclusive-end flag (`false` for `..`).
+
+So like **Phases 16b/16c**, Phase 10a is a **coverage-confirmation
+phase** — no grammar or lowering change, only explicit test pins for
+inclusive ranges in positions the original 6n tests skipped.
+
+### `coding-adventures-ruby-parser` 0.51.0 (+3 pins, 183 → 186)
+
+- `test_parse_inclusive_range_string_endpoints` — `"a".."z"` (the two
+  Dots after a String still fuse to `..`).
+- `test_parse_inclusive_range_as_call_argument` — `foo(1..5)`.
+- `test_parse_inclusive_range_parenthesized` — `(1..5)`.
+
+### `ruby-to-semantic-ir` 0.54.0 (+3 pins, 237 → 240)
+
+- `inclusive_range_in_assignment_rhs_lowers_with_false_flag` — `x = 1..5`
+  (binding RHS; accepts `LetBinding`/`Assign`).
+- `inclusive_range_string_endpoints_lower_with_false_flag` — `("a".."z")`
+  → range over two `StrLit` endpoints.
+- `inclusive_range_as_array_element_lowers_and_validates` — `[1..5]`
+  lowers to a `SeqLit` whose element is the range builtin, and the
+  module passes `semantic_ir::validate` (end-to-end).
+
+Each lowering pin asserts the exclusive flag is `false`.
+
+### Verification
+
+All green locally:
+`cargo test -p coding-adventures-ruby-lexer -p coding-adventures-ruby-parser -p ruby-to-semantic-ir`
+(lexer 173, parser 186, lowerer 240).
+
+### Security
+
+Test code + CHANGELOG only — no production logic, no I/O, no `unsafe`.
+`/security-review` passed clean in one round.

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.51.0] - 2026-05-31
+
+### Added (Phase 10a (FC) — inclusive range `1..5` coverage confirmation)
+
+Inclusive ranges were first implemented in **Phase 6n** (the `range`
+rule `range = logical_or [ ( "..." | ".." ) logical_or ]`, with the
+lexer's `fuse_range_ops` folding two adjacent `Dot` tokens into a single
+`Name("..")`).  No grammar change is required for Phase 10a — like
+Phases 16b/16c it is a coverage-confirmation phase that pins inclusive
+ranges in syntactic positions the original 6n tests did not cover.
+
+New parse pins (+3):
+
+- `test_parse_inclusive_range_string_endpoints` — `"a".."z"` (string
+  literal endpoints; the two Dots after a String still fuse to `..`).
+- `test_parse_inclusive_range_as_call_argument` — `foo(1..5)` (range as
+  a method-call argument).
+- `test_parse_inclusive_range_parenthesized` — `(1..5)` (parenthesized
+  range still parses to a `range` node carrying `..`).
+
+Test count: 183 → 186.
+
 ## [0.50.0] - 2026-05-30
 
 ### Added (Phase 16e (FC) — method-level rescue/ensure)

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -1625,6 +1625,62 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // Phase 10a (FC) — inclusive range `1..5` coverage confirmation.
+    //
+    // Inclusive ranges were first implemented in Phase 6n (the `range`
+    // rule + `lower_range`).  Phase 10a is a coverage-confirmation phase
+    // (cf. Phases 16b/16c): it adds explicit parser pins for inclusive
+    // ranges in syntactic positions the original 6n tests did not cover —
+    // string endpoints, a call argument, and a parenthesized range — so a
+    // regression in any of those positions is caught by name.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_inclusive_range_string_endpoints() {
+        // `"a".."z"` — string literal endpoints.  The lexer emits
+        // String Dot Dot String and `fuse_range_ops` folds the two Dots
+        // into a single `..`, so the range node is shape-identical to the
+        // integer case (two `logical_or` operands flanking `..`).
+        let ast = parse_ruby("\"a\"..\"z\"");
+        let r = find_descendant(&ast, "range").expect("expected range node");
+        assert!(
+            tree_has_token_value(r, ".."),
+            "expected `..` token inside the string-endpoint range"
+        );
+        let operand_count = r
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "logical_or"))
+            .count();
+        assert_eq!(operand_count, 2, "expected 2 logical_or operands");
+    }
+
+    #[test]
+    fn test_parse_inclusive_range_as_call_argument() {
+        // `foo(1..5)` — an inclusive range used as a method-call argument.
+        // The range node must appear below the call's argument list.
+        let ast = parse_ruby("foo(1..5)");
+        let r = find_descendant(&ast, "range").expect("expected range node");
+        assert!(
+            tree_has_token_value(r, ".."),
+            "expected `..` token in the call-argument range"
+        );
+    }
+
+    #[test]
+    fn test_parse_inclusive_range_parenthesized() {
+        // `(1..5)` — a parenthesized inclusive range.  Parens are a
+        // primary/atom wrapper; the range still parses to a `range` node
+        // carrying the `..` token.
+        let ast = parse_ruby("(1..5)");
+        let r = find_descendant(&ast, "range").expect("expected range node");
+        assert!(
+            tree_has_token_value(r, ".."),
+            "expected `..` token in the parenthesized range"
+        );
+    }
+
+    // -----------------------------------------------------------------------
     // Phase 6p — compound assignment `+=`, `-=`, `*=`, `/=`, `||=`, `&&=`
     // -----------------------------------------------------------------------
     //

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.54.0] - 2026-05-31
+
+### Added (Phase 10a (FC) — inclusive range `1..5` coverage confirmation)
+
+Inclusive ranges lower to `BuiltinCall("range", [start, end, BoolLit(false)])`
+since **Phase 6n** (the third arg is the exclusive-end flag — `false`
+for `..`, `true` for `...`).  No lowering change is required for Phase
+10a — like Phases 16b/16c it is a coverage-confirmation phase pinning
+inclusive ranges in positions the 6n tests skipped.
+
+New tests (+3):
+
+- `inclusive_range_in_assignment_rhs_lowers_with_false_flag` — `x = 1..5`
+  at statement level (binding RHS; accepts `LetBinding`/`Assign`).
+- `inclusive_range_string_endpoints_lower_with_false_flag` —
+  `("a".."z")` lowers to a range over two `StrLit` endpoints.
+- `inclusive_range_as_array_element_lowers_and_validates` — `[1..5]`
+  lowers to a `SeqLit` whose element is the range builtin, and the
+  module passes `semantic_ir::validate`.
+
+Each pins the inclusive flag to `false`.  Test count: 237 → 240.
+
 ## [0.53.0] - 2026-05-30
 
 ### Added (Phase 16e (FC) — method-level rescue/ensure)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -2083,6 +2083,94 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
+    // Phase 10a (FC) — inclusive range `1..5` coverage confirmation.
+    //
+    // Inclusive ranges lower to `BuiltinCall("range", [a, b, false])`
+    // since Phase 6n.  Phase 10a (a coverage-confirmation phase, cf.
+    // 16b/16c) adds explicit lowering pins for inclusive ranges in
+    // positions the 6n tests skipped: assignment-RHS at statement level,
+    // string endpoints, and as an array-literal element.  Each asserts
+    // the inclusive flag is `false` so an accidental flag flip is caught.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn inclusive_range_in_assignment_rhs_lowers_with_false_flag() {
+        // `x = 1..5` at statement level — the assigned value is the range.
+        // A first-occurrence binding lowers to `LetBinding` (the frontend
+        // reserves `Assign` for re-binding an already-declared name), so
+        // accept either binding form and read its `value`.
+        let m = lower("x = 1..5\n");
+        let found = main_body(&m).stmts.iter().find_map(|s| match s {
+            Stmt::LetBinding { value, .. } | Stmt::Assign { value, .. } => Some(value.clone()),
+            _ => None,
+        });
+        let value = found.expect("expected a binding statement for `x`");
+        match &value {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "range");
+                assert_eq!(args.len(), 3, "expected [start, end, exclusive_flag]");
+                assert!(matches!(&args[0], Expr::IntLit { value: 1, .. }));
+                assert!(matches!(&args[1], Expr::IntLit { value: 5, .. }));
+                assert!(
+                    matches!(&args[2], Expr::BoolLit { value: false, .. }),
+                    "inclusive `..` should set the exclusive flag false; got {:?}",
+                    &args[2]
+                );
+            }
+            other => panic!("expected BuiltinCall(range, …), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn inclusive_range_string_endpoints_lower_with_false_flag() {
+        // `def r() ("a".."z") end` — string endpoints, inclusive.  Parens
+        // avoid the bare-NAME method-call ambiguity (lessons.md).
+        let m = lower("def r\n  (\"a\"..\"z\")\nend\n");
+        let f = m.functions.iter().find(|f| f.name == "r").unwrap();
+        match &f.body.value {
+            Expr::BuiltinCall { name, args, .. } if name == "range" => {
+                assert_eq!(args.len(), 3);
+                assert!(
+                    matches!(&args[0], Expr::StrLit { value, .. } if value == "a"),
+                    "expected start StrLit \"a\"; got {:?}",
+                    &args[0]
+                );
+                assert!(
+                    matches!(&args[1], Expr::StrLit { value, .. } if value == "z"),
+                    "expected end StrLit \"z\"; got {:?}",
+                    &args[1]
+                );
+                assert!(matches!(&args[2], Expr::BoolLit { value: false, .. }));
+            }
+            other => panic!("expected BuiltinCall(range, …), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn inclusive_range_as_array_element_lowers_and_validates() {
+        // `def r() [1..5] end` — a range as the sole element of an array
+        // literal.  The array's element is itself the range builtin, and
+        // the whole module survives validation (end-to-end pin).
+        let m = lower("def r\n  [1..5]\nend\n");
+        let f = m.functions.iter().find(|f| f.name == "r").unwrap();
+        match &f.body.value {
+            Expr::SeqLit { items, .. } => {
+                assert_eq!(items.len(), 1, "expected a one-element array");
+                match &items[0] {
+                    Expr::BuiltinCall { name, args, .. } if name == "range" => {
+                        assert_eq!(args.len(), 3);
+                        assert!(matches!(&args[2], Expr::BoolLit { value: false, .. }));
+                    }
+                    other => panic!("expected range element, got {:?}", other),
+                }
+            }
+            other => panic!("expected SeqLit, got {:?}", other),
+        }
+        let result = semantic_ir::validate(&m);
+        assert!(result.is_ok(), "validator rejected array-of-range: {:?}", result);
+    }
+
+    // -----------------------------------------------------------------
     // Phase 6o — ternary `cond ? a : b` lowering
     // -----------------------------------------------------------------
     //


### PR DESCRIPTION
## Phase 10a (FC) — inclusive range `1..5` (coverage confirmation)

Inclusive ranges (`1..5`) were first implemented in **Phase 6n**:

- Grammar: `range = logical_or [ ( "..." | ".." ) logical_or ]`, with
  the lexer's `fuse_range_ops` folding two adjacent `Dot` tokens into a
  single `Name("..")`.
- Lowering: `BuiltinCall("range", [start, end, BoolLit(exclusive)])` —
  the third arg is the exclusive-end flag (`false` for `..`).

So like **Phases 16b/16c**, Phase 10a is a **coverage-confirmation
phase** — no grammar or lowering change, only explicit test pins for
inclusive ranges in positions the original 6n tests skipped.

### `coding-adventures-ruby-parser` 0.51.0 (+3 pins, 183 → 186)

- `test_parse_inclusive_range_string_endpoints` — `"a".."z"` (the two
  Dots after a String still fuse to `..`).
- `test_parse_inclusive_range_as_call_argument` — `foo(1..5)`.
- `test_parse_inclusive_range_parenthesized` — `(1..5)`.

### `ruby-to-semantic-ir` 0.54.0 (+3 pins, 237 → 240)

- `inclusive_range_in_assignment_rhs_lowers_with_false_flag` — `x = 1..5`
  (binding RHS; accepts `LetBinding`/`Assign`).
- `inclusive_range_string_endpoints_lower_with_false_flag` — `("a".."z")`
  → range over two `StrLit` endpoints.
- `inclusive_range_as_array_element_lowers_and_validates` — `[1..5]`
  lowers to a `SeqLit` whose element is the range builtin, and the
  module passes `semantic_ir::validate` (end-to-end).

Each lowering pin asserts the exclusive flag is `false`.

### Verification

All green locally:
`cargo test -p coding-adventures-ruby-lexer -p coding-adventures-ruby-parser -p ruby-to-semantic-ir`
(lexer 173, parser 186, lowerer 240).

### Security

Test code + CHANGELOG only — no production logic, no I/O, no `unsafe`.
`/security-review` passed clean in one round.
