### PR TITLE
test(ruby-fc): Phase 22a — `**` double-splat call-arg coverage pins

### DIFF
--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.58.0] - 2026-05-31
+
+### Added (Phase 22a (FC) — `**` double-splat call argument, coverage)
+
+No grammar change.  The `call_arg = [ "*" | "**" ] expression ;` rule
+(Phase 6s) already admits a `**` double-splat prefix in both head
+`method_call` argument lists and `dot_call` argument lists.  This phase
+locks the parse shape with three new-angle pins that earlier `**`
+coverage never exercised:
+
+- `test_parse_double_splat_only_call_arg` (`f(**opts)`) — a lone `**`
+  arg with no positional/splat siblings (prior pins only ran `**`
+  alongside `f(1, *arr, **hsh)`).
+- `test_parse_double_splat_hash_literal_inner` (`f(**{a: 1})`) — the
+  double-splat operand is itself a `hash_literal`, confirming the
+  `call_arg` expression slot accepts a brace literal after `**`.
+- `test_parse_double_splat_in_dot_call` (`obj.merge(**opts)`) — the
+  `**` rides through a `dot_call` argument list, a distinct grammar
+  path from the head-call args.
+
+Test count: 204 → 207.
+
 ## [0.57.0] - 2026-05-31
 
 ### Added (Phase 19d (FC) — `%r{...}` regex literal)

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -2539,6 +2539,53 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_double_splat_only_call_arg() {
+        // Phase 22a (coverage) — `f(**opts)` with the double-splat as the
+        // SOLE argument.  Earlier pins only exercised `**` alongside other
+        // args (`f(1, *arr, **hsh)`); this confirms a lone `**` arg still
+        // produces exactly one `call_arg` carrying the `**` prefix.
+        let ast = parse_ruby("f(**opts)");
+        let call = find_descendant(&ast, "method_call").expect("expected method_call");
+        let arg_count = call
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "call_arg"))
+            .count();
+        assert_eq!(arg_count, 1, "expected exactly 1 call_arg, got {arg_count}");
+        let call_arg = find_descendant(&ast, "call_arg").expect("expected call_arg");
+        assert!(tree_has_token_value(call_arg, "**"), "expected `**` prefix");
+        assert!(tree_has_token_value(call_arg, "opts"), "expected `opts` name");
+    }
+
+    #[test]
+    fn test_parse_double_splat_hash_literal_inner() {
+        // Phase 22a (coverage) — `f(**{a: 1})`: the double-splat operand is
+        // itself a hash literal, not a bare name.  Confirms the `call_arg`
+        // expression slot accepts a `hash_literal` after the `**` prefix.
+        let ast = parse_ruby("f(**{a: 1})");
+        let call_arg = find_descendant(&ast, "call_arg").expect("expected call_arg");
+        assert!(tree_has_token_value(call_arg, "**"), "expected `**` prefix");
+        // The inner hash literal must appear beneath the same call_arg.
+        let hash = find_descendant(call_arg, "hash_literal")
+            .expect("expected hash_literal inside the double-splat call_arg");
+        assert!(tree_has_token_value(hash, "a"), "expected key `a` in inner hash");
+    }
+
+    #[test]
+    fn test_parse_double_splat_in_dot_call() {
+        // Phase 22a (coverage) — `obj.merge(**opts)`: the double-splat rides
+        // through a `dot_call` argument list (a distinct grammar path from
+        // the head `method_call` args).  Both reuse `call_arg`, so `**`
+        // must surface there too.
+        let ast = parse_ruby("obj.merge(**opts)");
+        let dot = find_descendant(&ast, "dot_call").expect("expected dot_call");
+        let call_arg = find_descendant(dot, "call_arg")
+            .expect("expected call_arg inside dot_call");
+        assert!(tree_has_token_value(call_arg, "**"), "expected `**` in dot_call arg");
+        assert!(tree_has_token_value(call_arg, "opts"), "expected `opts` name");
+    }
+
+    #[test]
     fn test_parse_binary_star_still_parses_as_expression() {
         // Regression: `a * b` as a statement must still parse as a
         // bare expression-stmt with binary `*`, NOT as `a(splat b)`.

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.61.0] - 2026-05-31
+
+### Added (Phase 22a (FC) — `**` double-splat call argument, coverage)
+
+No lowering change.  `lower_call_arg` (Phase 6s) already maps a `**`
+double-splat call argument to `BuiltinCall("double_splat", [inner])`,
+mirroring the single-splat `BuiltinCall("splat", …)` shape.  This phase
+adds three new-angle lowering pins that earlier coverage did not run:
+
+- `double_splat_only_arg_passes_sir_validator` (`puts(**opts)`) — a
+  lone double-splat call arg both lowers to one `double_splat` builtin
+  AND passes `semantic_ir::validate` (the prior shape pins never ran the
+  validator on a double-splat-only call).
+- `double_splat_hash_literal_inner_lowers_and_validates`
+  (`puts(**{a: 1})`) — the double-splat operand lowers to a `MapLit`
+  wrapped by `double_splat`, and the module validates.
+- `double_splat_after_leading_positional_lowers_in_order`
+  (`f(7, **opts)`) — pins the positional-then-double-splat two-arg
+  ordering with no intervening single splat.
+
+(`puts` is used for the validator-backed pins because it is a known
+intrinsic — an unknown callee `f` trips the validator's
+unknown-function check; `puts` lowers to `BuiltinCall("puts", …)`.)
+
+Test count: 258 → 261.
+
 ## [0.60.0] - 2026-05-31
 
 ### Added (Phase 19d (FC) — `%r{...}` regex literal)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -3786,6 +3786,88 @@ mod tests {
     }
 
     #[test]
+    fn double_splat_only_arg_passes_sir_validator() {
+        // Phase 22a (coverage) — end-to-end: a lone `**opts` call arg
+        // lowers to a single `double_splat` BuiltinCall AND the resulting
+        // module validates cleanly.  Earlier pins asserted the node shape
+        // but never ran the validator on a double-splat-only call.
+        // Use `puts` (a known builtin) so the validator's unknown-callee
+        // check passes and we exercise only the double-splat arg path.
+        let m = lower("opts = {a: 1}\nputs(**opts)\n");
+        let result = semantic_ir::validate(&m);
+        assert!(
+            result.is_ok(),
+            "validator rejected double-splat-only call: {:?}",
+            result
+        );
+        let b = main_body(&m);
+        // `puts` is an intrinsic — it lowers to BuiltinCall("puts", …),
+        // not a DirectCall.  Its sole argument is the double-splat.
+        let args = match &b.value {
+            Expr::BuiltinCall { name, args, .. } if name == "puts" => args,
+            other => panic!("expected BuiltinCall(puts, ...), got {:?}", other),
+        };
+        assert_eq!(args.len(), 1, "expected exactly 1 arg");
+        assert!(matches!(
+            &args[0],
+            Expr::BuiltinCall { name, .. } if name == "double_splat"
+        ));
+    }
+
+    #[test]
+    fn double_splat_hash_literal_inner_lowers_and_validates() {
+        // Phase 22a (coverage) — `f(**{a: 1})`: the double-splat operand is
+        // an inline hash literal.  The inner expression must lower to a
+        // `MapLit` wrapped by `double_splat`, and the module must validate.
+        let m = lower("puts(**{a: 1})\n");
+        let result = semantic_ir::validate(&m);
+        assert!(
+            result.is_ok(),
+            "validator rejected double-splat of hash literal: {:?}",
+            result
+        );
+        let b = main_body(&m);
+        let args = match &b.value {
+            Expr::BuiltinCall { name, args, .. } if name == "puts" => args,
+            other => panic!("expected BuiltinCall(puts, ...), got {:?}", other),
+        };
+        assert_eq!(args.len(), 1);
+        match &args[0] {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "double_splat");
+                assert_eq!(args.len(), 1);
+                assert!(
+                    matches!(&args[0], Expr::MapLit { .. }),
+                    "expected MapLit operand, got {:?}",
+                    args[0]
+                );
+            }
+            other => panic!("expected BuiltinCall(double_splat, ...), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn double_splat_after_leading_positional_lowers_in_order() {
+        // Phase 22a (coverage) — `f(7, **opts)`: a positional arg followed
+        // by a double-splat.  Distinct from the existing mixed pin (which
+        // also threads a single `*arr` splat between them); here the splat
+        // is absent so we lock the two-arg positional-then-double-splat
+        // ordering specifically.
+        let m = lower("opts = {a: 1}\nf(7, **opts)\n");
+        let b = main_body(&m);
+        let args = match &b.value {
+            Expr::DirectCall { fn_name, args, .. } if fn_name == "f" => args,
+            other => panic!("expected DirectCall(f, ...), got {:?}", other),
+        };
+        assert_eq!(args.len(), 2, "expected 2 args, got {}", args.len());
+        assert!(matches!(&args[0], Expr::IntLit { value: 7, .. }));
+        assert!(matches!(
+            &args[1],
+            Expr::BuiltinCall { name, .. } if name == "double_splat"
+        ));
+    }
+
+    #[test]
     fn splat_call_arg_module_passes_sir_validator() {
         // End-to-end smoke check: a module that uses splat call args
         // validates cleanly.


### PR DESCRIPTION
## Phase 22a (FC) — `**` double-splat call argument (coverage)

Part of the Ruby 3.4 frontend-convergence track.

### Already implemented
The `**` double-splat call argument is **already supported end-to-end**:
- **Grammar:** `call_arg = [ "*" | "**" ] expression ;` (Phase 6s) admits a `**` prefix in both head `method_call` and `dot_call` argument lists.
- **Lowering:** `lower_call_arg` maps a `**` arg to `BuiltinCall("double_splat", [inner])`, mirroring the single-splat `BuiltinCall("splat", …)` shape.

So this is a **coverage-confirmation phase** (precedent 16b / 16c / 10a / 19b): **no grammar or lowering change**, only new-angle test pins that earlier `**` coverage never exercised. (The hash-literal merge form `{ **kwargs }` remains a separate queue item, 27a.)

### Parser pins (+3 → 207)
- `test_parse_double_splat_only_call_arg` — `f(**opts)` (lone `**` arg, no positional/splat siblings)
- `test_parse_double_splat_hash_literal_inner` — `f(**{a: 1})` (operand is a `hash_literal`)
- `test_parse_double_splat_in_dot_call` — `obj.merge(**opts)` (the `dot_call` arg path)

### Lowering pins (+3 → 261)
- `double_splat_only_arg_passes_sir_validator` — `puts(**opts)` (one `double_splat` builtin **and** `semantic_ir::validate` passes)
- `double_splat_hash_literal_inner_lowers_and_validates` — `puts(**{a: 1})` (`MapLit` operand wrapped by `double_splat`, validates)
- `double_splat_after_leading_positional_lowers_in_order` — `f(7, **opts)` (positional-then-double-splat ordering, no intervening single splat)

The validator-backed pins use `puts` (a known intrinsic lowering to `BuiltinCall("puts", …)`); an unknown callee `f` trips the validator's unknown-function check.

### Tests
`cargo test -p coding-adventures-ruby-lexer -p coding-adventures-ruby-parser -p ruby-to-semantic-ir` — lexer 173, parser 207, IR 261, all green.

### Changelogs
- `ruby-parser` 0.57.0 → 0.58.0
- `ruby-to-semantic-ir` 0.60.0 → 0.61.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
