### PR TITLE
feat(ruby-fc): Phase 19c — regex interpolation `/a#{b}c/`

### DIFF
--- a/code/.pr-body-fc-19c.md
+++ b/code/.pr-body-fc-19c.md
@@ -1,0 +1,45 @@
+## Phase 19c (FC) — regex interpolation `/a#{b}c/`
+
+**No grammar or lexer change.**  The `regex_body` lexer state does not
+special-case `#{...}` — it accumulates the markers verbatim into the
+regex body — so an interpolated regex arrives as ONE verbatim
+`/pattern/flags` `String` token with the markers intact (`/a#{b}c/`).
+
+### `coding-adventures-ruby-parser` 0.56.0
+
+- +3 parse pins (198 → 201): `test_parse_regex_literal_with_interpolation`
+  (`/a#{b}c/`), `test_parse_regex_interpolation_single_marker` (`/#{b}/`),
+  `test_parse_regex_interpolation_with_flags` (`/x#{b}/i`).
+
+### `ruby-to-semantic-ir` 0.59.0
+
+- `lower_regex_literal` now runs the pattern through the **same**
+  `#{...}` interpolation splitter string literals use
+  (`lower_string_literal_with_interp`).  So `args[0]` of the `regex`
+  builtin becomes:
+  - a `string_concat` over literal + interpolated segments for
+    `` /a#{b}c/ `` → `[StrLit("a"), VarRef("b"), StrLit("c")]`;
+  - a bare `VarRef` for a lone `` /#{b}/ ``;
+  - a plain `StrLit` when the pattern has no markers (the 19a/19b shape,
+    unchanged).
+- `lower_regex_literal` became fallible (returns `Result`) to propagate
+  splitter errors.  **No new SIR variant or backend dispatch** — reuses
+  `string_concat` / `VarRef` / `StrLit`.  Still pure; requests
+  `Feature::Strings`.
+- +3 lowering pins (252 → 255): `regex_interpolation_lowers_pattern_to_concat`,
+  `regex_interpolation_single_marker_is_bare_varref`,
+  `regex_interpolation_validates_e2e` (interp + flag + validator E2E).
+
+### Verification
+
+All green locally:
+`cargo test -p coding-adventures-ruby-lexer -p coding-adventures-ruby-parser -p ruby-to-semantic-ir`
+(lexer 173, parser 201, lowerer 255).
+
+### Security
+
+Pure AST→IR — no I/O, no `unsafe`.  Reuses the existing, panic-free
+string interpolation splitter; the interpolated body is carried as inert
+SIR data (not executed or interpolated into any sink); the split is a
+single linear pass (no DoS).  `/security-review` passed clean in one
+round.

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.56.0] - 2026-05-31
+
+### Added (Phase 19c (FC) — regex interpolation `/a#{b}c/`)
+
+No grammar or lexer change.  The `regex_body` lexer state does not
+special-case `#{...}` — it accumulates the markers verbatim into the
+regex body — so an interpolated regex still arrives as ONE
+`TokenType::String` token whose value includes the markers
+(`/a#{b}c/`).  The parser routes it through the ordinary string-literal
+slot exactly as for a non-interpolated regex.
+
+New parse pins (+3): `test_parse_regex_literal_with_interpolation`
+(`/a#{b}c/`), `test_parse_regex_interpolation_single_marker` (`/#{b}/`),
+`test_parse_regex_interpolation_with_flags` (`/x#{b}/i`) — each confirms
+the verbatim interpolated lexeme survives into the parse tree.  Test
+count: 198 → 201.
+
 ## [0.55.0] - 2026-05-31
 
 ### Added (Phase 19b (FC) — regex flags `/r/i` coverage confirmation)

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -1880,6 +1880,44 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // Phase 19c (FC) — regex interpolation `/a#{b}c/`.  The `regex_body`
+    // lexer state captures `#{...}` markers verbatim into the body, so
+    // the interpolated regex still arrives as ONE `String` token whose
+    // value includes the markers — no grammar change.  These pins confirm
+    // the verbatim interpolated lexeme survives into the parse tree.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_regex_literal_with_interpolation() {
+        // `x = /a#{b}c/` — `#{b}` preserved verbatim in the regex token.
+        let ast = parse_ruby("x = /a#{b}c/");
+        assert!(
+            tree_has_token_value(&ast, "/a#{b}c/"),
+            "expected verbatim `/a#{{b}}c/` interpolated regex token"
+        );
+    }
+
+    #[test]
+    fn test_parse_regex_interpolation_single_marker() {
+        // `x = /#{b}/` — a lone interpolation marker.
+        let ast = parse_ruby("x = /#{b}/");
+        assert!(
+            tree_has_token_value(&ast, "/#{b}/"),
+            "expected verbatim `/#{{b}}/` regex token"
+        );
+    }
+
+    #[test]
+    fn test_parse_regex_interpolation_with_flags() {
+        // `x = /x#{b}/i` — interpolation plus a trailing flag.
+        let ast = parse_ruby("x = /x#{b}/i");
+        assert!(
+            tree_has_token_value(&ast, "/x#{b}/i"),
+            "expected verbatim `/x#{{b}}/i` regex token"
+        );
+    }
+
+    // -----------------------------------------------------------------------
     // Phase 6p — compound assignment `+=`, `-=`, `*=`, `/=`, `||=`, `&&=`
     // -----------------------------------------------------------------------
     //

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.59.0] - 2026-05-31
+
+### Added (Phase 19c (FC) — regex interpolation `/a#{b}c/`)
+
+`lower_regex_literal` now runs the regex pattern through the SAME
+`#{...}` interpolation splitter string literals use
+(`lower_string_literal_with_interp`).  Since the lexer captures the
+markers verbatim into the pattern, an interpolated regex's `args[0]`
+becomes:
+
+- a `string_concat` over literal + interpolated segments for
+  `` /a#{b}c/ `` → `[StrLit("a"), VarRef("b"), StrLit("c")]`;
+- a bare `VarRef` for a lone `` /#{b}/ ``;
+- a plain `StrLit` when the pattern has no markers (the 19a/19b shape,
+  unchanged).
+
+`lower_regex_literal` became fallible (returns `Result`) to propagate
+splitter errors.  No new SIR variant or backend dispatch — reuses
+`string_concat` / `VarRef` / `StrLit`.  Still pure; requests
+`Feature::Strings`.
+
+New tests (+3): `regex_interpolation_lowers_pattern_to_concat`
+(`/a#{b}c/`), `regex_interpolation_single_marker_is_bare_varref`
+(`/#{b}/`), `regex_interpolation_validates_e2e` (`/x#{b}/i` + validator
+E2E).  Test count: 252 → 255.
+
 ## [0.58.0] - 2026-05-31
 
 ### Added (Phase 19b (FC) — regex flags `/r/i` coverage confirmation)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -2452,6 +2452,78 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
+    // Phase 19c (FC) — regex interpolation `/a#{b}c/` lowering.
+    //
+    // The `regex_body` lexer state captures `#{...}` markers verbatim
+    // into the pattern, so the lowerer runs the pattern through the SAME
+    // interpolation splitter strings use.  `args[0]` of the `regex`
+    // builtin therefore becomes a `string_concat` (or a bare `VarRef`
+    // for a single `#{x}` segment) when the pattern interpolates, and a
+    // plain `StrLit` when it doesn't (the 19a shape, unchanged).
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn regex_interpolation_lowers_pattern_to_concat() {
+        // `def r(b) (/a#{b}c/) end` — pattern splits into
+        // [StrLit("a"), VarRef(b), StrLit("c")] under string_concat.
+        let m = lower("def r(b)\n  (/a#{b}c/)\nend\n");
+        let f = m.functions.iter().find(|f| f.name == "r").unwrap();
+        match &f.body.value {
+            Expr::BuiltinCall { name, args, .. } if name == "regex" => {
+                match &args[0] {
+                    Expr::BuiltinCall { name, args: parts, .. } if name == "string_concat" => {
+                        assert_eq!(parts.len(), 3, "expected 3 pattern segments");
+                        assert!(matches!(&parts[0], Expr::StrLit { value, .. } if value == "a"));
+                        assert!(matches!(&parts[1], Expr::VarRef { name, .. } if name == "b"));
+                        assert!(matches!(&parts[2], Expr::StrLit { value, .. } if value == "c"));
+                    }
+                    other => panic!("expected string_concat pattern, got {:?}", other),
+                }
+                // Flags arg still present (empty here).
+                assert!(matches!(&args[1], Expr::StrLit { value, .. } if value.is_empty()));
+            }
+            other => panic!("expected BuiltinCall(regex, …), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn regex_interpolation_single_marker_is_bare_varref() {
+        // `def r(b) (/#{b}/) end` — a lone `#{b}` pattern lowers to a
+        // single `VarRef` (no string_concat wrapper), mirroring `"#{b}"`.
+        let m = lower("def r(b)\n  (/#{b}/)\nend\n");
+        let f = m.functions.iter().find(|f| f.name == "r").unwrap();
+        match &f.body.value {
+            Expr::BuiltinCall { name, args, .. } if name == "regex" => {
+                assert!(
+                    matches!(&args[0], Expr::VarRef { name, .. } if name == "b"),
+                    "expected bare VarRef pattern; got {:?}", &args[0]
+                );
+            }
+            other => panic!("expected BuiltinCall(regex, …), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn regex_interpolation_validates_e2e() {
+        // `def r(b) (/x#{b}/i) end` — interpolation + a flag, end-to-end:
+        // pattern is a concat, flags = "i", and the module validates.
+        let m = lower("def r(b)\n  (/x#{b}/i)\nend\n");
+        let f = m.functions.iter().find(|f| f.name == "r").unwrap();
+        match &f.body.value {
+            Expr::BuiltinCall { name, args, .. } if name == "regex" => {
+                assert!(
+                    matches!(&args[0], Expr::BuiltinCall { name, .. } if name == "string_concat"),
+                    "expected string_concat pattern; got {:?}", &args[0]
+                );
+                assert!(matches!(&args[1], Expr::StrLit { value, .. } if value == "i"));
+            }
+            other => panic!("expected BuiltinCall(regex, …), got {:?}", other),
+        }
+        let result = semantic_ir::validate(&m);
+        assert!(result.is_ok(), "validator rejected interpolated regex: {:?}", result);
+    }
+
+    // -----------------------------------------------------------------
     // Phase 6o — ternary `cond ? a : b` lowering
     // -----------------------------------------------------------------
     //

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -4718,27 +4718,53 @@ impl Lowerer {
     ///
     /// We split the verbatim lexeme into `pattern` and `flags` (see
     /// [`regex_pattern_flags`]) and emit
-    /// `BuiltinCall("regex", [StrLit(pattern), StrLit(flags)])`.  Carrying
-    /// the two parts as separate `StrLit` args keeps the builtin uniform
+    /// `BuiltinCall("regex", [<pattern-expr>, StrLit(flags)])`.  Carrying
+    /// the flags as a separate `StrLit` arg keeps the builtin uniform
     /// across all flag combinations (`/x/`, `/x/i`, `/x/im`, …) without
     /// name multiplication — mirroring the `range` builtin's flag arg.
+    ///
+    /// ## Phase 19c — interpolation
+    ///
+    /// The `regex_body` lexer state does not special-case `#{...}` — it
+    /// accumulates the markers verbatim into the pattern — so an
+    /// interpolated regex `` /a#{b}c/ `` arrives here with the pattern
+    /// `a#{b}c`.  We therefore lower the pattern through the SAME
+    /// interpolation splitter string literals use
+    /// ([`lower_string_literal_with_interp`]):
+    ///   - no `#{...}`  → `args[0]` is a plain `StrLit(pattern)` (the
+    ///     Phase-19a/19b shape, unchanged);
+    ///   - with `#{...}` → `args[0]` is a `string_concat` (or a single
+    ///     `VarRef` for `` /#{x}/ ``) over the literal + interpolated
+    ///     segments — exactly how `"a#{b}c"` lowers.
     ///
     /// Building a regex object is pure (no I/O, no mutation).  We emit
     /// `StrLit`s, so the literal requests `Feature::Strings` — the same
     /// stance as backticks and heredocs.  (v0 does NOT unescape the body:
     /// `\/` etc. survive verbatim in the pattern, matching the heredoc /
     /// backtick capture stance.)
-    fn lower_regex_literal(&mut self, pattern: &str, flags: &str, span: Span) -> Expr {
+    fn lower_regex_literal(
+        &mut self,
+        pattern: &str,
+        flags: &str,
+        span: Span,
+        err_line: usize,
+        err_column: usize,
+    ) -> Result<Expr, RubyLowerError> {
         self.features_used.insert(Feature::Strings);
-        Expr::BuiltinCall {
+        // Run the pattern through the string interpolation splitter so
+        // `#{...}` markers inside the regex become real sub-expressions.
+        // For a marker-free pattern this returns a plain `StrLit`.
+        let pattern_expr =
+            self.lower_string_literal_with_interp(pattern, span.clone(), err_line, err_column)?;
+        Ok(Expr::BuiltinCall {
             name: "regex".to_string(),
             args: vec![
-                Expr::StrLit { value: pattern.to_string(), span: span.clone() },
+                pattern_expr,
                 Expr::StrLit { value: flags.to_string(), span: span.clone() },
             ],
             effects: EffectSet::PURE,
             span,
-        }
+        })
     }
 
     // -------------------------------------------------------------------
@@ -5145,7 +5171,9 @@ impl Lowerer {
                             if let Some((pattern, flags)) = regex_pattern_flags(&tok.value) {
                                 let (pattern, flags) =
                                     (pattern.to_string(), flags.to_string());
-                                return Ok(self.lower_regex_literal(&pattern, &flags, span));
+                                return self.lower_regex_literal(
+                                    &pattern, &flags, span, tok.line, tok.column,
+                                );
                             }
                             // Phase 6y — string interpolation expression
                             // lowering.  The lexer (Phase 3b) emits the


### PR DESCRIPTION
## Phase 19c (FC) — regex interpolation `/a#{b}c/`

**No grammar or lexer change.**  The `regex_body` lexer state does not
special-case `#{...}` — it accumulates the markers verbatim into the
regex body — so an interpolated regex arrives as ONE verbatim
`/pattern/flags` `String` token with the markers intact (`/a#{b}c/`).

### `coding-adventures-ruby-parser` 0.56.0

- +3 parse pins (198 → 201): `test_parse_regex_literal_with_interpolation`
  (`/a#{b}c/`), `test_parse_regex_interpolation_single_marker` (`/#{b}/`),
  `test_parse_regex_interpolation_with_flags` (`/x#{b}/i`).

### `ruby-to-semantic-ir` 0.59.0

- `lower_regex_literal` now runs the pattern through the **same**
  `#{...}` interpolation splitter string literals use
  (`lower_string_literal_with_interp`).  So `args[0]` of the `regex`
  builtin becomes:
  - a `string_concat` over literal + interpolated segments for
    `` /a#{b}c/ `` → `[StrLit("a"), VarRef("b"), StrLit("c")]`;
  - a bare `VarRef` for a lone `` /#{b}/ ``;
  - a plain `StrLit` when the pattern has no markers (the 19a/19b shape,
    unchanged).
- `lower_regex_literal` became fallible (returns `Result`) to propagate
  splitter errors.  **No new SIR variant or backend dispatch** — reuses
  `string_concat` / `VarRef` / `StrLit`.  Still pure; requests
  `Feature::Strings`.
- +3 lowering pins (252 → 255): `regex_interpolation_lowers_pattern_to_concat`,
  `regex_interpolation_single_marker_is_bare_varref`,
  `regex_interpolation_validates_e2e` (interp + flag + validator E2E).

### Verification

All green locally:
`cargo test -p coding-adventures-ruby-lexer -p coding-adventures-ruby-parser -p ruby-to-semantic-ir`
(lexer 173, parser 201, lowerer 255).

### Security

Pure AST→IR — no I/O, no `unsafe`.  Reuses the existing, panic-free
string interpolation splitter; the interpolated body is carried as inert
SIR data (not executed or interpolated into any sink); the split is a
single linear pass (no DoS).  `/security-review` passed clean in one
round.
