### PR TITLE
feat(ruby-fc): Phase 22d — `super` keyword

### DIFF
--- a/code/grammars/ruby.grammar
+++ b/code/grammars/ruby.grammar
@@ -25,7 +25,7 @@
 # than PUTS, TRUE, FALSE, NIL as token types.
 
 program      = { statement } ;
-statement    = endless_def_statement | def_statement | class_statement | module_statement | if_statement | unless_statement | while_statement | until_statement | case_statement | begin_statement | return_statement | break_statement | next_statement | yield_statement | multi_assignment | modifier_statement | rightward_assignment | assignment | method_with_block | method_call | method_call_no_paren | expression_stmt ;
+statement    = endless_def_statement | def_statement | class_statement | module_statement | if_statement | unless_statement | while_statement | until_statement | case_statement | begin_statement | return_statement | break_statement | next_statement | yield_statement | super_statement | multi_assignment | modifier_statement | rightward_assignment | assignment | method_with_block | method_call | method_call_no_paren | expression_stmt ;
 # Phase 6r — multiple assignment `a, b = 1, 2`.
 #
 # Placed BEFORE `modifier_statement` and `assignment` so the multi-LHS
@@ -176,6 +176,26 @@ next_statement   = "next"   [ expression ] ;
 # double-splat (`yield **hsh`) work uniformly with method-call args.
 yield_statement = "yield" [ yield_args ] ;
 yield_args = LPAREN [ call_arg { COMMA call_arg } ] RPAREN
+           | call_arg { COMMA call_arg } ;
+# Phase 22d (FC) — `super` keyword.  Inside a method, `super` calls the
+# same-named method in the superclass.  Three surface forms, mirroring
+# `yield` exactly (and reusing `call_arg`, so splat/double-splat/
+# block-pass/forward args ride through uniformly):
+#
+#   super                # bare — "zsuper": forwards ALL of the current
+#                        #   method's arguments implicitly
+#   super()              # explicit EMPTY argument list (forwards nothing)
+#   super(x) / super x   # explicit args (parens or parenless)
+#
+# The bare-vs-`super()` distinction is semantically load-bearing in Ruby
+# (zsuper forwards the caller's args; `super()` forwards none), so the
+# lowerer keys on the PRESENCE of a `super_args` node: absent → bare
+# zsuper, present → explicit (even with zero call_args).  Placed in
+# `statement` right after `yield_statement` and BEFORE the
+# `method_call*` family so the KEYWORD-tagged `super` token doesn't fall
+# through to `method_call_no_paren` and lose its dedicated lowering.
+super_statement = "super" [ super_args ] ;
+super_args = LPAREN [ call_arg { COMMA call_arg } ] RPAREN
            | call_arg { COMMA call_arg } ;
 # Phase 6s — splat (`*args`) and double-splat (`**kwargs`) parameters.
 #

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.61.0] - 2026-05-31
+
+### Added (Phase 22d (FC) — `super` keyword)
+
+New `super_statement` rule (and a `super_args` rule mirroring
+`yield_args`), added to the `statement` alternation right after
+`yield_statement`:
+
+```
+super_statement = "super" [ super_args ] ;
+super_args = LPAREN [ call_arg { COMMA call_arg } ] RPAREN
+           | call_arg { COMMA call_arg } ;
+```
+
+`super` is a Ruby keyword (lexer-tagged KEYWORD), and `super_statement`
+is placed before the `method_call*` family so the keyword token gets its
+dedicated rule instead of falling through to `method_call_no_paren`.
+Three surface forms parse: bare `super` (no `super_args` — the
+implicit-forward "zsuper"), `super()` (explicit empty `super_args`), and
+`super(x, y)` / `super x` (explicit args).  `super_args` reuses
+`call_arg`, so splat / double-splat / block-pass / `...` forwarding ride
+through uniformly.  `_grammar.rs` regenerated.
+
+New parse pins (+3): `test_parse_super_bare` (`super`, no `super_args`),
+`test_parse_super_empty_parens` (`super()`, 0 call_args),
+`test_parse_super_with_args` (`super(x, y)`, 2 call_args).  Test count:
+214 → 217.
+
 ## [0.60.0] - 2026-05-31
 
 ### Added (Phase 22c (FC) — `...` argument forwarding)

--- a/code/packages/rust/ruby-parser/src/_grammar.rs
+++ b/code/packages/rust/ruby-parser/src/_grammar.rs
@@ -32,6 +32,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"break_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"next_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"yield_statement"#.to_string() },
+                GrammarElement::RuleReference { name: r#"super_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"multi_assignment"#.to_string() },
                 GrammarElement::RuleReference { name: r#"modifier_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"rightward_assignment"#.to_string() },
@@ -299,6 +300,38 @@ pub fn parser_grammar() -> ParserGrammar {
             line_number: 178,
         },
         GrammarRule {
+            name: r#"super_statement"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"super"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"super_args"#.to_string() }) },
+            ] },
+            line_number: 197,
+        },
+        GrammarRule {
+            name: r#"super_args"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                    GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                            GrammarElement::RuleReference { name: r#"call_arg"#.to_string() },
+                            GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                                    GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                                    GrammarElement::RuleReference { name: r#"call_arg"#.to_string() },
+                                ] }) },
+                        ] }) },
+                    GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+                ] },
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::RuleReference { name: r#"call_arg"#.to_string() },
+                    GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                            GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                            GrammarElement::RuleReference { name: r#"call_arg"#.to_string() },
+                        ] }) },
+                ] },
+            ] },
+            line_number: 198,
+        },
+        GrammarRule {
             name: r#"params"#.to_string(),
             body: GrammarElement::Alternation { choices: vec![
                 GrammarElement::Literal { value: r#"..."#.to_string() },
@@ -310,7 +343,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) },
                 ] },
             ] },
-            line_number: 207,
+            line_number: 227,
         },
         GrammarRule {
             name: r#"param"#.to_string(),
@@ -321,7 +354,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
             ] },
-            line_number: 208,
+            line_number: 228,
         },
         GrammarRule {
             name: r#"if_statement"#.to_string(),
@@ -338,7 +371,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 209,
+            line_number: 229,
         },
         GrammarRule {
             name: r#"elsif_clause"#.to_string(),
@@ -352,7 +385,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 210,
+            line_number: 230,
         },
         GrammarRule {
             name: r#"else_clause"#.to_string(),
@@ -363,7 +396,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 211,
+            line_number: 231,
         },
         GrammarRule {
             name: r#"unless_statement"#.to_string(),
@@ -378,7 +411,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 212,
+            line_number: 232,
         },
         GrammarRule {
             name: r#"while_statement"#.to_string(),
@@ -391,7 +424,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 213,
+            line_number: 233,
         },
         GrammarRule {
             name: r#"until_statement"#.to_string(),
@@ -404,7 +437,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 214,
+            line_number: 234,
         },
         GrammarRule {
             name: r#"case_statement"#.to_string(),
@@ -418,7 +451,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 237,
+            line_number: 257,
         },
         GrammarRule {
             name: r#"when_clause"#.to_string(),
@@ -437,7 +470,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 238,
+            line_number: 258,
         },
         GrammarRule {
             name: r#"in_clause"#.to_string(),
@@ -452,7 +485,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 260,
+            line_number: 280,
         },
         GrammarRule {
             name: r#"pattern"#.to_string(),
@@ -462,7 +495,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"literal_pattern"#.to_string() },
                 GrammarElement::RuleReference { name: r#"binding_pattern"#.to_string() },
             ] },
-            line_number: 261,
+            line_number: 281,
         },
         GrammarRule {
             name: r#"literal_pattern"#.to_string(),
@@ -472,12 +505,12 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"symbol_literal"#.to_string() },
                 GrammarElement::TokenReference { name: r#"KEYWORD"#.to_string() },
             ] },
-            line_number: 262,
+            line_number: 282,
         },
         GrammarRule {
             name: r#"binding_pattern"#.to_string(),
             body: GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
-            line_number: 263,
+            line_number: 283,
         },
         GrammarRule {
             name: r#"array_pattern"#.to_string(),
@@ -492,7 +525,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 264,
+            line_number: 284,
         },
         GrammarRule {
             name: r#"hash_pattern"#.to_string(),
@@ -507,7 +540,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 265,
+            line_number: 285,
         },
         GrammarRule {
             name: r#"hash_pattern_pair"#.to_string(),
@@ -516,7 +549,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"pattern"#.to_string() }) },
             ] },
-            line_number: 266,
+            line_number: 286,
         },
         GrammarRule {
             name: r#"begin_statement"#.to_string(),
@@ -532,7 +565,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"ensure_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 287,
+            line_number: 307,
         },
         GrammarRule {
             name: r#"rescue_clause"#.to_string(),
@@ -550,7 +583,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 296,
+            line_number: 316,
         },
         GrammarRule {
             name: r#"exception_list"#.to_string(),
@@ -561,7 +594,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
                     ] }) },
             ] },
-            line_number: 297,
+            line_number: 317,
         },
         GrammarRule {
             name: r#"ensure_clause"#.to_string(),
@@ -572,7 +605,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 298,
+            line_number: 318,
         },
         GrammarRule {
             name: r#"assignment"#.to_string(),
@@ -596,7 +629,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 318,
+            line_number: 338,
         },
         GrammarRule {
             name: r#"rightward_assignment"#.to_string(),
@@ -605,7 +638,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"=>"#.to_string() },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
             ] },
-            line_number: 337,
+            line_number: 357,
         },
         GrammarRule {
             name: r#"method_call"#.to_string(),
@@ -625,7 +658,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"dot_call"#.to_string() }) },
             ] },
-            line_number: 348,
+            line_number: 368,
         },
         GrammarRule {
             name: r#"dot_call"#.to_string(),
@@ -647,7 +680,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                     ] }) },
             ] },
-            line_number: 349,
+            line_number: 369,
         },
         GrammarRule {
             name: r#"scope_resolution"#.to_string(),
@@ -658,7 +691,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"KEYWORD"#.to_string() },
                     ] }) },
             ] },
-            line_number: 357,
+            line_number: 377,
         },
         GrammarRule {
             name: r#"call_arg"#.to_string(),
@@ -670,7 +703,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 387,
+            line_number: 407,
         },
         GrammarRule {
             name: r#"method_call_no_paren"#.to_string(),
@@ -685,17 +718,17 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 401,
+            line_number: 421,
         },
         GrammarRule {
             name: r#"expression_stmt"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"expression"#.to_string() },
-            line_number: 402,
+            line_number: 422,
         },
         GrammarRule {
             name: r#"expression"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"ternary"#.to_string() },
-            line_number: 509,
+            line_number: 529,
         },
         GrammarRule {
             name: r#"ternary"#.to_string(),
@@ -708,7 +741,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 510,
+            line_number: 530,
         },
         GrammarRule {
             name: r#"range"#.to_string(),
@@ -731,7 +764,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) },
                 ] },
             ] },
-            line_number: 511,
+            line_number: 531,
         },
         GrammarRule {
             name: r#"logical_or"#.to_string(),
@@ -745,7 +778,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_and"#.to_string() },
                     ] }) },
             ] },
-            line_number: 512,
+            line_number: 532,
         },
         GrammarRule {
             name: r#"logical_and"#.to_string(),
@@ -759,7 +792,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_not"#.to_string() },
                     ] }) },
             ] },
-            line_number: 513,
+            line_number: 533,
         },
         GrammarRule {
             name: r#"logical_not"#.to_string(),
@@ -770,7 +803,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) }) },
                 GrammarElement::RuleReference { name: r#"comparison"#.to_string() },
             ] },
-            line_number: 520,
+            line_number: 540,
         },
         GrammarRule {
             name: r#"comparison"#.to_string(),
@@ -788,7 +821,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"sum"#.to_string() },
                     ] }) },
             ] },
-            line_number: 521,
+            line_number: 541,
         },
         GrammarRule {
             name: r#"sum"#.to_string(),
@@ -802,7 +835,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term"#.to_string() },
                     ] }) },
             ] },
-            line_number: 522,
+            line_number: 542,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -816,7 +849,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"factor"#.to_string() },
                     ] }) },
             ] },
-            line_number: 523,
+            line_number: 543,
         },
         GrammarRule {
             name: r#"factor"#.to_string(),
@@ -843,7 +876,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"scope_resolution"#.to_string() },
                     ] }) },
             ] },
-            line_number: 533,
+            line_number: 553,
         },
         GrammarRule {
             name: r#"lambda_literal"#.to_string(),
@@ -856,7 +889,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"block"#.to_string() },
             ] },
-            line_number: 552,
+            line_number: 572,
         },
         GrammarRule {
             name: r#"unary_minus"#.to_string(),
@@ -864,7 +897,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"factor"#.to_string() },
             ] },
-            line_number: 553,
+            line_number: 573,
         },
         GrammarRule {
             name: r#"symbol_literal"#.to_string(),
@@ -876,7 +909,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 560,
+            line_number: 580,
         },
         GrammarRule {
             name: r#"array_literal"#.to_string(),
@@ -891,7 +924,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 561,
+            line_number: 581,
         },
         GrammarRule {
             name: r#"hash_literal"#.to_string(),
@@ -906,7 +939,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 562,
+            line_number: 582,
         },
         GrammarRule {
             name: r#"hash_entry"#.to_string(),
@@ -926,7 +959,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                 ] },
             ] },
-            line_number: 563,
+            line_number: 583,
         },
     ],
         version: 1,

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -2701,6 +2701,53 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_super_bare() {
+        // Phase 22d — bare `super` (zsuper): no argument list.  Must
+        // parse as a `super_statement` with NO `super_args` child (the
+        // absence is what marks it as implicit-forward zsuper).
+        let ast = parse_ruby("super");
+        let sup = find_descendant(&ast, "super_statement").expect("expected super_statement");
+        assert!(tree_has_token_value(sup, "super"), "expected `super` keyword");
+        assert!(
+            find_descendant(sup, "super_args").is_none(),
+            "bare super must have NO super_args node"
+        );
+    }
+
+    #[test]
+    fn test_parse_super_empty_parens() {
+        // Phase 22d — `super()`: explicit empty arg list.  A
+        // `super_args` node IS present (with zero `call_arg` children),
+        // distinguishing it from bare zsuper.
+        let ast = parse_ruby("super()");
+        let sup = find_descendant(&ast, "super_statement").expect("expected super_statement");
+        let args = find_descendant(sup, "super_args").expect("expected super_args node");
+        let arg_count = args
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "call_arg"))
+            .count();
+        assert_eq!(arg_count, 0, "super() must have 0 call_args");
+    }
+
+    #[test]
+    fn test_parse_super_with_args() {
+        // Phase 22d — `super(x, y)`: explicit args.  `super_args` holds
+        // two `call_arg` children.
+        let ast = parse_ruby("super(x, y)");
+        let sup = find_descendant(&ast, "super_statement").expect("expected super_statement");
+        let args = find_descendant(sup, "super_args").expect("expected super_args node");
+        let arg_count = args
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "call_arg"))
+            .count();
+        assert_eq!(arg_count, 2, "super(x, y) must have 2 call_args, got {arg_count}");
+        assert!(tree_has_token_value(sup, "x"));
+        assert!(tree_has_token_value(sup, "y"));
+    }
+
+    #[test]
     fn test_parse_binary_star_still_parses_as_expression() {
         // Regression: `a * b` as a statement must still parse as a
         // bare expression-stmt with binary `*`, NOT as `a(splat b)`.

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.64.0] - 2026-05-31
+
+### Added (Phase 22d (FC) — `super` keyword)
+
+New `super_statement` lowering arm, mirroring `yield`.  Two distinct
+lowerings keyed on whether a `super_args` node is present:
+
+- bare `super` (absent) → `BuiltinCall("zsuper", [])` — Ruby's implicit
+  "zsuper" that forwards ALL of the enclosing method's arguments, so it
+  carries no operands.
+- `super()` / `super(x)` / `super x` (present) → `BuiltinCall("super",
+  lowered_args)`, where `super()` lowers to **zero** args (forwards
+  nothing) — semantically distinct from bare zsuper.
+
+`super_args` reuses `lower_call_arg`, so splat / double-splat /
+block-pass / `...` envelopes nest inside `super` args for free.  Effects
+are PURE (matching `yield`): the dispatched parent method's effects are
+accounted for at its own definition/call site, so the marker stays PURE
+to avoid double-counting.  No new SIR variant.
+
+New lowering pins (+3): `bare_super_lowers_to_zsuper_builtin` (`super` →
+`zsuper`, 0 args), `super_empty_parens_lowers_to_super_builtin_no_args`
+(`super()` → `super`, 0 args), `super_with_args_lowers_and_passes_validator`
+(`super(1, 2)` → `super` with 2 args, validates).  Test count: 267 → 270.
+
 ## [0.63.0] - 2026-05-31
 
 ### Added (Phase 22c (FC) — `...` argument forwarding)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -4765,6 +4765,69 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // Phase 22d — `super` keyword lowering
+    //
+    //   super        → ExprStmt(BuiltinCall("zsuper", []))   (forward ALL)
+    //   super()      → ExprStmt(BuiltinCall("super",  []))   (forward NONE)
+    //   super(1, 2)  → ExprStmt(BuiltinCall("super",  [IntLit(1), IntLit(2)]))
+    //
+    // The bare-vs-`super()` split is keyed on the presence of a
+    // `super_args` node; `zsuper` and `super` are distinct builtin names.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn bare_super_lowers_to_zsuper_builtin() {
+        let m = lower("super\n");
+        let b = main_body(&m);
+        match &b.stmts[0] {
+            Stmt::ExprStmt { expr: Expr::BuiltinCall { name, args, .. }, .. } => {
+                assert_eq!(name, "zsuper", "bare super must lower to zsuper");
+                assert!(args.is_empty(), "zsuper carries no operands");
+            }
+            other => panic!("expected ExprStmt(BuiltinCall(zsuper, [])), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn super_empty_parens_lowers_to_super_builtin_no_args() {
+        // `super()` is semantically distinct from bare `super`: it
+        // forwards NO arguments.  Name is "super" (not "zsuper") with an
+        // empty arg list.
+        let m = lower("super()\n");
+        let b = main_body(&m);
+        match &b.stmts[0] {
+            Stmt::ExprStmt { expr: Expr::BuiltinCall { name, args, .. }, .. } => {
+                assert_eq!(name, "super", "super() must lower to `super`, not `zsuper`");
+                assert!(args.is_empty(), "super() forwards zero args");
+            }
+            other => panic!("expected ExprStmt(BuiltinCall(super, [])), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn super_with_args_lowers_and_passes_validator() {
+        // `super(1, 2)` → BuiltinCall("super", [IntLit(1), IntLit(2)]),
+        // and the module validates (args are recursively well-formed).
+        let m = lower("super(1, 2)\n");
+        let result = semantic_ir::validate(&m);
+        assert!(
+            result.is_ok(),
+            "validator rejected super with args: {:?}",
+            result
+        );
+        let b = main_body(&m);
+        match &b.stmts[0] {
+            Stmt::ExprStmt { expr: Expr::BuiltinCall { name, args, .. }, .. } => {
+                assert_eq!(name, "super");
+                assert_eq!(args.len(), 2);
+                assert!(matches!(&args[0], Expr::IntLit { value: 1, .. }));
+                assert!(matches!(&args[1], Expr::IntLit { value: 2, .. }));
+            }
+            other => panic!("expected ExprStmt(BuiltinCall(super, [1, 2])), got {:?}", other),
+        }
+    }
+
+    // -----------------------------------------------------------------------
     // Phase 6y — string interpolation lowering
     //
     // Output shapes covered:

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -841,6 +841,56 @@ impl Lowerer {
                     span: self.span_of(node),
                 })
             }
+            "super_statement" => {
+                // Phase 22d — `super` keyword.
+                //
+                // Grammar shape:
+                //   super_statement = "super" [ super_args ] ;
+                //   super_args      = LPAREN [ call_arg { COMMA call_arg } ] RPAREN
+                //                   | call_arg { COMMA call_arg } ;
+                //
+                // Two distinct lowerings keyed on whether a `super_args`
+                // node is PRESENT:
+                //   - absent  → bare `super` ("zsuper") forwards ALL of
+                //     the enclosing method's arguments implicitly, so it
+                //     carries no operands: `BuiltinCall("zsuper", [])`.
+                //   - present → explicit arg list (`super()`, `super(x)`,
+                //     `super x`): `BuiltinCall("super", lowered_args)`,
+                //     where `super()` lowers to zero args (forwards
+                //     nothing) — distinct from bare zsuper.
+                //
+                // Effects: PURE, matching `yield` — `super` dispatches to
+                // a parent method whose own effects are accounted for at
+                // its definition/call site; modelling the marker as PURE
+                // keeps the effect lattice from double-counting.
+                let super_args_node = self.find_node_child(node, "super_args");
+                let (name, args): (&str, Vec<Expr>) = if let Some(sa) = super_args_node {
+                    let call_arg_nodes: Vec<&GrammarASTNode> = sa
+                        .children
+                        .iter()
+                        .filter_map(|c| match c {
+                            ASTNodeOrToken::Node(n) if n.rule_name == "call_arg" => Some(n),
+                            _ => None,
+                        })
+                        .collect();
+                    let lowered: Vec<Expr> = call_arg_nodes
+                        .into_iter()
+                        .map(|n| self.lower_call_arg(n))
+                        .collect::<Result<Vec<_>, _>>()?;
+                    ("super", lowered)
+                } else {
+                    ("zsuper", Vec::new())
+                };
+                Ok(Stmt::ExprStmt {
+                    expr: Expr::BuiltinCall {
+                        name: name.to_string(),
+                        args,
+                        effects: EffectSet::PURE,
+                        span: self.span_of(node),
+                    },
+                    span: self.span_of(node),
+                })
+            }
             "return_statement" | "break_statement" | "next_statement" => {
                 // Phase 6j: control-flow keywords lower to BuiltinCall
                 // with Effect::Divergent.  Optional trailing expression


### PR DESCRIPTION
## Phase 22d (FC) — `super` keyword

Part of the Ruby 3.4 frontend-convergence track. Adds the `super` keyword, mirroring the existing `yield` handling.

### Grammar
```
super_statement = "super" [ super_args ] ;
super_args = LPAREN [ call_arg { COMMA call_arg } ] RPAREN
           | call_arg { COMMA call_arg } ;
```
`super_statement` is inserted into the `statement` alternation right after `yield_statement` (and before the `method_call*` family) so the KEYWORD-tagged `super` token gets its dedicated rule rather than falling through to `method_call_no_paren`. `super_args` reuses `call_arg`, so splat / double-splat / block-pass / `...` forwarding ride through uniformly. `_grammar.rs` regenerated.

### Lowering
Keys on the **presence** of a `super_args` node:
- **bare `super`** (absent) → `BuiltinCall("zsuper", [])` — Ruby's implicit "zsuper" that forwards **all** of the enclosing method's arguments, so it carries no operands.
- **`super()` / `super(x)` / `super x`** (present) → `BuiltinCall("super", lowered_args)`; `super()` lowers to **zero** args (forwards nothing) — semantically distinct from bare zsuper.

Effects are PURE (matching `yield`): the dispatched parent method's effects are accounted for at its own site, so the marker stays PURE to avoid double-counting. **No new SIR variant.**

### Parser pins (+3 → 217)
- `test_parse_super_bare` — `super` (no `super_args` node)
- `test_parse_super_empty_parens` — `super()` (`super_args`, 0 call_args)
- `test_parse_super_with_args` — `super(x, y)` (`super_args`, 2 call_args)

### Lowering pins (+3 → 270)
- `bare_super_lowers_to_zsuper_builtin` — `super` → `zsuper`, 0 args
- `super_empty_parens_lowers_to_super_builtin_no_args` — `super()` → `super`, 0 args
- `super_with_args_lowers_and_passes_validator` — `super(1, 2)` → `super`, 2 args + validates

### Tests
`cargo test -p coding-adventures-ruby-lexer -p coding-adventures-ruby-parser -p ruby-to-semantic-ir` — lexer 173, parser 217, IR 270, all green.

### Changelogs
- `ruby-parser` 0.60.0 → 0.61.0
- `ruby-to-semantic-ir` 0.63.0 → 0.64.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
