### PR TITLE
feat(closure-pass-constant-fold): CLOC12.03 — close gap-007 and gap-008

### DIFF
--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,83 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.4.0] - 2026-05-31
+
+### Added — CLOC12.03: close gap-007 and gap-008
+
+Two small fold-pass body extensions in `try_fold_binary_op`, each
+~15 lines, sitting after the existing per-type branches:
+
+**gap-007 — `NullLiteral OP NullLiteral`.** New branch returns the
+JS-spec result for every comparison operator on two `null` literals:
+
+```text
+null ==  null   →  true
+null === null   →  true
+null !=  null   →  false
+null !== null   →  false
+null <   null   →  false   (both coerce to 0; 0 < 0 is false)
+null >   null   →  false
+null <=  null   →  true
+null >=  null   →  true
+```
+
+Relational operators run through ECMAScript §IsLessThan, which
+calls ToNumber on each side. `ToNumber(null)` is `0`, so the four
+relational cases reduce to `0 OP 0`.
+
+**gap-008 — cross-type strict equality.** New branch handles
+`StrictEq`/`StrictNotEq` when both operands are literals of
+*different* JS types. Per ECMAScript §IsStrictlyEqual, `===` is
+`false` for any pair of values with different types, and `!==` is
+`true`. So:
+
+```text
+1 === "1"          →  false
+1 !== "1"          →  true
+true === 1         →  false
+true !== 1         →  true
+null === 0         →  false
+"a" === true       →  false
+```
+
+This branch fires *after* the same-type branches (numeric/numeric,
+string/string, boolean/boolean, null/null), so the only cases left
+to handle are literals of recognised-but-different JS types. Loose
+`==` is still left alone — that goes through the abstract-equality
+algorithm and stays gated by gap-003 / gap-004.
+
+A new internal helper `js_literal_type(&Expression) → Option<&'static str>`
+tags each Phase 1 primitive literal with a string discriminator
+(`"number"`, `"string"`, `"boolean"`, `"null"`). The tags are
+internal — they're not the result of the JS `typeof` operator
+(which has its own quirks like `typeof null === "object"`) — but
+they're sufficient to decide whether two literals have the same JS
+type for the strict-equality fold.
+
+### Test impact
+
+`tests/upstream/peephole_fold_constants_test.rs`:
+
+- `test_null_comparison_1_self_relations` was `#[ignore]`-ed in
+  CLOC12.02 with `gap-007` — now passes.
+- `test_number_string_strict_equality_lines` was `#[ignore]`-ed in
+  CLOC12.02 with `gap-008` — now passes.
+
+Total port score:
+
+|             | passing | ignored |
+|-------------|---------|---------|
+| CLOC12.02   | 5       | 7       |
+| **CLOC12.03** | **7** | **5**   |
+
+`code/specs/CLOC12-gaps.md` updated: `gap-007` and `gap-008` marked
+`RESOLVED-in-#NNNN` (PR number filled in once we know it).
+
+### Version bump
+
+`0.3.0` → `0.4.0`.
+
 ## [0.3.0] - 2026-05-31
 
 ### Added — CLOC12.02: first port of upstream `PeepholeFoldConstantsTest`

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -523,7 +523,92 @@ fn try_fold_binary_op(
         };
     }
 
+    // Null/null comparisons (closes CLOC12 gap-007).
+    //
+    // JS-spec behavior at compile time when both sides are
+    // `null` literals:
+    //
+    //     null == null        → true     (same primitive value)
+    //     null === null       → true     (same type + value)
+    //     null != null        → false
+    //     null !== null       → false
+    //     null <  null        → false    (both coerce to 0, 0 < 0 is false)
+    //     null >  null        → false    (0 > 0 is false)
+    //     null <= null        → true     (0 <= 0 is true)
+    //     null >= null        → true     (0 >= 0 is true)
+    //
+    // Relational operators on `null` go through the abstract
+    // relational comparison algorithm in the ECMAScript spec
+    // (§IsLessThan), which calls ToPrimitive then ToNumber. For
+    // `null`, ToNumber(null) is `0`. So `null < null` reduces to
+    // `0 < 0` which is `false`, and the symmetric cases follow.
+    if let (Expression::NullLiteral(_), Expression::NullLiteral(_)) = (left, right) {
+        return match op {
+            Eq | StrictEq => Some(FoldedLiteral::Boolean(true)),
+            NotEq | StrictNotEq => Some(FoldedLiteral::Boolean(false)),
+            Lt => Some(FoldedLiteral::Boolean(false)),
+            Gt => Some(FoldedLiteral::Boolean(false)),
+            LtEq => Some(FoldedLiteral::Boolean(true)),
+            GtEq => Some(FoldedLiteral::Boolean(true)),
+            _ => None,
+        };
+    }
+
+    // Cross-type strict equality (closes CLOC12 gap-008).
+    //
+    // Per ECMAScript §IsStrictlyEqual, `===` between two values
+    // of different *types* is always `false` (and `!==` is
+    // always `true`) regardless of values:
+    //
+    //     1 === "1"            → false
+    //     1 !== "1"            → true
+    //     true === 1           → false
+    //     null === undefined   → false       (different types — see also gap-001)
+    //
+    // We don't *touch* loose `==` here — that goes through the
+    // abstract-equality algorithm with coercion, which is
+    // gap-003 / gap-004. Strict equality is the easy case: just
+    // check whether the two literals are of different JS types.
+    //
+    // Why this runs after the same-type branches: those branches
+    // already handle `1 === 1`, `"a" === "a"`, `true === true`,
+    // `null === null`. By the time we get here, we know at least
+    // one side is not a literal we recognise *or* the two sides
+    // are of different JS literal types. We only want to fire
+    // when both are literals of *known but different* JS types.
+    if matches!(op, StrictEq | StrictNotEq) {
+        if let (Some(lt), Some(rt)) = (js_literal_type(left), js_literal_type(right)) {
+            if lt != rt {
+                return match op {
+                    StrictEq => Some(FoldedLiteral::Boolean(false)),
+                    StrictNotEq => Some(FoldedLiteral::Boolean(true)),
+                    _ => unreachable!(),
+                };
+            }
+        }
+    }
+
     None
+}
+
+/// Tag the JS type of a literal expression for the cross-type
+/// strict-equality fold (gap-008). Returns `None` for anything
+/// that isn't a Phase 1 primitive literal — identifiers, calls,
+/// member expressions, etc. — so the caller leaves them alone.
+///
+/// The string tags here are *internal* to this module; they're
+/// not the result of `typeof` (which has its own quirks like
+/// `typeof null === "object"`). For the strict-equality fold,
+/// what matters is that two different literal kinds get
+/// different tags, so the equality of the tags drives the fold.
+fn js_literal_type(expr: &Expression) -> Option<&'static str> {
+    match expr {
+        Expression::NumericLiteral(_) => Some("number"),
+        Expression::StringLiteral(_) => Some("string"),
+        Expression::BooleanLiteral(_) => Some("boolean"),
+        Expression::NullLiteral(_) => Some("null"),
+        _ => None,
+    }
 }
 
 /// Best-effort static string rendering of a literal expression. Used

--- a/code/packages/rust/closure-pass-constant-fold/tests/upstream/peephole_fold_constants_test.rs
+++ b/code/packages/rust/closure-pass-constant-fold/tests/upstream/peephole_fold_constants_test.rs
@@ -173,13 +173,11 @@ fn test_undefined_comparison_2() {
 /// (Subset of the full `testNullComparison1`. Lines that mention
 /// `undefined`, `void 0`, `NaN`, `Infinity` are deferred to gap-001.)
 ///
-/// **Why this is currently `#[ignore]`-ed:** the pass's
-/// `try_fold_binary_op` has dedicated branches for
-/// `NumericLiteral`/`NumericLiteral`, `StringLiteral`/`StringLiteral`,
-/// `BooleanLiteral`/`BooleanLiteral` comparisons, but no branch for
-/// `NullLiteral`/`NullLiteral`. Trivial to add — see gap-007.
+/// **gap-007 closed in CLOC12.03** — `try_fold_binary_op` now has a
+/// `NullLiteral`/`NullLiteral` branch that returns the JS-spec value
+/// for each operator (`==`/`===`/`<=`/`>=` → `true`, the rest →
+/// `false`).
 #[test]
-#[ignore = "blocked on gap-007: NullLiteral OP NullLiteral fold not implemented"]
 fn test_null_comparison_1_self_relations() {
     assert_fold(b(null_(), BinaryOperator::Eq, null_()), bool_(true));
     assert_fold(b(null_(), BinaryOperator::StrictEq, null_()), bool_(true));
@@ -278,14 +276,12 @@ fn test_number_string_comparison_literal_lines() {
 ///   test("1 !== '1'", "true");
 ///
 /// These hold by JS-spec (strict equality requires same JS type; a
-/// Number and a String can never `===`). Our pass *could* fold these
-/// trivially but currently falls through `try_fold_binary_op`'s
-/// per-type branches — none of them match a mixed
-/// `NumericLiteral`/`StringLiteral` pair, so the binary node is
-/// returned untouched. Filed as gap-008; orthogonal to gap-004 (which
-/// is about *loose* equality and abstract relational comparison).
+/// Number and a String can never `===`). **gap-008 closed in
+/// CLOC12.03** — `try_fold_binary_op` now has a cross-type
+/// strict-equality branch that fires when both sides are literals of
+/// different JS types. Stays orthogonal to gap-004 (which is about
+/// loose equality + abstract relational comparison).
 #[test]
-#[ignore = "blocked on gap-008: cross-type strict equality fold (Number === String → false) not implemented"]
 fn test_number_string_strict_equality_lines() {
     assert_fold(b(n(1.0), BinaryOperator::StrictEq, s("1")), bool_(false));
     assert_fold(

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -66,19 +66,17 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-007 — `NullLiteral OP NullLiteral` fold not implemented
 
-- **Status:** OPEN
+- **Status:** RESOLVED in CLOC12.03 (PR pending)
 - **Upstream test:** `PeepholeFoldConstantsTest::testNullComparison1` (`null OP null` self-relation lines)
 - **Ported file:** `closure-pass-constant-fold/tests/upstream/peephole_fold_constants_test.rs`
-- **Why it fails:** `try_fold_binary_op` has dedicated branches for `NumericLiteral`/`NumericLiteral`, `StringLiteral`/`StringLiteral`, `BooleanLiteral`/`BooleanLiteral`, but no branch for `NullLiteral`/`NullLiteral`. The binary node falls through and is returned unchanged.
-- **What it needs:** A small `NullLiteral`/`NullLiteral` branch returning `Boolean(true)` for `==`/`===`/`<=`/`>=` and `Boolean(false)` for `!=`/`!==`/`<`/`>`. Roughly 10 lines in `try_fold_binary_op`.
+- **Resolution:** Added a `NullLiteral`/`NullLiteral` branch in `try_fold_binary_op` returning `Boolean(true)` for `==`/`===`/`<=`/`>=` and `Boolean(false)` for `!=`/`!==`/`<`/`>`. Relational ops follow ECMAScript §IsLessThan with `ToNumber(null) = 0`.
 
 ### gap-008 — cross-type strict equality fold (`Number === String → false`)
 
-- **Status:** OPEN
+- **Status:** RESOLVED in CLOC12.03 (PR pending)
 - **Upstream test:** `PeepholeFoldConstantsTest::testNumberStringComparison` (`===`/`!==` lines)
 - **Ported file:** `closure-pass-constant-fold/tests/upstream/peephole_fold_constants_test.rs`
-- **Why it fails:** Strict equality between two literals of *different* JS types is `false` by definition (and `!==` is `true`). The current pass only fires same-type branches, so `1 === '1'` falls through and is returned unchanged.
-- **What it needs:** A pre-branch in `try_fold_binary_op` that, when both sides are literals of different JS types *and* the operator is `===`/`!==`, returns `Boolean(false)`/`Boolean(true)`. Roughly 15 lines, fully self-contained.
+- **Resolution:** Added a strict-equality-cross-type branch in `try_fold_binary_op` that fires after the same-type branches. Uses a new internal helper `js_literal_type` to tag each Phase 1 primitive literal with a discriminator (`"number"`/`"string"`/`"boolean"`/`"null"`); when both sides are tagged and tags differ, `===` → `false`, `!==` → `true`. Loose `==` is still untouched (gap-003/gap-004).
 
 ### gap-006 — unary plus / minus on identifiers, plus identifier-arithmetic shape
 


### PR DESCRIPTION
## Summary

- Two small fold-pass body extensions in `try_fold_binary_op` (~15 lines each) that close the two smallest open CLOC12 gaps from CLOC12.02's first port.
- **gap-007** — `NullLiteral OP NullLiteral` comparisons now fold to their JS-spec values.
- **gap-008** — cross-type `===`/`!==` between two literals of different JS types now fold to `false`/`true` per ECMAScript §IsStrictlyEqual.
- Two previously `#[ignore]`-ed ports in `tests/upstream/peephole_fold_constants_test.rs` now pass without modification.

## Port score

|             | passing | ignored |
|-------------|---------|---------|
| CLOC12.02   | 5       | 7       |
| **CLOC12.03** | **7** | **5**   |

## How they fold

**gap-007 — null/null:**

| Operator | Result | Why |
|----------|--------|-----|
| `==` `===` | `true` | same primitive value |
| `!=` `!==` | `false` | inverse of above |
| `<` `>` | `false` | `ToNumber(null) = 0`, `0 < 0` is `false` |
| `<=` `>=` | `true` | `0 <= 0` is `true` |

**gap-008 — cross-type strict equality:**

```js
1 === \"1\"        → false       1 !== \"1\"        → true
true === 1       → false       true !== 1       → true
null === 0       → false       null !== 0       → true
\"a\" === true     → false       \"a\" !== true     → true
```

Fires AFTER the same-type branches; loose `==` is still untouched and remains gated by gap-003/gap-004.

## New helper

`js_literal_type(&Expression) -> Option<&'static str>` — tags Phase 1 primitives. NOT the result of `typeof` (which has its own quirks like `typeof null === \"object\"`); just an internal discriminator sufficient for same-type-vs-different-type decisions.

## Spec sync

`code/specs/CLOC12-gaps.md`: gap-007 and gap-008 marked RESOLVED.

## Version

closure-pass-constant-fold `0.3.0` → `0.4.0`.

## Test plan

- [x] `cargo test` — 27 inline + 7 upstream pass, 5 ignored, 0 failed
- [x] Pure pattern matching, no unsafe, no IO/network
- [x] `unreachable!()` arm provably dead (gated by `matches!(op, StrictEq | StrictNotEq)`)
- [x] Branch ordering preserves existing same-type fold semantics
- [x] Security review: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)