### PR TITLE
Add SPICE cornered temperature DC table output

### DIFF
--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add `dc_temperature_sweep_corners` and
+  `format_corner_temperature_dc_table` for stable tab-separated named-corner
+  DC operating-point snapshots across explicit `.temp`-style analysis
+  temperatures.
 - Add `dc_temperature_sweep` and `format_temperature_dc_table` for stable
   tab-separated DC operating-point snapshots across explicit `.temp`-style
   analysis temperatures.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -6,7 +6,8 @@ The initial slices implement:
 
 - DC operating-point analysis for linear circuits using modified nodal analysis
   (MNA).
-- DC operating-point sweeps across explicit analysis temperatures.
+- DC operating-point sweeps across explicit analysis temperatures, including
+  named corner sweeps.
 - DC source sweeps over independent voltage and current sources.
 - DC sensitivity analysis for output-node voltage changes with respect to
   resistor and independent source parameters, including named corner sweeps.
@@ -33,9 +34,9 @@ The initial slices implement:
 - Constrained RC and RLC low-pass/high-pass/band-pass/notch pole-zero helpers,
   including named corner sweeps.
 - Stable text output tables for selected node voltages, branch currents,
-  DC operating-point temperature sweeps, transient samples, adaptive transient
-  samples, cornered transient samples, cornered adaptive transient samples, AC
-  phasors, cornered DC
+  DC operating-point temperature sweeps, cornered DC operating-point
+  temperature sweeps, transient samples, adaptive transient samples, cornered
+  transient samples, cornered adaptive transient samples, AC phasors, cornered DC
   operating points, cornered AC phasors, PSS steady-state periods,
   sensitivity entries, Fourier harmonics, cornered Fourier harmonics,
   transfer-function results, cornered transfer-function results, S-parameter

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -1727,6 +1727,17 @@ pub struct TemperatureDcResult {
     pub points: Vec<TemperatureDcPoint>,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct CornerTemperatureDcPoint {
+    pub corner_name: String,
+    pub points: Vec<TemperatureDcPoint>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CornerTemperatureDcResult {
+    pub points: Vec<CornerTemperatureDcPoint>,
+}
+
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct DcOpOptions {
     pub max_iterations: usize,
@@ -3695,6 +3706,52 @@ pub fn format_temperature_dc_table(
     Ok(rows.join("\n"))
 }
 
+pub fn format_corner_temperature_dc_table(
+    result: &CornerTemperatureDcResult,
+    probes: &[&str],
+) -> Result<String, SpiceError> {
+    let selected_probes = if probes.is_empty() {
+        result
+            .points
+            .iter()
+            .find_map(|corner| corner.points.first())
+            .map(|point| {
+                default_output_probes(&point.result.node_voltages, &point.result.branch_currents)
+            })
+            .unwrap_or_default()
+    } else {
+        probes.iter().map(|probe| probe.to_string()).collect()
+    };
+    let mut rows = vec![format!(
+        "Corner\tIndex\tTemperatureKelvin\t{}",
+        selected_probes.join("\t")
+    )];
+    for corner in &result.points {
+        for (index, point) in corner.points.iter().enumerate() {
+            let values: Result<Vec<String>, SpiceError> = selected_probes
+                .iter()
+                .map(|probe| {
+                    table_probe_value(
+                        &point.result.node_voltages,
+                        &point.result.branch_currents,
+                        probe,
+                        "format_corner_temperature_dc_table",
+                    )
+                    .map(format_table_number)
+                })
+                .collect();
+            rows.push(format!(
+                "{}\t{index}\t{}\t{}",
+                corner.corner_name,
+                format_table_number(point.temperature_kelvin),
+                values?.join("\t")
+            ));
+        }
+    }
+    rows.push(String::new());
+    Ok(rows.join("\n"))
+}
+
 pub fn format_dc_sweep_table(
     source_name: &str,
     points: &[DcSweepPoint],
@@ -4754,6 +4811,32 @@ pub fn dc_temperature_sweep(
         });
     }
     Ok(TemperatureDcResult { points })
+}
+
+pub fn dc_temperature_sweep_corners(
+    circuit: &Circuit,
+    temperatures_kelvin: &[f64],
+    nominal_temperature_kelvin: f64,
+    silicon_energy_gap_ev: f64,
+    options: DcOpOptions,
+    corners: &[CornerSpec],
+) -> Result<CornerTemperatureDcResult, SpiceError> {
+    let mut points = Vec::with_capacity(corners.len());
+    for corner in corners {
+        let corner_circuit = circuit_with_corner(circuit, corner)?;
+        points.push(CornerTemperatureDcPoint {
+            corner_name: corner.name.clone(),
+            points: dc_temperature_sweep(
+                &corner_circuit,
+                temperatures_kelvin,
+                nominal_temperature_kelvin,
+                silicon_energy_gap_ev,
+                options,
+            )?
+            .points,
+        });
+    }
+    Ok(CornerTemperatureDcResult { points })
 }
 
 fn circuit_with_corner(circuit: &Circuit, corner: &CornerSpec) -> Result<Circuit, SpiceError> {

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -1,8 +1,9 @@
 use spice_engine::{
     circuit_at_temperature, dc_corners, dc_op, dc_op_with_options, dc_sweep, dc_sweep_corners,
-    dc_temperature_sweep, format_corner_dc_sweep_table, format_corner_dc_table,
-    format_dc_sweep_table, format_temperature_dc_table, BSource, Bjt, BjtPolarity, Cccs, Ccvs,
-    Circuit, CornerOverride, CornerSpec, CurrentSource, DcConvergenceAid, DcOpOptions, Diode,
+    dc_temperature_sweep, dc_temperature_sweep_corners, format_corner_dc_sweep_table,
+    format_corner_dc_table, format_corner_temperature_dc_table, format_dc_sweep_table,
+    format_temperature_dc_table, BSource, Bjt, BjtPolarity, Cccs, Ccvs, Circuit, CornerOverride,
+    CornerSpec, CornerTemperatureDcResult, CurrentSource, DcConvergenceAid, DcOpOptions, Diode,
     Element, Inductor, Jfet, JfetPolarity, Mosfet, MosfetLevel1Params, MosfetType, Resistor,
     SinWaveform, SpiceError, SubcircuitDefinition, SubcircuitElement, TemperatureDcResult, Vccs,
     Vcvs, VoltageSource, Waveform, XInstance,
@@ -400,6 +401,48 @@ fn dc_temperature_sweep_text_output_table_is_stable() {
     assert_eq!(
         format_temperature_dc_table(&result, &["V(a)", "I(V1)"]).unwrap(),
         "Index\tTemperatureKelvin\tV(a)\tI(V1)\n0\t2.750000e+02\t4.560039e+00\t-1.023164e-04\n1\t3.001500e+02\t3.613836e+00\t-3.223638e-04\n2\t3.500000e+02\t6.351989e-01\t-1.015070e-03\n"
+    );
+}
+
+#[test]
+fn corner_temperature_dc_text_output_table_is_stable() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "V1", "vcc", "0", 5.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rbias", "vcc", "a", 4_300.0,
+    )));
+    circuit.add(Element::Diode(Diode::with_model(
+        "D1", "a", "0", 1.0e-15, 0.02585,
+    )));
+
+    let result = dc_temperature_sweep_corners(
+        &circuit,
+        &[275.0, 350.0],
+        300.15,
+        1.11,
+        DcOpOptions::default(),
+        &[
+            CornerSpec::new("nominal", vec![]),
+            CornerSpec::new(
+                "rbias-high",
+                vec![CornerOverride::new("Rbias", "resistance", 8_600.0)],
+            ),
+        ],
+    )
+    .unwrap();
+
+    let _: CornerTemperatureDcResult = result.clone();
+    assert_eq!(result.points[0].corner_name, "nominal");
+    assert_eq!(result.points[1].corner_name, "rbias-high");
+    assert!(
+        result.points[0].points[0].result.voltage("a").unwrap()
+            > result.points[0].points[1].result.voltage("a").unwrap()
+    );
+    assert_eq!(
+        format_corner_temperature_dc_table(&result, &["V(a)", "I(V1)"]).unwrap(),
+        "Corner\tIndex\tTemperatureKelvin\tV(a)\tI(V1)\nnominal\t0\t2.750000e+02\t4.560039e+00\t-1.023164e-04\nnominal\t1\t3.500000e+02\t6.351989e-01\t-1.015070e-03\nrbias-high\t0\t2.750000e+02\t4.218594e+00\t-9.086118e-05\nrbias-high\t1\t3.500000e+02\t6.144482e-01\t-5.099479e-04\n"
     );
 }
 

--- a/code/specs/spice-1970s-compatibility.md
+++ b/code/specs/spice-1970s-compatibility.md
@@ -402,6 +402,9 @@ Status:
 - DC operating points can now be evaluated and rendered across explicit
   `.temp`-style analysis temperatures in the live Rust SPICE package, covering
   temperature, node-voltage, and branch-current rows with stable ordering.
+- Named-corner DC operating points can now be evaluated and rendered across
+  explicit `.temp`-style analysis temperatures in the live Rust SPICE package,
+  preserving corner order and selected voltage/current probes.
 - `.disto` and `.pz` parser/control-card records plus first distortion and
   pole-zero result shapes are implemented across Python, TypeScript, and Rust,
   with smoke fixtures for nonlinear-device distortion output and a simple RC

--- a/code/specs/spice-macsyma-pending-work.md
+++ b/code/specs/spice-macsyma-pending-work.md
@@ -233,9 +233,9 @@ IC parameters for C/L; AC phasor specs for V/I sources.
   `spice-1970s-compatibility.md`. JFET device/model-card support, mutual
   inductors, ideal transmission lines, Gear-2 transient integration,
   pseudo-transient DC continuation, 1970s model-card depth, classic text output
-  cards including DC operating-point temperature tables, and the first Phase 8
-  small-signal distortion / pole-zero footholds are now reflected there with
-  per-phase status.
+  cards including direct and named-corner DC operating-point temperature
+  tables, and the first Phase 8 small-signal distortion / pole-zero footholds
+  are now reflected there with per-phase status.
 
 ---
 
@@ -258,7 +258,7 @@ and the sparse real solver path landed in PR #3391.
 |---|---|
 | **S-parameter extraction** | Two-port network characterisation. Run AC sweep, compute Y-parameters from node voltages and port currents, convert to S-parameters. Shipped in PR #3490; direct and named-corner S-parameter text tables plus named S-parameter corners are now exposed in the live Rust SPICE package. |
 | **Periodic steady-state (PSS)** | RF / oscillator analysis. Shooting-Newton method: find the initial condition `x(0)` such that `x(T) = x(0)`. Source-period estimation for periodic `SIN` / `PULSE` waveforms shipped in PR #3524; one-period node-closure residual helpers shipped in PR #3534; tolerance-aware residual closure shipped in PR #3540; branch-current residual closure shipped in PR #3553; ordered residual vectors shipped in PR #3560; residual vector norms shipped in PR #3566; finite-difference residual Jacobians shipped in PR #3570; Newton correction helpers shipped in PR #3578; Newton candidate helpers shipped in PR #3588; one-step Newton iteration acceptance shipped in PR #3770; bounded Newton solve shipped in PR #3776; direct PSS analysis output is now exposed in the live Rust SPICE package as a steady-state text table over selected voltage/current probes. PSS can also be evaluated and rendered as stable text tables across named corners in the live Rust SPICE package. |
-| **Multi-corner parallel sweep** | Run the same analysis at N PVT corners in parallel goroutines / subprocesses. Mostly an orchestration problem once the core engine is solid. DC operating-point corners shipped in PR #3495; DC source sweep corners shipped in PR #3501; AC frequency sweep corners shipped in PR #3511; transfer-function corners shipped in PR #3516; Monte Carlo DC, DC sensitivity, AC noise, S-parameters, PSS, constrained pole-zero, fixed-step and adaptive transient samples, Fourier post-processing, and transient-projected distortion corners are now exposed in the live Rust SPICE package; DC operating-point, AC frequency sweep, DC source sweep, transfer-function, Monte Carlo DC, DC sensitivity, AC noise, S-parameter, PSS, constrained pole-zero, fixed-step and adaptive transient sample, Fourier, and transient-projected distortion corner results also have stable text tables. |
+| **Multi-corner parallel sweep** | Run the same analysis at N PVT corners in parallel goroutines / subprocesses. Mostly an orchestration problem once the core engine is solid. DC operating-point corners shipped in PR #3495; DC source sweep corners shipped in PR #3501; AC frequency sweep corners shipped in PR #3511; transfer-function corners shipped in PR #3516; Monte Carlo DC, DC sensitivity, AC noise, S-parameters, PSS, constrained pole-zero, fixed-step and adaptive transient samples, DC temperature operating points, Fourier post-processing, and transient-projected distortion corners are now exposed in the live Rust SPICE package; DC operating-point, AC frequency sweep, DC source sweep, transfer-function, Monte Carlo DC, DC sensitivity, AC noise, S-parameter, PSS, constrained pole-zero, fixed-step and adaptive transient sample, DC temperature operating-point, Fourier, and transient-projected distortion corner results also have stable text tables. |
 | **Mixed-signal coupling with `hardware-vm`** | AMS simulation — digital events feed into analog SPICE nodes and vice versa. Long-range project; `hardware-vm.md` spec describes the interface. |
 | **Verilog-A compact models** | Custom device models. Requires a Verilog-A parser (`code/specs/verilog-a-parser.md` is referenced but not written). |
 


### PR DESCRIPTION
## Summary

- add named-corner DC temperature sweep result shapes and a `dc_temperature_sweep_corners` helper
- add stable `format_corner_temperature_dc_table` output preserving corner order, temperature, node-voltage, and branch-current probes
- document the new PVT-style temperature/corner DC table surface in the package README, changelog, and SPICE specs

## Validation

- `cargo fmt -p spice-engine --check`
- `cargo test -p spice-engine --test dc_tests corner_temperature_dc_text_output_table_is_stable`
- `cargo test -p spice-engine --test dc_tests`
- `cargo test -p spice-engine`
- `git diff --check`