### PR TITLE
feat(ruby-fc): Phase 22b — `&blk` block-pass call argument

### DIFF
--- a/code/grammars/ruby.grammar
+++ b/code/grammars/ruby.grammar
@@ -343,11 +343,19 @@ dot_call     = "." ( NAME | KEYWORD ) [ LPAREN [ call_arg { COMMA call_arg } ] R
 scope_resolution = "::" ( NAME | KEYWORD ) ;
 # Phase 6s — splat call arguments.  `f(*arr)` and `f(**hsh)` (and the
 # mixed form `f(1, *arr, **hsh, named: x)`) flow through here.  The
-# optional `[ "*" | "**" ]` prefix sits inside a single call_arg slot,
-# so positional and splat args interleave naturally on the COMMA
-# separator.  Lowering wraps the prefixed forms in
-# `BuiltinCall("splat", …)` / `BuiltinCall("double_splat", …)`.
-call_arg     = [ "*" | "**" ] expression ;
+# optional `[ "*" | "**" | "&" ]` prefix sits inside a single call_arg
+# slot, so positional, splat and block-pass args interleave naturally
+# on the COMMA separator.  Lowering wraps the prefixed forms in
+# `BuiltinCall("splat", …)` / `BuiltinCall("double_splat", …)` /
+# `BuiltinCall("block_pass", …)`.
+#
+# Phase 22b (FC) — block-pass argument `&blk`.  The lexer emits a lone
+# `&` as a Name-typed Op token (value "&"); the `&.` safe-nav fusion
+# only triggers when a `.` immediately follows, so `&blk` keeps the `&`
+# standalone.  There is no binary `&` rule in the expression hierarchy
+# (the chain is logical_or → logical_and → … → factor with no bitwise
+# layer), so admitting `&` as a call_arg prefix introduces no ambiguity.
+call_arg     = [ "*" | "**" | "&" ] expression ;
 # Phase 6h — paren-less method call.  Idiomatic Ruby allows
 # `puts 1, 2` (no parens) when the call has at least one argument.
 #

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.59.0] - 2026-05-31
+
+### Added (Phase 22b (FC) — `&blk` block-pass call argument)
+
+Grammar change: `call_arg` gained a `&` alternative in its optional
+prefix —
+
+```
+call_arg = [ "*" | "**" | "&" ] expression ;
+```
+
+so a block-pass argument (`f(&blk)`, `arr.each(&blk)`, `f(1, &blk)`)
+parses in both head `method_call` and `dot_call` argument lists, the
+same slots that already carry `*` splat and `**` double-splat. `_grammar.rs`
+regenerated.
+
+No ambiguity: the lexer emits a lone `&` as a Name-typed Op token (the
+`&.` safe-nav fusion only fires when a `.` immediately follows), and
+there is no binary `&` rule anywhere in the expression hierarchy
+(`logical_or → logical_and → … → factor`, no bitwise layer), so a
+leading `&` in a `call_arg` is unambiguous.
+
+New parse pins (+3): `test_parse_block_pass_call_arg` (`f(&blk)`),
+`test_parse_block_pass_after_positional` (`f(1, &blk)`),
+`test_parse_block_pass_in_dot_call` (`arr.each(&blk)`).  Test count:
+207 → 210.
+
 ## [0.58.0] - 2026-05-31
 
 ### Added (Phase 22a (FC) — `**` double-splat call argument, coverage)

--- a/code/packages/rust/ruby-parser/src/_grammar.rs
+++ b/code/packages/rust/ruby-parser/src/_grammar.rs
@@ -663,10 +663,11 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::Alternation { choices: vec![
                         GrammarElement::Literal { value: r#"*"#.to_string() },
                         GrammarElement::Literal { value: r#"**"#.to_string() },
+                        GrammarElement::Literal { value: r#"&"#.to_string() },
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 350,
+            line_number: 358,
         },
         GrammarRule {
             name: r#"method_call_no_paren"#.to_string(),
@@ -681,17 +682,17 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 364,
+            line_number: 372,
         },
         GrammarRule {
             name: r#"expression_stmt"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"expression"#.to_string() },
-            line_number: 365,
+            line_number: 373,
         },
         GrammarRule {
             name: r#"expression"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"ternary"#.to_string() },
-            line_number: 472,
+            line_number: 480,
         },
         GrammarRule {
             name: r#"ternary"#.to_string(),
@@ -704,7 +705,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 473,
+            line_number: 481,
         },
         GrammarRule {
             name: r#"range"#.to_string(),
@@ -727,7 +728,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) },
                 ] },
             ] },
-            line_number: 474,
+            line_number: 482,
         },
         GrammarRule {
             name: r#"logical_or"#.to_string(),
@@ -741,7 +742,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_and"#.to_string() },
                     ] }) },
             ] },
-            line_number: 475,
+            line_number: 483,
         },
         GrammarRule {
             name: r#"logical_and"#.to_string(),
@@ -755,7 +756,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_not"#.to_string() },
                     ] }) },
             ] },
-            line_number: 476,
+            line_number: 484,
         },
         GrammarRule {
             name: r#"logical_not"#.to_string(),
@@ -766,7 +767,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) }) },
                 GrammarElement::RuleReference { name: r#"comparison"#.to_string() },
             ] },
-            line_number: 483,
+            line_number: 491,
         },
         GrammarRule {
             name: r#"comparison"#.to_string(),
@@ -784,7 +785,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"sum"#.to_string() },
                     ] }) },
             ] },
-            line_number: 484,
+            line_number: 492,
         },
         GrammarRule {
             name: r#"sum"#.to_string(),
@@ -798,7 +799,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term"#.to_string() },
                     ] }) },
             ] },
-            line_number: 485,
+            line_number: 493,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -812,7 +813,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"factor"#.to_string() },
                     ] }) },
             ] },
-            line_number: 486,
+            line_number: 494,
         },
         GrammarRule {
             name: r#"factor"#.to_string(),
@@ -839,7 +840,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"scope_resolution"#.to_string() },
                     ] }) },
             ] },
-            line_number: 496,
+            line_number: 504,
         },
         GrammarRule {
             name: r#"lambda_literal"#.to_string(),
@@ -852,7 +853,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"block"#.to_string() },
             ] },
-            line_number: 515,
+            line_number: 523,
         },
         GrammarRule {
             name: r#"unary_minus"#.to_string(),
@@ -860,7 +861,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"factor"#.to_string() },
             ] },
-            line_number: 516,
+            line_number: 524,
         },
         GrammarRule {
             name: r#"symbol_literal"#.to_string(),
@@ -872,7 +873,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 523,
+            line_number: 531,
         },
         GrammarRule {
             name: r#"array_literal"#.to_string(),
@@ -887,7 +888,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 524,
+            line_number: 532,
         },
         GrammarRule {
             name: r#"hash_literal"#.to_string(),
@@ -902,7 +903,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 525,
+            line_number: 533,
         },
         GrammarRule {
             name: r#"hash_entry"#.to_string(),
@@ -922,7 +923,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                 ] },
             ] },
-            line_number: 526,
+            line_number: 534,
         },
     ],
         version: 1,

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -2586,6 +2586,55 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_block_pass_call_arg() {
+        // Phase 22b — `f(&blk)`: a block-pass argument.  The `&` prefix
+        // joins `*`/`**` in the `call_arg` rule.  Confirms exactly one
+        // `call_arg` carrying the `&` prefix and the operand name.
+        let ast = parse_ruby("f(&blk)");
+        let call = find_descendant(&ast, "method_call").expect("expected method_call");
+        let arg_count = call
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "call_arg"))
+            .count();
+        assert_eq!(arg_count, 1, "expected exactly 1 call_arg, got {arg_count}");
+        let call_arg = find_descendant(&ast, "call_arg").expect("expected call_arg");
+        assert!(tree_has_token_value(call_arg, "&"), "expected `&` prefix");
+        assert!(tree_has_token_value(call_arg, "blk"), "expected `blk` name");
+    }
+
+    #[test]
+    fn test_parse_block_pass_after_positional() {
+        // Phase 22b — `f(1, &blk)`: a positional arg followed by a
+        // block-pass.  Confirms `&` interleaves with ordinary args on
+        // the COMMA separator (two call_args total).
+        let ast = parse_ruby("f(1, &blk)");
+        let call = find_descendant(&ast, "method_call").expect("expected method_call");
+        let arg_count = call
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "call_arg"))
+            .count();
+        assert_eq!(arg_count, 2, "expected 2 call_args, got {arg_count}");
+        assert!(tree_has_token_value(call, "&"), "expected `&` somewhere in the call");
+        assert!(tree_has_token_value(call, "blk"), "expected `blk` name");
+    }
+
+    #[test]
+    fn test_parse_block_pass_in_dot_call() {
+        // Phase 22b — `arr.each(&blk)`: the block-pass rides through a
+        // `dot_call` argument list (the idiomatic `&:sym` / `&proc`
+        // higher-order-call form).  Both head and dot calls reuse
+        // `call_arg`, so `&` must surface in the dot-call path too.
+        let ast = parse_ruby("arr.each(&blk)");
+        let dot = find_descendant(&ast, "dot_call").expect("expected dot_call");
+        let call_arg = find_descendant(dot, "call_arg")
+            .expect("expected call_arg inside dot_call");
+        assert!(tree_has_token_value(call_arg, "&"), "expected `&` in dot_call arg");
+        assert!(tree_has_token_value(call_arg, "blk"), "expected `blk` name");
+    }
+
+    #[test]
     fn test_parse_binary_star_still_parses_as_expression() {
         // Regression: `a * b` as a statement must still parse as a
         // bare expression-stmt with binary `*`, NOT as `a(splat b)`.

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.62.0] - 2026-05-31
+
+### Added (Phase 22b (FC) — `&blk` block-pass call argument)
+
+`lower_call_arg` gained a `&` arm: a block-pass argument lowers to
+`BuiltinCall("block_pass", [inner])`, mirroring the `splat` /
+`double_splat` marker envelopes.  SIR has no first-class block-argument
+slot, so the marker lets downstream emitters reconstruct `&expr` (the
+operand may be a Proc, a `&:sym` symbol-to-proc, or any `to_proc`-able
+object — all preserved verbatim inside the envelope).  No new SIR
+variant; the prefix detector now matches `"*" | "**" | "&"`.
+
+New lowering pins (+3):
+- `block_pass_call_arg_lowers_to_block_pass_builtin` (`f(&blk)`) — node
+  shape: `block_pass` wrapping the `VarRef` operand.
+- `block_pass_call_arg_passes_sir_validator` (`puts(&blk)`) — lowers
+  AND passes `semantic_ir::validate` (uses the `puts` intrinsic so the
+  unknown-callee check passes).
+- `block_pass_after_positional_lowers_in_order` (`f(7, &blk)`) — locks
+  the positional-then-block-pass two-arg ordering.
+
+Test count: 261 → 264.
+
 ## [0.61.0] - 2026-05-31
 
 ### Added (Phase 22a (FC) — `**` double-splat call argument, coverage)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -3868,6 +3868,72 @@ mod tests {
     }
 
     #[test]
+    fn block_pass_call_arg_lowers_to_block_pass_builtin() {
+        // Phase 22b — `f(&blk)` → DirectCall(f, [BuiltinCall("block_pass",
+        // [VarRef(blk)])]).  Mirrors the splat / double_splat marker
+        // pattern; the operand keeps its identity inside the envelope.
+        let m = lower("blk = 1\nf(&blk)\n");
+        let b = main_body(&m);
+        let args = match &b.value {
+            Expr::DirectCall { fn_name, args, .. } if fn_name == "f" => args,
+            other => panic!("expected DirectCall(f, ...), got {:?}", other),
+        };
+        assert_eq!(args.len(), 1);
+        match &args[0] {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "block_pass");
+                assert_eq!(args.len(), 1);
+                assert!(matches!(&args[0], Expr::VarRef { name, .. } if name == "blk"));
+            }
+            other => panic!("expected BuiltinCall(block_pass, ...), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn block_pass_call_arg_passes_sir_validator() {
+        // Phase 22b — end-to-end: a block-pass call arg lowers cleanly
+        // AND the module validates.  `puts` is a known intrinsic, so the
+        // validator's unknown-callee check passes; an unknown `f` would
+        // trip it.  `puts` lowers to BuiltinCall("puts", …).
+        let m = lower("blk = 1\nputs(&blk)\n");
+        let result = semantic_ir::validate(&m);
+        assert!(
+            result.is_ok(),
+            "validator rejected block-pass call arg: {:?}",
+            result
+        );
+        let b = main_body(&m);
+        let args = match &b.value {
+            Expr::BuiltinCall { name, args, .. } if name == "puts" => args,
+            other => panic!("expected BuiltinCall(puts, ...), got {:?}", other),
+        };
+        assert_eq!(args.len(), 1);
+        assert!(matches!(
+            &args[0],
+            Expr::BuiltinCall { name, .. } if name == "block_pass"
+        ));
+    }
+
+    #[test]
+    fn block_pass_after_positional_lowers_in_order() {
+        // Phase 22b — `f(7, &blk)`: a positional arg followed by a
+        // block-pass.  Locks the two-arg ordering (IntLit, then the
+        // block_pass envelope) — block-pass is always trailing in Ruby.
+        let m = lower("blk = 1\nf(7, &blk)\n");
+        let b = main_body(&m);
+        let args = match &b.value {
+            Expr::DirectCall { fn_name, args, .. } if fn_name == "f" => args,
+            other => panic!("expected DirectCall(f, ...), got {:?}", other),
+        };
+        assert_eq!(args.len(), 2, "expected 2 args, got {}", args.len());
+        assert!(matches!(&args[0], Expr::IntLit { value: 7, .. }));
+        assert!(matches!(
+            &args[1],
+            Expr::BuiltinCall { name, .. } if name == "block_pass"
+        ));
+    }
+
+    #[test]
     fn splat_call_arg_module_passes_sir_validator() {
         // End-to-end smoke check: a module that uses splat call args
         // validates cleanly.

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -3459,9 +3459,9 @@ impl Lowerer {
         out
     }
 
-    /// Phase 6s — lower a single `call_arg` node.
+    /// Phase 6s / 22b — lower a single `call_arg` node.
     ///
-    /// Grammar shape: `call_arg = [ "*" | "**" ] expression ;`
+    /// Grammar shape: `call_arg = [ "*" | "**" | "&" ] expression ;`
     ///
     /// Lowering:
     /// - No prefix → return the lowered `expression` as-is.
@@ -3470,6 +3470,12 @@ impl Lowerer {
     ///   into target-language variadic forwarding.
     /// - `**` prefix → wrap in `BuiltinCall("double_splat", [inner])`
     ///   — same pattern, for keyword-argument spread.
+    /// - `&` prefix → wrap in `BuiltinCall("block_pass", [inner])`
+    ///   (Phase 22b) — the `&blk` block-pass argument, which converts
+    ///   the operand (a Proc, a Symbol via `&:sym`, or any object
+    ///   responding to `to_proc`) into the call's block.  Same marker
+    ///   pattern: SIR has no first-class block-argument slot, so the
+    ///   envelope lets downstream emitters reconstruct `&expr`.
     ///
     /// The BuiltinCall envelope preserves splat semantics through SIR
     /// (where the lossy v0 Param shape can't represent variadic
@@ -3479,13 +3485,15 @@ impl Lowerer {
         &mut self,
         node: &GrammarASTNode,
     ) -> Result<Expr, RubyLowerError> {
-        // Detect the leading `*` / `**` token (if present).  Both
-        // forms land on Token children with their value preserved
+        // Detect the leading `*` / `**` / `&` token (if present).  All
+        // three land on Token children with their value preserved
         // (the 1.8-baseline state machine coalesces `**` into one
-        // Name-typed Op token; `*` is a Star token).
+        // Name-typed Op token; `*` is a Star token; `&` is a Name-typed
+        // Op token — the `&.` safe-nav fusion does not fire because no
+        // `.` follows a block-pass `&`).
         let prefix = node.children.iter().find_map(|c| match c {
             ASTNodeOrToken::Token(t)
-                if matches!(t.value.as_str(), "*" | "**") =>
+                if matches!(t.value.as_str(), "*" | "**" | "&") =>
             {
                 Some(t.value.clone())
             }
@@ -3514,6 +3522,12 @@ impl Lowerer {
             },
             Some("**") => Expr::BuiltinCall {
                 name: "double_splat".to_string(),
+                args: vec![inner],
+                effects: EffectSet::PURE,
+                span,
+            },
+            Some("&") => Expr::BuiltinCall {
+                name: "block_pass".to_string(),
                 args: vec![inner],
                 effects: EffectSet::PURE,
                 span,


### PR DESCRIPTION
## Phase 22b (FC) — `&blk` block-pass call argument

Part of the Ruby 3.4 frontend-convergence track. Adds the **block-pass** call argument `&blk` — the `&` sibling of the `*` splat and `**` double-splat call-arg prefixes (Phase 6s).

### Grammar
```
call_arg = [ "*" | "**" ] expression ;
→
call_arg = [ "*" | "**" | "&" ] expression ;
```
`_grammar.rs` regenerated. So `f(&blk)`, `f(1, &blk)`, and `arr.each(&blk)` now parse in both head `method_call` and `dot_call` argument lists.

**Why this is unambiguous**
- The lexer emits a lone `&` as a Name-typed Op token (value `&`). The `&.` safe-nav fusion only fires when a `.` *immediately* follows, so `&blk` keeps the `&` standalone.
- There is **no binary `&` rule** anywhere in the expression hierarchy (`logical_or → logical_and → … → factor`, no bitwise layer), so a leading `&` in a `call_arg` cannot collide with an infix operator. The two forms are disjoint at the lexer level before the parser runs.

### Lowering
`lower_call_arg`'s prefix detector now matches `"*" | "**" | "&"`; a `&` arg lowers to `BuiltinCall("block_pass", [inner])` (PURE), mirroring the `splat` / `double_splat` marker envelopes. SIR has no first-class block-argument slot, so the marker lets downstream emitters reconstruct `&expr` (the operand may be a Proc, a `&:sym` symbol-to-proc, or any `to_proc`-able object — preserved verbatim). **No new SIR variant.**

### Parser pins (+3 → 210)
- `test_parse_block_pass_call_arg` — `f(&blk)`
- `test_parse_block_pass_after_positional` — `f(1, &blk)`
- `test_parse_block_pass_in_dot_call` — `arr.each(&blk)`

### Lowering pins (+3 → 264)
- `block_pass_call_arg_lowers_to_block_pass_builtin` — `f(&blk)` (node shape: `block_pass` wrapping the `VarRef`)
- `block_pass_call_arg_passes_sir_validator` — `puts(&blk)` (lowers **and** `semantic_ir::validate` passes; uses the `puts` intrinsic)
- `block_pass_after_positional_lowers_in_order` — `f(7, &blk)` (positional-then-block-pass ordering)

### Tests
`cargo test -p coding-adventures-ruby-lexer -p coding-adventures-ruby-parser -p ruby-to-semantic-ir` — lexer 173, parser 210, IR 264, all green.

### Changelogs
- `ruby-parser` 0.58.0 → 0.59.0
- `ruby-to-semantic-ir` 0.61.0 → 0.62.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
