### PR TITLE
feat(ruby-fc): Phase 10d — beginless range `..5` / `...5`

### DIFF
--- a/code/.pr-body-fc-10d.md
+++ b/code/.pr-body-fc-10d.md
@@ -1,0 +1,51 @@
+## Phase 10d (FC) — beginless range `..5` / `...5`
+
+Beginless ranges carry an **end with no start** (`..5`, `...5`, `(..5)`,
+`arr[..2]`).  This completes the Tier-2 range family: 10a inclusive,
+10b exclusive, 10c endless, 10d beginless.
+
+### `coding-adventures-ruby-parser` 0.53.0 (grammar)
+
+- `range = ( "..." | ".." ) logical_or
+          | logical_or [ ( "..." | ".." ) [ logical_or ] ] ;` — a new
+  FIRST alternative leads with the range op.  The two alternatives are
+  disjoint on their first token (`..`/`...` — a `Name` token from
+  `fuse_range_ops` — vs a `logical_or`, which never begins with `..`),
+  so there is no ambiguity and no backtracking hazard.  The beginless
+  alt requires a trailing operand (the end).
+- Regenerated `_grammar.rs`.
+- +3 parse pins (189 → 192): `test_parse_beginless_range_inclusive`
+  (`x = ..5`), `test_parse_beginless_range_exclusive` (`(...5)`),
+  `test_parse_beginless_range_parenthesized` (`(..5)`).  A bare leading
+  `..` at statement start is a separate dispatch quirk (like the
+  bare-NAME quirk), so the pins use expression positions.
+
+### `ruby-to-semantic-ir` 0.56.0 (lowering)
+
+- Endless (`1..`) and beginless (`..5`) ranges have identical arity
+  (one operand + one op token), so `lower_range` disambiguates by the
+  op token's position relative to the operand:
+  - endless  `1..` (child order `[operand, op]`) → `[start, NilLit, excl]`
+  - beginless `..5` (child order `[op, operand]`) → `[NilLit, end, excl]`
+  The missing endpoint is encoded as `NilLit` either way, preserving the
+  uniform `range` builtin.  **No new SIR variant, `Feature`, or backend
+  dispatch.**
+- +3 lowering pins (243 → 246):
+  `beginless_range_inclusive_lowers_with_nil_start` (`(..5)`),
+  `beginless_range_exclusive_lowers_with_nil_start` (`(...5)`),
+  `beginless_range_over_param_validates_e2e` (`(..b)` + validator E2E).
+
+### Verification
+
+All green locally:
+`cargo test -p coding-adventures-ruby-lexer -p coding-adventures-ruby-parser -p ruby-to-semantic-ir`
+(lexer 173, parser 192, lowerer 246).  The Phase-10c endless tests are
+unchanged and still pass (the disambiguation is additive).
+
+### Security
+
+Pure AST→IR logic — no I/O, no `unsafe`.  `op_idx`/`operand_idx` use
+`.position` (Option) with total `matches!` handling (no unwrap, no
+indexing); `operands[0]` is indexed only where the match guarantees
+`len == 1`; the fallback returns a `RubyLowerError`.  `/security-review`
+passed clean in one round.

--- a/code/grammars/ruby.grammar
+++ b/code/grammars/ruby.grammar
@@ -435,8 +435,19 @@ expression_stmt = expression ;
 # begin a `logical_or`), the optional cleanly matches nothing and the
 # node carries exactly one operand plus the op token: an endless range.
 # A bare `logical_or` (no op) still passes through; `1..5` still binds
-# two operands.  Beginless ranges (`..5`, a leading op with no LHS) are
-# a separate grammar shape and remain deferred to Phase 10d.
+# two operands.
+#
+# Phase 10d — beginless ranges (`..5`, `...5`, `(..5)`, `arr[..2]`).  A
+# beginless range LEADS with the range op (no left operand), so it needs
+# its own production placed FIRST in the alternation:
+#   range = ( "..." | ".." ) logical_or
+#         | logical_or [ ( "..." | ".." ) [ logical_or ] ] ;
+# The two alternatives are disjoint on their first token — a beginless
+# range starts with `..`/`...` (a Name token from `fuse_range_ops`),
+# while the normal/endless form starts with a `logical_or`, which can
+# never begin with `..`.  So no ambiguity and no backtracking hazard.
+# The beginless alt requires a trailing `logical_or` (the end operand);
+# a lone `..` with nothing on either side is not valid Ruby.
 # Phase 6o — ternary `cond ? a : b`.
 #
 # Precedence: ternary sits ABOVE range (looser than `..`/`...`)
@@ -460,7 +471,7 @@ expression_stmt = expression ;
 # consumes is the ternary separator, not a symbol opener.
 expression   = ternary ;
 ternary      = range [ "?" expression ":" expression ] ;
-range        = logical_or [ ( "..." | ".." ) [ logical_or ] ] ;
+range        = ( "..." | ".." ) logical_or | logical_or [ ( "..." | ".." ) [ logical_or ] ] ;
 logical_or   = logical_and { ( "||" | "or" ) logical_and } ;
 logical_and  = logical_not { ( "&&" | "and" ) logical_not } ;
 # `logical_not` uses `{ }` (zero-or-more) instead of right-recursive

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.53.0] - 2026-05-31
+
+### Added (Phase 10d (FC) — beginless range `..5` / `...5`)
+
+The `range` rule gained a FIRST alternative that leads with the op,
+enabling beginless ranges (an end with no start):
+
+- `range = ( "..." | ".." ) logical_or
+          | logical_or [ ( "..." | ".." ) [ logical_or ] ] ;` — the two
+  alternatives are disjoint on their first token (`..`/`...` vs a
+  `logical_or`), so there is no ambiguity and no backtracking hazard.
+  The beginless alt requires a trailing operand (the end).
+- Regenerated `_grammar.rs`.
+
+New parse pins (+3): `test_parse_beginless_range_inclusive` (`x = ..5`),
+`test_parse_beginless_range_exclusive` (`(...5)`),
+`test_parse_beginless_range_parenthesized` (`(..5)`).  (A bare leading
+`..` at statement start is a separate dispatch quirk — like the
+bare-NAME quirk — so the pins use expression positions.)  Test count:
+189 → 192.
+
 ## [0.52.0] - 2026-05-31
 
 ### Added (Phase 10c (FC) — endless range `1..` / `1...`)

--- a/code/packages/rust/ruby-parser/src/_grammar.rs
+++ b/code/packages/rust/ruby-parser/src/_grammar.rs
@@ -691,7 +691,7 @@ pub fn parser_grammar() -> ParserGrammar {
         GrammarRule {
             name: r#"expression"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"ternary"#.to_string() },
-            line_number: 461,
+            line_number: 472,
         },
         GrammarRule {
             name: r#"ternary"#.to_string(),
@@ -704,21 +704,30 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 462,
+            line_number: 473,
         },
         GrammarRule {
             name: r#"range"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::RuleReference { name: r#"logical_or"#.to_string() },
-                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
-                        GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
-                                GrammarElement::Literal { value: r#"..."#.to_string() },
-                                GrammarElement::Literal { value: r#".."#.to_string() },
-                            ] }) },
-                        GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"logical_or"#.to_string() }) },
-                    ] }) },
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                            GrammarElement::Literal { value: r#"..."#.to_string() },
+                            GrammarElement::Literal { value: r#".."#.to_string() },
+                        ] }) },
+                    GrammarElement::RuleReference { name: r#"logical_or"#.to_string() },
+                ] },
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::RuleReference { name: r#"logical_or"#.to_string() },
+                    GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                            GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                                    GrammarElement::Literal { value: r#"..."#.to_string() },
+                                    GrammarElement::Literal { value: r#".."#.to_string() },
+                                ] }) },
+                            GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"logical_or"#.to_string() }) },
+                        ] }) },
+                ] },
             ] },
-            line_number: 463,
+            line_number: 474,
         },
         GrammarRule {
             name: r#"logical_or"#.to_string(),
@@ -732,7 +741,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_and"#.to_string() },
                     ] }) },
             ] },
-            line_number: 464,
+            line_number: 475,
         },
         GrammarRule {
             name: r#"logical_and"#.to_string(),
@@ -746,7 +755,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_not"#.to_string() },
                     ] }) },
             ] },
-            line_number: 465,
+            line_number: 476,
         },
         GrammarRule {
             name: r#"logical_not"#.to_string(),
@@ -757,7 +766,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) }) },
                 GrammarElement::RuleReference { name: r#"comparison"#.to_string() },
             ] },
-            line_number: 472,
+            line_number: 483,
         },
         GrammarRule {
             name: r#"comparison"#.to_string(),
@@ -775,7 +784,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"sum"#.to_string() },
                     ] }) },
             ] },
-            line_number: 473,
+            line_number: 484,
         },
         GrammarRule {
             name: r#"sum"#.to_string(),
@@ -789,7 +798,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term"#.to_string() },
                     ] }) },
             ] },
-            line_number: 474,
+            line_number: 485,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -803,7 +812,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"factor"#.to_string() },
                     ] }) },
             ] },
-            line_number: 475,
+            line_number: 486,
         },
         GrammarRule {
             name: r#"factor"#.to_string(),
@@ -830,7 +839,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"scope_resolution"#.to_string() },
                     ] }) },
             ] },
-            line_number: 485,
+            line_number: 496,
         },
         GrammarRule {
             name: r#"lambda_literal"#.to_string(),
@@ -843,7 +852,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"block"#.to_string() },
             ] },
-            line_number: 504,
+            line_number: 515,
         },
         GrammarRule {
             name: r#"unary_minus"#.to_string(),
@@ -851,7 +860,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"factor"#.to_string() },
             ] },
-            line_number: 505,
+            line_number: 516,
         },
         GrammarRule {
             name: r#"symbol_literal"#.to_string(),
@@ -863,7 +872,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 512,
+            line_number: 523,
         },
         GrammarRule {
             name: r#"array_literal"#.to_string(),
@@ -878,7 +887,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 513,
+            line_number: 524,
         },
         GrammarRule {
             name: r#"hash_literal"#.to_string(),
@@ -893,7 +902,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 514,
+            line_number: 525,
         },
         GrammarRule {
             name: r#"hash_entry"#.to_string(),
@@ -913,7 +922,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                 ] },
             ] },
-            line_number: 515,
+            line_number: 526,
         },
     ],
         version: 1,

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -1744,6 +1744,65 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // Phase 10d (FC) — beginless range `..5` / `...5`.
+    //
+    // The `range` rule gained a FIRST alternative leading with the op:
+    //   range = ( "..." | ".." ) logical_or | logical_or [ … ] ;
+    // so a leading `..`/`...` followed by an operand parses to a `range`
+    // node carrying the op token and exactly ONE `logical_or` operand —
+    // same shape (count-wise) as an endless range, but the op token comes
+    // BEFORE the operand instead of after.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_beginless_range_inclusive() {
+        // `x = ..5` — beginless inclusive as an assignment RHS.  A bare
+        // leading `..` at statement start is a separate dispatch quirk
+        // (like the bare-NAME quirk); routing through an expression
+        // position (assignment RHS, parens, array) parses cleanly.
+        let ast = parse_ruby("x = ..5");
+        let r = find_descendant(&ast, "range").expect("expected range node");
+        assert!(
+            tree_has_token_value(r, ".."),
+            "expected `..` token in the beginless range"
+        );
+        let operand_count = r
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "logical_or"))
+            .count();
+        assert_eq!(operand_count, 1, "beginless range should carry exactly 1 operand");
+    }
+
+    #[test]
+    fn test_parse_beginless_range_exclusive() {
+        // `(...5)` — beginless exclusive carries the `...` token.
+        let ast = parse_ruby("(...5)");
+        let r = find_descendant(&ast, "range").expect("expected range node");
+        assert!(
+            tree_has_token_value(r, "..."),
+            "expected `...` token in the beginless exclusive range"
+        );
+    }
+
+    #[test]
+    fn test_parse_beginless_range_parenthesized() {
+        // `(..5)` — parenthesized beginless range.
+        let ast = parse_ruby("(..5)");
+        let r = find_descendant(&ast, "range").expect("expected range node");
+        assert!(
+            tree_has_token_value(r, ".."),
+            "expected `..` token in the parenthesized beginless range"
+        );
+        let operand_count = r
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "logical_or"))
+            .count();
+        assert_eq!(operand_count, 1, "beginless range should carry exactly 1 operand");
+    }
+
+    // -----------------------------------------------------------------------
     // Phase 6p — compound assignment `+=`, `-=`, `*=`, `/=`, `||=`, `&&=`
     // -----------------------------------------------------------------------
     //

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.56.0] - 2026-05-31
+
+### Added (Phase 10d (FC) — beginless range `..5` / `...5`)
+
+`lower_range` now handles beginless ranges (an end with no start).  A
+beginless range has the SAME arity as an endless range (one operand +
+one op token), so the lowerer disambiguates by the op token's position
+relative to the operand:
+
+- endless  `1..` (child order `[operand, op]`) → `[start, NilLit, excl]`
+- beginless `..5` (child order `[op, operand]`) → `[NilLit, end, excl]`
+
+The missing endpoint is encoded as `NilLit` either way, keeping the
+`range` builtin's uniform shape.  No new SIR variant, `Feature`, or
+backend dispatch.
+
+New tests (+3): `beginless_range_inclusive_lowers_with_nil_start`
+(`(..5)`), `beginless_range_exclusive_lowers_with_nil_start` (`(...5)`),
+`beginless_range_over_param_validates_e2e` (`(..b)` + validator E2E).
+Test count: 243 → 246.
+
 ## [0.55.0] - 2026-05-31
 
 ### Added (Phase 10c (FC) — endless range `1..` / `1...`)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -2244,6 +2244,81 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
+    // Phase 10d (FC) — beginless range `..5` / `...5` lowering.
+    //
+    // A beginless range carries an end but no start.  It lowers to the
+    // same `range` builtin with the open LOWER bound encoded as
+    // `NilLit`: `BuiltinCall("range", [NilLit, end, BoolLit(excl)])`.
+    // Endless (`1..`) and beginless (`..5`) have identical arity (one
+    // operand + op); the lowerer disambiguates by the op token's
+    // position relative to the operand.  Here we pin that a leading op
+    // produces a NIL START (args[0]) with the operand as the end.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn beginless_range_inclusive_lowers_with_nil_start() {
+        // `def r() (..5) end` — beginless inclusive.  Parens keep the
+        // body off the bare-NAME method-call path (lessons.md).
+        let m = lower("def r\n  (..5)\nend\n");
+        let f = m.functions.iter().find(|f| f.name == "r").unwrap();
+        match &f.body.value {
+            Expr::BuiltinCall { name, args, .. } if name == "range" => {
+                assert_eq!(args.len(), 3, "expected [nil_start, end, exclusive_flag]");
+                assert!(
+                    matches!(&args[0], Expr::NilLit { .. }),
+                    "beginless range start should be NilLit; got {:?}",
+                    &args[0]
+                );
+                assert!(matches!(&args[1], Expr::IntLit { value: 5, .. }));
+                assert!(
+                    matches!(&args[2], Expr::BoolLit { value: false, .. }),
+                    "inclusive `..` should set the exclusive flag false; got {:?}",
+                    &args[2]
+                );
+            }
+            other => panic!("expected BuiltinCall(range, …), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn beginless_range_exclusive_lowers_with_nil_start() {
+        // `def r() (...5) end` — beginless exclusive sets the flag true.
+        let m = lower("def r\n  (...5)\nend\n");
+        let f = m.functions.iter().find(|f| f.name == "r").unwrap();
+        match &f.body.value {
+            Expr::BuiltinCall { name, args, .. } if name == "range" => {
+                assert_eq!(args.len(), 3);
+                assert!(matches!(&args[0], Expr::NilLit { .. }), "start should be nil");
+                assert!(matches!(&args[1], Expr::IntLit { value: 5, .. }));
+                assert!(
+                    matches!(&args[2], Expr::BoolLit { value: true, .. }),
+                    "exclusive `...` should set the flag true; got {:?}",
+                    &args[2]
+                );
+            }
+            other => panic!("expected BuiltinCall(range, …), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn beginless_range_over_param_validates_e2e() {
+        // `def r(b) (..b) end` — beginless range whose end is a param
+        // (in scope, so the VarRef survives validation).  End-to-end pin:
+        // nil start, VarRef end, and the module passes validation.
+        let m = lower("def r(b)\n  (..b)\nend\n");
+        let f = m.functions.iter().find(|f| f.name == "r").unwrap();
+        match &f.body.value {
+            Expr::BuiltinCall { name, args, .. } if name == "range" => {
+                assert!(matches!(&args[0], Expr::NilLit { .. }));
+                assert!(matches!(&args[1], Expr::VarRef { name, .. } if name == "b"));
+            }
+            other => panic!("expected BuiltinCall(range, …), got {:?}", other),
+        }
+        let result = semantic_ir::validate(&m);
+        assert!(result.is_ok(), "validator rejected beginless range: {:?}", result);
+    }
+
+    // -----------------------------------------------------------------
     // Phase 6o — ternary `cond ? a : b` lowering
     // -----------------------------------------------------------------
     //

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -4194,9 +4194,12 @@ impl Lowerer {
     ///     The third argument carries the inclusive/exclusive flag so a
     ///     single builtin handles both forms without name multiplication.
     ///     `..` → exclusive=false; `...` → exclusive=true.
-    ///   - One operand child WITH a `..`/`...` token (Phase 10c endless
-    ///     range `1..`) → emit `BuiltinCall("range", [start, NilLit,
-    ///     BoolLit(exclusive)])`; the nil upper bound means "unbounded".
+    ///   - One operand child WITH a `..`/`...` token → either a Phase 10c
+    ///     endless range (`1..`, child order `[operand, op]`) or a Phase
+    ///     10d beginless range (`..5`, child order `[op, operand]`),
+    ///     disambiguated by the op token's position.  Endless emits
+    ///     `[start, NilLit, excl]`; beginless emits `[NilLit, end, excl]`
+    ///     — the missing endpoint is the nil one.
     ///
     /// Range is pure: building a range doesn't observe or mutate any
     /// state.  (Iterating over one *would* run code, but that's a
@@ -4242,25 +4245,48 @@ impl Lowerer {
                     span: op_span,
                 })
             }
-            // Phase 10c — endless range: one operand plus a range op,
-            // with no trailing operand (`1..`, `1...`).  The open end is
-            // encoded as `NilLit`, so the `range` builtin keeps its
-            // uniform `[start, end, exclusive]` shape — downstream
-            // consumers read a nil end as "unbounded above".  `..` and
-            // `...` are distinguished by the exclusive flag exactly as
-            // in the two-operand case.
+            // One operand plus a range op — this is EITHER a Phase 10c
+            // endless range (`1..`, child order `[operand, op]`) OR a
+            // Phase 10d beginless range (`..5`, child order `[op,
+            // operand]`).  They have identical arity, so we disambiguate
+            // by the position of the op token relative to the operand.
+            // Both lower to the uniform `range` builtin with the missing
+            // endpoint encoded as `NilLit`:
+            //   endless  `1..`  → [start,  NilLit, exclusive]  (nil end)
+            //   beginless `..5` → [NilLit, end,    exclusive]  (nil start)
+            // The exclusive flag distinguishes `..` from `...` as always.
             (1, Some(tok)) => {
-                let start = self.lower_expression(operands[0])?;
+                let op_idx = node.children.iter().position(|c| {
+                    matches!(c, ASTNodeOrToken::Token(t) if t.value == ".." || t.value == "...")
+                });
+                let operand_idx = node
+                    .children
+                    .iter()
+                    .position(|c| matches!(c, ASTNodeOrToken::Node(_)));
+                // Beginless when the op token comes BEFORE the operand.
+                let beginless = matches!((op_idx, operand_idx), (Some(o), Some(p)) if o < p);
+
+                let operand = self.lower_expression(operands[0])?;
                 let exclusive = tok.value == "...";
                 let op_span = self.span_of_token(tok);
-                Ok(Expr::BuiltinCall {
-                    name: "range".to_string(),
-                    args: vec![
-                        start,
-                        // Open (infinite) upper bound — `nil` end.
+                let args = if beginless {
+                    // `..5` — nil (unbounded) lower bound, `operand` is the end.
+                    vec![
+                        Expr::NilLit { span: op_span.clone() },
+                        operand,
+                        Expr::BoolLit { value: exclusive, span: op_span.clone() },
+                    ]
+                } else {
+                    // `1..` — `operand` is the start, nil (unbounded) upper bound.
+                    vec![
+                        operand,
                         Expr::NilLit { span: op_span.clone() },
                         Expr::BoolLit { value: exclusive, span: op_span.clone() },
-                    ],
+                    ]
+                };
+                Ok(Expr::BuiltinCall {
+                    name: "range".to_string(),
+                    args,
                     effects: EffectSet::PURE,
                     span: op_span,
                 })


### PR DESCRIPTION
## Phase 10d (FC) — beginless range `..5` / `...5`

Beginless ranges carry an **end with no start** (`..5`, `...5`, `(..5)`,
`arr[..2]`).  This completes the Tier-2 range family: 10a inclusive,
10b exclusive, 10c endless, 10d beginless.

### `coding-adventures-ruby-parser` 0.53.0 (grammar)

- `range = ( "..." | ".." ) logical_or
          | logical_or [ ( "..." | ".." ) [ logical_or ] ] ;` — a new
  FIRST alternative leads with the range op.  The two alternatives are
  disjoint on their first token (`..`/`...` — a `Name` token from
  `fuse_range_ops` — vs a `logical_or`, which never begins with `..`),
  so there is no ambiguity and no backtracking hazard.  The beginless
  alt requires a trailing operand (the end).
- Regenerated `_grammar.rs`.
- +3 parse pins (189 → 192): `test_parse_beginless_range_inclusive`
  (`x = ..5`), `test_parse_beginless_range_exclusive` (`(...5)`),
  `test_parse_beginless_range_parenthesized` (`(..5)`).  A bare leading
  `..` at statement start is a separate dispatch quirk (like the
  bare-NAME quirk), so the pins use expression positions.

### `ruby-to-semantic-ir` 0.56.0 (lowering)

- Endless (`1..`) and beginless (`..5`) ranges have identical arity
  (one operand + one op token), so `lower_range` disambiguates by the
  op token's position relative to the operand:
  - endless  `1..` (child order `[operand, op]`) → `[start, NilLit, excl]`
  - beginless `..5` (child order `[op, operand]`) → `[NilLit, end, excl]`
  The missing endpoint is encoded as `NilLit` either way, preserving the
  uniform `range` builtin.  **No new SIR variant, `Feature`, or backend
  dispatch.**
- +3 lowering pins (243 → 246):
  `beginless_range_inclusive_lowers_with_nil_start` (`(..5)`),
  `beginless_range_exclusive_lowers_with_nil_start` (`(...5)`),
  `beginless_range_over_param_validates_e2e` (`(..b)` + validator E2E).

### Verification

All green locally:
`cargo test -p coding-adventures-ruby-lexer -p coding-adventures-ruby-parser -p ruby-to-semantic-ir`
(lexer 173, parser 192, lowerer 246).  The Phase-10c endless tests are
unchanged and still pass (the disambiguation is additive).

### Security

Pure AST→IR logic — no I/O, no `unsafe`.  `op_idx`/`operand_idx` use
`.position` (Option) with total `matches!` handling (no unwrap, no
indexing); `operands[0]` is indexed only where the match guarantees
`len == 1`; the fallback returns a `RubyLowerError`.  `/security-review`
passed clean in one round.
