### PR TITLE
[codex] Add Board VM ping liveness path

### DIFF
--- a/code/packages/rust/board-vm-cli/README.md
+++ b/code/packages/rust/board-vm-cli/README.md
@@ -76,7 +76,7 @@ the run report.
 `repl` opens the same serial-plan-backed transport, sends `HELLO`, and then
 accepts a small interactive command set: `caps`, `upload-blink`, `upload-gpio-read <pin>
 [mode]`, `upload-time-now`, `run [budget]`, `blink [budget]`, `gpio-read <pin>
-[mode] [budget]`, `time-now [budget]`, `stop`, `hello`, `help`, and `quit`.
+[mode] [budget]`, `time-now [budget]`, `ping`, `stop`, `hello`, `help`, and `quit`.
 This is the first language-agnostic host shell: it drives the binary protocol
 through the shared client library, while future frontend packages can put
 richer syntax on top of the same transport calls. `gpio-read` and `time-now`

--- a/code/packages/rust/board-vm-cli/src/lib.rs
+++ b/code/packages/rust/board-vm-cli/src/lib.rs
@@ -334,6 +334,7 @@ pub enum ReplCommand {
     TimeNow {
         instruction_budget: Option<u32>,
     },
+    Ping,
     Stop,
     Quit,
 }
@@ -764,6 +765,7 @@ pub fn parse_repl_line(line: &str) -> Result<ReplCommand, CliError> {
         "time-now" | "time.now" | "now" => Ok(ReplCommand::TimeNow {
             instruction_budget: optional_repl_budget(words.next(), "time-now")?,
         }),
+        "ping" => Ok(ReplCommand::Ping),
         "stop" => Ok(ReplCommand::Stop),
         "quit" | "exit" => Ok(ReplCommand::Quit),
         other => Err(CliError::UnknownCommand(other.to_owned())),
@@ -1947,6 +1949,10 @@ where
             )?;
             write_run(output, &run)?;
         }
+        ReplCommand::Ping => {
+            client.ping()?;
+            writeln!(output, "pong")?;
+        }
         ReplCommand::Stop => {
             let run = client.stop()?;
             write_run(output, &run)?;
@@ -2162,7 +2168,7 @@ where
 {
     writeln!(
         output,
-        "commands: hello, caps, upload-blink, upload-gpio-read <pin> [mode], upload-time-now, run [budget], blink [budget], gpio-read <pin> [mode] [budget], time-now [budget], stop, help, quit"
+        "commands: hello, caps, upload-blink, upload-gpio-read <pin> [mode], upload-time-now, run [budget], blink [budget], gpio-read <pin> [mode] [budget], time-now [budget], ping, stop, help, quit"
     )?;
     Ok(())
 }
@@ -3134,6 +3140,7 @@ mod tests {
                 instruction_budget: Some(24)
             }
         );
+        assert_eq!(parse_repl_line("ping").unwrap(), ReplCommand::Ping);
         assert_eq!(parse_repl_line("stop").unwrap(), ReplCommand::Stop);
         assert_eq!(parse_repl_line("quit").unwrap(), ReplCommand::Quit);
         assert_eq!(parse_repl_line("exit").unwrap(), ReplCommand::Quit);
@@ -3418,7 +3425,7 @@ blink program_id=3 status=Halted instructions=7 elapsed_ms=250 stack_depth=1 ope
             endpoint,
             LoopbackBluetoothWireTransactor::new(),
         );
-        let input = std::io::Cursor::new(b"caps\nblink 24\nquit\n".to_vec());
+        let input = std::io::Cursor::new(b"caps\nblink 24\nping\nquit\n".to_vec());
         let mut out = Vec::new();
 
         run_repl_with_transport(&options, transport, input, &mut out).unwrap();
@@ -3434,6 +3441,7 @@ blink program_id=3 status=Halted instructions=7 elapsed_ms=250 stack_depth=1 ope
         assert!(output.contains("upload program_id=13 bytes="));
         assert!(output.contains("run program_id=13 status=Running"));
         assert!(output.contains("open_handles=1"));
+        assert!(output.contains("pong\n"));
     }
 
     #[test]

--- a/code/packages/rust/board-vm-client/src/lib.rs
+++ b/code/packages/rust/board-vm-client/src/lib.rs
@@ -392,6 +392,12 @@ where
         self.expect_run_report(written.request_id, written.len)
     }
 
+    pub fn ping(&mut self) -> Result<(), ClientError> {
+        let written = self.session.ping_frame(&mut self.request)?;
+        self.exchange_checked(written.request_id, written.len, MessageType::PONG)?;
+        Ok(())
+    }
+
     pub fn reboot_to_bootloader(&mut self) -> Result<(), ClientError> {
         let written = self.session.bootloader_reboot_frame(&mut self.request)?;
         self.exchange_checked(
@@ -569,6 +575,8 @@ mod tests {
                 FakeEvent::SleepMs(250),
             ]
         );
+
+        client.ping().unwrap();
 
         let stop = client.stop().unwrap();
         assert_eq!(stop.status, RunStatus::Stopped);

--- a/code/packages/rust/board-vm-device/src/lib.rs
+++ b/code/packages/rust/board-vm-device/src/lib.rs
@@ -1778,6 +1778,7 @@ where
             }
             MessageType::RUN => self.handle_run(request, payload_out, frame_out),
             MessageType::STOP => self.handle_stop(request, payload_out, frame_out),
+            MessageType::PING => self.handle_ping(request, frame_out),
             MessageType::BOOTLOADER_REBOOT => {
                 self.handle_bootloader_reboot(request, payload_out, frame_out)
             }
@@ -2014,6 +2015,17 @@ where
             &payload_out[..payload_len],
             frame_out,
         )
+    }
+
+    fn handle_ping(
+        &mut self,
+        request: Frame<'_>,
+        frame_out: &mut [u8],
+    ) -> Result<usize, BoardFault> {
+        if !request.payload.is_empty() {
+            return Err(BoardFault::InvalidFrame);
+        }
+        write_response(MessageType::PONG, request.request_id, &[], frame_out)
     }
 
     fn handle_bootloader_reboot(
@@ -3338,6 +3350,19 @@ mod tests {
                 Some(Event::SleepMs(250)),
             ]
         );
+
+        let ping = session.ping_frame(&mut request).unwrap();
+        let response_len = handle(
+            &mut device,
+            &request[..ping.len],
+            &mut device_payload,
+            &mut response,
+        );
+        let frame = decode_frame(&response[..response_len]).unwrap();
+        assert_eq!(frame.flags, FLAG_IS_RESPONSE);
+        assert_eq!(frame.message_type, MessageType::PONG);
+        assert_eq!(frame.request_id, ping.request_id);
+        assert!(frame.payload.is_empty());
 
         let stop = session.stop_frame(&mut request).unwrap();
         let response_len = handle(

--- a/code/packages/rust/board-vm-host/src/lib.rs
+++ b/code/packages/rust/board-vm-host/src/lib.rs
@@ -1487,6 +1487,10 @@ impl HostSession {
         self.request_frame(MessageType::STOP, &[], frame_out)
     }
 
+    pub fn ping_frame(&mut self, frame_out: &mut [u8]) -> Result<WrittenFrame, HostError> {
+        self.request_frame(MessageType::PING, &[], frame_out)
+    }
+
     pub fn bootloader_reboot_frame(
         &mut self,
         frame_out: &mut [u8],
@@ -5536,6 +5540,20 @@ mod tests {
         assert_eq!(written.request_id, 42);
         assert_eq!(decoded.flags, FLAG_RESPONSE_REQUIRED);
         assert_eq!(decoded.message_type, MessageType::BOOTLOADER_REBOOT);
+        assert!(decoded.payload.is_empty());
+    }
+
+    #[test]
+    fn writes_ping_frame() {
+        let mut session = HostSession::with_next_request_id(77);
+        let mut frame = [0u8; 32];
+
+        let written = session.ping_frame(&mut frame).unwrap();
+        let decoded = decode_frame(&frame[..written.len]).unwrap();
+
+        assert_eq!(written.request_id, 77);
+        assert_eq!(decoded.flags, FLAG_RESPONSE_REQUIRED);
+        assert_eq!(decoded.message_type, MessageType::PING);
         assert!(decoded.payload.is_empty());
     }
 

--- a/code/packages/rust/board-vm-loopback/src/lib.rs
+++ b/code/packages/rust/board-vm-loopback/src/lib.rs
@@ -223,6 +223,7 @@ impl<const MAX_PROGRAM_BYTES: usize, const MAX_STACK: usize, const MAX_HANDLES: 
             MessageType::PROGRAM_END => self.handle_program_end(request, payload_out, frame_out),
             MessageType::RUN => self.handle_run(request, payload_out, frame_out),
             MessageType::STOP => self.handle_stop(request, payload_out, frame_out),
+            MessageType::PING => self.handle_ping(request, frame_out),
             _ => Err(BoardError::UnsupportedMessage),
         }
     }
@@ -432,6 +433,17 @@ impl<const MAX_PROGRAM_BYTES: usize, const MAX_STACK: usize, const MAX_HANDLES: 
             &payload_out[..payload_len],
             frame_out,
         )
+    }
+
+    fn handle_ping(
+        &mut self,
+        request: Frame<'_>,
+        frame_out: &mut [u8],
+    ) -> Result<usize, BoardError> {
+        if !request.payload.is_empty() {
+            return Err(BoardError::InvalidFrame);
+        }
+        write_response(MessageType::PONG, request.request_id, &[], frame_out)
     }
 
     fn write_error_response(
@@ -828,6 +840,18 @@ mod tests {
                 FakeEvent::SleepMs(250),
             ]
         );
+
+        let ping = session.ping_frame(&mut request).unwrap();
+        let response_len = handle(
+            &mut board,
+            &request[..ping.len],
+            &mut board_payload,
+            &mut response,
+        );
+        let frame = decode_frame(&response[..response_len]).unwrap();
+        assert_eq!(frame.message_type, MessageType::PONG);
+        assert_eq!(frame.request_id, ping.request_id);
+        assert!(frame.payload.is_empty());
 
         let stop = session.stop_frame(&mut request).unwrap();
         let response_len = handle(


### PR DESCRIPTION
## Summary
- add host/client PING helpers that expect PONG responses
- teach the Board VM device and loopback board to answer PING with PONG
- cover PING during the blink background-run path before STOP, and expose ping in the CLI REPL

## Validation
- cargo fmt -p board-vm-host -p board-vm-loopback -p board-vm-device -p board-vm-client -p board-vm-cli
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-blink-conformance cargo test -p board-vm-host -p board-vm-loopback -p board-vm-device -p board-vm-client -p board-vm-cli
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-blink-conformance cargo test -p board-vm-protocol -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-loopback -p board-vm-client -p board-vm-eject -p board-vm-uno-r4 -p board-vm-esp32 -p board-vm-pico -p board-vm-arduino -p board-vm-targets -p board-vm-language-core -p board-vm-cli
- git diff --check
- git diff --cached --check