### PR TITLE
feat(ruby-fc): Phase 19a — regex literal `/pattern/flags`

### DIFF
--- a/code/.pr-body-fc-19a.md
+++ b/code/.pr-body-fc-19a.md
@@ -1,0 +1,55 @@
+## Phase 19a (FC) — regex literal `/pattern/flags`
+
+First regex-family phase.  **No grammar or lexer change**: the lexer
+already resolves the classic `/`-is-regex-vs-division ambiguity
+(`should_open_regex` + the `regex_body` sub-machine, driven by lex
+state) and emits a regex as a `TokenType::String` token carrying the
+verbatim `/pattern/flags` source (slashes included).  The parser routes
+it through the ordinary string-literal slot — the same lexeme-prefix
+sentinel trick the percent literals, heredocs (`<<`), and backticks
+(`` ` ``) already use.
+
+### `coding-adventures-ruby-parser` 0.54.0
+
+- +3 parse pins (192 → 195): `test_parse_regex_literal` (`x = /foo/`),
+  `test_parse_regex_literal_with_flags` (`x = /foo/i`),
+  `test_parse_regex_literal_in_call_argument` (`foo(/bar/)`).  Each
+  confirms the verbatim regex lexeme survives into the parse tree.
+
+### `ruby-to-semantic-ir` 0.57.0
+
+- `lower_factor_atom` gains a regex dispatch.  The new free helper
+  `regex_pattern_flags` recognises the `/p/flags` shape and splits it
+  into pattern + flags.  Path-shaped strings such as `"/usr/bin"`
+  (lexed value `/usr/bin`) are **rejected** — the trailing segment after
+  the final `/` must consist only of valid Ruby regex flag letters
+  (`imxounes`), and `b` is not a flag, so it stays a string.
+- `lower_regex_literal` emits
+  `BuiltinCall("regex", [StrLit(pattern), StrLit(flags)])` (flags = `""`
+  when none).  Building a regex is pure; the literal requests
+  `Feature::Strings` (it emits `StrLit`s), matching the backtick/heredoc
+  stance.  **No new SIR variant or backend dispatch** — reuses the
+  existing `BuiltinCall` + `StrLit`.
+- +3 lowering pins (246 → 249): `regex_literal_lowers_to_regex_builtin`
+  (`/foo/`, empty flags), `regex_literal_with_flags_carries_flags`
+  (`/foo/i`), `regex_literal_validates_e2e` (`(/foo/)` + validator E2E).
+
+### Residual v0 ambiguity (documented)
+
+A double-quoted string whose content has true regex shape (e.g.
+`"/a/i"`) is read as a regex — the same lexeme-prefix limitation
+backticks and heredocs already accept.  v0 does not unescape the body
+(`\/` survives verbatim in the pattern).
+
+### Verification
+
+All green locally:
+`cargo test -p coding-adventures-ruby-lexer -p coding-adventures-ruby-parser -p ruby-to-semantic-ir`
+(lexer 173, parser 195, lowerer 249).
+
+### Security
+
+Pure AST→IR logic — no I/O, no `unsafe`.  Slice boundaries are
+ASCII-safe (`/` is one byte; `rfind` returns a valid boundary).
+Pattern/flags are carried as inert `StrLit` data, not interpolated into
+any sink.  `/security-review` passed clean in one round.

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.54.0] - 2026-05-31
+
+### Added (Phase 19a (FC) — regex literal `/pattern/flags`)
+
+No grammar change.  The lexer already resolves the classic
+`/`-is-regex-vs-division ambiguity (`should_open_regex` / the
+`regex_body` sub-machine) and emits a regex as a `TokenType::String`
+token carrying the verbatim `/pattern/flags` source (slashes included)
+— the same lexeme-prefix sentinel trick percent literals, heredocs, and
+backticks use.  The parser therefore routes a regex through the ordinary
+string-literal slot.
+
+New parse pins (+3): `test_parse_regex_literal` (`x = /foo/`),
+`test_parse_regex_literal_with_flags` (`x = /foo/i`),
+`test_parse_regex_literal_in_call_argument` (`foo(/bar/)`) — each
+confirms the verbatim regex lexeme survives into the parse tree.  Test
+count: 192 → 195.
+
 ## [0.53.0] - 2026-05-31
 
 ### Added (Phase 10d (FC) — beginless range `..5` / `...5`)

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -1803,6 +1803,47 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // Phase 19a (FC) — regex literal `/pattern/flags`.
+    //
+    // The lexer resolves the `/`-vs-division ambiguity and emits a regex
+    // as a `String` token carrying the verbatim `/p/flags` (slashes
+    // included), so the parser routes it through the ordinary
+    // string-literal slot — no grammar change.  These pins confirm the
+    // verbatim lexeme survives into the parse tree.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_regex_literal() {
+        // `x = /foo/` — assignment RHS is a regex; the `/foo/` lexeme
+        // appears verbatim in the tree as a String token.
+        let ast = parse_ruby("x = /foo/");
+        assert!(
+            tree_has_token_value(&ast, "/foo/"),
+            "expected verbatim `/foo/` regex token in the parse tree"
+        );
+    }
+
+    #[test]
+    fn test_parse_regex_literal_with_flags() {
+        // `x = /foo/i` — flags ride along in the same verbatim lexeme.
+        let ast = parse_ruby("x = /foo/i");
+        assert!(
+            tree_has_token_value(&ast, "/foo/i"),
+            "expected verbatim `/foo/i` regex token in the parse tree"
+        );
+    }
+
+    #[test]
+    fn test_parse_regex_literal_in_call_argument() {
+        // `foo(/bar/)` — regex as a method-call argument.
+        let ast = parse_ruby("foo(/bar/)");
+        assert!(
+            tree_has_token_value(&ast, "/bar/"),
+            "expected verbatim `/bar/` regex token in the call argument"
+        );
+    }
+
+    // -----------------------------------------------------------------------
     // Phase 6p — compound assignment `+=`, `-=`, `*=`, `/=`, `||=`, `&&=`
     // -----------------------------------------------------------------------
     //

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.57.0] - 2026-05-31
+
+### Added (Phase 19a (FC) — regex literal `/pattern/flags`)
+
+`lower_factor_atom` gained a regex dispatch: a `String` token whose
+verbatim value has regex shape (recognised by the new free helper
+`regex_pattern_flags`) lowers via `lower_regex_literal` to
+`BuiltinCall("regex", [StrLit(pattern), StrLit(flags)])` (flags = `""`
+when none).  Building a regex is pure; the literal requests
+`Feature::Strings` (it emits `StrLit`s), matching the backtick/heredoc
+stance.  No new SIR variant or backend dispatch — reuses the existing
+`BuiltinCall` + `StrLit`.
+
+`regex_pattern_flags` rejects path-shaped strings like `"/usr/bin"`
+(lexed value `/usr/bin`) by requiring the trailing segment after the
+final `/` to consist only of valid Ruby regex flag letters (`imxounes`)
+— `b` is not a flag, so it stays a string.  (Residual v0 ambiguity: a
+double-quoted string whose content has true regex shape, e.g. `"/a/i"`,
+is read as a regex — the same lexeme-prefix limitation backticks and
+heredocs already accept.  v0 does not unescape the body.)
+
+New tests (+3): `regex_literal_lowers_to_regex_builtin` (`/foo/` → empty
+flags), `regex_literal_with_flags_carries_flags` (`/foo/i`),
+`regex_literal_validates_e2e` (`(/foo/)` + validator E2E).  Test count:
+246 → 249.
+
 ## [0.56.0] - 2026-05-31
 
 ### Added (Phase 10d (FC) — beginless range `..5` / `...5`)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -2319,6 +2319,77 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
+    // Phase 19a (FC) — regex literal `/pattern/flags` lowering.
+    //
+    // The lexer resolves the `/`-is-regex-vs-division ambiguity and emits
+    // the literal as a verbatim `/p/flags` String token; the lowerer
+    // splits it and emits `BuiltinCall("regex", [StrLit(pattern),
+    // StrLit(flags)])` (flags = "" when none).  Pure; requests
+    // `Feature::Strings`.  A path-shaped string like `"/usr/bin"` is NOT a
+    // regex (the flag-letter check rejects it).
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn regex_literal_lowers_to_regex_builtin() {
+        // `x = /foo/` — bare regex, no flags.
+        let m = lower("x = /foo/\n");
+        let value = main_body(&m).stmts.iter().find_map(|s| match s {
+            Stmt::LetBinding { value, .. } | Stmt::Assign { value, .. } => Some(value.clone()),
+            _ => None,
+        }).expect("expected a binding for `x`");
+        match &value {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "regex");
+                assert_eq!(args.len(), 2, "expected [pattern, flags]");
+                assert!(
+                    matches!(&args[0], Expr::StrLit { value, .. } if value == "foo"),
+                    "expected pattern StrLit \"foo\"; got {:?}", &args[0]
+                );
+                assert!(
+                    matches!(&args[1], Expr::StrLit { value, .. } if value.is_empty()),
+                    "expected empty flags StrLit; got {:?}", &args[1]
+                );
+            }
+            other => panic!("expected BuiltinCall(regex, …), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn regex_literal_with_flags_carries_flags() {
+        // `x = /foo/i` — case-insensitive flag preserved in args[1].
+        let m = lower("x = /foo/i\n");
+        let value = main_body(&m).stmts.iter().find_map(|s| match s {
+            Stmt::LetBinding { value, .. } | Stmt::Assign { value, .. } => Some(value.clone()),
+            _ => None,
+        }).expect("expected a binding for `x`");
+        match &value {
+            Expr::BuiltinCall { name, args, .. } if name == "regex" => {
+                assert!(matches!(&args[0], Expr::StrLit { value, .. } if value == "foo"));
+                assert!(
+                    matches!(&args[1], Expr::StrLit { value, .. } if value == "i"),
+                    "expected flags StrLit \"i\"; got {:?}", &args[1]
+                );
+            }
+            other => panic!("expected BuiltinCall(regex, …), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn regex_literal_validates_e2e() {
+        // `def r() (/foo/) end` — regex as a method body survives
+        // validation end-to-end.  Parens keep the body off the bare-NAME
+        // method-call path (lessons.md).
+        let m = lower("def r\n  (/foo/)\nend\n");
+        let f = m.functions.iter().find(|f| f.name == "r").unwrap();
+        match &f.body.value {
+            Expr::BuiltinCall { name, .. } if name == "regex" => {}
+            other => panic!("expected BuiltinCall(regex, …), got {:?}", other),
+        }
+        let result = semantic_ir::validate(&m);
+        assert!(result.is_ok(), "validator rejected regex literal: {:?}", result);
+    }
+
+    // -----------------------------------------------------------------
     // Phase 6o — ternary `cond ? a : b` lowering
     // -----------------------------------------------------------------
     //

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -336,6 +336,40 @@ fn block_references_any_name(block: &Block, names: &HashSet<String>) -> bool {
     false
 }
 
+/// Phase 19a (FC) — if `value` is a verbatim regex-literal lexeme
+/// (`/pattern/flags`), split it into `(pattern, flags)`; otherwise
+/// `None`.
+///
+/// A Ruby regex literal lexes (Phase 2 `regex_body`) to a
+/// `TokenType::String` token whose value is the verbatim source WITH the
+/// surrounding slashes — `/foo/`, `/foo/i`, `//`.  A double-quoted string
+/// has its delimiters stripped by the lexer, so a real string like
+/// `"foo"` yields `foo` (no leading slash) and is never mistaken here.
+///
+/// The split: drop the opening `/`, take everything up to the LAST `/`
+/// as the pattern, and the remainder as the flags.  To avoid mistaking a
+/// path-shaped string such as `"/usr/bin"` (lexed value `/usr/bin`) for a
+/// regex, the trailing segment must be made up ENTIRELY of valid Ruby
+/// regex flag letters (`imxounes`); `/usr/bin` fails because `b` is not a
+/// flag, so it stays a string.  (Residual v0 ambiguity: a double-quoted
+/// string whose content happens to have regex shape, e.g. `"/a/i"`, would
+/// be read as a regex — the same lexeme-prefix-sentinel limitation the
+/// backtick and heredoc literals already accept.)
+fn regex_pattern_flags(value: &str) -> Option<(&str, &str)> {
+    let rest = value.strip_prefix('/')?;
+    let close = rest.rfind('/')?;
+    let pattern = &rest[..close];
+    let flags = &rest[close + 1..];
+    if flags
+        .chars()
+        .all(|c| matches!(c, 'i' | 'm' | 'x' | 'o' | 'u' | 'n' | 'e' | 's'))
+    {
+        Some((pattern, flags))
+    } else {
+        None
+    }
+}
+
 /// Phase 15a (FC) — is this Name-token value a Ruby *instance
 /// variable* (`@x`)?  Instance vars lex as a `Name` token carrying the
 /// leading sigil.  A single `@` marks an instance variable; a double
@@ -4669,6 +4703,45 @@ impl Lowerer {
     }
 
     // -------------------------------------------------------------------
+    // Phase 19a (FC) — regex literal lowering (`/pattern/flags`)
+    // -------------------------------------------------------------------
+
+    /// Lower a Ruby regex literal `/pattern/flags` (Phase 19a).
+    ///
+    /// The lexer's `regex_body` sub-machine (entered via `should_open_regex`,
+    /// which resolves the classic `/`-is-regex-vs-division ambiguity from the
+    /// lex state) emits the whole literal as a single `TokenType::String`
+    /// token whose value is the verbatim `` /pattern/flags `` (leading slash
+    /// included).  This is the same lexeme-prefix sentinel trick the percent
+    /// literals, heredocs (`<<`), and backticks (`` ` ``) use — the parser
+    /// routes a regex through the ordinary string-literal slot.
+    ///
+    /// We split the verbatim lexeme into `pattern` and `flags` (see
+    /// [`regex_pattern_flags`]) and emit
+    /// `BuiltinCall("regex", [StrLit(pattern), StrLit(flags)])`.  Carrying
+    /// the two parts as separate `StrLit` args keeps the builtin uniform
+    /// across all flag combinations (`/x/`, `/x/i`, `/x/im`, …) without
+    /// name multiplication — mirroring the `range` builtin's flag arg.
+    ///
+    /// Building a regex object is pure (no I/O, no mutation).  We emit
+    /// `StrLit`s, so the literal requests `Feature::Strings` — the same
+    /// stance as backticks and heredocs.  (v0 does NOT unescape the body:
+    /// `\/` etc. survive verbatim in the pattern, matching the heredoc /
+    /// backtick capture stance.)
+    fn lower_regex_literal(&mut self, pattern: &str, flags: &str, span: Span) -> Expr {
+        self.features_used.insert(Feature::Strings);
+        Expr::BuiltinCall {
+            name: "regex".to_string(),
+            args: vec![
+                Expr::StrLit { value: pattern.to_string(), span: span.clone() },
+                Expr::StrLit { value: flags.to_string(), span: span.clone() },
+            ],
+            effects: EffectSet::PURE,
+            span,
+        }
+    }
+
+    // -------------------------------------------------------------------
     // Phase 6z — numeric literal lowering (float / hex / bin / oct / dec)
     // -------------------------------------------------------------------
 
@@ -5061,6 +5134,18 @@ impl Lowerer {
                                     &tok.value,
                                     span,
                                 ));
+                            }
+                            // Phase 19a (FC) — regex literal dispatch.  The
+                            // lexer's `regex_body` machine emits `/p/flags`
+                            // as a `String` token carrying the verbatim
+                            // source (slashes included).  `regex_pattern_flags`
+                            // recognises that shape (and rejects path-shaped
+                            // strings like `/usr/bin` via the flag-letter
+                            // check), splitting it into pattern + flags.
+                            if let Some((pattern, flags)) = regex_pattern_flags(&tok.value) {
+                                let (pattern, flags) =
+                                    (pattern.to_string(), flags.to_string());
+                                return Ok(self.lower_regex_literal(&pattern, &flags, span));
                             }
                             // Phase 6y — string interpolation expression
                             // lowering.  The lexer (Phase 3b) emits the


### PR DESCRIPTION
## Phase 19a (FC) — regex literal `/pattern/flags`

First regex-family phase.  **No grammar or lexer change**: the lexer
already resolves the classic `/`-is-regex-vs-division ambiguity
(`should_open_regex` + the `regex_body` sub-machine, driven by lex
state) and emits a regex as a `TokenType::String` token carrying the
verbatim `/pattern/flags` source (slashes included).  The parser routes
it through the ordinary string-literal slot — the same lexeme-prefix
sentinel trick the percent literals, heredocs (`<<`), and backticks
(`` ` ``) already use.

### `coding-adventures-ruby-parser` 0.54.0

- +3 parse pins (192 → 195): `test_parse_regex_literal` (`x = /foo/`),
  `test_parse_regex_literal_with_flags` (`x = /foo/i`),
  `test_parse_regex_literal_in_call_argument` (`foo(/bar/)`).  Each
  confirms the verbatim regex lexeme survives into the parse tree.

### `ruby-to-semantic-ir` 0.57.0

- `lower_factor_atom` gains a regex dispatch.  The new free helper
  `regex_pattern_flags` recognises the `/p/flags` shape and splits it
  into pattern + flags.  Path-shaped strings such as `"/usr/bin"`
  (lexed value `/usr/bin`) are **rejected** — the trailing segment after
  the final `/` must consist only of valid Ruby regex flag letters
  (`imxounes`), and `b` is not a flag, so it stays a string.
- `lower_regex_literal` emits
  `BuiltinCall("regex", [StrLit(pattern), StrLit(flags)])` (flags = `""`
  when none).  Building a regex is pure; the literal requests
  `Feature::Strings` (it emits `StrLit`s), matching the backtick/heredoc
  stance.  **No new SIR variant or backend dispatch** — reuses the
  existing `BuiltinCall` + `StrLit`.
- +3 lowering pins (246 → 249): `regex_literal_lowers_to_regex_builtin`
  (`/foo/`, empty flags), `regex_literal_with_flags_carries_flags`
  (`/foo/i`), `regex_literal_validates_e2e` (`(/foo/)` + validator E2E).

### Residual v0 ambiguity (documented)

A double-quoted string whose content has true regex shape (e.g.
`"/a/i"`) is read as a regex — the same lexeme-prefix limitation
backticks and heredocs already accept.  v0 does not unescape the body
(`\/` survives verbatim in the pattern).

### Verification

All green locally:
`cargo test -p coding-adventures-ruby-lexer -p coding-adventures-ruby-parser -p ruby-to-semantic-ir`
(lexer 173, parser 195, lowerer 249).

### Security

Pure AST→IR logic — no I/O, no `unsafe`.  Slice boundaries are
ASCII-safe (`/` is one byte; `rfind` returns a valid boundary).
Pattern/flags are carried as inert `StrLit` data, not interpolated into
any sink.  `/security-review` passed clean in one round.
