### PR TITLE
feat(ruby-fc): Phase 19d — `%r{...}` regex literal

### DIFF
--- a/code/.pr-body-fc-19d.md
+++ b/code/.pr-body-fc-19d.md
@@ -1,0 +1,47 @@
+## Phase 19d (FC) — `%r{...}` regex literal
+
+Completes the regex family (19a `/regex/`, 19b flags, 19c interpolation,
+19d `%r{}`).  **No grammar or lexer change**: the lexer's
+`percent_r_body` state emits the whole `%r{...}` literal as one verbatim
+`String` token (the `%`-family sentinel-by-prefix trick `%w`/`%q`/`%i`
+use), so the parser routes it through the ordinary string-literal slot.
+
+### `coding-adventures-ruby-parser` 0.57.0
+
+- +3 parse pins (201 → 204): `test_parse_percent_r_regex_literal`
+  (`%r{hello}`), `test_parse_percent_r_regex_empty` (`%r{}`),
+  `test_parse_percent_r_regex_in_call_argument` (`foo(%r{bar})`).
+
+### `ruby-to-semantic-ir` 0.60.0
+
+- `lower_factor_atom` gains a `%r{...}` dispatch (placed before the
+  `/.../` check).  The new free helper `percent_r_pattern_flags` strips
+  the `%r`, reads the opening delimiter, finds the matching closing
+  delimiter (bracket pairs `{}`/`[]`/`()`/`<>` or symmetric; last
+  occurrence — v0 does not track nested brackets), splits the body into
+  `(pattern, flags)` (flags validated as Ruby flag letters), then reuses
+  `lower_regex_literal` — so `%r{...}` produces the SAME
+  `BuiltinCall("regex", [pattern, StrLit(flags)])` shape as `/.../`, and
+  gets the pattern interpolation splitter for free.  **No new SIR variant
+  or backend dispatch.**
+- +3 lowering pins (255 → 258): `percent_r_regex_lowers_to_regex_builtin`
+  (`%r{hello}`), `percent_r_regex_empty_pattern_lowers` (`%r{}`),
+  `percent_r_regex_validates_e2e` (`%r{x}` + validator E2E).
+
+(v0 lexer note: `%r` uses `{}` as the canonical delimiter and does not
+slurp trailing flags; the helper is written generally so it already
+covers the broader delimiter/flag forms a future lexer pass may emit.)
+
+### Verification
+
+All green locally:
+`cargo test -p coding-adventures-ruby-lexer -p coding-adventures-ruby-parser -p ruby-to-semantic-ir`
+(lexer 173, parser 204, lowerer 258).
+
+### Security
+
+Pure AST→IR — no I/O, no `unsafe`.  All `%r` slice indices are proven
+valid UTF-8 char boundaries (even for multibyte delimiters); the path is
+fully fallible (`?`, no `unwrap` on untrusted input) and reuses the
+panic-free `lower_regex_literal`; linear single pass.  `/security-review`
+passed clean in one round.

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.57.0] - 2026-05-31
+
+### Added (Phase 19d (FC) — `%r{...}` regex literal)
+
+No grammar change.  The lexer's `percent_r_body` state emits the whole
+`%r{...}` literal as a single `TokenType::String` token carrying the
+verbatim source (the `%r` + braces preserved) — the `%`-family
+sentinel-by-prefix trick `%w`/`%q`/`%i` use.  The parser routes it
+through the ordinary string-literal slot.
+
+New parse pins (+3): `test_parse_percent_r_regex_literal` (`%r{hello}`),
+`test_parse_percent_r_regex_empty` (`%r{}`),
+`test_parse_percent_r_regex_in_call_argument` (`foo(%r{bar})`).  Test
+count: 201 → 204.
+
 ## [0.56.0] - 2026-05-31
 
 ### Added (Phase 19c (FC) — regex interpolation `/a#{b}c/`)

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -1918,6 +1918,44 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // Phase 19d (FC) — `%r{...}` regex literal.  The lexer emits the whole
+    // literal as one `String` token carrying the verbatim `%r{...}` source
+    // (the `%r` + braces preserved) — the `%`-family sentinel-by-prefix
+    // trick.  No grammar change.  These pins confirm the verbatim `%r{}`
+    // lexeme survives into the parse tree.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_percent_r_regex_literal() {
+        // `x = %r{hello}` — `%r{...}` regex as an assignment RHS.
+        let ast = parse_ruby("x = %r{hello}");
+        assert!(
+            tree_has_token_value(&ast, "%r{hello}"),
+            "expected verbatim `%r{{hello}}` regex token in the parse tree"
+        );
+    }
+
+    #[test]
+    fn test_parse_percent_r_regex_empty() {
+        // `x = %r{}` — empty `%r{}` regex.
+        let ast = parse_ruby("x = %r{}");
+        assert!(
+            tree_has_token_value(&ast, "%r{}"),
+            "expected verbatim `%r{{}}` regex token"
+        );
+    }
+
+    #[test]
+    fn test_parse_percent_r_regex_in_call_argument() {
+        // `foo(%r{bar})` — `%r{...}` regex as a method-call argument.
+        let ast = parse_ruby("foo(%r{bar})");
+        assert!(
+            tree_has_token_value(&ast, "%r{bar}"),
+            "expected verbatim `%r{{bar}}` regex token in the call argument"
+        );
+    }
+
+    // -----------------------------------------------------------------------
     // Phase 6p — compound assignment `+=`, `-=`, `*=`, `/=`, `||=`, `&&=`
     // -----------------------------------------------------------------------
     //

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.60.0] - 2026-05-31
+
+### Added (Phase 19d (FC) — `%r{...}` regex literal)
+
+`lower_factor_atom` gained a `%r{...}` dispatch (placed before the
+`/.../` check).  The new free helper `percent_r_pattern_flags` strips
+the `%r`, reads the opening delimiter, finds the matching closing
+delimiter (the last occurrence — v0 does not track nested brackets,
+matching the other percent literals), and splits the body into
+`(pattern, flags)` (flags validated as Ruby regex flag letters).  It
+then reuses `lower_regex_literal`, so a `%r{...}` produces the SAME
+`BuiltinCall("regex", [pattern, StrLit(flags)])` shape as `/.../` — and
+gets the pattern interpolation splitter for free.  No new SIR variant or
+backend dispatch.
+
+(v0 lexer note: `%r` uses `{}` as the canonical delimiter and does not
+slurp trailing flags; the helper is written generally — bracket pairs
+`{}`/`[]`/`()`/`<>` and symmetric delimiters, plus trailing flags — so
+it already covers the broader forms a future lexer pass may emit.)
+
+New tests (+3): `percent_r_regex_lowers_to_regex_builtin` (`%r{hello}`),
+`percent_r_regex_empty_pattern_lowers` (`%r{}`),
+`percent_r_regex_validates_e2e` (`%r{x}` + validator E2E).  Test count:
+255 → 258.
+
 ## [0.59.0] - 2026-05-31
 
 ### Added (Phase 19c (FC) — regex interpolation `/a#{b}c/`)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -2524,6 +2524,75 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
+    // Phase 19d (FC) — `%r{...}` regex literal lowering.
+    //
+    // `%r{pat}flags` lexes to a verbatim `String` token; the lowerer
+    // strips the `%r`, the open/close delimiters, and trailing flags,
+    // then reuses `lower_regex_literal` — so `%r{...}` produces the SAME
+    // `BuiltinCall("regex", [pattern, StrLit(flags)])` shape as `/.../`,
+    // and interpolation inside `%r{...}` is handled for free.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn percent_r_regex_lowers_to_regex_builtin() {
+        // `x = %r{hello}` — brace-delimited, no flags.
+        let m = lower("x = %r{hello}\n");
+        let value = main_body(&m).stmts.iter().find_map(|s| match s {
+            Stmt::LetBinding { value, .. } | Stmt::Assign { value, .. } => Some(value.clone()),
+            _ => None,
+        }).expect("expected a binding for `x`");
+        match &value {
+            Expr::BuiltinCall { name, args, .. } if name == "regex" => {
+                assert_eq!(args.len(), 2);
+                assert!(
+                    matches!(&args[0], Expr::StrLit { value, .. } if value == "hello"),
+                    "expected pattern StrLit \"hello\"; got {:?}", &args[0]
+                );
+                assert!(matches!(&args[1], Expr::StrLit { value, .. } if value.is_empty()));
+            }
+            other => panic!("expected BuiltinCall(regex, …), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn percent_r_regex_empty_pattern_lowers() {
+        // `x = %r{}` — empty brace-delimited regex.  Pattern is the empty
+        // string; flags empty.  (v0 `%r` uses `{}` as the canonical
+        // delimiter and does not slurp trailing flags — so the pattern is
+        // exactly the body between the braces.)
+        let m = lower("x = %r{}\n");
+        let value = main_body(&m).stmts.iter().find_map(|s| match s {
+            Stmt::LetBinding { value, .. } | Stmt::Assign { value, .. } => Some(value.clone()),
+            _ => None,
+        }).expect("expected a binding for `x`");
+        match &value {
+            Expr::BuiltinCall { name, args, .. } if name == "regex" => {
+                assert!(
+                    matches!(&args[0], Expr::StrLit { value, .. } if value.is_empty()),
+                    "expected empty pattern StrLit; got {:?}", &args[0]
+                );
+                assert!(matches!(&args[1], Expr::StrLit { value, .. } if value.is_empty()));
+            }
+            other => panic!("expected BuiltinCall(regex, …), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn percent_r_regex_validates_e2e() {
+        // `def r() (%r{x}) end` — `%r{}` regex survives validation.
+        let m = lower("def r\n  (%r{x})\nend\n");
+        let f = m.functions.iter().find(|f| f.name == "r").unwrap();
+        match &f.body.value {
+            Expr::BuiltinCall { name, args, .. } if name == "regex" => {
+                assert!(matches!(&args[0], Expr::StrLit { value, .. } if value == "x"));
+            }
+            other => panic!("expected BuiltinCall(regex, …), got {:?}", other),
+        }
+        let result = semantic_ir::validate(&m);
+        assert!(result.is_ok(), "validator rejected %r regex: {:?}", result);
+    }
+
+    // -----------------------------------------------------------------
     // Phase 6o — ternary `cond ? a : b` lowering
     // -----------------------------------------------------------------
     //

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -370,6 +370,51 @@ fn regex_pattern_flags(value: &str) -> Option<(&str, &str)> {
     }
 }
 
+/// The closing delimiter that pairs with a `%r` opening delimiter.
+/// Bracket pairs mirror (`{`→`}`, `[`→`]`, `(`→`)`, `<`→`>`); any other
+/// delimiter (`!`, `|`, `#`, …) is its own close.
+fn percent_literal_close(open: char) -> char {
+    match open {
+        '{' => '}',
+        '[' => ']',
+        '(' => ')',
+        '<' => '>',
+        c => c,
+    }
+}
+
+/// Phase 19d (FC) — if `value` is a `%r`-delimited regex lexeme
+/// (`%r{pat}flags`, `%r(pat)`, `%r!pat!i`, …), split it into
+/// `(pattern, flags)`; otherwise `None`.
+///
+/// The lexer's `percent_r_body` state emits the literal as a
+/// `TokenType::String` token whose value is the verbatim source WITH the
+/// `%r`, the opening/closing delimiters, and any trailing flags — the
+/// same lexeme-prefix sentinel trick `%w`/`%q`/`%i` use.  We drop the
+/// `%r`, read the opening delimiter (the next char), find the matching
+/// closing delimiter (the LAST occurrence — v0 does not track nested
+/// brackets, matching the other percent literals' stance), take the
+/// body in between as the pattern, and the remainder as the flags.  The
+/// flags must be valid Ruby regex flag letters (`imxounes`); anything
+/// else means this isn't a regex (kept `None` defensively).
+fn percent_r_pattern_flags(value: &str) -> Option<(&str, &str)> {
+    let rest = value.strip_prefix("%r")?;
+    let open = rest.chars().next()?;
+    let close = percent_literal_close(open);
+    let after_open = &rest[open.len_utf8()..];
+    let close_idx = after_open.rfind(close)?;
+    let pattern = &after_open[..close_idx];
+    let flags = &after_open[close_idx + close.len_utf8()..];
+    if flags
+        .chars()
+        .all(|c| matches!(c, 'i' | 'm' | 'x' | 'o' | 'u' | 'n' | 'e' | 's'))
+    {
+        Some((pattern, flags))
+    } else {
+        None
+    }
+}
+
 /// Phase 15a (FC) — is this Name-token value a Ruby *instance
 /// variable* (`@x`)?  Instance vars lex as a `Name` token carrying the
 /// leading sigil.  A single `@` marks an instance variable; a double
@@ -5160,6 +5205,20 @@ impl Lowerer {
                                     &tok.value,
                                     span,
                                 ));
+                            }
+                            // Phase 19d (FC) — `%r{...}` regex literal
+                            // dispatch.  The lexer emits `%r{pat}flags` as
+                            // a `String` token carrying the verbatim source
+                            // (the `%r`, delimiters, and flags all present).
+                            // We split it and reuse `lower_regex_literal`,
+                            // so interpolation inside `%r{...}` is handled
+                            // for free by the shared pattern splitter.
+                            if let Some((pattern, flags)) = percent_r_pattern_flags(&tok.value) {
+                                let (pattern, flags) =
+                                    (pattern.to_string(), flags.to_string());
+                                return self.lower_regex_literal(
+                                    &pattern, &flags, span, tok.line, tok.column,
+                                );
                             }
                             // Phase 19a (FC) — regex literal dispatch.  The
                             // lexer's `regex_body` machine emits `/p/flags`


### PR DESCRIPTION
## Phase 19d (FC) — `%r{...}` regex literal

Completes the regex family (19a `/regex/`, 19b flags, 19c interpolation,
19d `%r{}`).  **No grammar or lexer change**: the lexer's
`percent_r_body` state emits the whole `%r{...}` literal as one verbatim
`String` token (the `%`-family sentinel-by-prefix trick `%w`/`%q`/`%i`
use), so the parser routes it through the ordinary string-literal slot.

### `coding-adventures-ruby-parser` 0.57.0

- +3 parse pins (201 → 204): `test_parse_percent_r_regex_literal`
  (`%r{hello}`), `test_parse_percent_r_regex_empty` (`%r{}`),
  `test_parse_percent_r_regex_in_call_argument` (`foo(%r{bar})`).

### `ruby-to-semantic-ir` 0.60.0

- `lower_factor_atom` gains a `%r{...}` dispatch (placed before the
  `/.../` check).  The new free helper `percent_r_pattern_flags` strips
  the `%r`, reads the opening delimiter, finds the matching closing
  delimiter (bracket pairs `{}`/`[]`/`()`/`<>` or symmetric; last
  occurrence — v0 does not track nested brackets), splits the body into
  `(pattern, flags)` (flags validated as Ruby flag letters), then reuses
  `lower_regex_literal` — so `%r{...}` produces the SAME
  `BuiltinCall("regex", [pattern, StrLit(flags)])` shape as `/.../`, and
  gets the pattern interpolation splitter for free.  **No new SIR variant
  or backend dispatch.**
- +3 lowering pins (255 → 258): `percent_r_regex_lowers_to_regex_builtin`
  (`%r{hello}`), `percent_r_regex_empty_pattern_lowers` (`%r{}`),
  `percent_r_regex_validates_e2e` (`%r{x}` + validator E2E).

(v0 lexer note: `%r` uses `{}` as the canonical delimiter and does not
slurp trailing flags; the helper is written generally so it already
covers the broader delimiter/flag forms a future lexer pass may emit.)

### Verification

All green locally:
`cargo test -p coding-adventures-ruby-lexer -p coding-adventures-ruby-parser -p ruby-to-semantic-ir`
(lexer 173, parser 204, lowerer 258).

### Security

Pure AST→IR — no I/O, no `unsafe`.  All `%r` slice indices are proven
valid UTF-8 char boundaries (even for multibyte delimiters); the path is
fully fallible (`?`, no `unwrap` on untrusted input) and reuses the
panic-free `lower_regex_literal`; linear single pass.  `/security-review`
passed clean in one round.
