### PR TITLE
[codex] Honor Board VM ejected boot policy

### DIFF
--- a/code/packages/rust/board-vm-uno-r4-firmware/README.md
+++ b/code/packages/rust/board-vm-uno-r4-firmware/README.md
@@ -36,8 +36,8 @@ target/thumbv7em-none-eabihf/release/uno-r4-vm-blink-smoke
 
 `uno-r4-wifi-ejected-blink` is the first board-specific ejection runner. It
 loads the constants in `src/ejected_blink.rs`, validates their BVM module
-metadata against the Uno R4 backend capabilities, and runs the ejected program
-directly on boot without a host protocol session:
+metadata against the Uno R4 backend capabilities, and applies the artifact boot
+policy before running it directly on boot without a host protocol session:
 
 ```sh
 RUSTC="$(rustup which rustc)" rustup run stable cargo build --target thumbv7em-none-eabihf --bin uno-r4-wifi-ejected-blink --release

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/bin/uno_r4_wifi_ejected_blink.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/bin/uno_r4_wifi_ejected_blink.rs
@@ -6,8 +6,8 @@ mod firmware {
     use board_vm_runtime::Runtime;
     use board_vm_uno_r4::UnoR4Board;
     use board_vm_uno_r4_firmware::{
-        run_ejected_program_once, uno_r4_wifi_backend::UnoR4WifiLedBackend, EjectedFirmwareProgram,
-        EJECTED_INSTRUCTION_BUDGET,
+        run_ejected_boot_program_once, uno_r4_wifi_backend::UnoR4WifiLedBackend,
+        EjectedFirmwareProgram, EJECTED_INSTRUCTION_BUDGET,
     };
     use panic_halt as _;
 
@@ -19,7 +19,8 @@ mod firmware {
         let program = EjectedFirmwareProgram::blink();
 
         loop {
-            let _ = run_ejected_program_once(&mut runtime, program, EJECTED_INSTRUCTION_BUDGET);
+            let _ =
+                run_ejected_boot_program_once(&mut runtime, program, EJECTED_INSTRUCTION_BUDGET);
         }
     }
 }

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/lib.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/lib.rs
@@ -79,6 +79,12 @@ pub enum FirmwareSmokeError {
     ArtifactRequiredCapabilitiesMismatch,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EjectedBootAction {
+    StoreOnly,
+    Run,
+}
+
 impl From<ModuleError> for FirmwareSmokeError {
     fn from(value: ModuleError) -> Self {
         Self::Module(value)
@@ -131,6 +137,32 @@ pub fn validate_ejected_blink_program(board_max_stack: u8) -> Result<(), Firmwar
     )
 }
 
+pub fn ejected_boot_action(
+    program: EjectedFirmwareProgram<'_>,
+) -> Result<EjectedBootAction, FirmwareSmokeError> {
+    parse_checked_ejected_program(program)?;
+    boot_action_for_policy(program.boot_policy)
+}
+
+pub fn run_ejected_boot_program_once<H, const MAX_STACK: usize, const MAX_HANDLES: usize>(
+    runtime: &mut Runtime<H, MAX_STACK, MAX_HANDLES>,
+    program: EjectedFirmwareProgram<'_>,
+    instruction_budget: u32,
+) -> Result<Option<RunReport>, FirmwareSmokeError>
+where
+    H: BoardHal,
+{
+    let module = parse_checked_ejected_program(program)?;
+    match boot_action_for_policy(program.boot_policy)? {
+        EjectedBootAction::StoreOnly => Ok(None),
+        EjectedBootAction::Run => {
+            validate(&module, runtime.hal().capabilities(), MAX_STACK as u8)?;
+            runtime.reset_vm();
+            Ok(Some(runtime.run_module(&module, instruction_budget)?))
+        }
+    }
+}
+
 pub fn run_ejected_program_once<H, const MAX_STACK: usize, const MAX_HANDLES: usize>(
     runtime: &mut Runtime<H, MAX_STACK, MAX_HANDLES>,
     program: EjectedFirmwareProgram<'_>,
@@ -165,10 +197,7 @@ fn parse_checked_ejected_program(
             program.program_format,
         ));
     }
-    match program.boot_policy {
-        BOOT_STORE_ONLY | BOOT_RUN_AT_BOOT | BOOT_RUN_IF_NO_HOST => {}
-        other => return Err(FirmwareSmokeError::InvalidBootPolicy(other)),
-    }
+    boot_action_for_policy(program.boot_policy)?;
     if program.module_version != MODULE_VERSION {
         return Err(FirmwareSmokeError::Module(ModuleError::UnsupportedVersion(
             program.module_version,
@@ -188,6 +217,14 @@ fn parse_checked_ejected_program(
         return Err(FirmwareSmokeError::ArtifactRequiredCapabilitiesMismatch);
     }
     Ok(module)
+}
+
+fn boot_action_for_policy(boot_policy: u8) -> Result<EjectedBootAction, FirmwareSmokeError> {
+    match boot_policy {
+        BOOT_STORE_ONLY => Ok(EjectedBootAction::StoreOnly),
+        BOOT_RUN_AT_BOOT | BOOT_RUN_IF_NO_HOST => Ok(EjectedBootAction::Run),
+        other => Err(FirmwareSmokeError::InvalidBootPolicy(other)),
+    }
 }
 
 fn crc32_ieee(bytes: &[u8]) -> u32 {
@@ -307,6 +344,14 @@ mod tests {
     }
 
     #[test]
+    fn ejected_blink_boot_policy_runs_without_host() {
+        assert_eq!(
+            ejected_boot_action(EjectedFirmwareProgram::blink()).unwrap(),
+            EjectedBootAction::Run
+        );
+    }
+
+    #[test]
     fn rejects_ejected_artifact_metadata_mismatch() {
         let mut program = EjectedFirmwareProgram::blink();
         program.max_stack = program.max_stack.saturating_add(1);
@@ -402,5 +447,20 @@ mod tests {
                 Event::Sleep(250),
             ]
         );
+    }
+
+    #[test]
+    fn ejected_boot_cycle_skips_store_only_artifact() {
+        let hal = FakeHal::new();
+        let mut runtime: Runtime<_, 16, 8> = Runtime::new(hal);
+        let mut program = EjectedFirmwareProgram::blink();
+        program.boot_policy = BOOT_STORE_ONLY;
+
+        let report =
+            run_ejected_boot_program_once(&mut runtime, program, EJECTED_INSTRUCTION_BUDGET)
+                .unwrap();
+
+        assert!(report.is_none());
+        assert!(runtime.hal().events.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- add a firmware-side boot action for ejected Board VM artifacts
- route the Uno R4 ejected blink boot binary through the boot-policy-aware runner
- keep explicit run helpers available while `store-only` artifacts are skipped by boot execution

## Validation
- `cargo fmt -p board-vm-uno-r4-firmware`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-eject-boot-policy-conformance cargo test -p board-vm-uno-r4-firmware`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-eject-boot-policy-conformance cargo test -p board-vm-protocol -p board-vm-ir -p board-vm-host -p board-vm-device -p board-vm-loopback -p board-vm-client -p board-vm-eject -p board-vm-uno-r4-firmware -p board-vm-cli`
- `git diff --check`
- `git diff --cached --check`