### PR TITLE
feat(ruby-fc): Phase 22c — `...` argument forwarding

### DIFF
--- a/code/grammars/ruby.grammar
+++ b/code/grammars/ruby.grammar
@@ -190,7 +190,21 @@ yield_args = LPAREN [ call_arg { COMMA call_arg } ] RPAREN
 # accepted but semantically illegal in Ruby; the SIR lowerer accepts
 # the first of each and flags duplicates as a deferred limitation
 # (v0 keeps the grammar permissive and pushes shape validation up).
-params       = param { COMMA param } ;
+# Phase 22c (FC) — argument forwarding `...`.  Ruby 2.7+ lets a method
+# declare `def m(...)` and forward every argument (positional, keyword
+# and block) to an inner call with `n(...)`.  The lexer fuses `...` into
+# a single Name-typed token (value "...", shared with the exclusive
+# range operator — see `fuse_range_ops`).  Because `...` is Name-typed,
+# the `param = [ "*" | "**" ] NAME` branch WOULD greedily match it as a
+# parameter named "..." — so the bare `"..."` alternative is listed
+# FIRST to claim the token as a literal forwarding marker before the
+# `param` branch sees it.  Ordinary signatures (`def m(a, b)`,
+# `def m(*args)`) are unaffected: their first token is never `...`, so
+# the literal alternative fails and the `param` branch runs.  v0 lowering
+# drops the forwarding param (no Param node — `...` is a literal token
+# child, not a `param` node); the call-side `n(...)` marker carries the
+# forwarding semantics.
+params       = "..." | param { COMMA param } ;
 param        = [ "*" | "**" ] NAME ;
 if_statement = "if" expression { !"else" !"elsif" !"end" statement } { elsif_clause } [ else_clause ] "end" ;
 elsif_clause = "elsif" expression { !"else" !"elsif" !"end" statement } ;
@@ -355,6 +369,21 @@ scope_resolution = "::" ( NAME | KEYWORD ) ;
 # standalone.  There is no binary `&` rule in the expression hierarchy
 # (the chain is logical_or → logical_and → … → factor with no bitwise
 # layer), so admitting `&` as a call_arg prefix introduces no ambiguity.
+#
+# Phase 22c (FC) — forward-all argument `...`.  `n(...)` forwards every
+# argument received by an enclosing `def m(...)`.  No call_arg grammar
+# change is needed: the lexer fuses `...` into a single Name-typed token
+# (value "..."), and `factor`'s `NAME` alternative already matches it as
+# a bare-name expression — so `n(...)` parses as a call_arg whose
+# expression is the bare name `...`.  A beginless exclusive-range
+# argument (`m(...5)`) instead parses as a `range` (the `... 5` form),
+# keeping the two disjoint at the parse-tree level.  Lowering inspects
+# the lowered operand: a bare `VarRef { name: "..." }` becomes
+# `BuiltinCall("forward_args", [])`; anything else (incl. ranges) is
+# left untouched.  (Putting a literal `"..."` alternative here would be
+# dead — the NAME branch shadows it — and listing it first would break
+# `m(...5)` since the parser does not backtrack across the call_arg
+# boundary once `...` is consumed.)
 call_arg     = [ "*" | "**" | "&" ] expression ;
 # Phase 6h — paren-less method call.  Idiomatic Ruby allows
 # `puts 1, 2` (no parens) when the call has at least one argument.

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.60.0] - 2026-05-31
+
+### Added (Phase 22c (FC) — `...` argument forwarding)
+
+Ruby 2.7+ argument forwarding: `def m(...)` declares a method that
+forwards every argument, and `n(...)` forwards them to an inner call.
+
+Grammar change — `params` only:
+
+```
+params = "..." | param { COMMA param } ;
+```
+
+The lexer fuses `...` into a single **Name-typed** token (value `...`,
+shared with the exclusive-range operator).  Because `param = [ "*" |
+"**" ] NAME` would otherwise match `...` as a parameter *named* `...`,
+the bare `"..."` alternative is listed FIRST so it claims the token as a
+literal forwarding marker.  Ordinary signatures are unaffected (their
+first token is never `...`).  `_grammar.rs` regenerated.
+
+**No `call_arg` grammar change.**  `factor`'s `NAME` alternative already
+matches the `...` token as a bare-name expression, so `n(...)` parses as
+a call_arg whose expression is the bare name `...`.  A beginless
+exclusive-range argument `m(...5)` instead parses as a `range` (the
+`... 5` form), keeping the two disjoint at the parse-tree level — a
+literal `"..."` call_arg alternative was deliberately NOT added (listing
+it first breaks `m(...5)`, since the parser does not backtrack across the
+call_arg boundary once `...` is consumed; listing it last is dead code
+because `NAME` shadows it).
+
+New parse pins (+4): `test_parse_forward_all_call_arg` (`n(...)`),
+`test_parse_forward_all_param` (`def m(...)` → 0 `param` nodes),
+`test_parse_forward_all_roundtrip` (`def m(...) ; n(...) ; end`),
+`test_parse_beginless_range_arg_still_parses` (`m(...5)` regression —
+still a `range`).  Test count: 210 → 214.
+
 ## [0.59.0] - 2026-05-31
 
 ### Added (Phase 22b (FC) — `&blk` block-pass call argument)

--- a/code/packages/rust/ruby-parser/src/_grammar.rs
+++ b/code/packages/rust/ruby-parser/src/_grammar.rs
@@ -300,14 +300,17 @@ pub fn parser_grammar() -> ParserGrammar {
         },
         GrammarRule {
             name: r#"params"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::RuleReference { name: r#"param"#.to_string() },
-                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
-                        GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
-                        GrammarElement::RuleReference { name: r#"param"#.to_string() },
-                    ] }) },
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Literal { value: r#"..."#.to_string() },
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::RuleReference { name: r#"param"#.to_string() },
+                    GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                            GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                            GrammarElement::RuleReference { name: r#"param"#.to_string() },
+                        ] }) },
+                ] },
             ] },
-            line_number: 193,
+            line_number: 207,
         },
         GrammarRule {
             name: r#"param"#.to_string(),
@@ -318,7 +321,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
             ] },
-            line_number: 194,
+            line_number: 208,
         },
         GrammarRule {
             name: r#"if_statement"#.to_string(),
@@ -335,7 +338,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 195,
+            line_number: 209,
         },
         GrammarRule {
             name: r#"elsif_clause"#.to_string(),
@@ -349,7 +352,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 196,
+            line_number: 210,
         },
         GrammarRule {
             name: r#"else_clause"#.to_string(),
@@ -360,7 +363,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 197,
+            line_number: 211,
         },
         GrammarRule {
             name: r#"unless_statement"#.to_string(),
@@ -375,7 +378,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 198,
+            line_number: 212,
         },
         GrammarRule {
             name: r#"while_statement"#.to_string(),
@@ -388,7 +391,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 199,
+            line_number: 213,
         },
         GrammarRule {
             name: r#"until_statement"#.to_string(),
@@ -401,7 +404,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 200,
+            line_number: 214,
         },
         GrammarRule {
             name: r#"case_statement"#.to_string(),
@@ -415,7 +418,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 223,
+            line_number: 237,
         },
         GrammarRule {
             name: r#"when_clause"#.to_string(),
@@ -434,7 +437,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 224,
+            line_number: 238,
         },
         GrammarRule {
             name: r#"in_clause"#.to_string(),
@@ -449,7 +452,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 246,
+            line_number: 260,
         },
         GrammarRule {
             name: r#"pattern"#.to_string(),
@@ -459,7 +462,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"literal_pattern"#.to_string() },
                 GrammarElement::RuleReference { name: r#"binding_pattern"#.to_string() },
             ] },
-            line_number: 247,
+            line_number: 261,
         },
         GrammarRule {
             name: r#"literal_pattern"#.to_string(),
@@ -469,12 +472,12 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"symbol_literal"#.to_string() },
                 GrammarElement::TokenReference { name: r#"KEYWORD"#.to_string() },
             ] },
-            line_number: 248,
+            line_number: 262,
         },
         GrammarRule {
             name: r#"binding_pattern"#.to_string(),
             body: GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
-            line_number: 249,
+            line_number: 263,
         },
         GrammarRule {
             name: r#"array_pattern"#.to_string(),
@@ -489,7 +492,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 250,
+            line_number: 264,
         },
         GrammarRule {
             name: r#"hash_pattern"#.to_string(),
@@ -504,7 +507,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 251,
+            line_number: 265,
         },
         GrammarRule {
             name: r#"hash_pattern_pair"#.to_string(),
@@ -513,7 +516,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"pattern"#.to_string() }) },
             ] },
-            line_number: 252,
+            line_number: 266,
         },
         GrammarRule {
             name: r#"begin_statement"#.to_string(),
@@ -529,7 +532,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"ensure_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 273,
+            line_number: 287,
         },
         GrammarRule {
             name: r#"rescue_clause"#.to_string(),
@@ -547,7 +550,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 282,
+            line_number: 296,
         },
         GrammarRule {
             name: r#"exception_list"#.to_string(),
@@ -558,7 +561,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
                     ] }) },
             ] },
-            line_number: 283,
+            line_number: 297,
         },
         GrammarRule {
             name: r#"ensure_clause"#.to_string(),
@@ -569,7 +572,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 284,
+            line_number: 298,
         },
         GrammarRule {
             name: r#"assignment"#.to_string(),
@@ -593,7 +596,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 304,
+            line_number: 318,
         },
         GrammarRule {
             name: r#"rightward_assignment"#.to_string(),
@@ -602,7 +605,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"=>"#.to_string() },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
             ] },
-            line_number: 323,
+            line_number: 337,
         },
         GrammarRule {
             name: r#"method_call"#.to_string(),
@@ -622,7 +625,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"dot_call"#.to_string() }) },
             ] },
-            line_number: 334,
+            line_number: 348,
         },
         GrammarRule {
             name: r#"dot_call"#.to_string(),
@@ -644,7 +647,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                     ] }) },
             ] },
-            line_number: 335,
+            line_number: 349,
         },
         GrammarRule {
             name: r#"scope_resolution"#.to_string(),
@@ -655,7 +658,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"KEYWORD"#.to_string() },
                     ] }) },
             ] },
-            line_number: 343,
+            line_number: 357,
         },
         GrammarRule {
             name: r#"call_arg"#.to_string(),
@@ -667,7 +670,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 358,
+            line_number: 387,
         },
         GrammarRule {
             name: r#"method_call_no_paren"#.to_string(),
@@ -682,17 +685,17 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 372,
+            line_number: 401,
         },
         GrammarRule {
             name: r#"expression_stmt"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"expression"#.to_string() },
-            line_number: 373,
+            line_number: 402,
         },
         GrammarRule {
             name: r#"expression"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"ternary"#.to_string() },
-            line_number: 480,
+            line_number: 509,
         },
         GrammarRule {
             name: r#"ternary"#.to_string(),
@@ -705,7 +708,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 481,
+            line_number: 510,
         },
         GrammarRule {
             name: r#"range"#.to_string(),
@@ -728,7 +731,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) },
                 ] },
             ] },
-            line_number: 482,
+            line_number: 511,
         },
         GrammarRule {
             name: r#"logical_or"#.to_string(),
@@ -742,7 +745,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_and"#.to_string() },
                     ] }) },
             ] },
-            line_number: 483,
+            line_number: 512,
         },
         GrammarRule {
             name: r#"logical_and"#.to_string(),
@@ -756,7 +759,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_not"#.to_string() },
                     ] }) },
             ] },
-            line_number: 484,
+            line_number: 513,
         },
         GrammarRule {
             name: r#"logical_not"#.to_string(),
@@ -767,7 +770,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) }) },
                 GrammarElement::RuleReference { name: r#"comparison"#.to_string() },
             ] },
-            line_number: 491,
+            line_number: 520,
         },
         GrammarRule {
             name: r#"comparison"#.to_string(),
@@ -785,7 +788,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"sum"#.to_string() },
                     ] }) },
             ] },
-            line_number: 492,
+            line_number: 521,
         },
         GrammarRule {
             name: r#"sum"#.to_string(),
@@ -799,7 +802,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term"#.to_string() },
                     ] }) },
             ] },
-            line_number: 493,
+            line_number: 522,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -813,7 +816,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"factor"#.to_string() },
                     ] }) },
             ] },
-            line_number: 494,
+            line_number: 523,
         },
         GrammarRule {
             name: r#"factor"#.to_string(),
@@ -840,7 +843,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"scope_resolution"#.to_string() },
                     ] }) },
             ] },
-            line_number: 504,
+            line_number: 533,
         },
         GrammarRule {
             name: r#"lambda_literal"#.to_string(),
@@ -853,7 +856,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"block"#.to_string() },
             ] },
-            line_number: 523,
+            line_number: 552,
         },
         GrammarRule {
             name: r#"unary_minus"#.to_string(),
@@ -861,7 +864,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"factor"#.to_string() },
             ] },
-            line_number: 524,
+            line_number: 553,
         },
         GrammarRule {
             name: r#"symbol_literal"#.to_string(),
@@ -873,7 +876,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 531,
+            line_number: 560,
         },
         GrammarRule {
             name: r#"array_literal"#.to_string(),
@@ -888,7 +891,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 532,
+            line_number: 561,
         },
         GrammarRule {
             name: r#"hash_literal"#.to_string(),
@@ -903,7 +906,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 533,
+            line_number: 562,
         },
         GrammarRule {
             name: r#"hash_entry"#.to_string(),
@@ -923,7 +926,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                 ] },
             ] },
-            line_number: 534,
+            line_number: 563,
         },
     ],
         version: 1,

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -2635,6 +2635,72 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_forward_all_call_arg() {
+        // Phase 22c — `n(...)`: forward-all argument.  The bare `...`
+        // matches the new `"..."` alternative of `call_arg` (the
+        // expression branch fails because `...` cannot complete a
+        // beginless range with no operand before `)`).  Confirms one
+        // call_arg carrying the `...` token.
+        let ast = parse_ruby("n(...)");
+        let call = find_descendant(&ast, "method_call").expect("expected method_call");
+        let arg_count = call
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "call_arg"))
+            .count();
+        assert_eq!(arg_count, 1, "expected exactly 1 call_arg, got {arg_count}");
+        let call_arg = find_descendant(&ast, "call_arg").expect("expected call_arg");
+        assert!(tree_has_token_value(call_arg, "..."), "expected `...` forward token");
+    }
+
+    #[test]
+    fn test_parse_forward_all_param() {
+        // Phase 22c — `def m(...)`: forward-all parameter declaration.
+        // The bare `...` matches the new whole-`params` alternative.
+        let ast = parse_ruby("def m(...)\n  puts(1)\nend");
+        let params = find_descendant(&ast, "params").expect("expected params");
+        assert!(tree_has_token_value(params, "..."), "expected `...` in params");
+        // No `param` subnode is produced for the bare forward form.
+        let param_count = params
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "param"))
+            .count();
+        assert_eq!(param_count, 0, "bare `...` params must have 0 `param` nodes");
+    }
+
+    #[test]
+    fn test_parse_forward_all_roundtrip() {
+        // Phase 22c — the canonical forwarding shape:
+        //   def m(...)
+        //     n(...)
+        //   end
+        // Both the param decl and the inner forwarding call must parse.
+        let ast = parse_ruby("def m(...)\n  n(...)\nend");
+        let params = find_descendant(&ast, "params").expect("expected params");
+        assert!(tree_has_token_value(params, "..."), "expected `...` in params");
+        let call = find_descendant(&ast, "method_call").expect("expected inner method_call");
+        let call_arg = find_descendant(call, "call_arg").expect("expected forwarding call_arg");
+        assert!(tree_has_token_value(call_arg, "..."), "expected `...` in inner call");
+    }
+
+    #[test]
+    fn test_parse_beginless_range_arg_still_parses() {
+        // Phase 22c regression — `m(...5)`: a beginless EXCLUSIVE-range
+        // argument must STILL parse as a range (not as forward-all),
+        // because the prefixed-expression branch is tried first and the
+        // `...5` completes a `range`.  The `...` token lives nested in
+        // the call_arg's expression subtree, and a `range` node exists.
+        let ast = parse_ruby("m(...5)");
+        let call_arg = find_descendant(&ast, "call_arg").expect("expected call_arg");
+        assert!(
+            find_descendant(call_arg, "range").is_some(),
+            "expected a range node for the beginless-range argument"
+        );
+        assert!(tree_has_token_value(call_arg, "5"), "expected range endpoint `5`");
+    }
+
+    #[test]
     fn test_parse_binary_star_still_parses_as_expression() {
         // Regression: `a * b` as a statement must still parse as a
         // bare expression-stmt with binary `*`, NOT as `a(splat b)`.

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.63.0] - 2026-05-31
+
+### Added (Phase 22c (FC) — `...` argument forwarding)
+
+`lower_call_arg` now rewrites a bare-name `...` operand into the nullary
+marker `BuiltinCall("forward_args", [])`.  Because the lexer fuses `...`
+into a single Name-typed token, `n(...)` parses with the bare name `...`
+in the call_arg's expression slot, which lowers to `VarRef { name: "..."
+}`; the new check (on the no-prefix path only) detects that exact name
+and substitutes the marker.  `...` is not a legal Ruby identifier, so a
+bare `VarRef("...")` can only have come from forwarding — the rewrite is
+unambiguous.  A beginless-range argument `m(...5)` lowers to a `range`
+builtin (the `...` is the operator, not a bare name) and is left
+untouched.  No new SIR variant.
+
+`def m(...)` lowers to a function with **zero** params (v0 lossy: the
+bare `...` is a literal token in `params`, not a `param` node, so the
+param collector emits nothing); the call-side `forward_args` marker
+carries the forwarding semantics.
+
+New lowering pins (+3):
+- `forward_args_call_arg_lowers_to_forward_args_builtin` (`f(...)`) —
+  node shape: `BuiltinCall("forward_args", [])` (no operand).
+- `forward_all_def_and_call_passes_sir_validator`
+  (`def m(...) ; puts(...) ; end`) — round-trip lowers, `m` has 0 params,
+  and the module passes `semantic_ir::validate` (`puts` intrinsic).
+- `beginless_range_arg_does_not_lower_to_forward_args` (`m(...5)`) —
+  regression: lowers to `BuiltinCall("range", …)`, not `forward_args`.
+
+Test count: 264 → 267.
+
 ## [0.62.0] - 2026-05-31
 
 ### Added (Phase 22b (FC) — `&blk` block-pass call argument)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -3934,6 +3934,80 @@ mod tests {
     }
 
     #[test]
+    fn forward_args_call_arg_lowers_to_forward_args_builtin() {
+        // Phase 22c — `f(...)` → DirectCall(f, [BuiltinCall("forward_args",
+        // [])]).  A nullary marker (no operand): the forwarding `...`
+        // has no expression child, unlike splat/double_splat/block_pass.
+        let m = lower("f(...)\n");
+        let b = main_body(&m);
+        let args = match &b.value {
+            Expr::DirectCall { fn_name, args, .. } if fn_name == "f" => args,
+            other => panic!("expected DirectCall(f, ...), got {:?}", other),
+        };
+        assert_eq!(args.len(), 1);
+        match &args[0] {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "forward_args");
+                assert!(args.is_empty(), "forward_args takes no operand");
+            }
+            other => panic!("expected BuiltinCall(forward_args, []), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn forward_all_def_and_call_passes_sir_validator() {
+        // Phase 22c — the canonical forwarding round-trip:
+        //   def m(...)
+        //     puts(...)
+        //   end
+        // `def m(...)` lowers to a function with ZERO params (v0 lossy:
+        // the bare `...` produces no Param node).  The inner `puts(...)`
+        // forwards via the `forward_args` marker.  `puts` is a known
+        // intrinsic, so the whole module validates.
+        let m = lower("def m(...)\n  puts(...)\nend\n");
+        let result = semantic_ir::validate(&m);
+        assert!(
+            result.is_ok(),
+            "validator rejected forward-all def/call round-trip: {:?}",
+            result
+        );
+        let f = m
+            .functions
+            .iter()
+            .find(|f| f.name == "m")
+            .expect("expected user-defined function `m`");
+        assert_eq!(
+            f.params.len(),
+            0,
+            "bare `...` forward param lowers to zero Params (v0 lossy)"
+        );
+    }
+
+    #[test]
+    fn beginless_range_arg_does_not_lower_to_forward_args() {
+        // Phase 22c regression — `m(...5)` is a beginless exclusive-range
+        // argument, NOT forward-all.  It must lower to the range builtin
+        // (BuiltinCall("range", …)), confirming the direct-child-only
+        // `...` detection doesn't swallow nested range operators.
+        let m = lower("m(...5)\n");
+        let b = main_body(&m);
+        let args = match &b.value {
+            Expr::DirectCall { fn_name, args, .. } if fn_name == "m" => args,
+            other => panic!("expected DirectCall(m, ...), got {:?}", other),
+        };
+        assert_eq!(args.len(), 1);
+        match &args[0] {
+            Expr::BuiltinCall { name, .. } => {
+                assert_eq!(
+                    name, "range",
+                    "beginless-range arg must be a `range` builtin, not `forward_args`"
+                );
+            }
+            other => panic!("expected BuiltinCall(range, ...), got {:?}", other),
+        }
+    }
+
+    #[test]
     fn splat_call_arg_module_passes_sir_validator() {
         // End-to-end smoke check: a module that uses splat call args
         // validates cleanly.

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -3513,6 +3513,30 @@ impl Lowerer {
             })?;
         let inner = self.lower_expression(expr_node)?;
         let span = self.span_of(node);
+        // Phase 22c — forward-all argument `...`.  The lexer fuses `...`
+        // into a single Name-typed token, so `n(...)` parses with the
+        // bare name `...` in the call_arg's expression slot, which lowers
+        // to `VarRef { name: "..." }`.  Rewrite that into the nullary
+        // marker `BuiltinCall("forward_args", [])`.  A beginless range
+        // argument `m(...5)` instead lowers to a `range` BuiltinCall (the
+        // `...` is the range operator, not a bare name), so it is left
+        // untouched.  `...` is not a legal Ruby identifier, so a bare
+        // `VarRef("...")` can only have come from argument forwarding —
+        // the match is unambiguous.  A leading `*`/`**`/`&` prefix never
+        // co-occurs with `...` (Ruby forbids `*...`), so this check runs
+        // only on the no-prefix path.
+        if prefix.is_none() {
+            if let Expr::VarRef { name, .. } = &inner {
+                if name == "..." {
+                    return Ok(Expr::BuiltinCall {
+                        name: "forward_args".to_string(),
+                        args: vec![],
+                        effects: EffectSet::PURE,
+                        span,
+                    });
+                }
+            }
+        }
         Ok(match prefix.as_deref() {
             Some("*") => Expr::BuiltinCall {
                 name: "splat".to_string(),


### PR DESCRIPTION
## Phase 22c (FC) — `...` argument forwarding

Part of the Ruby 3.4 frontend-convergence track. Adds Ruby 2.7+ **argument forwarding**: `def m(...)` declares a forward-all method and `n(...)` forwards every argument (positional, keyword, block) to an inner call.

### Grammar (`params` only)
```
params = param { COMMA param } ;
→
params = "..." | param { COMMA param } ;
```
`_grammar.rs` regenerated. The lexer fuses `...` into a single **Name-typed** token (value `...`, shared with the exclusive-range operator). Because `param = [ "*" | "**" ] NAME` would otherwise match `...` as a parameter *named* `...`, the bare `"..."` alternative is listed **first** to claim the token as a literal forwarding marker. Ordinary signatures are unaffected (first token is never `...`).

**No `call_arg` grammar change.** `factor`'s `NAME` alternative already matches the `...` token as a bare-name expression, so `n(...)` parses as a call_arg whose expression is the bare name `...`. A beginless exclusive-range argument `m(...5)` instead parses as a `range` (the `... 5` form) — disjoint at the parse tree. A literal `"..."` call_arg alternative was deliberately **not** added: listing it first breaks `m(...5)` (the parser doesn't backtrack across the call_arg boundary once `...` is consumed); listing it last is dead code (`NAME` shadows it).

### Lowering
`lower_call_arg` rewrites a bare-name `...` operand (which lowers to `VarRef { name: "..." }`) into the nullary marker `BuiltinCall("forward_args", [])`, on the no-prefix path only. `...` is not a legal Ruby identifier, so the match is unambiguous; `m(...5)` lowers to a `range` builtin and is left untouched. `def m(...)` lowers to a function with **zero** params (v0 lossy: `...` is a literal token in `params`, not a `param` node); the call-side marker carries the forwarding semantics. **No new SIR variant.**

### Parser pins (+4 → 214)
- `test_parse_forward_all_call_arg` — `n(...)`
- `test_parse_forward_all_param` — `def m(...)` (0 `param` nodes)
- `test_parse_forward_all_roundtrip` — `def m(...) ; n(...) ; end`
- `test_parse_beginless_range_arg_still_parses` — `m(...5)` regression (still a `range`)

### Lowering pins (+3 → 267)
- `forward_args_call_arg_lowers_to_forward_args_builtin` — `f(...)` (node shape: nullary `forward_args`)
- `forward_all_def_and_call_passes_sir_validator` — `def m(...) ; puts(...) ; end` (validator E2E, `m` has 0 params)
- `beginless_range_arg_does_not_lower_to_forward_args` — `m(...5)` (lowers to `range`, not `forward_args`)

### Tests
`cargo test -p coding-adventures-ruby-lexer -p coding-adventures-ruby-parser -p ruby-to-semantic-ir` — lexer 173, parser 214, IR 267, all green.

### Changelogs
- `ruby-parser` 0.59.0 → 0.60.0
- `ruby-to-semantic-ir` 0.62.0 → 0.63.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
