### PR TITLE
Add SPICE temperature DC table output

### DIFF
--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add `dc_temperature_sweep` and `format_temperature_dc_table` for stable
+  tab-separated DC operating-point snapshots across explicit `.temp`-style
+  analysis temperatures.
 - Add `format_adaptive_transient_table`, `transient_adaptive_corners`, and
   `format_corner_adaptive_transient_table` for stable tab-separated adaptive
   transient sample text output snapshots, including method, rejected-step, and

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -6,6 +6,7 @@ The initial slices implement:
 
 - DC operating-point analysis for linear circuits using modified nodal analysis
   (MNA).
+- DC operating-point sweeps across explicit analysis temperatures.
 - DC source sweeps over independent voltage and current sources.
 - DC sensitivity analysis for output-node voltage changes with respect to
   resistor and independent source parameters, including named corner sweeps.
@@ -32,8 +33,9 @@ The initial slices implement:
 - Constrained RC and RLC low-pass/high-pass/band-pass/notch pole-zero helpers,
   including named corner sweeps.
 - Stable text output tables for selected node voltages, branch currents,
-  transient samples, adaptive transient samples, cornered transient samples,
-  cornered adaptive transient samples, AC phasors, cornered DC
+  DC operating-point temperature sweeps, transient samples, adaptive transient
+  samples, cornered transient samples, cornered adaptive transient samples, AC
+  phasors, cornered DC
   operating points, cornered AC phasors, PSS steady-state periods,
   sensitivity entries, Fourier harmonics, cornered Fourier harmonics,
   transfer-function results, cornered transfer-function results, S-parameter

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -1716,6 +1716,17 @@ pub struct CornerSweepResult {
     pub points: Vec<CornerPoint>,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct TemperatureDcPoint {
+    pub temperature_kelvin: f64,
+    pub result: DcResult,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TemperatureDcResult {
+    pub points: Vec<TemperatureDcPoint>,
+}
+
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct DcOpOptions {
     pub max_iterations: usize,
@@ -3642,6 +3653,48 @@ pub fn format_corner_dc_table(
     Ok(rows.join("\n"))
 }
 
+pub fn format_temperature_dc_table(
+    result: &TemperatureDcResult,
+    probes: &[&str],
+) -> Result<String, SpiceError> {
+    let selected_probes = if probes.is_empty() {
+        result
+            .points
+            .first()
+            .map(|point| {
+                default_output_probes(&point.result.node_voltages, &point.result.branch_currents)
+            })
+            .unwrap_or_default()
+    } else {
+        probes.iter().map(|probe| probe.to_string()).collect()
+    };
+    let mut rows = vec![format!(
+        "Index\tTemperatureKelvin\t{}",
+        selected_probes.join("\t")
+    )];
+    for (index, point) in result.points.iter().enumerate() {
+        let values: Result<Vec<String>, SpiceError> = selected_probes
+            .iter()
+            .map(|probe| {
+                table_probe_value(
+                    &point.result.node_voltages,
+                    &point.result.branch_currents,
+                    probe,
+                    "format_temperature_dc_table",
+                )
+                .map(format_table_number)
+            })
+            .collect();
+        rows.push(format!(
+            "{index}\t{}\t{}",
+            format_table_number(point.temperature_kelvin),
+            values?.join("\t")
+        ));
+    }
+    rows.push(String::new());
+    Ok(rows.join("\n"))
+}
+
 pub fn format_dc_sweep_table(
     source_name: &str,
     points: &[DcSweepPoint],
@@ -4678,6 +4731,29 @@ pub fn dc_corners(
         });
     }
     Ok(CornerSweepResult { points })
+}
+
+pub fn dc_temperature_sweep(
+    circuit: &Circuit,
+    temperatures_kelvin: &[f64],
+    nominal_temperature_kelvin: f64,
+    silicon_energy_gap_ev: f64,
+    options: DcOpOptions,
+) -> Result<TemperatureDcResult, SpiceError> {
+    let mut points = Vec::with_capacity(temperatures_kelvin.len());
+    for &temperature_kelvin in temperatures_kelvin {
+        let temperature_circuit = circuit_at_temperature(
+            circuit,
+            temperature_kelvin,
+            nominal_temperature_kelvin,
+            silicon_energy_gap_ev,
+        )?;
+        points.push(TemperatureDcPoint {
+            temperature_kelvin,
+            result: dc_op_with_options(&temperature_circuit, options)?,
+        });
+    }
+    Ok(TemperatureDcResult { points })
 }
 
 fn circuit_with_corner(circuit: &Circuit, corner: &CornerSpec) -> Result<Circuit, SpiceError> {

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -1,9 +1,10 @@
 use spice_engine::{
     circuit_at_temperature, dc_corners, dc_op, dc_op_with_options, dc_sweep, dc_sweep_corners,
-    format_corner_dc_sweep_table, format_corner_dc_table, format_dc_sweep_table, BSource, Bjt,
-    BjtPolarity, Cccs, Ccvs, Circuit, CornerOverride, CornerSpec, CurrentSource, DcConvergenceAid,
-    DcOpOptions, Diode, Element, Inductor, Jfet, JfetPolarity, Mosfet, MosfetLevel1Params,
-    MosfetType, Resistor, SinWaveform, SpiceError, SubcircuitDefinition, SubcircuitElement, Vccs,
+    dc_temperature_sweep, format_corner_dc_sweep_table, format_corner_dc_table,
+    format_dc_sweep_table, format_temperature_dc_table, BSource, Bjt, BjtPolarity, Cccs, Ccvs,
+    Circuit, CornerOverride, CornerSpec, CurrentSource, DcConvergenceAid, DcOpOptions, Diode,
+    Element, Inductor, Jfet, JfetPolarity, Mosfet, MosfetLevel1Params, MosfetType, Resistor,
+    SinWaveform, SpiceError, SubcircuitDefinition, SubcircuitElement, TemperatureDcResult, Vccs,
     Vcvs, VoltageSource, Waveform, XInstance,
 };
 
@@ -363,6 +364,43 @@ fn dc_diode_temperature_scaling_reduces_fixed_current_forward_drop() {
 
     assert!(cold_result.voltage("a").unwrap() > nominal_result.voltage("a").unwrap());
     assert!(hot_result.voltage("a").unwrap() < nominal_result.voltage("a").unwrap());
+}
+
+#[test]
+fn dc_temperature_sweep_text_output_table_is_stable() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "V1", "vcc", "0", 5.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rbias", "vcc", "a", 4_300.0,
+    )));
+    circuit.add(Element::Diode(Diode::with_model(
+        "D1", "a", "0", 1.0e-15, 0.02585,
+    )));
+
+    let result = dc_temperature_sweep(
+        &circuit,
+        &[275.0, 300.15, 350.0],
+        300.15,
+        1.11,
+        DcOpOptions::default(),
+    )
+    .unwrap();
+
+    let _: TemperatureDcResult = result.clone();
+    assert!(
+        result.points[0].result.voltage("a").unwrap()
+            > result.points[1].result.voltage("a").unwrap()
+    );
+    assert!(
+        result.points[2].result.voltage("a").unwrap()
+            < result.points[1].result.voltage("a").unwrap()
+    );
+    assert_eq!(
+        format_temperature_dc_table(&result, &["V(a)", "I(V1)"]).unwrap(),
+        "Index\tTemperatureKelvin\tV(a)\tI(V1)\n0\t2.750000e+02\t4.560039e+00\t-1.023164e-04\n1\t3.001500e+02\t3.613836e+00\t-3.223638e-04\n2\t3.500000e+02\t6.351989e-01\t-1.015070e-03\n"
+    );
 }
 
 #[test]

--- a/code/specs/spice-1970s-compatibility.md
+++ b/code/specs/spice-1970s-compatibility.md
@@ -399,6 +399,9 @@ Status:
 - Deck-level `.temp` cards are resolved into Kelvin helper temperatures across
   Python, TypeScript, and Rust, and explicit `.noise temp=<kelvin>` values take
   precedence for noise-engine calls.
+- DC operating points can now be evaluated and rendered across explicit
+  `.temp`-style analysis temperatures in the live Rust SPICE package, covering
+  temperature, node-voltage, and branch-current rows with stable ordering.
 - `.disto` and `.pz` parser/control-card records plus first distortion and
   pole-zero result shapes are implemented across Python, TypeScript, and Rust,
   with smoke fixtures for nonlinear-device distortion output and a simple RC

--- a/code/specs/spice-macsyma-pending-work.md
+++ b/code/specs/spice-macsyma-pending-work.md
@@ -233,8 +233,9 @@ IC parameters for C/L; AC phasor specs for V/I sources.
   `spice-1970s-compatibility.md`. JFET device/model-card support, mutual
   inductors, ideal transmission lines, Gear-2 transient integration,
   pseudo-transient DC continuation, 1970s model-card depth, classic text output
-  cards, and the first Phase 8 small-signal distortion / pole-zero footholds
-  are now reflected there with per-phase status.
+  cards including DC operating-point temperature tables, and the first Phase 8
+  small-signal distortion / pole-zero footholds are now reflected there with
+  per-phase status.
 
 ---
 


### PR DESCRIPTION
## Summary

- add a Rust `dc_temperature_sweep` helper that evaluates DC operating points across explicit `.temp`-style Kelvin temperatures
- add stable `format_temperature_dc_table` output with temperature, node-voltage, and branch-current probes
- document the new temperature table surface in the package README, changelog, and SPICE specs

## Validation

- `cargo fmt -p spice-engine --check`
- `cargo test -p spice-engine --test dc_tests dc_temperature_sweep_text_output_table_is_stable`
- `cargo test -p spice-engine --test dc_tests`
- `cargo test -p spice-engine`
- `git diff --check`