### PR TITLE
Track browser media policy metadata

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -373,6 +373,7 @@ def check_browser_expected_lists(
             "nonce",
             "referrerpolicy",
             "fetchpriority",
+            "csp",
             "blocking",
             "browsing_context_name",
             "loading",
@@ -514,9 +515,20 @@ def check_browser_expected_lists(
             "width",
             "height",
             "preload",
+            "crossorigin",
+            "controlslist",
         ):
             require_optional_nullable_string(media_path, media, field, errors)
-        for field in ("controls", "autoplay", "loop_media", "muted", "playsinline"):
+        require_optional_string_list(media_path, media, "controlslist_tokens", errors)
+        for field in (
+            "controls",
+            "autoplay",
+            "loop_media",
+            "muted",
+            "playsinline",
+            "disableremoteplayback",
+            "disablepictureinpicture",
+        ):
             require_optional_boolean(media_path, media, field, errors)
 
     for index, context in enumerate(object_list_items(expected, "embedded_contexts")):
@@ -531,6 +543,8 @@ def check_browser_expected_lists(
             "width",
             "height",
             "loading",
+            "fetchpriority",
+            "csp",
             "allow",
             "referrerpolicy",
             "srcdoc",

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -941,6 +941,7 @@ pub struct BrowserResource {
     pub nonce: Option<String>,
     pub referrerpolicy: Option<String>,
     pub fetchpriority: Option<String>,
+    pub csp: Option<String>,
     pub blocking: Option<String>,
     pub blocking_tokens: Vec<String>,
     pub browsing_context_name: Option<String>,
@@ -1508,6 +1509,11 @@ pub struct BrowserMedia {
     pub muted: bool,
     pub playsinline: bool,
     pub preload: Option<String>,
+    pub crossorigin: Option<String>,
+    pub controlslist: Option<String>,
+    pub controlslist_tokens: Vec<String>,
+    pub disableremoteplayback: bool,
+    pub disablepictureinpicture: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1521,6 +1527,8 @@ pub struct BrowserEmbeddedContext {
     pub width: Option<String>,
     pub height: Option<String>,
     pub loading: Option<String>,
+    pub fetchpriority: Option<String>,
+    pub csp: Option<String>,
     pub sandbox: Vec<String>,
     pub allow: Option<String>,
     pub allowfullscreen: bool,
@@ -9038,6 +9046,7 @@ fn collect_head_browser_facts(nodes: &[Node], summary: &mut BrowserDocument) {
                         nonce: element.attribute("nonce").map(ToOwned::to_owned),
                         referrerpolicy: element.attribute("referrerpolicy").map(ToOwned::to_owned),
                         fetchpriority: element.attribute("fetchpriority").map(ToOwned::to_owned),
+                        csp: None,
                         blocking: element.attribute("blocking").map(ToOwned::to_owned),
                         blocking_tokens: browser_blocking_tokens(element),
                         browsing_context_name: None,
@@ -9412,6 +9421,7 @@ fn collect_body_resource(element: &Element, summary: &mut BrowserDocument) {
         nonce: element.attribute("nonce").map(ToOwned::to_owned),
         referrerpolicy: element.attribute("referrerpolicy").map(ToOwned::to_owned),
         fetchpriority: element.attribute("fetchpriority").map(ToOwned::to_owned),
+        csp: browser_browsing_context_csp(element),
         blocking: element.attribute("blocking").map(ToOwned::to_owned),
         blocking_tokens: browser_blocking_tokens(element),
         browsing_context_name: browser_browsing_context_name(element),
@@ -9494,6 +9504,8 @@ fn browser_embedded_context(
         allow: browser_browsing_context_allow(element),
         allowfullscreen: browser_browsing_context_allowfullscreen(element),
         referrerpolicy: browser_browsing_context_referrerpolicy(element),
+        fetchpriority: browser_browsing_context_fetchpriority(element),
+        csp: browser_browsing_context_csp(element),
         srcdoc: browser_browsing_context_srcdoc(element),
         credentialless: browser_browsing_context_credentialless(element),
         fallback_text: visible_text_for_nodes(&element.children),
@@ -9792,6 +9804,7 @@ fn browser_link_resource(
         nonce: element.attribute("nonce").map(ToOwned::to_owned),
         referrerpolicy: element.attribute("referrerpolicy").map(ToOwned::to_owned),
         fetchpriority: element.attribute("fetchpriority").map(ToOwned::to_owned),
+        csp: None,
         blocking: element.attribute("blocking").map(ToOwned::to_owned),
         blocking_tokens: browser_blocking_tokens(element),
         browsing_context_name: None,
@@ -10643,6 +10656,22 @@ fn browser_browsing_context_referrerpolicy(element: &Element) -> Option<String> 
     }
 }
 
+fn browser_browsing_context_fetchpriority(element: &Element) -> Option<String> {
+    if is_browser_browsing_context_element(element) {
+        element.attribute("fetchpriority").map(ToOwned::to_owned)
+    } else {
+        None
+    }
+}
+
+fn browser_browsing_context_csp(element: &Element) -> Option<String> {
+    if element.name == "iframe" {
+        element.attribute("csp").map(ToOwned::to_owned)
+    } else {
+        None
+    }
+}
+
 fn browser_browsing_context_srcdoc(element: &Element) -> Option<String> {
     if element.name == "iframe" {
         element.attribute("srcdoc").map(ToOwned::to_owned)
@@ -10863,6 +10892,11 @@ fn browser_media_element(element: &Element, base_href: Option<&str>) -> BrowserM
         muted: browser_media_muted(element),
         playsinline: browser_media_playsinline(element),
         preload: browser_media_preload(element),
+        crossorigin: browser_media_crossorigin(element),
+        controlslist: browser_media_controlslist(element),
+        controlslist_tokens: browser_media_controlslist_tokens(element),
+        disableremoteplayback: browser_media_disableremoteplayback(element),
+        disablepictureinpicture: browser_media_disablepictureinpicture(element),
     }
 }
 
@@ -10902,6 +10936,38 @@ fn browser_media_playsinline(element: &Element) -> bool {
     matches!(element.name.as_str(), "audio" | "video")
         && (element.attribute("playsinline").is_some()
             || element.attribute("webkit-playsinline").is_some())
+}
+
+fn browser_media_crossorigin(element: &Element) -> Option<String> {
+    if matches!(element.name.as_str(), "audio" | "video") {
+        element.attribute("crossorigin").map(ToOwned::to_owned)
+    } else {
+        None
+    }
+}
+
+fn browser_media_controlslist(element: &Element) -> Option<String> {
+    if matches!(element.name.as_str(), "audio" | "video") {
+        element.attribute("controlslist").map(ToOwned::to_owned)
+    } else {
+        None
+    }
+}
+
+fn browser_media_controlslist_tokens(element: &Element) -> Vec<String> {
+    browser_media_controlslist(element)
+        .as_deref()
+        .map(split_html_classes)
+        .unwrap_or_default()
+}
+
+fn browser_media_disableremoteplayback(element: &Element) -> bool {
+    matches!(element.name.as_str(), "audio" | "video")
+        && element.attribute("disableremoteplayback").is_some()
+}
+
+fn browser_media_disablepictureinpicture(element: &Element) -> bool {
+    element.name == "video" && element.attribute("disablepictureinpicture").is_some()
 }
 
 fn browser_table_section_kind(element: &Element) -> Option<String> {

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -296,6 +296,8 @@ struct ExpectedResource {
     #[serde(default)]
     fetchpriority: Option<String>,
     #[serde(default)]
+    csp: Option<String>,
+    #[serde(default)]
     blocking: Option<String>,
     #[serde(default)]
     blocking_tokens: Vec<String>,
@@ -528,6 +530,16 @@ struct ExpectedMedia {
     playsinline: bool,
     #[serde(default)]
     preload: Option<String>,
+    #[serde(default)]
+    crossorigin: Option<String>,
+    #[serde(default)]
+    controlslist: Option<String>,
+    #[serde(default)]
+    controlslist_tokens: Vec<String>,
+    #[serde(default)]
+    disableremoteplayback: bool,
+    #[serde(default)]
+    disablepictureinpicture: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -549,6 +561,10 @@ struct ExpectedEmbeddedContext {
     height: Option<String>,
     #[serde(default)]
     loading: Option<String>,
+    #[serde(default)]
+    fetchpriority: Option<String>,
+    #[serde(default)]
+    csp: Option<String>,
     #[serde(default)]
     sandbox: Vec<String>,
     #[serde(default)]
@@ -894,8 +910,7 @@ fn browser_resource_priority_metadata_tracks_rel_and_blocking_tokens() {
     let expected = case.expected.into_browser_document();
 
     assert_eq!(
-        actual.metadata.resource_hints,
-        expected.metadata.resource_hints,
+        actual.metadata.resource_hints, expected.metadata.resource_hints,
         "resource hints should preserve rel and blocking token metadata",
     );
     assert_eq!(
@@ -989,6 +1004,54 @@ fn browser_embedded_context_metadata_tracks_frame_object_embed_and_srcdoc() {
         actual.embedded_contexts,
         case.expected.into_browser_document().embedded_contexts,
         "embedded contexts should preserve frame, object, embed, and srcdoc-only iframe metadata",
+    );
+}
+
+#[test]
+fn browser_embedded_policy_metadata_tracks_fetchpriority_and_csp() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+    let case = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "embedded-resource-page")
+        .expect("embedded resource fixture case should exist");
+
+    let actual = parse_browser_document(&case.input)
+        .expect("embedded resource fixture should parse into browser document facts");
+    let expected = case.expected.into_browser_document();
+
+    assert_eq!(
+        actual.resources, expected.resources,
+        "frame resources should preserve fetch priority and CSP policy metadata",
+    );
+    assert_eq!(
+        actual.embedded_contexts, expected.embedded_contexts,
+        "embedded contexts should preserve fetch priority and CSP policy metadata",
+    );
+}
+
+#[test]
+fn browser_media_policy_metadata_tracks_controls_and_remote_playback_hints() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+    let case = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "media-playback-poster-page")
+        .expect("media playback fixture case should exist");
+
+    let actual = parse_browser_document(&case.input)
+        .expect("media playback fixture should parse into browser document facts");
+    let expected = case.expected.into_browser_document();
+
+    assert_eq!(
+        actual.resources, expected.resources,
+        "media resources should preserve cross-origin fetch metadata",
+    );
+    assert_eq!(
+        actual.media, expected.media,
+        "media summaries should preserve controlslist and remote playback policy metadata",
     );
 }
 
@@ -1434,6 +1497,7 @@ impl ExpectedResource {
             nonce: self.nonce,
             referrerpolicy: self.referrerpolicy,
             fetchpriority: self.fetchpriority,
+            csp: self.csp,
             blocking: self.blocking,
             blocking_tokens,
             browsing_context_name: self.browsing_context_name,
@@ -1630,6 +1694,11 @@ impl ExpectedMedia {
             muted: self.muted,
             playsinline: self.playsinline,
             preload: self.preload,
+            crossorigin: self.crossorigin,
+            controlslist: self.controlslist,
+            controlslist_tokens: self.controlslist_tokens,
+            disableremoteplayback: self.disableremoteplayback,
+            disablepictureinpicture: self.disablepictureinpicture,
         }
     }
 }
@@ -1646,6 +1715,8 @@ impl ExpectedEmbeddedContext {
             width: self.width,
             height: self.height,
             loading: self.loading,
+            fetchpriority: self.fetchpriority,
+            csp: self.csp,
             sandbox: self.sandbox,
             allow: self.allow,
             allowfullscreen: self.allowfullscreen,

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -351,7 +351,7 @@
     {
       "id": "embedded-resource-page",
       "description": "Body resource and embedded-context inventories preserve frame, object, video, embed, and srcdoc-only iframe metadata for fetch, policy, and layout planning.",
-      "input": "<base href=\"https://example.test/media/index.html\"><body><iframe src=frame.html name=preview loading=lazy sandbox=\"allow-scripts allow-same-origin\" allow=\"fullscreen; geolocation\" allowfullscreen referrerpolicy=no-referrer srcdoc=\"<p>Fallback</p>\" credentialless width=320 height=200 title=Frame></iframe><object data=movie.swf type=\"application/x-shockwave-flash\" width=400 height=300></object><video src=movie.mp4 width=640 height=360 controls></video><embed src=legacy.mov type=\"video/quicktime\" width=160 height=120><iframe name=inline srcdoc=\"<h1>Inline</h1>\" sandbox allow=payment title=Inline width=240 height=120></iframe>",
+      "input": "<base href=\"https://example.test/media/index.html\"><body><iframe src=frame.html name=preview loading=lazy fetchpriority=high csp=\"script-src 'self'\" sandbox=\"allow-scripts allow-same-origin\" allow=\"fullscreen; geolocation\" allowfullscreen referrerpolicy=no-referrer srcdoc=\"<p>Fallback</p>\" credentialless width=320 height=200 title=Frame></iframe><object data=movie.swf type=\"application/x-shockwave-flash\" width=400 height=300></object><video src=movie.mp4 width=640 height=360 controls></video><embed src=legacy.mov type=\"video/quicktime\" width=160 height=120><iframe name=inline srcdoc=\"<h1>Inline</h1>\" sandbox allow=payment title=Inline width=240 height=120></iframe>",
       "expected": {
         "title": null,
         "base_href": "https://example.test/media/index.html",
@@ -359,7 +359,7 @@
         "body_text": "",
         "metas": [],
         "resources": [
-          { "kind": "frame", "url": "frame.html", "resolved_url": "https://example.test/media/frame.html", "rel": null, "type_hint": null, "media": null, "title": "Frame", "width": "320", "height": "200", "referrerpolicy": "no-referrer", "browsing_context_name": "preview", "loading": "lazy", "sandbox": ["allow-scripts", "allow-same-origin"], "allow": "fullscreen; geolocation", "allowfullscreen": true, "srcdoc": "<p>Fallback</p>", "credentialless": true, "async_script": false, "defer_script": false },
+          { "kind": "frame", "url": "frame.html", "resolved_url": "https://example.test/media/frame.html", "rel": null, "type_hint": null, "media": null, "title": "Frame", "width": "320", "height": "200", "referrerpolicy": "no-referrer", "fetchpriority": "high", "csp": "script-src 'self'", "browsing_context_name": "preview", "loading": "lazy", "sandbox": ["allow-scripts", "allow-same-origin"], "allow": "fullscreen; geolocation", "allowfullscreen": true, "srcdoc": "<p>Fallback</p>", "credentialless": true, "async_script": false, "defer_script": false },
           { "kind": "object", "url": "movie.swf", "resolved_url": "https://example.test/media/movie.swf", "rel": null, "type_hint": "application/x-shockwave-flash", "media": null, "title": null, "width": "400", "height": "300", "async_script": false, "defer_script": false },
           { "kind": "video", "url": "movie.mp4", "resolved_url": "https://example.test/media/movie.mp4", "rel": null, "type_hint": null, "media": null, "title": null, "width": "640", "height": "360", "async_script": false, "defer_script": false },
           { "kind": "embed", "url": "legacy.mov", "resolved_url": "https://example.test/media/legacy.mov", "rel": null, "type_hint": "video/quicktime", "media": null, "title": null, "width": "160", "height": "120", "async_script": false, "defer_script": false }
@@ -379,7 +379,7 @@
           }
         ],
         "embedded_contexts": [
-          { "element": "iframe", "url": "frame.html", "resolved_url": "https://example.test/media/frame.html", "browsing_context_name": "preview", "title": "Frame", "width": "320", "height": "200", "loading": "lazy", "sandbox": ["allow-scripts", "allow-same-origin"], "allow": "fullscreen; geolocation", "allowfullscreen": true, "referrerpolicy": "no-referrer", "srcdoc": "<p>Fallback</p>", "credentialless": true, "fallback_text": "" },
+          { "element": "iframe", "url": "frame.html", "resolved_url": "https://example.test/media/frame.html", "browsing_context_name": "preview", "title": "Frame", "width": "320", "height": "200", "loading": "lazy", "fetchpriority": "high", "csp": "script-src 'self'", "sandbox": ["allow-scripts", "allow-same-origin"], "allow": "fullscreen; geolocation", "allowfullscreen": true, "referrerpolicy": "no-referrer", "srcdoc": "<p>Fallback</p>", "credentialless": true, "fallback_text": "" },
           { "element": "object", "url": "movie.swf", "resolved_url": "https://example.test/media/movie.swf", "type_hint": "application/x-shockwave-flash", "width": "400", "height": "300", "fallback_text": "" },
           { "element": "embed", "url": "legacy.mov", "resolved_url": "https://example.test/media/legacy.mov", "type_hint": "video/quicktime", "width": "160", "height": "120", "fallback_text": "" },
           { "element": "iframe", "url": null, "resolved_url": null, "browsing_context_name": "inline", "title": "Inline", "width": "240", "height": "120", "allow": "payment", "srcdoc": "<h1>Inline</h1>", "fallback_text": "" }
@@ -390,8 +390,8 @@
     },
     {
       "id": "media-playback-poster-page",
-      "description": "Media summaries expose playback state and poster resolution metadata.",
-      "input": "<base href=\"https://example.test/watch/index.html\"><body><video id=hero src=movie.mp4 poster=poster.jpg controls autoplay loop muted playsinline preload=metadata width=640 height=360></video><audio src=theme.ogg controls preload=none></audio>",
+      "description": "Media summaries expose playback state, poster resolution, and playback policy metadata.",
+      "input": "<base href=\"https://example.test/watch/index.html\"><body><video id=hero src=movie.mp4 poster=poster.jpg controls controlslist=\"nodownload noplaybackrate\" crossorigin=anonymous autoplay loop muted playsinline preload=metadata disableremoteplayback disablepictureinpicture width=640 height=360></video><audio src=theme.ogg controls controlslist=nodownload crossorigin=use-credentials preload=none disableremoteplayback></audio>",
       "expected": {
         "title": null,
         "base_href": "https://example.test/watch/index.html",
@@ -399,8 +399,8 @@
         "body_text": "",
         "metas": [],
         "resources": [
-          { "kind": "video", "url": "movie.mp4", "resolved_url": "https://example.test/watch/movie.mp4", "rel": null, "type_hint": null, "media": null, "title": null, "width": "640", "height": "360", "async_script": false, "defer_script": false },
-          { "kind": "audio", "url": "theme.ogg", "resolved_url": "https://example.test/watch/theme.ogg", "rel": null, "type_hint": null, "media": null, "title": null, "width": null, "height": null, "async_script": false, "defer_script": false }
+          { "kind": "video", "url": "movie.mp4", "resolved_url": "https://example.test/watch/movie.mp4", "rel": null, "type_hint": null, "media": null, "title": null, "width": "640", "height": "360", "crossorigin": "anonymous", "async_script": false, "defer_script": false },
+          { "kind": "audio", "url": "theme.ogg", "resolved_url": "https://example.test/watch/theme.ogg", "rel": null, "type_hint": null, "media": null, "title": null, "width": null, "height": null, "crossorigin": "use-credentials", "async_script": false, "defer_script": false }
         ],
         "anchors": [
           { "id": "hero", "name": null, "text": "" }
@@ -422,14 +422,23 @@
             "loop_media": true,
             "muted": true,
             "playsinline": true,
-            "preload": "metadata"
+            "preload": "metadata",
+            "crossorigin": "anonymous",
+            "controlslist": "nodownload noplaybackrate",
+            "controlslist_tokens": ["nodownload", "noplaybackrate"],
+            "disableremoteplayback": true,
+            "disablepictureinpicture": true
           },
           {
             "kind": "audio",
             "src": "theme.ogg",
             "resolved_src": "https://example.test/watch/theme.ogg",
             "controls": true,
-            "preload": "none"
+            "preload": "none",
+            "crossorigin": "use-credentials",
+            "controlslist": "nodownload",
+            "controlslist_tokens": ["nodownload"],
+            "disableremoteplayback": true
           }
         ],
         "forms": [],


### PR DESCRIPTION
## Summary
- add media playback policy metadata for crossorigin, controlslist tokens, remote playback, and picture-in-picture controls
- add iframe fetchpriority and CSP metadata to resource and embedded-context summaries
- extend browser-readiness fixtures, schema checks, and targeted parser tests for the new metadata

## Validation
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py
- python3 -m py_compile code/packages/rust/html-lexer/tests/fixtures/*.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit-full
- cargo test -p coding-adventures-html-parser browser_embedded_policy_metadata_tracks_fetchpriority_and_csp
- cargo test -p coding-adventures-html-parser browser_media_policy_metadata_tracks_controls_and_remote_playback_hints
- cargo test -p coding-adventures-html-parser browser_resource_priority_metadata_tracks_rel_and_blocking_tokens
- cargo test -p coding-adventures-html-parser browser_script_style_security_metadata_tracks_nonces_and_fetch_policy
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser