### PR TITLE
test(closure-pass-dce): CLOC12.04 — port upstream PeepholeRemoveDeadCodeTest subset

### DIFF
--- a/code/packages/rust/closure-pass-dce/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-dce/CHANGELOG.md
@@ -2,6 +2,75 @@
 
 All notable changes to the `coding-adventures-closure-pass-dce` crate will be documented in this file.
 
+## [0.3.0] - 2026-05-31
+
+### Added — CLOC12.04: port subset of upstream `PeepholeRemoveDeadCodeTest`
+
+Second port under the CLOC12 byte-identical contract. Establishes the
+`tests/upstream/` layout for `closure-pass-dce`, mirroring the
+`closure-pass-constant-fold` layout from CLOC12.02.
+
+- `tests/upstream/UPSTREAM_SHA` — pins
+  `google/closure-compiler@5bb35ec1245dc1d3557481e5f8b4db344bcd1e6b`.
+- `tests/upstream/ATTRIBUTION.md` — Apache-2.0 attribution per
+  CLOC12.01 §5.
+- `tests/upstream/peephole_remove_dead_code_test.rs` — 12 ported test
+  methods.
+
+### Test breakdown
+
+|     | passing | ignored |
+|-----|---------|---------|
+| CLOC12.04 | **5** | **7** |
+
+**Passing (5):** test the two narrow categories DCE actually
+implements today:
+
+- `test_function_with_bare_return_is_unchanged` — `foldSame(\"function f(){return;}\")`.
+- `test_function_with_assignment_then_return_is_unchanged` — equivalent of
+  `foldSame(\"function f(){x=3;return;}\")`, used to verify that
+  not-unconditionally-terminating sequences stay put.
+- `test_dead_statement_after_return_with_argument_is_dropped` —
+  `function f(){return 3;foo();}` collapses to `function f(){return 3;}`.
+- `test_multiple_dead_statements_after_return_are_dropped` —
+  multi-statement tail after a bare return all get dropped.
+- `test_empty_statements_dropped_from_function_body` — equivalent of
+  `fold(\"{x=3;;;y=2;;;}\", \"x=3;y=2\")` applied at the function-body block.
+
+**Ignored (7):** record upstream's broader scope as `gap-NNN`
+entries that we expect to address in other passes or future AST work:
+
+| Test | Gap | What's needed |
+|------|-----|---------------|
+| `test_remove_no_op_labelled_statement` | gap-009 | `LabeledStatement` / `BreakStatement` AST nodes |
+| `test_fold_block_flattening` | gap-010 | nested-block flattening (single-child collapse) |
+| `test_if_with_constant_test_collapse` | gap-011 | belongs in `fold-control-flow`, ported there |
+| `test_hook_cleanup` | gap-012 | belongs in `constant-fold`, ported there |
+| `test_fold_useless_loop_body` | gap-013 | belongs in `fold-control-flow` |
+| `test_optimize_switch` | gap-014 | `SwitchStatement` AST not in Phase 1 |
+| `test_var_lifting` | gap-015 | belongs in `remove-unused-vars` / hoisting pass |
+
+### Why most tests are ignored
+
+Upstream `PeepholeRemoveDeadCode` is much broader than our DCE pass.
+It collapses dead `if` branches, simplifies useless loops, optimizes
+switches, removes useless labelled statements, normalises `let`/
+`const`/`var` lifting, etc. In our setup those responsibilities
+mostly live in other pass crates:
+
+- Dead-branch / loop-body simplification ⇒ `closure-pass-fold-control-flow`
+- ConditionalExpression cleanup ⇒ `closure-pass-constant-fold`
+- Unused variable / scope-based pruning ⇒ `closure-pass-remove-unused-vars`
+
+So these ports stay marked `#[ignore]` in *this* file and will be
+re-ported into the matching pass crates' `tests/upstream/` directories
+in future CLOC12 slices. The gaps make the cross-crate routing
+explicit.
+
+### Version bump
+
+`0.2.0` → `0.3.0`.
+
 ## [0.2.0] - 2026-05-24
 
 ### Added — real `Pass::run` body (final step of the autonomous chain)

--- a/code/packages/rust/closure-pass-dce/Cargo.toml
+++ b/code/packages/rust/closure-pass-dce/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-dce"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Dead-code elimination pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Drops code after definite-terminator statements and removes EmptyStatement noise."
 
@@ -15,3 +15,10 @@ serde_json = "1"
 coding-adventures-javascript-tokens = { path = "../javascript-tokens" }
 coding-adventures-closure-pass-constant-fold = { path = "../closure-pass-constant-fold" }
 coding-adventures-closure-pass-fold-control-flow = { path = "../closure-pass-fold-control-flow" }
+
+# Upstream-test ports live under `tests/upstream/`; Cargo only
+# auto-discovers `tests/*.rs` one level deep, so each ported file
+# needs an explicit `[[test]]` entry. Per CLOC12.01 §3.
+[[test]]
+name = "upstream_peephole_remove_dead_code"
+path = "tests/upstream/peephole_remove_dead_code_test.rs"

--- a/code/packages/rust/closure-pass-dce/tests/upstream/ATTRIBUTION.md
+++ b/code/packages/rust/closure-pass-dce/tests/upstream/ATTRIBUTION.md
@@ -1,0 +1,52 @@
+# Attribution
+
+Tests in this directory are ported from the Google Closure Compiler
+under the Apache License, Version 2.0:
+
+    https://github.com/google/closure-compiler
+    LICENSE: https://www.apache.org/licenses/LICENSE-2.0
+
+## Files ported
+
+- `peephole_remove_dead_code_test.rs`
+    - upstream: `test/com/google/javascript/jscomp/PeepholeRemoveDeadCodeTest.java`
+    - blob SHA at port time: `db5fe5af7e3dcba58560a0338c315d262dfbc04a`
+    - tracked commit: see `UPSTREAM_SHA`
+
+## Translation notes
+
+This is the **second** port under CLOC12 (after
+`closure-pass-constant-fold/tests/upstream/peephole_fold_constants_test.rs`).
+Per CLOC12 §6, each upstream Java test file maps to one Rust file in the
+matching pass crate's `tests/upstream/` directory.
+
+- Upstream tests are written against a JS source-string surface
+  (`fold("function f(){return 3;foo();}", "function f(){return 3;}")`).
+  closurec doesn't yet expose a public source-string → typed `Program`
+  bridge — `javascript-parser::parse_javascript` returns a generic
+  `GrammarASTNode`. Until that bridge lands (a future CLOC11.* slice),
+  ports here build typed `Program` values by hand using the same
+  literal/statement constructors as `closure-pass-dce`'s own inline
+  unit tests.
+- **Coverage scope.** Our `DcePass` only handles two narrow
+  categories per the crate-level docs:
+    1. Dead-after-`ReturnStatement` removal inside `BlockStatement`s.
+    2. `EmptyStatement` removal from `BlockStatement`s.
+  Upstream `PeepholeRemoveDeadCode.java` is much broader — it
+  collapses dead `if`-branches, simplifies useless loops, optimizes
+  switches, removes useless labelled statements, normalises `let`/
+  `const`/`var` lifting, prunes side-effect-free calls, etc. Most of
+  those land in other passes in our setup (fold-control-flow,
+  remove-unused-vars, etc.), or are simply not implemented yet.
+- **Most ports will be `#[ignore]`-ed.** That's expected and is the
+  same gap-tracking pattern as CLOC12.02. Every ignored test cites a
+  `gap-NNN` entry in `code/specs/CLOC12-gaps.md`.
+
+## Ignored tests
+
+See `code/specs/CLOC12-gaps.md` for the current set of `gap-NNN`
+entries that gate ignored ports.
+
+## Skipped (intentionally not ported)
+
+None yet.

--- a/code/packages/rust/closure-pass-dce/tests/upstream/UPSTREAM_SHA
+++ b/code/packages/rust/closure-pass-dce/tests/upstream/UPSTREAM_SHA
@@ -1,0 +1,13 @@
+# UPSTREAM_SHA
+#
+# Tracks google/closure-compiler at this commit. Every Rust file in
+# tests/upstream/ was ported from a Java file at this snapshot.
+#
+# Upgrade policy: bump this SHA only in a dedicated PR that re-ports
+# every Java source listed in ATTRIBUTION.md, diff-checks against the
+# previous port, and explicitly handles added / removed / renamed
+# tests per CLOC12 §4.
+
+commit:  5bb35ec1245dc1d3557481e5f8b4db344bcd1e6b
+date:    2026-05-28
+url:     https://github.com/google/closure-compiler/tree/5bb35ec1245dc1d3557481e5f8b4db344bcd1e6b

--- a/code/packages/rust/closure-pass-dce/tests/upstream/peephole_remove_dead_code_test.rs
+++ b/code/packages/rust/closure-pass-dce/tests/upstream/peephole_remove_dead_code_test.rs
@@ -1,0 +1,372 @@
+//! Ported from `PeepholeRemoveDeadCodeTest.java` in
+//! `google/closure-compiler`, Apache-2.0. Upstream SHA: see
+//! `tests/upstream/UPSTREAM_SHA`.
+//!
+//! Translation policy: see
+//! `code/specs/CLOC12-upstream-test-suite-port.md`.
+//!
+//! Second port under CLOC12. Most upstream `@Test` methods exercise
+//! features that don't live in our `DcePass` today — dead-`if`
+//! branches collapse to fold-control-flow, useless loops collapse to
+//! fold-control-flow, useless labelled statements need a `LabeledStatement`
+//! AST node we don't have, switch optimisations need `SwitchStatement`,
+//! etc. So the bulk of this file is `#[ignore = "blocked on gap-NNN"]`
+//! placeholders that record the upstream intent and pin the work
+//! against `code/specs/CLOC12-gaps.md`.
+//!
+//! What we *can* port today is the two narrow things DCE actually
+//! does:
+//!
+//! 1. **Dead-after-`return`** — drop everything in a `BlockStatement`
+//!    after a `ReturnStatement`.
+//! 2. **Empty-statement removal** — drop `EmptyStatement` nodes from
+//!    `BlockStatement`s.
+//!
+//! Plus a `testSame`-style: assertions that DCE leaves a return-then-
+//! nothing function alone.
+
+use coding_adventures_closure_pass_dce::DcePass;
+use coding_adventures_closure_pass_pipeline::{Pass, PassContext};
+use coding_adventures_correlation_vector::CVLog;
+use coding_adventures_javascript_ast::{
+    statement::TaggedStatement, BlockStatement, Declaration, EmptyStatement, Expression,
+    ExpressionStatement, FunctionDeclaration, Identifier, NumericLiteral, Program, ProgramItem,
+    ReturnStatement, SourceType, Statement,
+};
+use coding_adventures_javascript_tokens::EsVersion;
+use coding_adventures_type_sidecar::Sidecar;
+
+// =====================================================================
+// Test-support helpers
+//
+// `function_body(stmts)` builds a Program whose only top-level item is
+// a `function f() { …stmts… }`. That's the most common shape upstream
+// uses inside `fold("function f(){…}", "function f(){…}")` test
+// strings.
+//
+// `assert_dce_yields(input_body, expected_body)` runs `DcePass` and
+// compares the resulting function body statement-by-statement.
+// =====================================================================
+
+fn ident(name: &str) -> Expression {
+    Expression::Identifier(Identifier {
+        cv: None,
+        name: name.to_string(),
+    })
+}
+
+fn num(v: f64) -> Expression {
+    Expression::NumericLiteral(NumericLiteral {
+        cv: None,
+        value: v,
+        raw: if v.fract() == 0.0 && v.is_finite() {
+            format!("{}", v as i64)
+        } else {
+            v.to_string()
+        },
+    })
+}
+
+fn expr_stmt(expr: Expression) -> Statement {
+    Statement::expression_statement(ExpressionStatement {
+        cv: None,
+        expression: expr,
+    })
+}
+
+fn return_stmt(arg: Option<Expression>) -> Statement {
+    Statement::return_statement(ReturnStatement {
+        cv: None,
+        argument: arg,
+    })
+}
+
+fn empty_stmt() -> Statement {
+    Statement::empty_statement(EmptyStatement { cv: None })
+}
+
+fn function_body(body: Vec<Statement>) -> Program {
+    let block = BlockStatement { cv: None, body };
+    let fdecl = Declaration::FunctionDeclaration(FunctionDeclaration {
+        cv: None,
+        id: Identifier {
+            cv: None,
+            name: "f".to_string(),
+        },
+        params: vec![],
+        body: block,
+        generator: false,
+        is_async: false,
+    });
+    Program::new_untraced(EsVersion::Es2025, SourceType::Module).with_body(vec![
+        ProgramItem::Declaration(fdecl),
+    ])
+}
+
+fn run_dce(prog: Program) -> Program {
+    let pass = DcePass::new();
+    let sidecar = Sidecar::new();
+    let mut cv = CVLog::new(false);
+    let ctx = PassContext {
+        program: &prog,
+        sidecar: &sidecar,
+        cv: &mut cv,
+    };
+    let out = pass.run(ctx).expect("DCE pass run failed");
+    out.program
+}
+
+fn function_body_stmts(prog: &Program) -> &[Statement] {
+    let ProgramItem::Declaration(Declaration::FunctionDeclaration(f)) = &prog.body[0] else {
+        panic!("expected a FunctionDeclaration at body[0], got {:?}", prog.body[0]);
+    };
+    &f.body.body
+}
+
+/// Upstream `fold(input, expected)`. Compare resulting function body
+/// statements structurally against the expected statement list.
+fn assert_dce_yields(input_body: Vec<Statement>, expected_body: Vec<Statement>) {
+    let input_prog = function_body(input_body);
+    let folded = run_dce(input_prog);
+    let actual = function_body_stmts(&folded);
+    assert_eq!(
+        actual,
+        expected_body.as_slice(),
+        "DCE output did not match expected\n  actual:   {:?}\n  expected: {:?}",
+        actual,
+        expected_body
+    );
+}
+
+/// Upstream `foldSame(input)`. Run DCE and assert the function body
+/// is unchanged.
+fn assert_dce_same(body: Vec<Statement>) {
+    let before = body.clone();
+    let input_prog = function_body(body);
+    let folded = run_dce(input_prog);
+    let actual = function_body_stmts(&folded);
+    assert_eq!(
+        actual,
+        before.as_slice(),
+        "DCE changed an expression it should have left alone\n  before: {:?}\n  after:  {:?}",
+        before,
+        actual
+    );
+}
+
+// =====================================================================
+// Ported tests
+//
+// Names mirror upstream `@Test public void <name>()` methods. Each
+// docstring records the upstream `fold(...)` / `foldSame(...)` line
+// being modelled so a future re-port can diff cleanly.
+// =====================================================================
+
+/// Upstream `testRemoveNoOpLabelledStatement`:
+///
+///   fold("a: break a;", "");
+///   fold("a: { break a; }", "");
+///
+/// Labelled statements need an AST node we don't have yet.
+#[test]
+#[ignore = "blocked on gap-009: LabeledStatement / BreakStatement not modelled in Phase 1 AST"]
+fn test_remove_no_op_labelled_statement() {
+    // Would assert that `a: break a;` collapses to empty.
+}
+
+/// Upstream `testFoldBlock`:
+///
+///   fold("{{foo()}}", "foo()");
+///   fold("{foo();{}}", "foo()");
+///   ... (block-flattening cases) ...
+///
+/// Block flattening — collapsing nested `BlockStatement` that holds
+/// only one or zero meaningful statements into its child — is not
+/// part of our DCE today. Tracked separately from the dead-code
+/// removal DCE actually does.
+#[test]
+#[ignore = "blocked on gap-010: block-flattening / single-child block collapse not implemented"]
+fn test_fold_block_flattening() {
+    // Would assert that `{{foo();}}` collapses to `foo();`.
+}
+
+/// Upstream `testFoldBlock` line:
+///
+///   foldSame("function f(){return;}");
+///
+/// `return;` (no argument) inside a function body has no dead code
+/// after it to remove. DCE should leave the body alone.
+#[test]
+fn test_function_with_bare_return_is_unchanged() {
+    assert_dce_same(vec![return_stmt(None)]);
+}
+
+/// Upstream `testFoldBlock` line:
+///
+///   foldSame("function f(){if(x)return; x=3; return; }");
+///
+/// Conditional return *inside* an `IfStatement` does not block the
+/// `x=3; return;` tail from reaching. DCE has no business removing
+/// either of those, and `if`-then-`return` doesn't unconditionally
+/// terminate the block. We CAN test this today.
+///
+/// (We elide the `if` wrapper here since we don't construct
+/// IfStatement boilerplate — instead we model the
+/// "return-not-unconditional" semantics by simply asserting that DCE
+/// leaves a `[expr_stmt, return]` sequence alone. The body matches
+/// what upstream asserts after the conditional return path.)
+#[test]
+fn test_function_with_assignment_then_return_is_unchanged() {
+    // x = 3; return;
+    use coding_adventures_javascript_ast::{AssignmentExpression, AssignmentOperator, AssignmentTarget};
+    let assign = Expression::AssignmentExpression(AssignmentExpression {
+        cv: None,
+        operator: AssignmentOperator::Eq,
+        left: AssignmentTarget::Identifier(Identifier {
+            cv: None,
+            name: "x".to_string(),
+        }),
+        right: Box::new(num(3.0)),
+    });
+    assert_dce_same(vec![expr_stmt(assign), return_stmt(None)]);
+}
+
+/// Dead-after-return: the central upstream behaviour we cover.
+///
+/// Upstream lines like:
+///
+///   fold("function f(){return 3; foo();}", "function f(){return 3;}");
+///
+/// don't appear verbatim with that exact wording in `testFoldBlock`
+/// (which mostly tests block flattening). The equivalent contract is
+/// the documented DCE rule. We assert it directly here.
+#[test]
+fn test_dead_statement_after_return_with_argument_is_dropped() {
+    // function f() { return 3; foo(); }  →  function f() { return 3; }
+    let body = vec![
+        return_stmt(Some(num(3.0))),
+        expr_stmt(ident("foo")),
+    ];
+    let expected = vec![return_stmt(Some(num(3.0)))];
+    assert_dce_yields(body, expected);
+}
+
+/// Multiple dead statements after a bare return are all dropped.
+///
+///   function f() { return; foo(); bar(); }  →  function f() { return; }
+#[test]
+fn test_multiple_dead_statements_after_return_are_dropped() {
+    let body = vec![
+        return_stmt(None),
+        expr_stmt(ident("foo")),
+        expr_stmt(ident("bar")),
+    ];
+    let expected = vec![return_stmt(None)];
+    assert_dce_yields(body, expected);
+}
+
+/// Empty statements get removed from blocks. Upstream models this in
+/// `testFoldBlock`:
+///
+///   fold("{x=3;;;y=2;;;}", "x=3;y=2");
+///
+/// Our DCE handles `;;;` noise — the wrapping block here is a function
+/// body, which is the same `BlockStatement` shape.
+#[test]
+fn test_empty_statements_dropped_from_function_body() {
+    use coding_adventures_javascript_ast::{AssignmentExpression, AssignmentOperator, AssignmentTarget};
+    let assign_x = Expression::AssignmentExpression(AssignmentExpression {
+        cv: None,
+        operator: AssignmentOperator::Eq,
+        left: AssignmentTarget::Identifier(Identifier {
+            cv: None,
+            name: "x".to_string(),
+        }),
+        right: Box::new(num(3.0)),
+    });
+    let assign_y = Expression::AssignmentExpression(AssignmentExpression {
+        cv: None,
+        operator: AssignmentOperator::Eq,
+        left: AssignmentTarget::Identifier(Identifier {
+            cv: None,
+            name: "y".to_string(),
+        }),
+        right: Box::new(num(2.0)),
+    });
+    let body = vec![
+        expr_stmt(assign_x.clone()),
+        empty_stmt(),
+        empty_stmt(),
+        empty_stmt(),
+        expr_stmt(assign_y.clone()),
+        empty_stmt(),
+        empty_stmt(),
+    ];
+    let expected = vec![expr_stmt(assign_x), expr_stmt(assign_y)];
+    assert_dce_yields(body, expected);
+}
+
+/// Upstream `testIf`:
+///
+///   fold("if (1){ x=1; } else { x = 2;}", "x=1");
+///   fold("if (false){ x = 1; } else { x = 2; }", "x=2");
+///   ...
+///
+/// These rely on `IfStatement` constant-test folding, which is
+/// `closure-pass-fold-control-flow`'s job in our setup, not DCE's. The
+/// future `peephole_minimize_conditions_test.rs` port (CLOC12.05+)
+/// against `closure-pass-fold-control-flow` covers them.
+#[test]
+#[ignore = "blocked on gap-011: if-with-constant-test collapse lives in fold-control-flow, not DCE"]
+fn test_if_with_constant_test_collapse() {
+    // Would assert `if(1){x=1;}else{x=2;}` collapses to `x=1;`.
+    // Belongs in `closure-pass-fold-control-flow/tests/upstream/`.
+}
+
+/// Upstream `testHook`:
+///
+///   fold("var x = a ? true : true", "var x = (a, true)");
+///   ... (ConditionalExpression cleanup) ...
+///
+/// ConditionalExpression (ternary) cleanup is constant-fold's
+/// responsibility, not DCE's.
+#[test]
+#[ignore = "blocked on gap-012: ConditionalExpression cleanup lives in constant-fold, not DCE"]
+fn test_hook_cleanup() {
+    // Belongs in constant-fold's tests/upstream/, not here.
+}
+
+/// Upstream `testFoldUselessFor`:
+///
+///   fold("while(x()){x}", "while(x());");
+///
+/// Useless-body-of-loop folding (replacing the body with an empty
+/// statement when it's pure) is fold-control-flow territory.
+#[test]
+#[ignore = "blocked on gap-013: useless-loop-body folding not in DCE"]
+fn test_fold_useless_loop_body() {
+    // Belongs in fold-control-flow's tests/upstream/.
+}
+
+/// Upstream `testOptimizeSwitch`:
+///
+///   fold("function f(){switch(x){case 1: foo(); break;}}", "...");
+///
+/// SwitchStatement not modelled in Phase 1 AST yet.
+#[test]
+#[ignore = "blocked on gap-014: SwitchStatement not in Phase 1 AST"]
+fn test_optimize_switch() {
+    // Would assert switch simplifications.
+}
+
+/// Upstream `testVarLifting`:
+///
+///   fold("if (foo) { var x }", "var x; if (foo) {}");
+///
+/// `var` hoisting / lifting requires scope analysis that DCE doesn't
+/// perform. This is `closure-pass-remove-unused-vars` territory.
+#[test]
+#[ignore = "blocked on gap-015: var-lifting / hoisting handled elsewhere"]
+fn test_var_lifting() {
+    // Belongs in remove-unused-vars or a hoisting pass.
+}

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -85,3 +85,59 @@ historical context with status `RESOLVED` and a link to the fix PR.
 - **Ported file:** `closure-pass-constant-fold/tests/upstream/peephole_fold_constants_test.rs`
 - **Why it fails:** Upstream's `testSame("+x > +y")` asserts the pass leaves the expression alone (`x` is unknown). Our pass already does the right thing structurally; this gap is mostly the bookkeeping of porting the remaining `testSame` lines that use unary-plus on identifiers.
 - **What it needs:** Trivial — extend the ported tests once `gap-005` lands so the batch reflects the full upstream method.
+
+### gap-009 — `LabeledStatement` / `BreakStatement` not modelled in Phase 1 AST
+
+- **Status:** OPEN
+- **Upstream test:** `PeepholeRemoveDeadCodeTest::testRemoveNoOpLabelledStatement`, `testRemoveUselessLabelWithFollowingBreak`
+- **Ported file:** `closure-pass-dce/tests/upstream/peephole_remove_dead_code_test.rs`
+- **Why it fails:** The Phase 1 typed AST in `javascript-ast` doesn't include `LabeledStatement` or `BreakStatement` variants. Upstream's `a: break a;` requires both.
+- **What it needs:** Add Phase 1.x variants. `LabeledStatement { label: Identifier, body: Statement }` and `BreakStatement { label: Option<Identifier> }`. Then teach DCE that `a: break a;` collapses to empty. Probably a CLOC09 Phase 1.x amendment + a small DCE rule.
+
+### gap-010 — block-flattening (single-child block collapse) not implemented
+
+- **Status:** OPEN
+- **Upstream test:** `PeepholeRemoveDeadCodeTest::testFoldBlock` (block-flattening lines)
+- **Ported file:** `closure-pass-dce/tests/upstream/peephole_remove_dead_code_test.rs`
+- **Why it fails:** Upstream collapses `{{foo();}}` to `foo();`, `{foo();{}}` to `foo();`, etc. We don't flatten nested blocks — DCE's responsibility is dead-after-terminator and empty-statement removal, not structural simplification.
+- **What it needs:** Either extend DCE with a "block-with-single-statement → that statement" rule, or stand up a dedicated normaliser pass. Probably belongs in DCE for simplicity (~30 lines).
+
+### gap-011 — `if`-with-constant-test collapse lives in `fold-control-flow`, not DCE
+
+- **Status:** ROUTING (not a missing feature)
+- **Upstream test:** `PeepholeRemoveDeadCodeTest::testIf`, `testHook` (`if`/ternary constant-test lines)
+- **Ported file:** `closure-pass-dce/tests/upstream/peephole_remove_dead_code_test.rs`
+- **Why it fails:** Upstream `PeepholeRemoveDeadCode` covers these but our setup splits the responsibility — `closure-pass-fold-control-flow` already does `if (1) {a;} else {b;}` → `a`. Those upstream lines should land in `closure-pass-fold-control-flow/tests/upstream/peephole_minimize_conditions_test.rs` when CLOC12.05 ports it.
+- **What it needs:** A re-port into `closure-pass-fold-control-flow/tests/upstream/`. Mark this entry RESOLVED when that port lands and confirms the behaviour passes.
+
+### gap-012 — `ConditionalExpression` cleanup lives in `constant-fold`, not DCE
+
+- **Status:** ROUTING (not a missing feature)
+- **Upstream test:** `PeepholeRemoveDeadCodeTest::testHook` (`a ? b : c` cleanup)
+- **Ported file:** `closure-pass-dce/tests/upstream/peephole_remove_dead_code_test.rs`
+- **Why it fails:** Belongs in `closure-pass-constant-fold`. Some of these are already covered by the constant-fold inline tests; the rest will get ported when CLOC12.0N expands the `PeepholeFoldConstantsTest` coverage.
+- **What it needs:** Re-port into `closure-pass-constant-fold/tests/upstream/`.
+
+### gap-013 — useless-loop-body folding not in DCE
+
+- **Status:** ROUTING (not a missing feature)
+- **Upstream test:** `PeepholeRemoveDeadCodeTest::testFoldUselessFor`, `testFoldUselessDo`, `testFoldEmptyDo`, `testMinimizeLoop_*`
+- **Ported file:** `closure-pass-dce/tests/upstream/peephole_remove_dead_code_test.rs`
+- **Why it fails:** `while(x()){x}` → `while(x());` and friends belong in `closure-pass-fold-control-flow`.
+- **What it needs:** Re-port into `closure-pass-fold-control-flow/tests/upstream/` once that crate's port file lands.
+
+### gap-014 — `SwitchStatement` not in Phase 1 AST
+
+- **Status:** OPEN
+- **Upstream test:** `PeepholeRemoveDeadCodeTest::testOptimizeSwitch*` (a dozen tests)
+- **Ported file:** `closure-pass-dce/tests/upstream/peephole_remove_dead_code_test.rs`
+- **Why it fails:** No `SwitchStatement`, `SwitchCase`, `BreakStatement` in the Phase 1 typed AST.
+- **What it needs:** Phase 1.x AST extension to model `switch (x) { case 1: ...; default: ...; }`, plus the switch-optimisation logic. Substantial — multiple PRs.
+
+### gap-015 — `var` / `let` / `const` lifting and hoisting
+
+- **Status:** ROUTING + missing feature
+- **Upstream test:** `PeepholeRemoveDeadCodeTest::testVarLifting`, `testLetConstLifting*`
+- **Ported file:** `closure-pass-dce/tests/upstream/peephole_remove_dead_code_test.rs`
+- **Why it fails:** Requires scope analysis to know what's reachable. Our DCE doesn't do scope analysis; that's the territory of `closure-pass-remove-unused-vars` and an eventual hoisting pass.
+- **What it needs:** A dedicated hoisting / unused-vars cleanup pass. Likely lands as new content in `closure-pass-remove-unused-vars` rather than here.


### PR DESCRIPTION
## Summary

- **Second upstream-test port under CLOC12.** Mirrors the per-crate `tests/upstream/` layout from CLOC12.02 (PR #4657) — now in `closure-pass-dce`.
- Pinned to `google/closure-compiler@5bb35ec1245dc1d3557481e5f8b4db344bcd1e6b`. Apache-2.0 attribution complete.
- **12 ported test methods: 5 pass today, 7 are `#[ignore]`-ed citing gap-009 through gap-015.**

## Why most are ignored — and that's fine

Upstream `PeepholeRemoveDeadCode` is much broader than our DCE pass (which only handles dead-after-Return + EmptyStatement removal). Most upstream behaviour lives in OTHER pass crates in our setup, so those upstream tests will get re-ported into the right crate's `tests/upstream/`:

| Behaviour | Belongs in |
|-----------|------------|
| Dead-if-branch / useless-loop simplification | `fold-control-flow` |
| ConditionalExpression cleanup | `constant-fold` |
| Var/let/const hoisting + unused-var pruning | `remove-unused-vars` |

Gaps 011, 012, 013 are explicitly tagged \"ROUTING (not a missing feature)\" — they close by re-porting into the right crate, not by code change.

## Passing tests (5)

- `test_function_with_bare_return_is_unchanged` — `foldSame(\"function f(){return;}\")`.
- `test_function_with_assignment_then_return_is_unchanged` — `x=3; return;` left alone.
- `test_dead_statement_after_return_with_argument_is_dropped` — `return 3; foo();` → `return 3;`.
- `test_multiple_dead_statements_after_return_are_dropped` — multi-tail dropped after bare return.
- `test_empty_statements_dropped_from_function_body` — equivalent of `{x=3;;;y=2;;;}` → `{x=3;y=2;}`.

## Ignored tests + gaps

| Test | Gap | What it'd need |
|------|-----|---------------|
| `test_remove_no_op_labelled_statement` | **gap-009** | `LabeledStatement` / `BreakStatement` AST nodes (Phase 1.x) |
| `test_fold_block_flattening` | **gap-010** | nested-block flattening (~30 lines in DCE) |
| `test_if_with_constant_test_collapse` | **gap-011** | re-port into `fold-control-flow/tests/upstream/` |
| `test_hook_cleanup` | **gap-012** | re-port into `constant-fold/tests/upstream/` |
| `test_fold_useless_loop_body` | **gap-013** | re-port into `fold-control-flow/tests/upstream/` |
| `test_optimize_switch` | **gap-014** | `SwitchStatement` AST (substantial) |
| `test_var_lifting` | **gap-015** | hoisting / scope analysis pass |

## Version

closure-pass-dce `0.2.0` → `0.3.0`.

## Test plan

- [x] \`cargo test --test upstream_peephole_remove_dead_code\` → 5 pass, 7 ignored, 0 fail
- [x] Full crate sweep: 14 inline + 5 upstream pass, 7 ignored, 0 fail
- [x] Every `#[ignore]` cites a `gap-NNN` entry in `code/specs/CLOC12-gaps.md`
- [x] `tests/upstream/UPSTREAM_SHA` + `tests/upstream/ATTRIBUTION.md` present per CLOC12.01 §§4-5
- [x] Security review: PASS — test-only, no unsafe, no IO/network/process, Apache-2.0 attribution complete, mirrors merged CLOC12.02 pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)