### PR TITLE
feat(ruby-fc): Phase 11b — `redo` keyword

### DIFF
--- a/code/grammars/ruby.grammar
+++ b/code/grammars/ruby.grammar
@@ -25,7 +25,7 @@
 # than PUTS, TRUE, FALSE, NIL as token types.
 
 program      = { statement } ;
-statement    = endless_def_statement | def_statement | class_statement | module_statement | if_statement | unless_statement | while_statement | until_statement | case_statement | begin_statement | return_statement | break_statement | next_statement | yield_statement | super_statement | multi_assignment | modifier_statement | rightward_assignment | assignment | method_with_block | method_call | method_call_no_paren | expression_stmt ;
+statement    = endless_def_statement | def_statement | class_statement | module_statement | if_statement | unless_statement | while_statement | until_statement | case_statement | begin_statement | return_statement | break_statement | next_statement | redo_statement | yield_statement | super_statement | multi_assignment | modifier_statement | rightward_assignment | assignment | method_with_block | method_call | method_call_no_paren | expression_stmt ;
 # Phase 6r — multiple assignment `a, b = 1, 2`.
 #
 # Placed BEFORE `modifier_statement` and `assignment` so the multi-LHS
@@ -153,6 +153,10 @@ block_params = "|" NAME { COMMA NAME } "|" ;
 return_statement = "return" [ expression ] ;
 break_statement  = "break"  [ expression ] ;
 next_statement   = "next"   [ expression ] ;
+# Phase 11b (FC) — `redo` restarts the current loop iteration WITHOUT
+# re-evaluating the loop condition or advancing the iterator.  Unlike
+# `break`/`next`, `redo` never carries a value — it is a bare keyword.
+redo_statement   = "redo" ;
 # Phase 6t — `yield` keyword.  Inside a method body, `yield` invokes
 # the block argument supplied by the caller (if any), forwarding the
 # given arguments to it.  All three surface forms supported:

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.63.0] - 2026-05-31
+
+### Added (Phase 11b (FC) — `redo` keyword)
+
+New `redo_statement` rule, added to the `statement` alternation right
+after `next_statement`:
+
+```
+redo_statement = "redo" ;
+```
+
+`redo` is a Ruby keyword (lexer-tagged KEYWORD) that restarts the
+current loop iteration WITHOUT re-evaluating the loop condition or
+advancing the iterator.  Unlike `break`/`next`, it never carries a
+value — it is a bare keyword with no optional trailing expression.
+`_grammar.rs` regenerated.
+
+New parse pins (+3): `test_parse_redo_bare` (`redo` → `redo_statement`),
+`test_parse_redo_has_no_expression_child` (no `expression` subnode),
+`test_parse_redo_inside_while_body` (`while x; redo; end` — nests in a
+loop body).  Test count: 220 → 223.
+
 ## [0.62.0] - 2026-05-31
 
 ### Added (Phase 11a (FC) — `break`/`next` WITH VALUES, coverage-confirmation)

--- a/code/packages/rust/ruby-parser/src/_grammar.rs
+++ b/code/packages/rust/ruby-parser/src/_grammar.rs
@@ -31,6 +31,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"return_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"break_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"next_statement"#.to_string() },
+                GrammarElement::RuleReference { name: r#"redo_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"yield_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"super_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"multi_assignment"#.to_string() },
@@ -268,12 +269,17 @@ pub fn parser_grammar() -> ParserGrammar {
             line_number: 155,
         },
         GrammarRule {
+            name: r#"redo_statement"#.to_string(),
+            body: GrammarElement::Literal { value: r#"redo"#.to_string() },
+            line_number: 159,
+        },
+        GrammarRule {
             name: r#"yield_statement"#.to_string(),
             body: GrammarElement::Sequence { elements: vec![
                 GrammarElement::Literal { value: r#"yield"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"yield_args"#.to_string() }) },
             ] },
-            line_number: 177,
+            line_number: 181,
         },
         GrammarRule {
             name: r#"yield_args"#.to_string(),
@@ -297,7 +303,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) },
                 ] },
             ] },
-            line_number: 178,
+            line_number: 182,
         },
         GrammarRule {
             name: r#"super_statement"#.to_string(),
@@ -305,7 +311,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"super"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"super_args"#.to_string() }) },
             ] },
-            line_number: 197,
+            line_number: 201,
         },
         GrammarRule {
             name: r#"super_args"#.to_string(),
@@ -329,7 +335,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) },
                 ] },
             ] },
-            line_number: 198,
+            line_number: 202,
         },
         GrammarRule {
             name: r#"params"#.to_string(),
@@ -343,7 +349,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) },
                 ] },
             ] },
-            line_number: 227,
+            line_number: 231,
         },
         GrammarRule {
             name: r#"param"#.to_string(),
@@ -354,7 +360,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
             ] },
-            line_number: 228,
+            line_number: 232,
         },
         GrammarRule {
             name: r#"if_statement"#.to_string(),
@@ -371,7 +377,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 229,
+            line_number: 233,
         },
         GrammarRule {
             name: r#"elsif_clause"#.to_string(),
@@ -385,7 +391,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 230,
+            line_number: 234,
         },
         GrammarRule {
             name: r#"else_clause"#.to_string(),
@@ -396,7 +402,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 231,
+            line_number: 235,
         },
         GrammarRule {
             name: r#"unless_statement"#.to_string(),
@@ -411,7 +417,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 232,
+            line_number: 236,
         },
         GrammarRule {
             name: r#"while_statement"#.to_string(),
@@ -424,7 +430,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 233,
+            line_number: 237,
         },
         GrammarRule {
             name: r#"until_statement"#.to_string(),
@@ -437,7 +443,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 234,
+            line_number: 238,
         },
         GrammarRule {
             name: r#"case_statement"#.to_string(),
@@ -451,7 +457,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 257,
+            line_number: 261,
         },
         GrammarRule {
             name: r#"when_clause"#.to_string(),
@@ -470,7 +476,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 258,
+            line_number: 262,
         },
         GrammarRule {
             name: r#"in_clause"#.to_string(),
@@ -485,7 +491,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 280,
+            line_number: 284,
         },
         GrammarRule {
             name: r#"pattern"#.to_string(),
@@ -495,7 +501,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"literal_pattern"#.to_string() },
                 GrammarElement::RuleReference { name: r#"binding_pattern"#.to_string() },
             ] },
-            line_number: 281,
+            line_number: 285,
         },
         GrammarRule {
             name: r#"literal_pattern"#.to_string(),
@@ -505,12 +511,12 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"symbol_literal"#.to_string() },
                 GrammarElement::TokenReference { name: r#"KEYWORD"#.to_string() },
             ] },
-            line_number: 282,
+            line_number: 286,
         },
         GrammarRule {
             name: r#"binding_pattern"#.to_string(),
             body: GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
-            line_number: 283,
+            line_number: 287,
         },
         GrammarRule {
             name: r#"array_pattern"#.to_string(),
@@ -525,7 +531,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 284,
+            line_number: 288,
         },
         GrammarRule {
             name: r#"hash_pattern"#.to_string(),
@@ -540,7 +546,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 285,
+            line_number: 289,
         },
         GrammarRule {
             name: r#"hash_pattern_pair"#.to_string(),
@@ -549,7 +555,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"pattern"#.to_string() }) },
             ] },
-            line_number: 286,
+            line_number: 290,
         },
         GrammarRule {
             name: r#"begin_statement"#.to_string(),
@@ -565,7 +571,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"ensure_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 307,
+            line_number: 311,
         },
         GrammarRule {
             name: r#"rescue_clause"#.to_string(),
@@ -583,7 +589,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 316,
+            line_number: 320,
         },
         GrammarRule {
             name: r#"exception_list"#.to_string(),
@@ -594,7 +600,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
                     ] }) },
             ] },
-            line_number: 317,
+            line_number: 321,
         },
         GrammarRule {
             name: r#"ensure_clause"#.to_string(),
@@ -605,7 +611,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 318,
+            line_number: 322,
         },
         GrammarRule {
             name: r#"assignment"#.to_string(),
@@ -629,7 +635,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 338,
+            line_number: 342,
         },
         GrammarRule {
             name: r#"rightward_assignment"#.to_string(),
@@ -638,7 +644,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"=>"#.to_string() },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
             ] },
-            line_number: 357,
+            line_number: 361,
         },
         GrammarRule {
             name: r#"method_call"#.to_string(),
@@ -658,7 +664,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"dot_call"#.to_string() }) },
             ] },
-            line_number: 368,
+            line_number: 372,
         },
         GrammarRule {
             name: r#"dot_call"#.to_string(),
@@ -680,7 +686,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                     ] }) },
             ] },
-            line_number: 369,
+            line_number: 373,
         },
         GrammarRule {
             name: r#"scope_resolution"#.to_string(),
@@ -691,7 +697,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"KEYWORD"#.to_string() },
                     ] }) },
             ] },
-            line_number: 377,
+            line_number: 381,
         },
         GrammarRule {
             name: r#"call_arg"#.to_string(),
@@ -703,7 +709,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 407,
+            line_number: 411,
         },
         GrammarRule {
             name: r#"method_call_no_paren"#.to_string(),
@@ -718,17 +724,17 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 421,
+            line_number: 425,
         },
         GrammarRule {
             name: r#"expression_stmt"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"expression"#.to_string() },
-            line_number: 422,
+            line_number: 426,
         },
         GrammarRule {
             name: r#"expression"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"ternary"#.to_string() },
-            line_number: 529,
+            line_number: 533,
         },
         GrammarRule {
             name: r#"ternary"#.to_string(),
@@ -741,7 +747,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 530,
+            line_number: 534,
         },
         GrammarRule {
             name: r#"range"#.to_string(),
@@ -764,7 +770,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) },
                 ] },
             ] },
-            line_number: 531,
+            line_number: 535,
         },
         GrammarRule {
             name: r#"logical_or"#.to_string(),
@@ -778,7 +784,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_and"#.to_string() },
                     ] }) },
             ] },
-            line_number: 532,
+            line_number: 536,
         },
         GrammarRule {
             name: r#"logical_and"#.to_string(),
@@ -792,7 +798,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_not"#.to_string() },
                     ] }) },
             ] },
-            line_number: 533,
+            line_number: 537,
         },
         GrammarRule {
             name: r#"logical_not"#.to_string(),
@@ -803,7 +809,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) }) },
                 GrammarElement::RuleReference { name: r#"comparison"#.to_string() },
             ] },
-            line_number: 540,
+            line_number: 544,
         },
         GrammarRule {
             name: r#"comparison"#.to_string(),
@@ -821,7 +827,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"sum"#.to_string() },
                     ] }) },
             ] },
-            line_number: 541,
+            line_number: 545,
         },
         GrammarRule {
             name: r#"sum"#.to_string(),
@@ -835,7 +841,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term"#.to_string() },
                     ] }) },
             ] },
-            line_number: 542,
+            line_number: 546,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -849,7 +855,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"factor"#.to_string() },
                     ] }) },
             ] },
-            line_number: 543,
+            line_number: 547,
         },
         GrammarRule {
             name: r#"factor"#.to_string(),
@@ -876,7 +882,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"scope_resolution"#.to_string() },
                     ] }) },
             ] },
-            line_number: 553,
+            line_number: 557,
         },
         GrammarRule {
             name: r#"lambda_literal"#.to_string(),
@@ -889,7 +895,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"block"#.to_string() },
             ] },
-            line_number: 572,
+            line_number: 576,
         },
         GrammarRule {
             name: r#"unary_minus"#.to_string(),
@@ -897,7 +903,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"factor"#.to_string() },
             ] },
-            line_number: 573,
+            line_number: 577,
         },
         GrammarRule {
             name: r#"symbol_literal"#.to_string(),
@@ -909,7 +915,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 580,
+            line_number: 584,
         },
         GrammarRule {
             name: r#"array_literal"#.to_string(),
@@ -924,7 +930,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 581,
+            line_number: 585,
         },
         GrammarRule {
             name: r#"hash_literal"#.to_string(),
@@ -939,7 +945,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 582,
+            line_number: 586,
         },
         GrammarRule {
             name: r#"hash_entry"#.to_string(),
@@ -959,7 +965,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                 ] },
             ] },
-            line_number: 583,
+            line_number: 587,
         },
     ],
         version: 1,

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -1339,6 +1339,42 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // Phase 11b — `redo` keyword (restart current loop iteration)
+    //
+    // `redo` is a bare control-flow keyword (lexer-tagged KEYWORD) that
+    // never carries a value.  The grammar rule `redo_statement = "redo"`
+    // sits in the `statement` alternation right after `next_statement`.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_redo_bare() {
+        let ast = parse_ruby("redo");
+        assert!(find_statement_inner(&ast, "redo_statement").is_some());
+    }
+
+    #[test]
+    fn test_parse_redo_has_no_expression_child() {
+        // `redo` carries no operand — unlike `break`/`next`, its subtree
+        // must contain NO `expression` node.
+        let ast = parse_ruby("redo");
+        let r = find_statement_inner(&ast, "redo_statement")
+            .expect("expected redo_statement");
+        assert!(!r
+            .children
+            .iter()
+            .any(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "expression")));
+    }
+
+    #[test]
+    fn test_parse_redo_inside_while_body() {
+        // `redo` is most idiomatic inside a loop body; confirm it parses
+        // as a statement within a `while … end` block.  Use the recursive
+        // descendant search since the keyword nests below the top level.
+        let ast = parse_ruby("while x\n  redo\nend");
+        assert!(find_descendant(&ast, "redo_statement").is_some());
+    }
+
+    // -----------------------------------------------------------------------
     // Phase 6k — unary minus `-5`, `-x`, `-(1+2)`
     // -----------------------------------------------------------------------
 

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.66.0] - 2026-05-31
+
+### Added (Phase 11b (FC) — `redo` keyword)
+
+New `redo_statement` lowering arm:
+
+```
+redo → ExprStmt(BuiltinCall("redo", [], Divergent))
+```
+
+`redo` lowers to a **zero-argument** Divergent `BuiltinCall` — distinct
+from `break`/`next`, which always carry an operand (`NilLit` when bare).
+It restarts the current loop iteration without re-checking the loop
+condition, so it diverges from straight-line control flow.  No new SIR
+variant: it reuses the existing `BuiltinCall` envelope, so the walker,
+validator, printer, and all four backends handle it generically by name
+(same as `break`/`next`/`yield`/`super`).
+
+New lowering pins (+3): `redo_lowers_to_zero_arg_divergent_builtin`
+(`redo` → `redo`, 0 args, Divergent),
+`redo_inside_while_body_lowers` (`while x; redo; end` — the marker lands
+inside the `Stmt::While` body), `redo_module_passes_sir_validator`
+(validates).  Test count: 274 → 277.
+
 ## [0.65.0] - 2026-05-31
 
 ### Added (Phase 11a (FC) — `break`/`next` WITH VALUES, coverage-confirmation)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -1677,6 +1677,53 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
+    // Phase 11b — `redo` keyword (restart current loop iteration)
+    //
+    // `redo` lowers to a ZERO-argument Divergent BuiltinCall, distinct
+    // from `break`/`next` (which always carry an operand, NilLit when
+    // bare).  It restarts the current loop iteration without re-checking
+    // the condition, so it diverges from straight-line control flow.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn redo_lowers_to_zero_arg_divergent_builtin() {
+        let m = lower("redo");
+        let b = main_body(&m);
+        match &b.stmts[0] {
+            Stmt::ExprStmt { expr: Expr::BuiltinCall { name, args, effects, .. }, .. } => {
+                assert_eq!(name, "redo");
+                assert!(args.is_empty(), "redo carries no operand, got {:?}", args);
+                assert!(effects.contains(Effect::Divergent));
+            }
+            other => panic!("expected ExprStmt(BuiltinCall(redo, [])), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn redo_inside_while_body_lowers() {
+        // `redo` nested in a loop body still lowers to its builtin; find
+        // the `Stmt::While` and confirm its body holds BuiltinCall(redo).
+        let m = lower("x = 0\nwhile x\n  redo\nend\n");
+        let b = main_body(&m);
+        let while_body = b.stmts.iter().find_map(|s| match s {
+            Stmt::While { body, .. } => Some(body),
+            _ => None,
+        }).expect("expected a Stmt::While in the module body");
+        let has_redo = while_body.stmts.iter().any(|s| matches!(
+            s,
+            Stmt::ExprStmt { expr: Expr::BuiltinCall { name, .. }, .. } if name == "redo"
+        ));
+        assert!(has_redo, "expected BuiltinCall(redo) in the while body");
+    }
+
+    #[test]
+    fn redo_module_passes_sir_validator() {
+        let m = lower("x = 0\nwhile x\n  redo\nend\n");
+        let result = semantic_ir::validate(&m);
+        assert!(result.is_ok(), "validator rejected our output: {:?}", result);
+    }
+
+    // -----------------------------------------------------------------
     // Phase 6k — unary minus → BuiltinCall("neg", [x]).
     // -----------------------------------------------------------------
 

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -917,6 +917,24 @@ impl Lowerer {
                     span: self.span_of(node),
                 })
             }
+            "redo_statement" => {
+                // Phase 11b: `redo` restarts the current loop iteration
+                // without re-checking the condition.  It is a bare
+                // keyword that never carries a value, so it lowers to a
+                // zero-argument Divergent BuiltinCall — distinct from
+                // `break`/`next`, which always carry an operand (NilLit
+                // when bare).  No `expression` child to inspect.
+                let expr = Expr::BuiltinCall {
+                    name: "redo".to_string(),
+                    args: vec![],
+                    effects: EffectSet::PURE.with(Effect::Divergent),
+                    span: self.span_of(node),
+                };
+                Ok(Stmt::ExprStmt {
+                    expr,
+                    span: self.span_of(node),
+                })
+            }
             other => Err(RubyLowerError {
                 message: format!("unsupported statement form `{other}`"),
                 line: node.start_line.unwrap_or(0),


### PR DESCRIPTION
## Phase 11b (FC) — `redo` keyword

Adds support for Ruby's `redo` loop-control keyword, which restarts the
**current** loop iteration without re-evaluating the loop condition or
advancing the iterator. Unlike `break`/`next`, `redo` never carries a
value — it is a bare keyword.

### Grammar

New rule, placed in the `statement` alternation right after
`next_statement`:

```
redo_statement = "redo" ;
```

`redo` already lexes as a `KEYWORD` (it was in the lexer's keyword set),
so no lexer change is required. `_grammar.rs` regenerated via
`grammar-tools`.

### Lowering

New `redo_statement` arm lowers to a **zero-argument** Divergent
`BuiltinCall`:

```
redo → ExprStmt(BuiltinCall("redo", [], Divergent))
```

This is deliberately distinct from `break`/`next`, which always carry an
operand (`NilLit` when bare). **No new SIR variant** — `redo` reuses the
existing `BuiltinCall` envelope, so the walker, validator, printer, and
all four backends handle it generically by name (exactly as
`break`/`next`/`yield`/`super` are).

### Parser pins (+3, 220 → 223)

- `test_parse_redo_bare` — `redo` → `redo_statement`
- `test_parse_redo_has_no_expression_child` — confirms no `expression` subnode
- `test_parse_redo_inside_while_body` — `while x; redo; end` nests correctly

### Lowering pins (+3, 274 → 277)

- `redo_lowers_to_zero_arg_divergent_builtin` — `redo` → `BuiltinCall("redo", [])`, Divergent
- `redo_inside_while_body_lowers` — the marker lands inside the `Stmt::While` body
- `redo_module_passes_sir_validator` — `x = 0; while x; redo; end` validates

### Verification

- `cargo test -p coding-adventures-ruby-lexer -p coding-adventures-ruby-parser -p ruby-to-semantic-ir` — all green (parser 223, IR 277).
- `/security-review` — PASSED (no I/O, no unsafe, fixed-string builtin name, no user data in sensitive paths).

### Changelogs

- `coding-adventures-ruby-parser` 0.62.0 → 0.63.0
- `ruby-to-semantic-ir` 0.65.0 → 0.66.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
