### PR TITLE
feat(ruby-fc): Phase 10c — endless range `1..` / `1...`

### DIFF
--- a/code/.pr-body-fc-10c.md
+++ b/code/.pr-body-fc-10c.md
@@ -1,0 +1,45 @@
+## Phase 10c (FC) — endless range `1..` / `1...`
+
+Endless ranges carry a start with **no end** (`1..`, `1...`, `(1..)`,
+`arr[2..]`).  This is the first **genuinely-new** Tier-2 range form:
+Phase 6n required operands on both sides, and Phases 10a/10b were
+coverage-only confirmations of the inclusive/exclusive two-operand forms.
+
+### `coding-adventures-ruby-parser` 0.52.0 (grammar)
+
+- `range = logical_or [ ( "..." | ".." ) [ logical_or ] ] ;` — the
+  trailing operand is now optional.  When the range op is present but
+  the next token is a closer (`)`, `]`, `,`, newline, EOF) that cannot
+  begin a `logical_or`, the inner optional matches nothing and the node
+  carries one operand plus the op token: an endless range.  `1..5` still
+  binds two operands; a bare `logical_or` still passes through.
+  Beginless ranges (`..5`) remain deferred to Phase 10d.
+- Regenerated `_grammar.rs`.
+- +3 parse pins (186 → 189): `test_parse_endless_range_inclusive`
+  (`1..`), `test_parse_endless_range_exclusive` (`1...`),
+  `test_parse_endless_range_parenthesized` (`(1..)`).
+
+### `ruby-to-semantic-ir` 0.55.0 (lowering)
+
+- `lower_range` gains a third case `(1, Some(op))`: an endless range
+  lowers to `BuiltinCall("range", [start, NilLit, BoolLit(exclusive)])`.
+  The nil upper bound means "unbounded above"; the exclusive flag
+  distinguishes `..` (false) from `...` (true) exactly as in the
+  two-operand case.  **No new SIR variant, `Feature`, or backend
+  dispatch** — reuses the existing `range` builtin and `NilLit`.
+- +3 lowering pins (240 → 243): `endless_range_inclusive_lowers_with_nil_end`
+  (`(1..)`), `endless_range_exclusive_lowers_with_nil_end` (`(1...)`),
+  `endless_range_over_param_validates_e2e` (`(a..)` + validator E2E).
+
+### Verification
+
+All green locally:
+`cargo test -p coding-adventures-ruby-lexer -p coding-adventures-ruby-parser -p ruby-to-semantic-ir`
+(lexer 173, parser 189, lowerer 243).
+
+### Security
+
+Pure AST→IR logic — no I/O, no `unsafe`.  The new arm indexes
+`operands[0]` only when the match guarantees `len == 1`; the fallback
+returns a `RubyLowerError` (no panic).  `/security-review` passed clean
+in one round.

--- a/code/grammars/ruby.grammar
+++ b/code/grammars/ruby.grammar
@@ -427,6 +427,16 @@ expression_stmt = expression ;
 # Operator alternation lists `"..."` before `".."` defensively, but
 # the lexer already pre-fuses the two forms into distinct tokens so
 # the order is not actually significant.
+#
+# Phase 10c — endless ranges (`1..`, `1...`, `(1..)`, `arr[2..]`).  The
+# trailing operand is now ITSELF optional: `[ ( "..." | ".." ) [ logical_or ] ]`.
+# When the range operator is present but no `logical_or` follows (the
+# next token is a closer — `)`, `]`, `,`, newline, or EOF — which cannot
+# begin a `logical_or`), the optional cleanly matches nothing and the
+# node carries exactly one operand plus the op token: an endless range.
+# A bare `logical_or` (no op) still passes through; `1..5` still binds
+# two operands.  Beginless ranges (`..5`, a leading op with no LHS) are
+# a separate grammar shape and remain deferred to Phase 10d.
 # Phase 6o — ternary `cond ? a : b`.
 #
 # Precedence: ternary sits ABOVE range (looser than `..`/`...`)
@@ -450,7 +460,7 @@ expression_stmt = expression ;
 # consumes is the ternary separator, not a symbol opener.
 expression   = ternary ;
 ternary      = range [ "?" expression ":" expression ] ;
-range        = logical_or [ ( "..." | ".." ) logical_or ] ;
+range        = logical_or [ ( "..." | ".." ) [ logical_or ] ] ;
 logical_or   = logical_and { ( "||" | "or" ) logical_and } ;
 logical_and  = logical_not { ( "&&" | "and" ) logical_not } ;
 # `logical_not` uses `{ }` (zero-or-more) instead of right-recursive

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.52.0] - 2026-05-31
+
+### Added (Phase 10c (FC) — endless range `1..` / `1...`)
+
+The `range` rule's trailing operand is now **optional**, enabling
+endless ranges (a start with no end):
+
+- `range = logical_or [ ( "..." | ".." ) [ logical_or ] ] ;` — when the
+  range op is present but the next token is a closer (`)`, `]`, `,`,
+  newline, EOF) that cannot begin a `logical_or`, the inner optional
+  matches nothing and the node carries one operand plus the op token.
+  `1..5` still binds two operands; a bare `logical_or` still passes
+  through.  Beginless ranges (`..5`) remain deferred to Phase 10d.
+- Regenerated `_grammar.rs`.
+
+New parse pins (+3): `test_parse_endless_range_inclusive` (`1..`),
+`test_parse_endless_range_exclusive` (`1...`),
+`test_parse_endless_range_parenthesized` (`(1..)`).  Each asserts the
+range node carries exactly one `logical_or` operand.  Test count:
+186 → 189.
+
 ## [0.51.0] - 2026-05-31
 
 ### Added (Phase 10a (FC) — inclusive range `1..5` coverage confirmation)

--- a/code/packages/rust/ruby-parser/src/_grammar.rs
+++ b/code/packages/rust/ruby-parser/src/_grammar.rs
@@ -691,7 +691,7 @@ pub fn parser_grammar() -> ParserGrammar {
         GrammarRule {
             name: r#"expression"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"ternary"#.to_string() },
-            line_number: 451,
+            line_number: 461,
         },
         GrammarRule {
             name: r#"ternary"#.to_string(),
@@ -704,7 +704,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 452,
+            line_number: 462,
         },
         GrammarRule {
             name: r#"range"#.to_string(),
@@ -715,10 +715,10 @@ pub fn parser_grammar() -> ParserGrammar {
                                 GrammarElement::Literal { value: r#"..."#.to_string() },
                                 GrammarElement::Literal { value: r#".."#.to_string() },
                             ] }) },
-                        GrammarElement::RuleReference { name: r#"logical_or"#.to_string() },
+                        GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"logical_or"#.to_string() }) },
                     ] }) },
             ] },
-            line_number: 453,
+            line_number: 463,
         },
         GrammarRule {
             name: r#"logical_or"#.to_string(),
@@ -732,7 +732,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_and"#.to_string() },
                     ] }) },
             ] },
-            line_number: 454,
+            line_number: 464,
         },
         GrammarRule {
             name: r#"logical_and"#.to_string(),
@@ -746,7 +746,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_not"#.to_string() },
                     ] }) },
             ] },
-            line_number: 455,
+            line_number: 465,
         },
         GrammarRule {
             name: r#"logical_not"#.to_string(),
@@ -757,7 +757,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) }) },
                 GrammarElement::RuleReference { name: r#"comparison"#.to_string() },
             ] },
-            line_number: 462,
+            line_number: 472,
         },
         GrammarRule {
             name: r#"comparison"#.to_string(),
@@ -775,7 +775,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"sum"#.to_string() },
                     ] }) },
             ] },
-            line_number: 463,
+            line_number: 473,
         },
         GrammarRule {
             name: r#"sum"#.to_string(),
@@ -789,7 +789,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term"#.to_string() },
                     ] }) },
             ] },
-            line_number: 464,
+            line_number: 474,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -803,7 +803,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"factor"#.to_string() },
                     ] }) },
             ] },
-            line_number: 465,
+            line_number: 475,
         },
         GrammarRule {
             name: r#"factor"#.to_string(),
@@ -830,7 +830,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"scope_resolution"#.to_string() },
                     ] }) },
             ] },
-            line_number: 475,
+            line_number: 485,
         },
         GrammarRule {
             name: r#"lambda_literal"#.to_string(),
@@ -843,7 +843,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"block"#.to_string() },
             ] },
-            line_number: 494,
+            line_number: 504,
         },
         GrammarRule {
             name: r#"unary_minus"#.to_string(),
@@ -851,7 +851,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"factor"#.to_string() },
             ] },
-            line_number: 495,
+            line_number: 505,
         },
         GrammarRule {
             name: r#"symbol_literal"#.to_string(),
@@ -863,7 +863,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 502,
+            line_number: 512,
         },
         GrammarRule {
             name: r#"array_literal"#.to_string(),
@@ -878,7 +878,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 503,
+            line_number: 513,
         },
         GrammarRule {
             name: r#"hash_literal"#.to_string(),
@@ -893,7 +893,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 504,
+            line_number: 514,
         },
         GrammarRule {
             name: r#"hash_entry"#.to_string(),
@@ -913,7 +913,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                 ] },
             ] },
-            line_number: 505,
+            line_number: 515,
         },
     ],
         version: 1,

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -1681,6 +1681,69 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // Phase 10c (FC) — endless range `1..` / `1...`.
+    //
+    // The `range` rule's trailing operand is now optional:
+    //   range = logical_or [ ( "..." | ".." ) [ logical_or ] ]
+    // so a range op with no following operand (the next token is a
+    // closer that cannot begin a `logical_or`) yields a `range` node
+    // with exactly ONE `logical_or` operand plus the op token.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_endless_range_inclusive() {
+        // `1..` — endless inclusive range: one operand, `..` token, no
+        // trailing operand.
+        let ast = parse_ruby("1..");
+        let r = find_descendant(&ast, "range").expect("expected range node");
+        assert!(
+            tree_has_token_value(r, ".."),
+            "expected `..` token in the endless range"
+        );
+        let operand_count = r
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "logical_or"))
+            .count();
+        assert_eq!(operand_count, 1, "endless range should carry exactly 1 operand");
+    }
+
+    #[test]
+    fn test_parse_endless_range_exclusive() {
+        // `1...` — endless exclusive range carries the `...` token.
+        let ast = parse_ruby("1...");
+        let r = find_descendant(&ast, "range").expect("expected range node");
+        assert!(
+            tree_has_token_value(r, "..."),
+            "expected `...` token in the endless exclusive range"
+        );
+        let operand_count = r
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "logical_or"))
+            .count();
+        assert_eq!(operand_count, 1, "endless range should carry exactly 1 operand");
+    }
+
+    #[test]
+    fn test_parse_endless_range_parenthesized() {
+        // `(1..)` — the closer here is `)`; the optional operand matches
+        // nothing and the range stays endless.
+        let ast = parse_ruby("(1..)");
+        let r = find_descendant(&ast, "range").expect("expected range node");
+        assert!(
+            tree_has_token_value(r, ".."),
+            "expected `..` token in the parenthesized endless range"
+        );
+        let operand_count = r
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "logical_or"))
+            .count();
+        assert_eq!(operand_count, 1, "endless range should carry exactly 1 operand");
+    }
+
+    // -----------------------------------------------------------------------
     // Phase 6p — compound assignment `+=`, `-=`, `*=`, `/=`, `||=`, `&&=`
     // -----------------------------------------------------------------------
     //

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.55.0] - 2026-05-31
+
+### Added (Phase 10c (FC) — endless range `1..` / `1...`)
+
+`lower_range` gained a third case for endless ranges (one operand plus
+a range op, no trailing operand).  The open upper bound is encoded as
+`NilLit`, keeping the `range` builtin's uniform shape:
+
+- `1..` → `BuiltinCall("range", [start, NilLit, BoolLit(false)])`
+- `1...` → `BuiltinCall("range", [start, NilLit, BoolLit(true)])`
+
+A nil end means "unbounded above"; the exclusive flag distinguishes
+`..` from `...` exactly as in the two-operand case, so no new SIR
+variant, `Feature`, or backend dispatch is required.
+
+New tests (+3): `endless_range_inclusive_lowers_with_nil_end` (`(1..)`),
+`endless_range_exclusive_lowers_with_nil_end` (`(1...)`),
+`endless_range_over_param_validates_e2e` (`(a..)` + validator E2E).
+Test count: 240 → 243.
+
 ## [0.54.0] - 2026-05-31
 
 ### Added (Phase 10a (FC) — inclusive range `1..5` coverage confirmation)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -2171,6 +2171,79 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
+    // Phase 10c (FC) — endless range `1..` / `1...` lowering.
+    //
+    // An endless range carries a start but no end.  It lowers to the
+    // same `range` builtin with the open upper bound encoded as
+    // `NilLit`: `BuiltinCall("range", [start, NilLit, BoolLit(excl)])`.
+    // The exclusive flag still distinguishes `..` (false) from `...`
+    // (true), so downstream emitters need no new dispatch — a nil end
+    // simply means "unbounded above".
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn endless_range_inclusive_lowers_with_nil_end() {
+        // `def r() (1..) end` — endless inclusive.  Parens keep the
+        // body off the bare-NAME method-call path (lessons.md).
+        let m = lower("def r\n  (1..)\nend\n");
+        let f = m.functions.iter().find(|f| f.name == "r").unwrap();
+        match &f.body.value {
+            Expr::BuiltinCall { name, args, .. } if name == "range" => {
+                assert_eq!(args.len(), 3, "expected [start, nil_end, exclusive_flag]");
+                assert!(matches!(&args[0], Expr::IntLit { value: 1, .. }));
+                assert!(
+                    matches!(&args[1], Expr::NilLit { .. }),
+                    "endless range end should be NilLit; got {:?}",
+                    &args[1]
+                );
+                assert!(
+                    matches!(&args[2], Expr::BoolLit { value: false, .. }),
+                    "inclusive `..` should set the exclusive flag false; got {:?}",
+                    &args[2]
+                );
+            }
+            other => panic!("expected BuiltinCall(range, …), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn endless_range_exclusive_lowers_with_nil_end() {
+        // `def r() (1...) end` — endless exclusive sets the flag true.
+        let m = lower("def r\n  (1...)\nend\n");
+        let f = m.functions.iter().find(|f| f.name == "r").unwrap();
+        match &f.body.value {
+            Expr::BuiltinCall { name, args, .. } if name == "range" => {
+                assert_eq!(args.len(), 3);
+                assert!(matches!(&args[1], Expr::NilLit { .. }), "end should be nil");
+                assert!(
+                    matches!(&args[2], Expr::BoolLit { value: true, .. }),
+                    "exclusive `...` should set the flag true; got {:?}",
+                    &args[2]
+                );
+            }
+            other => panic!("expected BuiltinCall(range, …), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn endless_range_over_param_validates_e2e() {
+        // `def r(a) (a..) end` — endless range whose start is a param
+        // (in scope, so the VarRef survives validation).  End-to-end pin:
+        // lower + validate succeeds, and the end is nil.
+        let m = lower("def r(a)\n  (a..)\nend\n");
+        let f = m.functions.iter().find(|f| f.name == "r").unwrap();
+        match &f.body.value {
+            Expr::BuiltinCall { name, args, .. } if name == "range" => {
+                assert!(matches!(&args[0], Expr::VarRef { name, .. } if name == "a"));
+                assert!(matches!(&args[1], Expr::NilLit { .. }));
+            }
+            other => panic!("expected BuiltinCall(range, …), got {:?}", other),
+        }
+        let result = semantic_ir::validate(&m);
+        assert!(result.is_ok(), "validator rejected endless range: {:?}", result);
+    }
+
+    // -----------------------------------------------------------------
     // Phase 6o — ternary `cond ? a : b` lowering
     // -----------------------------------------------------------------
     //

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -4181,11 +4181,12 @@ impl Lowerer {
     // Phase 6n — range expressions `..` / `...`
     // -------------------------------------------------------------------
 
-    /// Lower a `range` node.  Grammar shape:
+    /// Lower a `range` node.  Grammar shape (Phase 10c made the trailing
+    /// operand optional):
     ///
-    ///   range = logical_or [ ( "..." | ".." ) logical_or ]
+    ///   range = logical_or [ ( "..." | ".." ) [ logical_or ] ]
     ///
-    /// Two cases:
+    /// Three cases:
     ///   - One operand child, no `..`/`...` token → pass through (the
     ///     range rule is just a transparent wrapper in this case).
     ///   - Two operand children with a `..` or `...` token between them
@@ -4193,6 +4194,9 @@ impl Lowerer {
     ///     The third argument carries the inclusive/exclusive flag so a
     ///     single builtin handles both forms without name multiplication.
     ///     `..` → exclusive=false; `...` → exclusive=true.
+    ///   - One operand child WITH a `..`/`...` token (Phase 10c endless
+    ///     range `1..`) → emit `BuiltinCall("range", [start, NilLit,
+    ///     BoolLit(exclusive)])`; the nil upper bound means "unbounded".
     ///
     /// Range is pure: building a range doesn't observe or mutate any
     /// state.  (Iterating over one *would* run code, but that's a
@@ -4238,13 +4242,36 @@ impl Lowerer {
                     span: op_span,
                 })
             }
+            // Phase 10c — endless range: one operand plus a range op,
+            // with no trailing operand (`1..`, `1...`).  The open end is
+            // encoded as `NilLit`, so the `range` builtin keeps its
+            // uniform `[start, end, exclusive]` shape — downstream
+            // consumers read a nil end as "unbounded above".  `..` and
+            // `...` are distinguished by the exclusive flag exactly as
+            // in the two-operand case.
+            (1, Some(tok)) => {
+                let start = self.lower_expression(operands[0])?;
+                let exclusive = tok.value == "...";
+                let op_span = self.span_of_token(tok);
+                Ok(Expr::BuiltinCall {
+                    name: "range".to_string(),
+                    args: vec![
+                        start,
+                        // Open (infinite) upper bound — `nil` end.
+                        Expr::NilLit { span: op_span.clone() },
+                        Expr::BoolLit { value: exclusive, span: op_span.clone() },
+                    ],
+                    effects: EffectSet::PURE,
+                    span: op_span,
+                })
+            }
             // Shouldn't happen given the grammar shape — but be
-            // defensive: a missing operator with two operands or a
-            // present operator with the wrong operand count points
-            // at a grammar regeneration gone awry.
+            // defensive: a missing operator with two operands or any
+            // other operand/op combination points at a grammar
+            // regeneration gone awry.
             (n, _) => Err(RubyLowerError {
                 message: format!(
-                    "range node had {n} operand(s) and op={:?} — expected (1, None) or (2, Some(..|...))",
+                    "range node had {n} operand(s) and op={:?} — expected (1, None), (1, Some(..|...)), or (2, Some(..|...))",
                     op_tok.map(|t| t.value.clone()),
                 ),
                 line: node.start_line.unwrap_or(0),


### PR DESCRIPTION
## Phase 10c (FC) — endless range `1..` / `1...`

Endless ranges carry a start with **no end** (`1..`, `1...`, `(1..)`,
`arr[2..]`).  This is the first **genuinely-new** Tier-2 range form:
Phase 6n required operands on both sides, and Phases 10a/10b were
coverage-only confirmations of the inclusive/exclusive two-operand forms.

### `coding-adventures-ruby-parser` 0.52.0 (grammar)

- `range = logical_or [ ( "..." | ".." ) [ logical_or ] ] ;` — the
  trailing operand is now optional.  When the range op is present but
  the next token is a closer (`)`, `]`, `,`, newline, EOF) that cannot
  begin a `logical_or`, the inner optional matches nothing and the node
  carries one operand plus the op token: an endless range.  `1..5` still
  binds two operands; a bare `logical_or` still passes through.
  Beginless ranges (`..5`) remain deferred to Phase 10d.
- Regenerated `_grammar.rs`.
- +3 parse pins (186 → 189): `test_parse_endless_range_inclusive`
  (`1..`), `test_parse_endless_range_exclusive` (`1...`),
  `test_parse_endless_range_parenthesized` (`(1..)`).

### `ruby-to-semantic-ir` 0.55.0 (lowering)

- `lower_range` gains a third case `(1, Some(op))`: an endless range
  lowers to `BuiltinCall("range", [start, NilLit, BoolLit(exclusive)])`.
  The nil upper bound means "unbounded above"; the exclusive flag
  distinguishes `..` (false) from `...` (true) exactly as in the
  two-operand case.  **No new SIR variant, `Feature`, or backend
  dispatch** — reuses the existing `range` builtin and `NilLit`.
- +3 lowering pins (240 → 243): `endless_range_inclusive_lowers_with_nil_end`
  (`(1..)`), `endless_range_exclusive_lowers_with_nil_end` (`(1...)`),
  `endless_range_over_param_validates_e2e` (`(a..)` + validator E2E).

### Verification

All green locally:
`cargo test -p coding-adventures-ruby-lexer -p coding-adventures-ruby-parser -p ruby-to-semantic-ir`
(lexer 173, parser 189, lowerer 243).

### Security

Pure AST→IR logic — no I/O, no `unsafe`.  The new arm indexes
`operands[0]` only when the match guarantees `len == 1`; the fallback
returns a `RubyLowerError` (no panic).  `/security-review` passed clean
in one round.
