### PR TITLE
test(ruby-fc): Phase 11d — pin `return` WITH VALUE (coverage-confirmation)

### DIFF
--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.65.0] - 2026-05-31
+
+### Added (Phase 11d (FC) — `return` WITH VALUE, coverage-confirmation)
+
+No grammar change.  The Phase 6j rule already accepts an optional
+trailing expression after `return`:
+
+```
+return_statement = "return" [ expression ] ;
+```
+
+The pre-existing pins covered `return 42`, bare `return`, and
+`return x + 1` inside a def.  These pins add new payload shapes from
+fresh angles so a future grammar edit cannot silently drop
+value-carrying returns.
+
+New parse pins (+3): `test_parse_return_with_array_value` (`return [1, 2]`),
+`test_parse_return_with_string_value` (`return "ok"`),
+`test_parse_return_with_paren_value` (`return (1 + 2)`, `+` token
+survives).  Test count: 226 → 229.
+
 ## [0.64.0] - 2026-05-31
 
 ### Added (Phase 11c (FC) — `retry` keyword)

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -1411,6 +1411,53 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // Phase 11d — `return` WITH VALUE (coverage-confirmation)
+    //
+    // The Phase 6j rule `return_statement = "return" [ expression ]` already
+    // accepts a trailing expression.  Existing pins cover `return 42`, bare
+    // `return`, and `return x + 1` inside a def.  These pins lock in new
+    // payload shapes — an array literal, a string literal, and a
+    // parenthesized binary expression — so a future grammar edit cannot
+    // silently drop value-carrying returns.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_return_with_array_value() {
+        let ast = parse_ruby("return [1, 2]");
+        let r = find_statement_inner(&ast, "return_statement")
+            .expect("expected return_statement");
+        assert!(r
+            .children
+            .iter()
+            .any(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "expression")));
+    }
+
+    #[test]
+    fn test_parse_return_with_string_value() {
+        let ast = parse_ruby("return \"ok\"");
+        let r = find_statement_inner(&ast, "return_statement")
+            .expect("expected return_statement");
+        assert!(r
+            .children
+            .iter()
+            .any(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "expression")));
+    }
+
+    #[test]
+    fn test_parse_return_with_paren_value() {
+        // `return (1 + 2)` — parenthesized payload; the `+` token must
+        // survive somewhere inside the return_statement subtree.
+        let ast = parse_ruby("return (1 + 2)");
+        let r = find_statement_inner(&ast, "return_statement")
+            .expect("expected return_statement");
+        assert!(r
+            .children
+            .iter()
+            .any(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "expression")));
+        assert!(tree_has_token_value(r, "+"));
+    }
+
+    // -----------------------------------------------------------------------
     // Phase 6k — unary minus `-5`, `-x`, `-(1+2)`
     // -----------------------------------------------------------------------
 

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.68.0] - 2026-05-31
+
+### Added (Phase 11d (FC) — `return` WITH VALUE, coverage-confirmation)
+
+No lowering change.  The Phase 6j arm already folds an optional trailing
+expression after `return` into the single `BuiltinCall` argument
+(bare → `NilLit`):
+
+```
+return [1, 2]  → ExprStmt(BuiltinCall("return", [SeqLit ...], Divergent))
+return "ok"    → ExprStmt(BuiltinCall("return", [StrLit ...], Divergent))
+```
+
+The pre-existing pins covered `return 42`, bare `return`, `return x + 1`
+inside a def, and a def-body validator run.  These pins add new payload
+angles so the value-carrying contract stays nailed down.
+
+New lowering pins (+3): `return_with_array_value_lowers_to_seqlit_arg`
+(`return [1, 2]` → `SeqLit` arg, Divergent),
+`return_with_string_value_lowers_to_strlit_arg` (`return "ok"` →
+`StrLit` arg, Divergent),
+`return_with_top_level_local_value_passes_sir_validator`
+(`x = 5; return x` at top level validates — distinct from the existing
+def-body pin).  Test count: 280 → 283.
+
 ## [0.67.0] - 2026-05-31
 
 ### Added (Phase 11c (FC) — `retry` keyword)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -1772,6 +1772,55 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
+    // Phase 11d — `return` WITH VALUE (coverage-confirmation)
+    //
+    // The Phase 6j arm already folds an optional trailing expression
+    // after `return` into the single BuiltinCall argument (bare ->
+    // NilLit).  Existing pins cover `return 42`, bare `return`, and
+    // `return x + 1` inside a def, plus a def-body validator run.  These
+    // pins lock the contract from new payload angles: an array literal,
+    // a string literal, and a validator end-to-end run where the payload
+    // is a top-level local (distinct from the existing def-body pin).
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn return_with_array_value_lowers_to_seqlit_arg() {
+        let m = lower("return [1, 2]");
+        let b = main_body(&m);
+        match &b.stmts[0] {
+            Stmt::ExprStmt { expr: Expr::BuiltinCall { name, args, effects, .. }, .. } => {
+                assert_eq!(name, "return");
+                assert!(matches!(args[0], Expr::SeqLit { .. }), "got {:?}", args[0]);
+                assert!(effects.contains(Effect::Divergent));
+            }
+            other => panic!("expected ExprStmt(BuiltinCall(return, [array])), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn return_with_string_value_lowers_to_strlit_arg() {
+        let m = lower("return \"ok\"");
+        let b = main_body(&m);
+        match &b.stmts[0] {
+            Stmt::ExprStmt { expr: Expr::BuiltinCall { name, args, effects, .. }, .. } => {
+                assert_eq!(name, "return");
+                assert!(matches!(args[0], Expr::StrLit { .. }), "got {:?}", args[0]);
+                assert!(effects.contains(Effect::Divergent));
+            }
+            other => panic!("expected ExprStmt(BuiltinCall(return, [string])), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn return_with_top_level_local_value_passes_sir_validator() {
+        // Assign `x` first so the VarRef payload resolves, then return it
+        // at top level (distinct from the existing def-body validator pin).
+        let m = lower("x = 5\nreturn x\n");
+        let result = semantic_ir::validate(&m);
+        assert!(result.is_ok(), "validator rejected our output: {:?}", result);
+    }
+
+    // -----------------------------------------------------------------
     // Phase 6k — unary minus → BuiltinCall("neg", [x]).
     // -----------------------------------------------------------------
 


### PR DESCRIPTION
## Phase 11d (FC) — `return` WITH VALUE (coverage-confirmation)

**Coverage-confirmation phase: NO grammar or lowering change.** Test pins
only, locking in behavior the Phase 6j work already implemented
(precedent: 11a / 16b / 22a).

### Why no implementation change

The Phase 6j rule already accepts an optional trailing expression after
`return`, and the Phase 6j lowering arm already folds it into the single
`BuiltinCall` argument (bare → `NilLit`):

```
return [1, 2]  → ExprStmt(BuiltinCall("return", [SeqLit ...], Divergent))
return "ok"    → ExprStmt(BuiltinCall("return", [StrLit ...], Divergent))
```

Pre-existing pins covered `return 42`, bare `return`, `return x + 1`
inside a def, and a def-body validator run. This PR adds **new payload
angles** so a future grammar/lowering edit cannot silently drop
value-carrying returns.

### Parser pins (+3, 226 → 229)

- `test_parse_return_with_array_value` — `return [1, 2]`
- `test_parse_return_with_string_value` — `return "ok"`
- `test_parse_return_with_paren_value` — `return (1 + 2)` (`+` token survives)

### Lowering pins (+3, 280 → 283)

- `return_with_array_value_lowers_to_seqlit_arg` — `return [1, 2]` → `BuiltinCall("return", [SeqLit])`, Divergent
- `return_with_string_value_lowers_to_strlit_arg` — `return "ok"` → `BuiltinCall("return", [StrLit])`, Divergent
- `return_with_top_level_local_value_passes_sir_validator` — `x = 5; return x` at top level validates (distinct from the existing def-body pin)

### Verification

- `cargo test -p coding-adventures-ruby-lexer -p coding-adventures-ruby-parser -p ruby-to-semantic-ir` — all green (lexer 173, parser 229, IR 283).
- `/security-review` — PASSED (test-only diff, no production code paths).

### Changelogs

- `coding-adventures-ruby-parser` 0.64.0 → 0.65.0
- `ruby-to-semantic-ir` 0.67.0 → 0.68.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
