### PR TITLE
test(ruby-fc): Phase 19b — regex flags `/r/i` (coverage confirmation)

### DIFF
--- a/code/.pr-body-fc-19b.md
+++ b/code/.pr-body-fc-19b.md
@@ -1,0 +1,32 @@
+## Phase 19b (FC) — regex flags `/r/i` (coverage confirmation)
+
+Regex flags were implemented in **Phase 19a**: they ride along in the
+verbatim `/pattern/flags` lexeme and land in `args[1]` (a `StrLit`) of
+the `BuiltinCall("regex", …)`.  So like **Phases 16b/16c**, 19b is a
+**coverage-confirmation phase** — no grammar or lowering change, only
+explicit pins for MULTI-flag regexes (the 19a tests only covered a
+single `i`).
+
+### `coding-adventures-ruby-parser` 0.55.0 (+3 pins, 195 → 198)
+
+- `test_parse_regex_literal_multi_flag` — `x = /foo/im`.
+- `test_parse_regex_literal_three_flags` — `x = /a/mix`.
+- `test_parse_regex_literal_multi_flag_in_call_argument` — `foo(/bar/im)`.
+
+### `ruby-to-semantic-ir` 0.58.0 (+3 pins, 249 → 252)
+
+- `regex_literal_multi_flag_preserves_all_flags` — `/foo/im` → flags
+  `"im"` (order preserved).
+- `regex_literal_all_common_flags_lower` — `/a/mix` → `"mix"`.
+- `regex_literal_multi_flag_validates_e2e` — `(/x/im)` + validator E2E.
+
+### Verification
+
+All green locally:
+`cargo test -p coding-adventures-ruby-lexer -p coding-adventures-ruby-parser -p ruby-to-semantic-ir`
+(lexer 173, parser 198, lowerer 252).
+
+### Security
+
+Test code + CHANGELOG only — no production logic, no I/O, no `unsafe`.
+`/security-review` passed clean in one round.

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.55.0] - 2026-05-31
+
+### Added (Phase 19b (FC) — regex flags `/r/i` coverage confirmation)
+
+No grammar change.  Regex flags already ride along in the verbatim
+`/pattern/flags` lexeme (Phase 19a), so 19b is a coverage-confirmation
+phase (cf. 16b/16c) pinning MULTI-flag lexemes (the 19a tests only
+covered a single `i`).
+
+New parse pins (+3): `test_parse_regex_literal_multi_flag` (`/foo/im`),
+`test_parse_regex_literal_three_flags` (`/a/mix`),
+`test_parse_regex_literal_multi_flag_in_call_argument` (`foo(/bar/im)`).
+Test count: 195 → 198.
+
 ## [0.54.0] - 2026-05-31
 
 ### Added (Phase 19a (FC) — regex literal `/pattern/flags`)

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -1844,6 +1844,42 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // Phase 19b (FC) — regex flags `/r/i` (coverage).  Flags ride along
+    // in the verbatim `/p/flags` lexeme (no grammar change since 19a);
+    // these pins confirm MULTI-flag lexemes survive into the parse tree.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_regex_literal_multi_flag() {
+        // `x = /foo/im` — two trailing flag letters in the lexeme.
+        let ast = parse_ruby("x = /foo/im");
+        assert!(
+            tree_has_token_value(&ast, "/foo/im"),
+            "expected verbatim `/foo/im` multi-flag regex token"
+        );
+    }
+
+    #[test]
+    fn test_parse_regex_literal_three_flags() {
+        // `x = /a/mix` — three flag letters.
+        let ast = parse_ruby("x = /a/mix");
+        assert!(
+            tree_has_token_value(&ast, "/a/mix"),
+            "expected verbatim `/a/mix` three-flag regex token"
+        );
+    }
+
+    #[test]
+    fn test_parse_regex_literal_multi_flag_in_call_argument() {
+        // `foo(/bar/im)` — multi-flag regex as a call argument.
+        let ast = parse_ruby("foo(/bar/im)");
+        assert!(
+            tree_has_token_value(&ast, "/bar/im"),
+            "expected verbatim `/bar/im` regex token in the call argument"
+        );
+    }
+
+    // -----------------------------------------------------------------------
     // Phase 6p — compound assignment `+=`, `-=`, `*=`, `/=`, `||=`, `&&=`
     // -----------------------------------------------------------------------
     //

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.58.0] - 2026-05-31
+
+### Added (Phase 19b (FC) — regex flags `/r/i` coverage confirmation)
+
+No lowering change.  The `regex` builtin's `args[1]` already carries the
+flag letters verbatim (Phase 19a), so 19b is a coverage-confirmation
+phase (cf. 16b/16c) exercising MULTI-flag combinations the 19a tests
+didn't (single `i` only).
+
+New tests (+3): `regex_literal_multi_flag_preserves_all_flags`
+(`/foo/im` → flags `"im"`, order preserved),
+`regex_literal_all_common_flags_lower` (`/a/mix` → `"mix"`),
+`regex_literal_multi_flag_validates_e2e` (`(/x/im)` + validator E2E).
+Test count: 249 → 252.
+
 ## [0.57.0] - 2026-05-31
 
 ### Added (Phase 19a (FC) — regex literal `/pattern/flags`)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -2390,6 +2390,68 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
+    // Phase 19b (FC) — regex flags `/r/i` coverage confirmation.
+    //
+    // Phase 19a already carries the flag letters in `args[1]` of the
+    // `regex` builtin, so flags are a coverage-confirmation phase (cf.
+    // 16b/16c): these pins exercise MULTI-flag combinations (the 19a
+    // tests only covered a single `i`) and confirm the flag string is
+    // preserved verbatim and in order.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn regex_literal_multi_flag_preserves_all_flags() {
+        // `x = /foo/im` — two flags; both letters preserved in order.
+        let m = lower("x = /foo/im\n");
+        let value = main_body(&m).stmts.iter().find_map(|s| match s {
+            Stmt::LetBinding { value, .. } | Stmt::Assign { value, .. } => Some(value.clone()),
+            _ => None,
+        }).expect("expected a binding for `x`");
+        match &value {
+            Expr::BuiltinCall { name, args, .. } if name == "regex" => {
+                assert!(matches!(&args[0], Expr::StrLit { value, .. } if value == "foo"));
+                assert!(
+                    matches!(&args[1], Expr::StrLit { value, .. } if value == "im"),
+                    "expected flags StrLit \"im\" (order preserved); got {:?}", &args[1]
+                );
+            }
+            other => panic!("expected BuiltinCall(regex, …), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn regex_literal_all_common_flags_lower() {
+        // `x = /a/mix` — the three common Ruby regex flags together.
+        // Order is preserved exactly as written.
+        let m = lower("x = /a/mix\n");
+        let value = main_body(&m).stmts.iter().find_map(|s| match s {
+            Stmt::LetBinding { value, .. } | Stmt::Assign { value, .. } => Some(value.clone()),
+            _ => None,
+        }).expect("expected a binding for `x`");
+        match &value {
+            Expr::BuiltinCall { name, args, .. } if name == "regex" => {
+                assert!(matches!(&args[1], Expr::StrLit { value, .. } if value == "mix"));
+            }
+            other => panic!("expected BuiltinCall(regex, …), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn regex_literal_multi_flag_validates_e2e() {
+        // `def r() (/x/im) end` — multi-flag regex survives validation.
+        let m = lower("def r\n  (/x/im)\nend\n");
+        let f = m.functions.iter().find(|f| f.name == "r").unwrap();
+        match &f.body.value {
+            Expr::BuiltinCall { name, args, .. } if name == "regex" => {
+                assert!(matches!(&args[1], Expr::StrLit { value, .. } if value == "im"));
+            }
+            other => panic!("expected BuiltinCall(regex, …), got {:?}", other),
+        }
+        let result = semantic_ir::validate(&m);
+        assert!(result.is_ok(), "validator rejected multi-flag regex: {:?}", result);
+    }
+
+    // -----------------------------------------------------------------
     // Phase 6o — ternary `cond ? a : b` lowering
     // -----------------------------------------------------------------
     //


### PR DESCRIPTION
## Phase 19b (FC) — regex flags `/r/i` (coverage confirmation)

Regex flags were implemented in **Phase 19a**: they ride along in the
verbatim `/pattern/flags` lexeme and land in `args[1]` (a `StrLit`) of
the `BuiltinCall("regex", …)`.  So like **Phases 16b/16c**, 19b is a
**coverage-confirmation phase** — no grammar or lowering change, only
explicit pins for MULTI-flag regexes (the 19a tests only covered a
single `i`).

### `coding-adventures-ruby-parser` 0.55.0 (+3 pins, 195 → 198)

- `test_parse_regex_literal_multi_flag` — `x = /foo/im`.
- `test_parse_regex_literal_three_flags` — `x = /a/mix`.
- `test_parse_regex_literal_multi_flag_in_call_argument` — `foo(/bar/im)`.

### `ruby-to-semantic-ir` 0.58.0 (+3 pins, 249 → 252)

- `regex_literal_multi_flag_preserves_all_flags` — `/foo/im` → flags
  `"im"` (order preserved).
- `regex_literal_all_common_flags_lower` — `/a/mix` → `"mix"`.
- `regex_literal_multi_flag_validates_e2e` — `(/x/im)` + validator E2E.

### Verification

All green locally:
`cargo test -p coding-adventures-ruby-lexer -p coding-adventures-ruby-parser -p ruby-to-semantic-ir`
(lexer 173, parser 198, lowerer 252).

### Security

Test code + CHANGELOG only — no production logic, no I/O, no `unsafe`.
`/security-review` passed clean in one round.
