### PR TITLE
Track browser resource priority tokens

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -327,6 +327,8 @@ def check_browser_document_metadata(
             "imagesizes",
         ):
             require_optional_nullable_string(hint_path, hint, field, errors)
+        require_optional_string_list(hint_path, hint, "rel_tokens", errors)
+        require_optional_string_list(hint_path, hint, "blocking_tokens", errors)
 
     for index, theme_color in enumerate(object_list_items(metadata, "theme_colors")):
         theme_color_path = f"{metadata_path}.theme_colors[{index}]"
@@ -384,6 +386,8 @@ def check_browser_expected_lists(
             "track_label",
         ):
             require_optional_nullable_string(resource_path, resource, field, errors)
+        require_optional_string_list(resource_path, resource, "rel_tokens", errors)
+        require_optional_string_list(resource_path, resource, "blocking_tokens", errors)
         require_optional_string_list(resource_path, resource, "sandbox", errors)
         require_optional_boolean(resource_path, resource, "allowfullscreen", errors)
         require_optional_boolean(resource_path, resource, "credentialless", errors)
@@ -407,6 +411,7 @@ def check_browser_expected_lists(
             "text",
         ):
             require_optional_nullable_string(script_path, script, field, errors)
+        require_optional_string_list(script_path, script, "blocking_tokens", errors)
         for field in ("async_script", "defer_script", "nomodule"):
             require_optional_boolean(script_path, script, field, errors)
 
@@ -429,6 +434,8 @@ def check_browser_expected_lists(
             "text",
         ):
             require_optional_nullable_string(stylesheet_path, stylesheet, field, errors)
+        require_optional_string_list(stylesheet_path, stylesheet, "rel_tokens", errors)
+        require_optional_string_list(stylesheet_path, stylesheet, "blocking_tokens", errors)
         for field in ("disabled", "alternate"):
             require_optional_boolean(stylesheet_path, stylesheet, field, errors)
 

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -885,6 +885,7 @@ pub struct BrowserResourceHint {
     pub url: String,
     pub resolved_url: Option<String>,
     pub rel: Option<String>,
+    pub rel_tokens: Vec<String>,
     pub as_hint: Option<String>,
     pub type_hint: Option<String>,
     pub media: Option<String>,
@@ -894,6 +895,7 @@ pub struct BrowserResourceHint {
     pub referrerpolicy: Option<String>,
     pub fetchpriority: Option<String>,
     pub blocking: Option<String>,
+    pub blocking_tokens: Vec<String>,
     pub imagesrcset: Option<String>,
     pub resolved_imagesrcset: Option<String>,
     pub imagesizes: Option<String>,
@@ -927,6 +929,7 @@ pub struct BrowserResource {
     pub url: String,
     pub resolved_url: Option<String>,
     pub rel: Option<String>,
+    pub rel_tokens: Vec<String>,
     pub as_hint: Option<String>,
     pub type_hint: Option<String>,
     pub media: Option<String>,
@@ -939,6 +942,7 @@ pub struct BrowserResource {
     pub referrerpolicy: Option<String>,
     pub fetchpriority: Option<String>,
     pub blocking: Option<String>,
+    pub blocking_tokens: Vec<String>,
     pub browsing_context_name: Option<String>,
     pub loading: Option<String>,
     pub sandbox: Vec<String>,
@@ -972,6 +976,7 @@ pub struct BrowserScript {
     pub referrerpolicy: Option<String>,
     pub fetchpriority: Option<String>,
     pub blocking: Option<String>,
+    pub blocking_tokens: Vec<String>,
     pub text: Option<String>,
 }
 
@@ -981,6 +986,7 @@ pub struct BrowserStylesheet {
     pub href: Option<String>,
     pub resolved_href: Option<String>,
     pub rel: Option<String>,
+    pub rel_tokens: Vec<String>,
     pub type_hint: Option<String>,
     pub media: Option<String>,
     pub title: Option<String>,
@@ -992,6 +998,7 @@ pub struct BrowserStylesheet {
     pub referrerpolicy: Option<String>,
     pub fetchpriority: Option<String>,
     pub blocking: Option<String>,
+    pub blocking_tokens: Vec<String>,
     pub text: Option<String>,
 }
 
@@ -9019,6 +9026,7 @@ fn collect_head_browser_facts(nodes: &[Node], summary: &mut BrowserDocument) {
                         url: src.to_string(),
                         resolved_url: resolve_browser_url(src, summary.base_href.as_deref()),
                         rel: None,
+                        rel_tokens: Vec::new(),
                         as_hint: None,
                         type_hint: element.attribute("type").map(ToOwned::to_owned),
                         media: None,
@@ -9031,6 +9039,7 @@ fn collect_head_browser_facts(nodes: &[Node], summary: &mut BrowserDocument) {
                         referrerpolicy: element.attribute("referrerpolicy").map(ToOwned::to_owned),
                         fetchpriority: element.attribute("fetchpriority").map(ToOwned::to_owned),
                         blocking: element.attribute("blocking").map(ToOwned::to_owned),
+                        blocking_tokens: browser_blocking_tokens(element),
                         browsing_context_name: None,
                         loading: None,
                         sandbox: Vec::new(),
@@ -9265,6 +9274,7 @@ fn browser_resource_hint_from_link(
         url: href.to_string(),
         resolved_url: resolve_browser_url(href, base_href),
         rel: element.attribute("rel").map(ToOwned::to_owned),
+        rel_tokens: browser_rel_tokens(element),
         as_hint: element.attribute("as").map(ToOwned::to_owned),
         type_hint: element.attribute("type").map(ToOwned::to_owned),
         media: element.attribute("media").map(ToOwned::to_owned),
@@ -9274,6 +9284,7 @@ fn browser_resource_hint_from_link(
         referrerpolicy: element.attribute("referrerpolicy").map(ToOwned::to_owned),
         fetchpriority: element.attribute("fetchpriority").map(ToOwned::to_owned),
         blocking: element.attribute("blocking").map(ToOwned::to_owned),
+        blocking_tokens: browser_blocking_tokens(element),
         resolved_imagesrcset: imagesrcset
             .as_deref()
             .map(|srcset| resolve_browser_srcset(srcset, base_href)),
@@ -9389,6 +9400,7 @@ fn collect_body_resource(element: &Element, summary: &mut BrowserDocument) {
         resolved_url: resolve_browser_url(&url, summary.base_href.as_deref()),
         url,
         rel: None,
+        rel_tokens: Vec::new(),
         as_hint: None,
         type_hint: element.attribute("type").map(ToOwned::to_owned),
         media: element.attribute("media").map(ToOwned::to_owned),
@@ -9401,6 +9413,7 @@ fn collect_body_resource(element: &Element, summary: &mut BrowserDocument) {
         referrerpolicy: element.attribute("referrerpolicy").map(ToOwned::to_owned),
         fetchpriority: element.attribute("fetchpriority").map(ToOwned::to_owned),
         blocking: element.attribute("blocking").map(ToOwned::to_owned),
+        blocking_tokens: browser_blocking_tokens(element),
         browsing_context_name: browser_browsing_context_name(element),
         loading: browser_browsing_context_loading(element),
         sandbox: browser_browsing_context_sandbox(element),
@@ -9767,6 +9780,7 @@ fn browser_link_resource(
         url: href.to_string(),
         resolved_url: resolve_browser_url(href, base_href),
         rel: element.attribute("rel").map(ToOwned::to_owned),
+        rel_tokens: browser_rel_tokens(element),
         as_hint: element.attribute("as").map(ToOwned::to_owned),
         type_hint: element.attribute("type").map(ToOwned::to_owned),
         media: element.attribute("media").map(ToOwned::to_owned),
@@ -9779,6 +9793,7 @@ fn browser_link_resource(
         referrerpolicy: element.attribute("referrerpolicy").map(ToOwned::to_owned),
         fetchpriority: element.attribute("fetchpriority").map(ToOwned::to_owned),
         blocking: element.attribute("blocking").map(ToOwned::to_owned),
+        blocking_tokens: browser_blocking_tokens(element),
         browsing_context_name: None,
         loading: None,
         sandbox: Vec::new(),
@@ -10727,6 +10742,7 @@ fn browser_script_element(element: &Element, base_href: Option<&str>) -> Browser
         referrerpolicy: element.attribute("referrerpolicy").map(ToOwned::to_owned),
         fetchpriority: element.attribute("fetchpriority").map(ToOwned::to_owned),
         blocking: element.attribute("blocking").map(ToOwned::to_owned),
+        blocking_tokens: browser_blocking_tokens(element),
         text: element_text_if_non_empty(element),
     }
 }
@@ -10768,6 +10784,7 @@ fn browser_style_element(element: &Element, base_href: Option<&str>) -> BrowserS
             .and_then(|href| resolve_browser_url(href, base_href)),
         href,
         rel: element.attribute("rel").map(ToOwned::to_owned),
+        rel_tokens: browser_rel_tokens(element),
         type_hint: element.attribute("type").map(ToOwned::to_owned),
         media: element.attribute("media").map(ToOwned::to_owned),
         title: element.attribute("title").map(ToOwned::to_owned),
@@ -10779,6 +10796,7 @@ fn browser_style_element(element: &Element, base_href: Option<&str>) -> BrowserS
         referrerpolicy: element.attribute("referrerpolicy").map(ToOwned::to_owned),
         fetchpriority: element.attribute("fetchpriority").map(ToOwned::to_owned),
         blocking: element.attribute("blocking").map(ToOwned::to_owned),
+        blocking_tokens: browser_blocking_tokens(element),
         text: if element.name == "style" {
             element_text_if_non_empty(element)
         } else {
@@ -10804,6 +10822,13 @@ fn browser_rel_tokens_contain(tokens: &[String], token: &str) -> bool {
 fn browser_rel_tokens(element: &Element) -> Vec<String> {
     element
         .attribute("rel")
+        .map(split_html_classes)
+        .unwrap_or_default()
+}
+
+fn browser_blocking_tokens(element: &Element) -> Vec<String> {
+    element
+        .attribute("blocking")
         .map(split_html_classes)
         .unwrap_or_default()
 }

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -135,6 +135,8 @@ struct ExpectedResourceHint {
     #[serde(default)]
     rel: Option<String>,
     #[serde(default)]
+    rel_tokens: Vec<String>,
+    #[serde(default)]
     as_hint: Option<String>,
     #[serde(default)]
     type_hint: Option<String>,
@@ -152,6 +154,8 @@ struct ExpectedResourceHint {
     fetchpriority: Option<String>,
     #[serde(default)]
     blocking: Option<String>,
+    #[serde(default)]
+    blocking_tokens: Vec<String>,
     #[serde(default)]
     imagesrcset: Option<String>,
     #[serde(default)]
@@ -271,6 +275,8 @@ struct ExpectedResource {
     resolved_url: Option<String>,
     rel: Option<String>,
     #[serde(default)]
+    rel_tokens: Vec<String>,
+    #[serde(default)]
     as_hint: Option<String>,
     type_hint: Option<String>,
     media: Option<String>,
@@ -291,6 +297,8 @@ struct ExpectedResource {
     fetchpriority: Option<String>,
     #[serde(default)]
     blocking: Option<String>,
+    #[serde(default)]
+    blocking_tokens: Vec<String>,
     #[serde(default)]
     browsing_context_name: Option<String>,
     #[serde(default)]
@@ -349,6 +357,8 @@ struct ExpectedScript {
     #[serde(default)]
     blocking: Option<String>,
     #[serde(default)]
+    blocking_tokens: Vec<String>,
+    #[serde(default)]
     text: Option<String>,
 }
 
@@ -361,6 +371,8 @@ struct ExpectedStylesheet {
     resolved_href: Option<String>,
     #[serde(default)]
     rel: Option<String>,
+    #[serde(default)]
+    rel_tokens: Vec<String>,
     #[serde(default)]
     type_hint: Option<String>,
     #[serde(default)]
@@ -383,6 +395,8 @@ struct ExpectedStylesheet {
     fetchpriority: Option<String>,
     #[serde(default)]
     blocking: Option<String>,
+    #[serde(default)]
+    blocking_tokens: Vec<String>,
     #[serde(default)]
     text: Option<String>,
 }
@@ -866,6 +880,39 @@ fn browser_script_style_security_metadata_tracks_nonces_and_fetch_policy() {
 }
 
 #[test]
+fn browser_resource_priority_metadata_tracks_rel_and_blocking_tokens() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+    let case = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "script-style-loading-page")
+        .expect("script style loading fixture case should exist");
+
+    let actual = parse_browser_document(&case.input)
+        .expect("script style loading fixture should parse into browser document facts");
+    let expected = case.expected.into_browser_document();
+
+    assert_eq!(
+        actual.metadata.resource_hints,
+        expected.metadata.resource_hints,
+        "resource hints should preserve rel and blocking token metadata",
+    );
+    assert_eq!(
+        actual.resources, expected.resources,
+        "resources should preserve rel and blocking token metadata",
+    );
+    assert_eq!(
+        actual.scripts, expected.scripts,
+        "scripts should preserve blocking token metadata",
+    );
+    assert_eq!(
+        actual.stylesheets, expected.stylesheets,
+        "stylesheets should preserve rel and blocking token metadata",
+    );
+}
+
+#[test]
 fn browser_form_validation_metadata_tracks_constraint_candidates() {
     let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
         .expect("browser readiness fixture should parse");
@@ -1234,11 +1281,15 @@ impl ExpectedHttpEquivHint {
 
 impl ExpectedResourceHint {
     fn into_browser_resource_hint(self) -> BrowserResourceHint {
+        let rel_tokens = expected_tokens_from_raw(self.rel_tokens, self.rel.as_deref());
+        let blocking_tokens =
+            expected_tokens_from_raw(self.blocking_tokens, self.blocking.as_deref());
         BrowserResourceHint {
             kind: self.kind,
             url: self.url,
             resolved_url: self.resolved_url,
             rel: self.rel,
+            rel_tokens,
             as_hint: self.as_hint,
             type_hint: self.type_hint,
             media: self.media,
@@ -1248,6 +1299,7 @@ impl ExpectedResourceHint {
             referrerpolicy: self.referrerpolicy,
             fetchpriority: self.fetchpriority,
             blocking: self.blocking,
+            blocking_tokens,
             imagesrcset: self.imagesrcset,
             resolved_imagesrcset: self.resolved_imagesrcset,
             imagesizes: self.imagesizes,
@@ -1362,11 +1414,15 @@ impl ExpectedDataAttribute {
 
 impl ExpectedResource {
     fn into_browser_resource(self) -> BrowserResource {
+        let rel_tokens = expected_tokens_from_raw(self.rel_tokens, self.rel.as_deref());
+        let blocking_tokens =
+            expected_tokens_from_raw(self.blocking_tokens, self.blocking.as_deref());
         BrowserResource {
             kind: self.kind,
             url: self.url,
             resolved_url: self.resolved_url,
             rel: self.rel,
+            rel_tokens,
             as_hint: self.as_hint,
             type_hint: self.type_hint,
             media: self.media,
@@ -1379,6 +1435,7 @@ impl ExpectedResource {
             referrerpolicy: self.referrerpolicy,
             fetchpriority: self.fetchpriority,
             blocking: self.blocking,
+            blocking_tokens,
             browsing_context_name: self.browsing_context_name,
             loading: self.loading,
             sandbox: self.sandbox,
@@ -1401,6 +1458,8 @@ impl ExpectedResource {
 
 impl ExpectedScript {
     fn into_browser_script(self) -> BrowserScript {
+        let blocking_tokens =
+            expected_tokens_from_raw(self.blocking_tokens, self.blocking.as_deref());
         BrowserScript {
             script_kind: self.script_kind,
             src: self.src,
@@ -1415,6 +1474,7 @@ impl ExpectedScript {
             referrerpolicy: self.referrerpolicy,
             fetchpriority: self.fetchpriority,
             blocking: self.blocking,
+            blocking_tokens,
             text: self.text,
         }
     }
@@ -1422,11 +1482,15 @@ impl ExpectedScript {
 
 impl ExpectedStylesheet {
     fn into_browser_stylesheet(self) -> BrowserStylesheet {
+        let rel_tokens = expected_tokens_from_raw(self.rel_tokens, self.rel.as_deref());
+        let blocking_tokens =
+            expected_tokens_from_raw(self.blocking_tokens, self.blocking.as_deref());
         BrowserStylesheet {
             source: self.source,
             href: self.href,
             resolved_href: self.resolved_href,
             rel: self.rel,
+            rel_tokens,
             type_hint: self.type_hint,
             media: self.media,
             title: self.title,
@@ -1438,9 +1502,24 @@ impl ExpectedStylesheet {
             referrerpolicy: self.referrerpolicy,
             fetchpriority: self.fetchpriority,
             blocking: self.blocking,
+            blocking_tokens,
             text: self.text,
         }
     }
+}
+
+fn expected_tokens_from_raw(tokens: Vec<String>, raw: Option<&str>) -> Vec<String> {
+    if !tokens.is_empty() {
+        return tokens;
+    }
+    raw.map(split_html_test_tokens).unwrap_or_default()
+}
+
+fn split_html_test_tokens(raw: &str) -> Vec<String> {
+    raw.split_ascii_whitespace()
+        .filter(|token| !token.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
 }
 
 impl ExpectedAnchor {

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -287,24 +287,24 @@
           "manifest_url": "site.webmanifest",
           "resolved_manifest_url": "https://example.test/app/site.webmanifest",
           "resource_hints": [
-            { "kind": "preconnect", "url": "https://cdn.example.test", "resolved_url": "https://cdn.example.test", "rel": "preconnect", "crossorigin": "" },
-            { "kind": "preload", "url": "fonts/site.woff2", "resolved_url": "https://example.test/app/fonts/site.woff2", "rel": "preload", "as_hint": "font", "type_hint": "font/woff2", "integrity": "sha384-font", "crossorigin": "anonymous", "fetchpriority": "high" },
-            { "kind": "modulepreload", "url": "scripts/app.mjs", "resolved_url": "https://example.test/app/scripts/app.mjs", "rel": "modulepreload", "integrity": "sha384-module", "referrerpolicy": "no-referrer", "blocking": "render" },
-            { "kind": "preload", "url": "hero.jpg", "resolved_url": "https://example.test/app/hero.jpg", "rel": "preload", "as_hint": "image", "fetchpriority": "high", "imagesrcset": "hero-small.jpg 480w, hero-large.jpg 960w", "resolved_imagesrcset": "https://example.test/app/hero-small.jpg 480w, https://example.test/app/hero-large.jpg 960w", "imagesizes": "50vw" },
-            { "kind": "prefetch", "url": "next.html", "resolved_url": "https://example.test/app/next.html", "rel": "prefetch", "as_hint": "document" }
+            { "kind": "preconnect", "url": "https://cdn.example.test", "resolved_url": "https://cdn.example.test", "rel": "preconnect", "rel_tokens": ["preconnect"], "crossorigin": "" },
+            { "kind": "preload", "url": "fonts/site.woff2", "resolved_url": "https://example.test/app/fonts/site.woff2", "rel": "preload", "rel_tokens": ["preload"], "as_hint": "font", "type_hint": "font/woff2", "integrity": "sha384-font", "crossorigin": "anonymous", "fetchpriority": "high" },
+            { "kind": "modulepreload", "url": "scripts/app.mjs", "resolved_url": "https://example.test/app/scripts/app.mjs", "rel": "modulepreload", "rel_tokens": ["modulepreload"], "integrity": "sha384-module", "referrerpolicy": "no-referrer", "blocking": "render", "blocking_tokens": ["render"] },
+            { "kind": "preload", "url": "hero.jpg", "resolved_url": "https://example.test/app/hero.jpg", "rel": "preload", "rel_tokens": ["preload"], "as_hint": "image", "fetchpriority": "high", "imagesrcset": "hero-small.jpg 480w, hero-large.jpg 960w", "resolved_imagesrcset": "https://example.test/app/hero-small.jpg 480w, https://example.test/app/hero-large.jpg 960w", "imagesizes": "50vw" },
+            { "kind": "prefetch", "url": "next.html", "resolved_url": "https://example.test/app/next.html", "rel": "prefetch", "rel_tokens": ["prefetch"], "as_hint": "document" }
           ]
         },
         "body_text": "",
         "metas": [],
         "resources": [
-          { "kind": "preconnect", "url": "https://cdn.example.test", "resolved_url": "https://cdn.example.test", "rel": "preconnect", "crossorigin": "", "async_script": false, "defer_script": false },
-          { "kind": "preload", "url": "fonts/site.woff2", "resolved_url": "https://example.test/app/fonts/site.woff2", "rel": "preload", "as_hint": "font", "type_hint": "font/woff2", "integrity": "sha384-font", "crossorigin": "anonymous", "fetchpriority": "high", "async_script": false, "defer_script": false },
-          { "kind": "modulepreload", "url": "scripts/app.mjs", "resolved_url": "https://example.test/app/scripts/app.mjs", "rel": "modulepreload", "integrity": "sha384-module", "referrerpolicy": "no-referrer", "blocking": "render", "async_script": false, "defer_script": false },
-          { "kind": "preload", "url": "hero.jpg", "resolved_url": "https://example.test/app/hero.jpg", "rel": "preload", "as_hint": "image", "fetchpriority": "high", "imagesrcset": "hero-small.jpg 480w, hero-large.jpg 960w", "resolved_imagesrcset": "https://example.test/app/hero-small.jpg 480w, https://example.test/app/hero-large.jpg 960w", "imagesizes": "50vw", "async_script": false, "defer_script": false },
-          { "kind": "prefetch", "url": "next.html", "resolved_url": "https://example.test/app/next.html", "rel": "prefetch", "as_hint": "document", "async_script": false, "defer_script": false },
-          { "kind": "manifest", "url": "site.webmanifest", "resolved_url": "https://example.test/app/site.webmanifest", "rel": "manifest", "crossorigin": "use-credentials", "async_script": false, "defer_script": false },
-          { "kind": "canonical", "url": "https://example.test/app/", "resolved_url": "https://example.test/app/", "rel": "canonical", "async_script": false, "defer_script": false },
-          { "kind": "icon", "url": "favicon.ico", "resolved_url": "https://example.test/app/favicon.ico", "rel": "shortcut icon", "type_hint": "image/x-icon", "async_script": false, "defer_script": false }
+          { "kind": "preconnect", "url": "https://cdn.example.test", "resolved_url": "https://cdn.example.test", "rel": "preconnect", "rel_tokens": ["preconnect"], "crossorigin": "", "async_script": false, "defer_script": false },
+          { "kind": "preload", "url": "fonts/site.woff2", "resolved_url": "https://example.test/app/fonts/site.woff2", "rel": "preload", "rel_tokens": ["preload"], "as_hint": "font", "type_hint": "font/woff2", "integrity": "sha384-font", "crossorigin": "anonymous", "fetchpriority": "high", "async_script": false, "defer_script": false },
+          { "kind": "modulepreload", "url": "scripts/app.mjs", "resolved_url": "https://example.test/app/scripts/app.mjs", "rel": "modulepreload", "rel_tokens": ["modulepreload"], "integrity": "sha384-module", "referrerpolicy": "no-referrer", "blocking": "render", "blocking_tokens": ["render"], "async_script": false, "defer_script": false },
+          { "kind": "preload", "url": "hero.jpg", "resolved_url": "https://example.test/app/hero.jpg", "rel": "preload", "rel_tokens": ["preload"], "as_hint": "image", "fetchpriority": "high", "imagesrcset": "hero-small.jpg 480w, hero-large.jpg 960w", "resolved_imagesrcset": "https://example.test/app/hero-small.jpg 480w, https://example.test/app/hero-large.jpg 960w", "imagesizes": "50vw", "async_script": false, "defer_script": false },
+          { "kind": "prefetch", "url": "next.html", "resolved_url": "https://example.test/app/next.html", "rel": "prefetch", "rel_tokens": ["prefetch"], "as_hint": "document", "async_script": false, "defer_script": false },
+          { "kind": "manifest", "url": "site.webmanifest", "resolved_url": "https://example.test/app/site.webmanifest", "rel": "manifest", "rel_tokens": ["manifest"], "crossorigin": "use-credentials", "async_script": false, "defer_script": false },
+          { "kind": "canonical", "url": "https://example.test/app/", "resolved_url": "https://example.test/app/", "rel": "canonical", "rel_tokens": ["canonical"], "async_script": false, "defer_script": false },
+          { "kind": "icon", "url": "favicon.ico", "resolved_url": "https://example.test/app/favicon.ico", "rel": "shortcut icon", "rel_tokens": ["shortcut", "icon"], "type_hint": "image/x-icon", "async_script": false, "defer_script": false }
         ],
         "anchors": [],
         "headings": [],
@@ -446,25 +446,25 @@
         "base_target": null,
         "metadata": {
           "resource_hints": [
-            { "kind": "preload", "url": "app.css", "resolved_url": "https://example.test/app/app.css", "rel": "stylesheet preload", "media": "screen", "integrity": "sha256-css", "crossorigin": "anonymous", "nonce": "styleNonce", "referrerpolicy": "no-referrer", "fetchpriority": "high", "blocking": "render" }
+            { "kind": "preload", "url": "app.css", "resolved_url": "https://example.test/app/app.css", "rel": "stylesheet preload", "rel_tokens": ["stylesheet", "preload"], "media": "screen", "integrity": "sha256-css", "crossorigin": "anonymous", "nonce": "styleNonce", "referrerpolicy": "no-referrer", "fetchpriority": "high", "blocking": "render", "blocking_tokens": ["render"] }
           ]
         },
         "body_text": "",
         "metas": [],
         "resources": [
-          { "kind": "stylesheet", "url": "app.css", "resolved_url": "https://example.test/app/app.css", "rel": "stylesheet preload", "type_hint": null, "media": "screen", "title": "main", "integrity": "sha256-css", "crossorigin": "anonymous", "nonce": "styleNonce", "referrerpolicy": "no-referrer", "fetchpriority": "high", "blocking": "render", "async_script": false, "defer_script": false },
-          { "kind": "stylesheet", "url": "print.css", "resolved_url": "https://example.test/app/print.css", "rel": "alternate stylesheet", "type_hint": null, "media": null, "title": "print", "async_script": false, "defer_script": false },
-          { "kind": "script", "url": "app.js", "resolved_url": "https://example.test/app/app.js", "rel": null, "type_hint": "module", "media": null, "title": null, "integrity": "sha384-js", "crossorigin": "use-credentials", "nonce": "moduleNonce", "referrerpolicy": "origin", "fetchpriority": "low", "blocking": "render", "async_script": true, "defer_script": false },
+          { "kind": "stylesheet", "url": "app.css", "resolved_url": "https://example.test/app/app.css", "rel": "stylesheet preload", "rel_tokens": ["stylesheet", "preload"], "type_hint": null, "media": "screen", "title": "main", "integrity": "sha256-css", "crossorigin": "anonymous", "nonce": "styleNonce", "referrerpolicy": "no-referrer", "fetchpriority": "high", "blocking": "render", "blocking_tokens": ["render"], "async_script": false, "defer_script": false },
+          { "kind": "stylesheet", "url": "print.css", "resolved_url": "https://example.test/app/print.css", "rel": "alternate stylesheet", "rel_tokens": ["alternate", "stylesheet"], "type_hint": null, "media": null, "title": "print", "async_script": false, "defer_script": false },
+          { "kind": "script", "url": "app.js", "resolved_url": "https://example.test/app/app.js", "rel": null, "type_hint": "module", "media": null, "title": null, "integrity": "sha384-js", "crossorigin": "use-credentials", "nonce": "moduleNonce", "referrerpolicy": "origin", "fetchpriority": "low", "blocking": "render", "blocking_tokens": ["render"], "async_script": true, "defer_script": false },
           { "kind": "script", "url": "late.js", "resolved_url": "https://example.test/app/late.js", "rel": null, "type_hint": null, "media": null, "title": null, "nonce": "lateNonce", "async_script": false, "defer_script": true }
         ],
         "scripts": [
-          { "script_kind": "module", "src": "app.js", "resolved_src": "https://example.test/app/app.js", "type_hint": "module", "async_script": true, "integrity": "sha384-js", "crossorigin": "use-credentials", "nonce": "moduleNonce", "referrerpolicy": "origin", "fetchpriority": "low", "blocking": "render" },
+          { "script_kind": "module", "src": "app.js", "resolved_src": "https://example.test/app/app.js", "type_hint": "module", "async_script": true, "integrity": "sha384-js", "crossorigin": "use-credentials", "nonce": "moduleNonce", "referrerpolicy": "origin", "fetchpriority": "low", "blocking": "render", "blocking_tokens": ["render"] },
           { "script_kind": "classic", "src": null, "resolved_src": null, "type_hint": null, "defer_script": true, "nomodule": true, "nonce": "legacyNonce", "text": "legacy();" },
           { "script_kind": "classic", "src": "late.js", "resolved_src": "https://example.test/app/late.js", "type_hint": null, "nonce": "lateNonce", "defer_script": true }
         ],
         "stylesheets": [
-          { "source": "link", "href": "app.css", "resolved_href": "https://example.test/app/app.css", "rel": "stylesheet preload", "media": "screen", "title": "main", "integrity": "sha256-css", "crossorigin": "anonymous", "nonce": "styleNonce", "referrerpolicy": "no-referrer", "fetchpriority": "high", "blocking": "render" },
-          { "source": "link", "href": "print.css", "resolved_href": "https://example.test/app/print.css", "rel": "alternate stylesheet", "title": "print", "disabled": true, "alternate": true },
+          { "source": "link", "href": "app.css", "resolved_href": "https://example.test/app/app.css", "rel": "stylesheet preload", "rel_tokens": ["stylesheet", "preload"], "media": "screen", "title": "main", "integrity": "sha256-css", "crossorigin": "anonymous", "nonce": "styleNonce", "referrerpolicy": "no-referrer", "fetchpriority": "high", "blocking": "render", "blocking_tokens": ["render"] },
+          { "source": "link", "href": "print.css", "resolved_href": "https://example.test/app/print.css", "rel": "alternate stylesheet", "rel_tokens": ["alternate", "stylesheet"], "title": "print", "disabled": true, "alternate": true },
           { "source": "style", "media": "print", "title": "print", "nonce": "inlineStyleNonce", "text": "body { color: black; }" }
         ],
         "anchors": [],


### PR DESCRIPTION
## Summary
- add tokenized rel metadata to browser resource hints, resources, and stylesheets
- add tokenized blocking metadata to resource hints, resources, scripts, and stylesheets
- extend readiness fixture/schema coverage for preload/modulepreload/render-blocking scheduling facts

## Tests
- cargo check -p coding-adventures-html-parser
- cargo test -p coding-adventures-html-parser browser_resource_priority_metadata_tracks_rel_and_blocking_tokens
- cargo test -p coding-adventures-html-parser browser_script_style_security_metadata_tracks_nonces_and_fetch_policy
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py
- python3 -m py_compile code/packages/rust/html-lexer/tests/fixtures/*.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit-full
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser