### PR TITLE
feat(ruby-fc): Phase 11c — `retry` keyword

### DIFF
--- a/code/grammars/ruby.grammar
+++ b/code/grammars/ruby.grammar
@@ -25,7 +25,7 @@
 # than PUTS, TRUE, FALSE, NIL as token types.
 
 program      = { statement } ;
-statement    = endless_def_statement | def_statement | class_statement | module_statement | if_statement | unless_statement | while_statement | until_statement | case_statement | begin_statement | return_statement | break_statement | next_statement | redo_statement | yield_statement | super_statement | multi_assignment | modifier_statement | rightward_assignment | assignment | method_with_block | method_call | method_call_no_paren | expression_stmt ;
+statement    = endless_def_statement | def_statement | class_statement | module_statement | if_statement | unless_statement | while_statement | until_statement | case_statement | begin_statement | return_statement | break_statement | next_statement | redo_statement | retry_statement | yield_statement | super_statement | multi_assignment | modifier_statement | rightward_assignment | assignment | method_with_block | method_call | method_call_no_paren | expression_stmt ;
 # Phase 6r — multiple assignment `a, b = 1, 2`.
 #
 # Placed BEFORE `modifier_statement` and `assignment` so the multi-LHS
@@ -157,6 +157,10 @@ next_statement   = "next"   [ expression ] ;
 # re-evaluating the loop condition or advancing the iterator.  Unlike
 # `break`/`next`, `redo` never carries a value — it is a bare keyword.
 redo_statement   = "redo" ;
+# Phase 11c (FC) — `retry` re-executes the enclosing `begin` block from
+# the top (inside a `rescue` clause).  Like `redo`, it is a bare keyword
+# that never carries a value.
+retry_statement  = "retry" ;
 # Phase 6t — `yield` keyword.  Inside a method body, `yield` invokes
 # the block argument supplied by the caller (if any), forwarding the
 # given arguments to it.  All three surface forms supported:

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.64.0] - 2026-05-31
+
+### Added (Phase 11c (FC) — `retry` keyword)
+
+New `retry_statement` rule, added to the `statement` alternation right
+after `redo_statement`:
+
+```
+retry_statement = "retry" ;
+```
+
+`retry` is a Ruby keyword (lexer-tagged KEYWORD) that re-executes the
+enclosing `begin` block from the top, inside a `rescue` clause.  Like
+`redo`, it is a bare keyword that never carries a value.  `_grammar.rs`
+regenerated.
+
+New parse pins (+3): `test_parse_retry_bare` (`retry` → `retry_statement`),
+`test_parse_retry_has_no_expression_child` (no `expression` subnode),
+`test_parse_retry_inside_begin_rescue_body`
+(`begin; x = 1; rescue; retry; end` — nests in a rescue clause).
+Test count: 223 → 226.
+
 ## [0.63.0] - 2026-05-31
 
 ### Added (Phase 11b (FC) — `redo` keyword)

--- a/code/packages/rust/ruby-parser/src/_grammar.rs
+++ b/code/packages/rust/ruby-parser/src/_grammar.rs
@@ -32,6 +32,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"break_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"next_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"redo_statement"#.to_string() },
+                GrammarElement::RuleReference { name: r#"retry_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"yield_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"super_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"multi_assignment"#.to_string() },
@@ -274,12 +275,17 @@ pub fn parser_grammar() -> ParserGrammar {
             line_number: 159,
         },
         GrammarRule {
+            name: r#"retry_statement"#.to_string(),
+            body: GrammarElement::Literal { value: r#"retry"#.to_string() },
+            line_number: 163,
+        },
+        GrammarRule {
             name: r#"yield_statement"#.to_string(),
             body: GrammarElement::Sequence { elements: vec![
                 GrammarElement::Literal { value: r#"yield"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"yield_args"#.to_string() }) },
             ] },
-            line_number: 181,
+            line_number: 185,
         },
         GrammarRule {
             name: r#"yield_args"#.to_string(),
@@ -303,7 +309,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) },
                 ] },
             ] },
-            line_number: 182,
+            line_number: 186,
         },
         GrammarRule {
             name: r#"super_statement"#.to_string(),
@@ -311,7 +317,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"super"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"super_args"#.to_string() }) },
             ] },
-            line_number: 201,
+            line_number: 205,
         },
         GrammarRule {
             name: r#"super_args"#.to_string(),
@@ -335,7 +341,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) },
                 ] },
             ] },
-            line_number: 202,
+            line_number: 206,
         },
         GrammarRule {
             name: r#"params"#.to_string(),
@@ -349,7 +355,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) },
                 ] },
             ] },
-            line_number: 231,
+            line_number: 235,
         },
         GrammarRule {
             name: r#"param"#.to_string(),
@@ -360,7 +366,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
             ] },
-            line_number: 232,
+            line_number: 236,
         },
         GrammarRule {
             name: r#"if_statement"#.to_string(),
@@ -377,7 +383,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 233,
+            line_number: 237,
         },
         GrammarRule {
             name: r#"elsif_clause"#.to_string(),
@@ -391,7 +397,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 234,
+            line_number: 238,
         },
         GrammarRule {
             name: r#"else_clause"#.to_string(),
@@ -402,7 +408,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 235,
+            line_number: 239,
         },
         GrammarRule {
             name: r#"unless_statement"#.to_string(),
@@ -417,7 +423,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 236,
+            line_number: 240,
         },
         GrammarRule {
             name: r#"while_statement"#.to_string(),
@@ -430,7 +436,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 237,
+            line_number: 241,
         },
         GrammarRule {
             name: r#"until_statement"#.to_string(),
@@ -443,7 +449,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 238,
+            line_number: 242,
         },
         GrammarRule {
             name: r#"case_statement"#.to_string(),
@@ -457,7 +463,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 261,
+            line_number: 265,
         },
         GrammarRule {
             name: r#"when_clause"#.to_string(),
@@ -476,7 +482,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 262,
+            line_number: 266,
         },
         GrammarRule {
             name: r#"in_clause"#.to_string(),
@@ -491,7 +497,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 284,
+            line_number: 288,
         },
         GrammarRule {
             name: r#"pattern"#.to_string(),
@@ -501,7 +507,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"literal_pattern"#.to_string() },
                 GrammarElement::RuleReference { name: r#"binding_pattern"#.to_string() },
             ] },
-            line_number: 285,
+            line_number: 289,
         },
         GrammarRule {
             name: r#"literal_pattern"#.to_string(),
@@ -511,12 +517,12 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"symbol_literal"#.to_string() },
                 GrammarElement::TokenReference { name: r#"KEYWORD"#.to_string() },
             ] },
-            line_number: 286,
+            line_number: 290,
         },
         GrammarRule {
             name: r#"binding_pattern"#.to_string(),
             body: GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
-            line_number: 287,
+            line_number: 291,
         },
         GrammarRule {
             name: r#"array_pattern"#.to_string(),
@@ -531,7 +537,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 288,
+            line_number: 292,
         },
         GrammarRule {
             name: r#"hash_pattern"#.to_string(),
@@ -546,7 +552,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 289,
+            line_number: 293,
         },
         GrammarRule {
             name: r#"hash_pattern_pair"#.to_string(),
@@ -555,7 +561,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"pattern"#.to_string() }) },
             ] },
-            line_number: 290,
+            line_number: 294,
         },
         GrammarRule {
             name: r#"begin_statement"#.to_string(),
@@ -571,7 +577,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"ensure_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 311,
+            line_number: 315,
         },
         GrammarRule {
             name: r#"rescue_clause"#.to_string(),
@@ -589,7 +595,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 320,
+            line_number: 324,
         },
         GrammarRule {
             name: r#"exception_list"#.to_string(),
@@ -600,7 +606,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
                     ] }) },
             ] },
-            line_number: 321,
+            line_number: 325,
         },
         GrammarRule {
             name: r#"ensure_clause"#.to_string(),
@@ -611,7 +617,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 322,
+            line_number: 326,
         },
         GrammarRule {
             name: r#"assignment"#.to_string(),
@@ -635,7 +641,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 342,
+            line_number: 346,
         },
         GrammarRule {
             name: r#"rightward_assignment"#.to_string(),
@@ -644,7 +650,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"=>"#.to_string() },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
             ] },
-            line_number: 361,
+            line_number: 365,
         },
         GrammarRule {
             name: r#"method_call"#.to_string(),
@@ -664,7 +670,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"dot_call"#.to_string() }) },
             ] },
-            line_number: 372,
+            line_number: 376,
         },
         GrammarRule {
             name: r#"dot_call"#.to_string(),
@@ -686,7 +692,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                     ] }) },
             ] },
-            line_number: 373,
+            line_number: 377,
         },
         GrammarRule {
             name: r#"scope_resolution"#.to_string(),
@@ -697,7 +703,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"KEYWORD"#.to_string() },
                     ] }) },
             ] },
-            line_number: 381,
+            line_number: 385,
         },
         GrammarRule {
             name: r#"call_arg"#.to_string(),
@@ -709,7 +715,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 411,
+            line_number: 415,
         },
         GrammarRule {
             name: r#"method_call_no_paren"#.to_string(),
@@ -724,17 +730,17 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 425,
+            line_number: 429,
         },
         GrammarRule {
             name: r#"expression_stmt"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"expression"#.to_string() },
-            line_number: 426,
+            line_number: 430,
         },
         GrammarRule {
             name: r#"expression"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"ternary"#.to_string() },
-            line_number: 533,
+            line_number: 537,
         },
         GrammarRule {
             name: r#"ternary"#.to_string(),
@@ -747,7 +753,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 534,
+            line_number: 538,
         },
         GrammarRule {
             name: r#"range"#.to_string(),
@@ -770,7 +776,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) },
                 ] },
             ] },
-            line_number: 535,
+            line_number: 539,
         },
         GrammarRule {
             name: r#"logical_or"#.to_string(),
@@ -784,7 +790,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_and"#.to_string() },
                     ] }) },
             ] },
-            line_number: 536,
+            line_number: 540,
         },
         GrammarRule {
             name: r#"logical_and"#.to_string(),
@@ -798,7 +804,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_not"#.to_string() },
                     ] }) },
             ] },
-            line_number: 537,
+            line_number: 541,
         },
         GrammarRule {
             name: r#"logical_not"#.to_string(),
@@ -809,7 +815,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) }) },
                 GrammarElement::RuleReference { name: r#"comparison"#.to_string() },
             ] },
-            line_number: 544,
+            line_number: 548,
         },
         GrammarRule {
             name: r#"comparison"#.to_string(),
@@ -827,7 +833,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"sum"#.to_string() },
                     ] }) },
             ] },
-            line_number: 545,
+            line_number: 549,
         },
         GrammarRule {
             name: r#"sum"#.to_string(),
@@ -841,7 +847,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term"#.to_string() },
                     ] }) },
             ] },
-            line_number: 546,
+            line_number: 550,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -855,7 +861,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"factor"#.to_string() },
                     ] }) },
             ] },
-            line_number: 547,
+            line_number: 551,
         },
         GrammarRule {
             name: r#"factor"#.to_string(),
@@ -882,7 +888,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"scope_resolution"#.to_string() },
                     ] }) },
             ] },
-            line_number: 557,
+            line_number: 561,
         },
         GrammarRule {
             name: r#"lambda_literal"#.to_string(),
@@ -895,7 +901,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"block"#.to_string() },
             ] },
-            line_number: 576,
+            line_number: 580,
         },
         GrammarRule {
             name: r#"unary_minus"#.to_string(),
@@ -903,7 +909,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"factor"#.to_string() },
             ] },
-            line_number: 577,
+            line_number: 581,
         },
         GrammarRule {
             name: r#"symbol_literal"#.to_string(),
@@ -915,7 +921,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 584,
+            line_number: 588,
         },
         GrammarRule {
             name: r#"array_literal"#.to_string(),
@@ -930,7 +936,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 585,
+            line_number: 589,
         },
         GrammarRule {
             name: r#"hash_literal"#.to_string(),
@@ -945,7 +951,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 586,
+            line_number: 590,
         },
         GrammarRule {
             name: r#"hash_entry"#.to_string(),
@@ -965,7 +971,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                 ] },
             ] },
-            line_number: 587,
+            line_number: 591,
         },
     ],
         version: 1,

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -1375,6 +1375,42 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // Phase 11c — `retry` keyword (re-execute enclosing begin block)
+    //
+    // `retry` is a bare control-flow keyword (lexer-tagged KEYWORD) that
+    // never carries a value.  The grammar rule `retry_statement = "retry"`
+    // sits in the `statement` alternation right after `redo_statement`.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_retry_bare() {
+        let ast = parse_ruby("retry");
+        assert!(find_statement_inner(&ast, "retry_statement").is_some());
+    }
+
+    #[test]
+    fn test_parse_retry_has_no_expression_child() {
+        // `retry` carries no operand — its subtree must contain NO
+        // `expression` node (like `redo`, unlike `break`/`next`).
+        let ast = parse_ruby("retry");
+        let r = find_statement_inner(&ast, "retry_statement")
+            .expect("expected retry_statement");
+        assert!(!r
+            .children
+            .iter()
+            .any(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "expression")));
+    }
+
+    #[test]
+    fn test_parse_retry_inside_begin_rescue_body() {
+        // `retry` is idiomatic inside a `rescue` clause; confirm it parses
+        // as a statement within a `begin … rescue … end` block.  Use the
+        // recursive descendant search since the keyword nests deep.
+        let ast = parse_ruby("begin\n  x = 1\nrescue\n  retry\nend");
+        assert!(find_descendant(&ast, "retry_statement").is_some());
+    }
+
+    // -----------------------------------------------------------------------
     // Phase 6k — unary minus `-5`, `-x`, `-(1+2)`
     // -----------------------------------------------------------------------
 

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.67.0] - 2026-05-31
+
+### Added (Phase 11c (FC) — `retry` keyword)
+
+New `retry_statement` lowering, folded into the Phase 11b arm
+(`redo_statement | retry_statement`):
+
+```
+retry → ExprStmt(BuiltinCall("retry", [], Divergent))
+```
+
+`retry` mirrors `redo`: a bare keyword lowering to a **zero-argument**
+Divergent `BuiltinCall`.  It re-executes the enclosing `begin` block
+from the top inside a `rescue` clause, so it diverges from straight-line
+control flow.  No new SIR variant — it reuses the existing `BuiltinCall`
+envelope, so the walker, validator, printer, and all four backends
+handle it generically by name (same as `redo`/`break`/`next`).
+
+New lowering pins (+3): `retry_lowers_to_zero_arg_divergent_builtin`
+(`retry` → `retry`, 0 args, Divergent),
+`retry_inside_begin_rescue_lowers` (`begin; x = 1; rescue; retry; end`
+— the marker lands inside a `Stmt::TryCatch` rescue-clause body),
+`retry_module_passes_sir_validator` (validates).  Test count: 277 → 280.
+
 ## [0.66.0] - 2026-05-31
 
 ### Added (Phase 11b (FC) — `redo` keyword)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -1724,6 +1724,54 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
+    // Phase 11c — `retry` keyword (re-execute enclosing begin block)
+    //
+    // `retry` mirrors `redo`: a bare keyword lowering to a ZERO-argument
+    // Divergent BuiltinCall.  It re-runs the enclosing `begin` block from
+    // the top inside a `rescue` clause, so it diverges from straight-line
+    // control flow.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn retry_lowers_to_zero_arg_divergent_builtin() {
+        let m = lower("retry");
+        let b = main_body(&m);
+        match &b.stmts[0] {
+            Stmt::ExprStmt { expr: Expr::BuiltinCall { name, args, effects, .. }, .. } => {
+                assert_eq!(name, "retry");
+                assert!(args.is_empty(), "retry carries no operand, got {:?}", args);
+                assert!(effects.contains(Effect::Divergent));
+            }
+            other => panic!("expected ExprStmt(BuiltinCall(retry, [])), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn retry_inside_begin_rescue_lowers() {
+        // `retry` nested in a rescue clause lowers to its builtin; find
+        // the `Stmt::TryCatch` and confirm its catch block holds
+        // BuiltinCall(retry).
+        let m = lower("begin\n  x = 1\nrescue\n  retry\nend\n");
+        let b = main_body(&m);
+        let rescues = b.stmts.iter().find_map(|s| match s {
+            Stmt::TryCatch { rescues, .. } => Some(rescues),
+            _ => None,
+        }).expect("expected a Stmt::TryCatch in the module body");
+        let has_retry = rescues.iter().any(|rc| rc.body.iter().any(|s| matches!(
+            s,
+            Stmt::ExprStmt { expr: Expr::BuiltinCall { name, .. }, .. } if name == "retry"
+        )));
+        assert!(has_retry, "expected BuiltinCall(retry) in a rescue clause body");
+    }
+
+    #[test]
+    fn retry_module_passes_sir_validator() {
+        let m = lower("begin\n  x = 1\nrescue\n  retry\nend\n");
+        let result = semantic_ir::validate(&m);
+        assert!(result.is_ok(), "validator rejected our output: {:?}", result);
+    }
+
+    // -----------------------------------------------------------------
     // Phase 6k — unary minus → BuiltinCall("neg", [x]).
     // -----------------------------------------------------------------
 

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -917,15 +917,22 @@ impl Lowerer {
                     span: self.span_of(node),
                 })
             }
-            "redo_statement" => {
-                // Phase 11b: `redo` restarts the current loop iteration
-                // without re-checking the condition.  It is a bare
-                // keyword that never carries a value, so it lowers to a
+            "redo_statement" | "retry_statement" => {
+                // Phase 11b/11c: `redo` restarts the current loop
+                // iteration without re-checking the condition; `retry`
+                // re-executes the enclosing `begin` block from the top
+                // (inside a `rescue` clause).  Both are bare keywords
+                // that never carry a value, so they lower to a
                 // zero-argument Divergent BuiltinCall — distinct from
                 // `break`/`next`, which always carry an operand (NilLit
                 // when bare).  No `expression` child to inspect.
+                let name = match node.rule_name.as_str() {
+                    "redo_statement" => "redo",
+                    "retry_statement" => "retry",
+                    _ => unreachable!(),
+                };
                 let expr = Expr::BuiltinCall {
-                    name: "redo".to_string(),
+                    name: name.to_string(),
                     args: vec![],
                     effects: EffectSet::PURE.with(Effect::Divergent),
                     span: self.span_of(node),


### PR DESCRIPTION
## Phase 11c (FC) — `retry` keyword

Adds support for Ruby's `retry` keyword, which re-executes the enclosing
`begin` block from the top, inside a `rescue` clause. Like `redo`, it is
a bare keyword that never carries a value. This mirrors the Phase 11b
`redo` implementation exactly.

### Grammar

New rule, placed in the `statement` alternation right after
`redo_statement`:

```
retry_statement = "retry" ;
```

`retry` already lexes as a `KEYWORD` (it was in the lexer's keyword set),
so no lexer change is required. `_grammar.rs` regenerated via
`grammar-tools`.

### Lowering

The Phase 11b arm now matches `redo_statement | retry_statement` and
keys the builtin name off the rule, lowering to a **zero-argument**
Divergent `BuiltinCall`:

```
retry → ExprStmt(BuiltinCall("retry", [], Divergent))
```

**No new SIR variant** — `retry` reuses the existing `BuiltinCall`
envelope, so the walker, validator, printer, and all four backends
handle it generically by name (exactly as `redo`/`break`/`next` are).

### Parser pins (+3, 223 → 226)

- `test_parse_retry_bare` — `retry` → `retry_statement`
- `test_parse_retry_has_no_expression_child` — confirms no `expression` subnode
- `test_parse_retry_inside_begin_rescue_body` — `begin; x = 1; rescue; retry; end` nests correctly

### Lowering pins (+3, 277 → 280)

- `retry_lowers_to_zero_arg_divergent_builtin` — `retry` → `BuiltinCall("retry", [])`, Divergent
- `retry_inside_begin_rescue_lowers` — the marker lands inside a `Stmt::TryCatch` rescue-clause body
- `retry_module_passes_sir_validator` — `begin; x = 1; rescue; retry; end` validates

### Verification

- `cargo test -p coding-adventures-ruby-lexer -p coding-adventures-ruby-parser -p ruby-to-semantic-ir` — all green (parser 226, IR 280).
- `/security-review` — PASSED (constant builtin name, no I/O, no unsafe, no user data in sensitive paths).

### Changelogs

- `coding-adventures-ruby-parser` 0.63.0 → 0.64.0
- `ruby-to-semantic-ir` 0.66.0 → 0.67.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
