### PR TITLE
test(ruby-fc): Phase 11a — pin `break`/`next` WITH VALUES (coverage-confirmation)

### DIFF
--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.62.0] - 2026-05-31
+
+### Added (Phase 11a (FC) — `break`/`next` WITH VALUES, coverage-confirmation)
+
+No grammar change.  The Phase 6j rules already accept an optional
+trailing expression after the loop-control keywords:
+
+```
+break_statement = "break" [ expression ] ;
+next_statement  = "next"  [ expression ] ;
+```
+
+This release adds parse pins from new angles so a future grammar edit
+cannot silently drop value-carrying loop control.  The pre-existing
+pins covered `break 1 + 2` and a bare `next`; the new pins cover a bare
+integer payload, a value-carrying `next`, and a name-plus-literal binary
+payload whose `+` token must survive inside the `break_statement`
+subtree.
+
+New parse pins (+3): `test_parse_break_with_int_value` (`break 5`),
+`test_parse_next_with_value` (`next 7`),
+`test_parse_break_with_binary_name_value` (`break x + 1`).  Test count:
+217 → 220.
+
 ## [0.61.0] - 2026-05-31
 
 ### Added (Phase 22d (FC) — `super` keyword)

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -1287,6 +1287,58 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // Phase 11a — `break`/`next` WITH VALUES (coverage-confirmation)
+    //
+    // The Phase 6j grammar rules already accept an optional trailing
+    // expression after `break`/`next` (`break_statement = "break" [ expression ]`).
+    // These pins lock in additional surface forms from new angles —
+    // a bare integer payload, `next` carrying a value, and a binary
+    // expression payload — so a future grammar edit cannot silently
+    // drop value-carrying loop control without tripping a test.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_break_with_int_value() {
+        // `break 5` — simple integer payload (distinct from the
+        // existing `break 1 + 2` pin, which exercises a binary expr).
+        let ast = parse_ruby("break 5");
+        let b = find_statement_inner(&ast, "break_statement")
+            .expect("expected break_statement");
+        assert!(b
+            .children
+            .iter()
+            .any(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "expression")));
+    }
+
+    #[test]
+    fn test_parse_next_with_value() {
+        // `next 7` — `next` carrying an integer payload (the existing
+        // `next` pin is bare; this confirms the optional-expr arm fires
+        // for `next` as well as `break`).
+        let ast = parse_ruby("next 7");
+        let n = find_statement_inner(&ast, "next_statement")
+            .expect("expected next_statement");
+        assert!(n
+            .children
+            .iter()
+            .any(|c| matches!(c, ASTNodeOrToken::Node(nn) if nn.rule_name == "expression")));
+    }
+
+    #[test]
+    fn test_parse_break_with_binary_name_value() {
+        // `break x + 1` — a name-plus-literal binary expression payload;
+        // the `+` token must survive inside the break_statement subtree.
+        let ast = parse_ruby("break x + 1");
+        let b = find_statement_inner(&ast, "break_statement")
+            .expect("expected break_statement");
+        assert!(b
+            .children
+            .iter()
+            .any(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "expression")));
+        assert!(tree_has_token_value(b, "+"));
+    }
+
+    // -----------------------------------------------------------------------
     // Phase 6k — unary minus `-5`, `-x`, `-(1+2)`
     // -----------------------------------------------------------------------
 

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.65.0] - 2026-05-31
+
+### Added (Phase 11a (FC) — `break`/`next` WITH VALUES, coverage-confirmation)
+
+No lowering change.  The Phase 6j arm
+(`return_statement | break_statement | next_statement`) already folds an
+optional trailing expression into the single `BuiltinCall` argument and
+falls back to `NilLit` when bare:
+
+```
+break 5   → ExprStmt(BuiltinCall("break", [IntLit 5], Divergent))
+next 7    → ExprStmt(BuiltinCall("next",  [IntLit 7], Divergent))
+break     → ExprStmt(BuiltinCall("break", [NilLit],   Divergent))
+```
+
+This release adds lowering pins from new angles so the value-carrying
+contract is nailed down independently of `return` (whose pins already
+existed): a value-carrying `break`, a value-carrying `next`, a bare
+`break` (NilLit arg), and a validator end-to-end run where the payload
+is a resolved local variable (`x = 1; break x`).
+
+New lowering pins (+4): `break_with_value_lowers_to_int_arg` (`break 5`),
+`next_with_value_lowers_to_int_arg` (`next 7`),
+`bare_break_lowers_with_nil_arg` (`break` → NilLit),
+`break_with_local_var_value_passes_sir_validator` (`x = 1; break x`,
+validates).  Test count: 270 → 274.
+
 ## [0.64.0] - 2026-05-31
 
 ### Added (Phase 22d (FC) — `super` keyword)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -1616,6 +1616,67 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
+    // Phase 11a — `break`/`next` WITH VALUES (coverage-confirmation)
+    //
+    // The Phase 6j lowering arm already maps an optional trailing
+    // expression after `break`/`next` into the single `BuiltinCall`
+    // argument (bare → NilLit).  These pins lock that contract from
+    // additional angles: a value-carrying `break`, a value-carrying
+    // `next`, a bare `break` (NilLit arg), and a validator end-to-end
+    // run where the payload is a resolved local variable.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn break_with_value_lowers_to_int_arg() {
+        let m = lower("break 5");
+        let b = main_body(&m);
+        match &b.stmts[0] {
+            Stmt::ExprStmt { expr: Expr::BuiltinCall { name, args, effects, .. }, .. } => {
+                assert_eq!(name, "break");
+                assert!(matches!(args[0], Expr::IntLit { value: 5, .. }));
+                assert!(effects.contains(Effect::Divergent));
+            }
+            other => panic!("expected ExprStmt(BuiltinCall(break, [5])), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn next_with_value_lowers_to_int_arg() {
+        let m = lower("next 7");
+        let b = main_body(&m);
+        match &b.stmts[0] {
+            Stmt::ExprStmt { expr: Expr::BuiltinCall { name, args, effects, .. }, .. } => {
+                assert_eq!(name, "next");
+                assert!(matches!(args[0], Expr::IntLit { value: 7, .. }));
+                assert!(effects.contains(Effect::Divergent));
+            }
+            other => panic!("expected ExprStmt(BuiltinCall(next, [7])), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn bare_break_lowers_with_nil_arg() {
+        let m = lower("break");
+        let b = main_body(&m);
+        match &b.stmts[0] {
+            Stmt::ExprStmt { expr: Expr::BuiltinCall { name, args, .. }, .. } => {
+                assert_eq!(name, "break");
+                assert!(matches!(args[0], Expr::NilLit { .. }));
+            }
+            other => panic!("expected ExprStmt(BuiltinCall(break, [nil])), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn break_with_local_var_value_passes_sir_validator() {
+        // Assign `x` first so the VarRef payload resolves, then break
+        // with it; the lowered module must satisfy the SIR validator.
+        let m = lower("x = 1\nbreak x\n");
+        let result = semantic_ir::validate(&m);
+        assert!(result.is_ok(), "validator rejected our output: {:?}", result);
+    }
+
+    // -----------------------------------------------------------------
     // Phase 6k — unary minus → BuiltinCall("neg", [x]).
     // -----------------------------------------------------------------
 


### PR DESCRIPTION
## Phase 11a (FC) — `break`/`next` WITH VALUES (coverage-confirmation)

**Coverage-confirmation phase: NO grammar or lowering change.** This PR
adds test pins only, locking in behavior that the Phase 6j work already
implemented (precedent: 16b / 10a / 22a).

### Why no implementation change

The Phase 6j grammar rules already accept an optional trailing
expression after the loop-control keywords:

```
break_statement = "break" [ expression ] ;
next_statement  = "next"  [ expression ] ;
```

…and the Phase 6j lowering arm
(`return_statement | break_statement | next_statement`) already folds
that expression into the single `BuiltinCall` argument, falling back to
`NilLit` when bare:

```
break 5  → ExprStmt(BuiltinCall("break", [IntLit 5], Divergent))
next 7   → ExprStmt(BuiltinCall("next",  [IntLit 7], Divergent))
break    → ExprStmt(BuiltinCall("break", [NilLit],   Divergent))
```

The pre-existing pins covered `return 42` / bare `return` / `break 1`+`next 1`
and `break 1 + 2`. This PR adds **new angles** so a future grammar or
lowering edit cannot silently drop value-carrying loop control.

### Parser pins (+3, 217 → 220)

- `test_parse_break_with_int_value` — `break 5` (simple integer payload)
- `test_parse_next_with_value` — `next 7` (`next` carrying a value)
- `test_parse_break_with_binary_name_value` — `break x + 1` (`+` token
  survives inside the `break_statement` subtree)

### Lowering pins (+4, 270 → 274)

- `break_with_value_lowers_to_int_arg` — `break 5` → `BuiltinCall("break", [IntLit 5])`, Divergent
- `next_with_value_lowers_to_int_arg` — `next 7` → `BuiltinCall("next", [IntLit 7])`, Divergent
- `bare_break_lowers_with_nil_arg` — `break` → `BuiltinCall("break", [NilLit])`
- `break_with_local_var_value_passes_sir_validator` — `x = 1; break x`
  lowers and passes the SIR validator (the `VarRef` payload resolves)

### Verification

- `cargo test -p coding-adventures-ruby-lexer -p coding-adventures-ruby-parser -p ruby-to-semantic-ir` — all green (parser 220, IR 274).
- `/security-review` — PASSED (test-only diff, no production code paths).

### Changelogs

- `coding-adventures-ruby-parser` 0.61.0 → 0.62.0
- `ruby-to-semantic-ir` 0.64.0 → 0.65.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
