### PR TITLE
feat(ruby-fc): Phase 21a — block-local variables `{ |x; y| ... }`

### DIFF
--- a/code/grammars/ruby.grammar
+++ b/code/grammars/ruby.grammar
@@ -148,7 +148,16 @@ method_with_block = ( NAME | KEYWORD ) [ LPAREN [ expression { COMMA expression 
 block        = do_block | brace_block ;
 do_block     = "do" [ block_params ] { !"end" statement } "end" ;
 brace_block  = LBRACE [ block_params ] { statement } RBRACE ;
-block_params = "|" NAME { COMMA NAME } "|" ;
+# Phase 21a (FC) — block-local variables.  After the regular block
+# parameters, an optional `;` introduces a list of *block-local*
+# variables: `{ |x; y, z| … }`.  These are fresh locals scoped to the
+# block body (they shadow any same-named outer binding and never bind
+# to an argument).  The `;` is a `Semicolon` token; the names after it
+# are ordinary `NAME` tokens, so the lowerer splits the pipe contents
+# at the semicolon: names before it are params, names after it are
+# block-locals (declared in the block's local scope but NOT added to
+# the parameter list).
+block_params = "|" NAME { COMMA NAME } [ ";" NAME { COMMA NAME } ] "|" ;
 # Phase 6j — control-flow keywords: `return`, `break`, `next`.
 return_statement = "return" [ expression ] ;
 break_statement  = "break"  [ expression ] ;

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.66.0] - 2026-05-31
+
+### Added (Phase 21a (FC) — block-local variables `{ |x; y| … }`)
+
+The `block_params` rule now accepts an optional `;`-introduced list of
+block-local variables after the regular parameters:
+
+```
+block_params = "|" NAME { COMMA NAME } [ ";" NAME { COMMA NAME } ] "|" ;
+```
+
+`{ |x; y, z| … }` declares `x` as a block parameter and `y`, `z` as
+fresh block-local variables scoped to the body.  The `;` is a
+`Semicolon` token; the lexer already emits it, so only the grammar rule
+(and a regen of `_grammar.rs`) was needed on the parser side.
+
+New parse pins (+3): `test_parse_brace_block_with_one_block_local`
+(`{ |x; y| x }` — Semicolon token + names `x`,`y`),
+`test_parse_do_block_with_two_block_locals` (`do |a; b, c|` — names
+`a`,`b`,`c`), `test_parse_block_without_locals_has_no_semicolon`
+(regression: plain `|x, y|` has no Semicolon).  Test count: 229 → 232.
+
 ## [0.65.0] - 2026-05-31
 
 ### Added (Phase 11d (FC) — `return` WITH VALUE, coverage-confirmation)

--- a/code/packages/rust/ruby-parser/src/_grammar.rs
+++ b/code/packages/rust/ruby-parser/src/_grammar.rs
@@ -241,9 +241,17 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
                         GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
                     ] }) },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Literal { value: r#";"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                        GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                                GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                            ] }) },
+                    ] }) },
                 GrammarElement::Literal { value: r#"|"#.to_string() },
             ] },
-            line_number: 151,
+            line_number: 160,
         },
         GrammarRule {
             name: r#"return_statement"#.to_string(),
@@ -251,7 +259,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"return"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"expression"#.to_string() }) },
             ] },
-            line_number: 153,
+            line_number: 162,
         },
         GrammarRule {
             name: r#"break_statement"#.to_string(),
@@ -259,7 +267,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"break"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"expression"#.to_string() }) },
             ] },
-            line_number: 154,
+            line_number: 163,
         },
         GrammarRule {
             name: r#"next_statement"#.to_string(),
@@ -267,17 +275,17 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"next"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"expression"#.to_string() }) },
             ] },
-            line_number: 155,
+            line_number: 164,
         },
         GrammarRule {
             name: r#"redo_statement"#.to_string(),
             body: GrammarElement::Literal { value: r#"redo"#.to_string() },
-            line_number: 159,
+            line_number: 168,
         },
         GrammarRule {
             name: r#"retry_statement"#.to_string(),
             body: GrammarElement::Literal { value: r#"retry"#.to_string() },
-            line_number: 163,
+            line_number: 172,
         },
         GrammarRule {
             name: r#"yield_statement"#.to_string(),
@@ -285,7 +293,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"yield"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"yield_args"#.to_string() }) },
             ] },
-            line_number: 185,
+            line_number: 194,
         },
         GrammarRule {
             name: r#"yield_args"#.to_string(),
@@ -309,7 +317,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) },
                 ] },
             ] },
-            line_number: 186,
+            line_number: 195,
         },
         GrammarRule {
             name: r#"super_statement"#.to_string(),
@@ -317,7 +325,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"super"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"super_args"#.to_string() }) },
             ] },
-            line_number: 205,
+            line_number: 214,
         },
         GrammarRule {
             name: r#"super_args"#.to_string(),
@@ -341,7 +349,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) },
                 ] },
             ] },
-            line_number: 206,
+            line_number: 215,
         },
         GrammarRule {
             name: r#"params"#.to_string(),
@@ -355,7 +363,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) },
                 ] },
             ] },
-            line_number: 235,
+            line_number: 244,
         },
         GrammarRule {
             name: r#"param"#.to_string(),
@@ -366,7 +374,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
             ] },
-            line_number: 236,
+            line_number: 245,
         },
         GrammarRule {
             name: r#"if_statement"#.to_string(),
@@ -383,7 +391,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 237,
+            line_number: 246,
         },
         GrammarRule {
             name: r#"elsif_clause"#.to_string(),
@@ -397,7 +405,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 238,
+            line_number: 247,
         },
         GrammarRule {
             name: r#"else_clause"#.to_string(),
@@ -408,7 +416,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 239,
+            line_number: 248,
         },
         GrammarRule {
             name: r#"unless_statement"#.to_string(),
@@ -423,7 +431,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 240,
+            line_number: 249,
         },
         GrammarRule {
             name: r#"while_statement"#.to_string(),
@@ -436,7 +444,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 241,
+            line_number: 250,
         },
         GrammarRule {
             name: r#"until_statement"#.to_string(),
@@ -449,7 +457,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 242,
+            line_number: 251,
         },
         GrammarRule {
             name: r#"case_statement"#.to_string(),
@@ -463,7 +471,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 265,
+            line_number: 274,
         },
         GrammarRule {
             name: r#"when_clause"#.to_string(),
@@ -482,7 +490,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 266,
+            line_number: 275,
         },
         GrammarRule {
             name: r#"in_clause"#.to_string(),
@@ -497,7 +505,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 288,
+            line_number: 297,
         },
         GrammarRule {
             name: r#"pattern"#.to_string(),
@@ -507,7 +515,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"literal_pattern"#.to_string() },
                 GrammarElement::RuleReference { name: r#"binding_pattern"#.to_string() },
             ] },
-            line_number: 289,
+            line_number: 298,
         },
         GrammarRule {
             name: r#"literal_pattern"#.to_string(),
@@ -517,12 +525,12 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"symbol_literal"#.to_string() },
                 GrammarElement::TokenReference { name: r#"KEYWORD"#.to_string() },
             ] },
-            line_number: 290,
+            line_number: 299,
         },
         GrammarRule {
             name: r#"binding_pattern"#.to_string(),
             body: GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
-            line_number: 291,
+            line_number: 300,
         },
         GrammarRule {
             name: r#"array_pattern"#.to_string(),
@@ -537,7 +545,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 292,
+            line_number: 301,
         },
         GrammarRule {
             name: r#"hash_pattern"#.to_string(),
@@ -552,7 +560,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 293,
+            line_number: 302,
         },
         GrammarRule {
             name: r#"hash_pattern_pair"#.to_string(),
@@ -561,7 +569,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"pattern"#.to_string() }) },
             ] },
-            line_number: 294,
+            line_number: 303,
         },
         GrammarRule {
             name: r#"begin_statement"#.to_string(),
@@ -577,7 +585,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"ensure_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 315,
+            line_number: 324,
         },
         GrammarRule {
             name: r#"rescue_clause"#.to_string(),
@@ -595,7 +603,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 324,
+            line_number: 333,
         },
         GrammarRule {
             name: r#"exception_list"#.to_string(),
@@ -606,7 +614,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
                     ] }) },
             ] },
-            line_number: 325,
+            line_number: 334,
         },
         GrammarRule {
             name: r#"ensure_clause"#.to_string(),
@@ -617,7 +625,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 326,
+            line_number: 335,
         },
         GrammarRule {
             name: r#"assignment"#.to_string(),
@@ -641,7 +649,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 346,
+            line_number: 355,
         },
         GrammarRule {
             name: r#"rightward_assignment"#.to_string(),
@@ -650,7 +658,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"=>"#.to_string() },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
             ] },
-            line_number: 365,
+            line_number: 374,
         },
         GrammarRule {
             name: r#"method_call"#.to_string(),
@@ -670,7 +678,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"dot_call"#.to_string() }) },
             ] },
-            line_number: 376,
+            line_number: 385,
         },
         GrammarRule {
             name: r#"dot_call"#.to_string(),
@@ -692,7 +700,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                     ] }) },
             ] },
-            line_number: 377,
+            line_number: 386,
         },
         GrammarRule {
             name: r#"scope_resolution"#.to_string(),
@@ -703,7 +711,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"KEYWORD"#.to_string() },
                     ] }) },
             ] },
-            line_number: 385,
+            line_number: 394,
         },
         GrammarRule {
             name: r#"call_arg"#.to_string(),
@@ -715,7 +723,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 415,
+            line_number: 424,
         },
         GrammarRule {
             name: r#"method_call_no_paren"#.to_string(),
@@ -730,17 +738,17 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 429,
+            line_number: 438,
         },
         GrammarRule {
             name: r#"expression_stmt"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"expression"#.to_string() },
-            line_number: 430,
+            line_number: 439,
         },
         GrammarRule {
             name: r#"expression"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"ternary"#.to_string() },
-            line_number: 537,
+            line_number: 546,
         },
         GrammarRule {
             name: r#"ternary"#.to_string(),
@@ -753,7 +761,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 538,
+            line_number: 547,
         },
         GrammarRule {
             name: r#"range"#.to_string(),
@@ -776,7 +784,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) },
                 ] },
             ] },
-            line_number: 539,
+            line_number: 548,
         },
         GrammarRule {
             name: r#"logical_or"#.to_string(),
@@ -790,7 +798,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_and"#.to_string() },
                     ] }) },
             ] },
-            line_number: 540,
+            line_number: 549,
         },
         GrammarRule {
             name: r#"logical_and"#.to_string(),
@@ -804,7 +812,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_not"#.to_string() },
                     ] }) },
             ] },
-            line_number: 541,
+            line_number: 550,
         },
         GrammarRule {
             name: r#"logical_not"#.to_string(),
@@ -815,7 +823,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) }) },
                 GrammarElement::RuleReference { name: r#"comparison"#.to_string() },
             ] },
-            line_number: 548,
+            line_number: 557,
         },
         GrammarRule {
             name: r#"comparison"#.to_string(),
@@ -833,7 +841,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"sum"#.to_string() },
                     ] }) },
             ] },
-            line_number: 549,
+            line_number: 558,
         },
         GrammarRule {
             name: r#"sum"#.to_string(),
@@ -847,7 +855,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term"#.to_string() },
                     ] }) },
             ] },
-            line_number: 550,
+            line_number: 559,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -861,7 +869,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"factor"#.to_string() },
                     ] }) },
             ] },
-            line_number: 551,
+            line_number: 560,
         },
         GrammarRule {
             name: r#"factor"#.to_string(),
@@ -888,7 +896,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"scope_resolution"#.to_string() },
                     ] }) },
             ] },
-            line_number: 561,
+            line_number: 570,
         },
         GrammarRule {
             name: r#"lambda_literal"#.to_string(),
@@ -901,7 +909,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"block"#.to_string() },
             ] },
-            line_number: 580,
+            line_number: 589,
         },
         GrammarRule {
             name: r#"unary_minus"#.to_string(),
@@ -909,7 +917,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"factor"#.to_string() },
             ] },
-            line_number: 581,
+            line_number: 590,
         },
         GrammarRule {
             name: r#"symbol_literal"#.to_string(),
@@ -921,7 +929,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 588,
+            line_number: 597,
         },
         GrammarRule {
             name: r#"array_literal"#.to_string(),
@@ -936,7 +944,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 589,
+            line_number: 598,
         },
         GrammarRule {
             name: r#"hash_literal"#.to_string(),
@@ -951,7 +959,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 590,
+            line_number: 599,
         },
         GrammarRule {
             name: r#"hash_entry"#.to_string(),
@@ -971,7 +979,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                 ] },
             ] },
-            line_number: 591,
+            line_number: 600,
         },
     ],
         version: 1,

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -1059,6 +1059,78 @@ mod tests {
         assert_eq!(names, vec!["x", "y"]);
     }
 
+    // -----------------------------------------------------------------------
+    // Phase 21a (FC) — block-local variables `{ |x; y| … }`
+    //
+    // After the regular block parameters, an optional `;` introduces a list
+    // of block-local variables.  The pipe contents become
+    // `NAME { COMMA NAME } [ ";" NAME { COMMA NAME } ]`.  These pins confirm
+    // the `;` Semicolon token and the block-local names parse inside the
+    // `block_params` node.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_brace_block_with_one_block_local() {
+        let ast = parse_ruby("each { |x; y| x }");
+        let mwb = find_statement_inner(&ast, "method_with_block")
+            .expect("expected method_with_block");
+        let bp = find_descendant(mwb, "block_params").expect("expected block_params");
+        // The `;` Semicolon token survives inside block_params.
+        assert!(bp.children.iter().any(|c| matches!(
+            c,
+            ASTNodeOrToken::Token(t) if matches!(t.type_, lexer::token::TokenType::Semicolon)
+        )));
+        // Both `x` (param) and `y` (block-local) appear as Name tokens.
+        let names: Vec<&str> = bp
+            .children
+            .iter()
+            .filter_map(|c| match c {
+                ASTNodeOrToken::Token(t)
+                    if matches!(t.type_, lexer::token::TokenType::Name) && t.value != "|" =>
+                {
+                    Some(t.value.as_str())
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(names, vec!["x", "y"]);
+    }
+
+    #[test]
+    fn test_parse_do_block_with_two_block_locals() {
+        let ast = parse_ruby("each do |a; b, c|\n  puts a\nend");
+        let mwb = find_statement_inner(&ast, "method_with_block")
+            .expect("expected method_with_block");
+        let bp = find_descendant(mwb, "block_params").expect("expected block_params");
+        let names: Vec<&str> = bp
+            .children
+            .iter()
+            .filter_map(|c| match c {
+                ASTNodeOrToken::Token(t)
+                    if matches!(t.type_, lexer::token::TokenType::Name) && t.value != "|" =>
+                {
+                    Some(t.value.as_str())
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(names, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn test_parse_block_without_locals_has_no_semicolon() {
+        // Regression: a plain `|x, y|` block must NOT contain a Semicolon
+        // token in its block_params (the `;` clause is optional).
+        let ast = parse_ruby("each { |x, y| x }");
+        let mwb = find_statement_inner(&ast, "method_with_block")
+            .expect("expected method_with_block");
+        let bp = find_descendant(mwb, "block_params").expect("expected block_params");
+        assert!(!bp.children.iter().any(|c| matches!(
+            c,
+            ASTNodeOrToken::Token(t) if matches!(t.type_, lexer::token::TokenType::Semicolon)
+        )));
+    }
+
     #[test]
     fn test_parse_method_call_with_args_and_block() {
         let ast = parse_ruby("each(1, 2) { puts 1 }");

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.69.0] - 2026-05-31
+
+### Added (Phase 21a (FC) — block-local variables `{ |x; y| … }`)
+
+The block lowerer now splits the `block_params` pipe contents at the
+`;` (Semicolon) token: names before it are block parameters
+(`Scope::Param`), names after it are **block-local variables** — fresh
+locals scoped to the block body.
+
+Block-locals are:
+- declared in the block's `declared_locals` scope so VarRefs to them
+  resolve as `Scope::Local` (NOT `Scope::Param`);
+- excluded from the synthetic function's parameter list;
+- materialized as explicit `LetBinding <name> = NilLit` statements
+  prepended to the block body, so the SIR validator recognizes them
+  (Ruby block-locals start unbound / nil).
+
+New lowering pins (+3): `block_local_is_not_a_param`
+(`do |x; y|` → `__block_0.params` is just `[x]`),
+`block_local_varref_resolves_as_local_not_param`
+(`do |x; y| y = x; puts(y) end` → `y` VarRef is `Scope::Local`),
+`block_with_block_local_passes_sir_validator` (validator end-to-end).
+Test count: 283 → 286.
+
 ## [0.68.0] - 2026-05-31
 
 ### Added (Phase 11d (FC) — `return` WITH VALUE, coverage-confirmation)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -1407,6 +1407,59 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
+    // Phase 21a (FC) — block-local variables `{ |x; y| … }`.
+    //
+    // Names after the `;` in the pipe header are *block-local*: declared
+    // in the block body's local scope (so VarRefs resolve as
+    // `Scope::Local`) but NOT added to the synthetic function's
+    // parameter list.  Params before the `;` stay `Scope::Param`.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn block_local_is_not_a_param() {
+        let m = lower("each do |x; y|\n  puts(x)\nend\n");
+        let block_fn = m
+            .functions
+            .iter()
+            .find(|f| f.name == "__block_0")
+            .expect("expected __block_0");
+        // Only `x` is a parameter; `y` (block-local) is excluded.
+        assert_eq!(block_fn.params.len(), 1);
+        assert_eq!(block_fn.params[0].name, "x");
+        assert!(block_fn.params.iter().all(|p| p.name != "y"));
+    }
+
+    #[test]
+    fn block_local_varref_resolves_as_local_not_param() {
+        // Assign the block-local inside the body, then reference it: the
+        // VarRef must resolve to Scope::Local (it is declared, not a param).
+        let m = lower("each do |x; y|\n  y = x\n  puts(y)\nend\n");
+        let block_fn = m
+            .functions
+            .iter()
+            .find(|f| f.name == "__block_0")
+            .expect("expected __block_0");
+        // `y` is declared as a local (via the `;` clause) and is NOT a param.
+        assert!(block_fn.params.iter().all(|p| p.name != "y"));
+        // The `puts(y)` tail call references `y` as Scope::Local.
+        if let Expr::BuiltinCall { args, .. } = &block_fn.body.value {
+            assert!(matches!(
+                &args[0],
+                Expr::VarRef { name, scope, .. } if name == "y" && *scope == Scope::Local
+            ), "expected y as Scope::Local, got {:?}", args.first());
+        } else {
+            panic!("expected BuiltinCall body, got {:?}", block_fn.body.value);
+        }
+    }
+
+    #[test]
+    fn block_with_block_local_passes_sir_validator() {
+        let m = lower("each do |x; y|\n  y = x\n  puts(y)\nend\n");
+        let result = semantic_ir::validate(&m);
+        assert!(result.is_ok(), "validator rejected our output: {:?}", result);
+    }
+
+    // -----------------------------------------------------------------
     // Phase 6h — paren-less method calls (`puts 1`, `puts 1, 2`).
     // -----------------------------------------------------------------
 

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -3736,28 +3736,46 @@ impl Lowerer {
         // classifies bare `|` ops as Name tokens (see
         // ruby-lexer/src/lib.rs::classify_op_token), so we filter
         // them out by value, not by type.
+        // Phase 21a (FC) — block-local variables.  The `block_params`
+        // pipe contents may contain a `;` (Semicolon token) that
+        // separates the parameter names (before) from block-local
+        // variable names (after): `{ |x; y, z| … }`.  Names before the
+        // semicolon are parameters; names after it are fresh locals
+        // scoped to the block body (declared so VarRefs resolve, but
+        // NOT added to the parameter list).  We walk the pipe tokens in
+        // order, flipping a flag when we hit the `;`.
         let params_node = self.find_node_child(inner, "block_params");
-        let params: Vec<Param> = match params_node {
-            Some(pn) => pn
-                .children
-                .iter()
-                .filter_map(|c| match c {
+        let mut params: Vec<Param> = Vec::new();
+        let mut block_locals: Vec<String> = Vec::new();
+        if let Some(pn) = params_node {
+            let mut seen_semicolon = false;
+            for c in &pn.children {
+                match c {
+                    ASTNodeOrToken::Token(t)
+                        if matches!(t.type_, TokenType::Semicolon) =>
+                    {
+                        seen_semicolon = true;
+                    }
                     ASTNodeOrToken::Token(t)
                         if matches!(t.type_, TokenType::Name) && t.value != "|" =>
                     {
-                        Some(Param {
-                            name: t.value.clone(),
-                            sir_type: None,
-                            span: self.span_of_token(t),
-                        })
+                        if seen_semicolon {
+                            block_locals.push(t.value.clone());
+                        } else {
+                            params.push(Param {
+                                name: t.value.clone(),
+                                sir_type: None,
+                                span: self.span_of_token(t),
+                            });
+                        }
                     }
-                    _ => None,
-                })
-                .collect(),
-            None => Vec::new(),
-        };
-        // Block params are untyped → declare dynamic-typing.
-        if !params.is_empty() {
+                    _ => {}
+                }
+            }
+        }
+        // Block params are untyped → declare dynamic-typing.  Block-local
+        // variables are likewise dynamically typed.
+        if !params.is_empty() || !block_locals.is_empty() {
             self.features_used.insert(Feature::DynamicTyping);
         }
 
@@ -3769,6 +3787,12 @@ impl Lowerer {
         for p in &params {
             self.declared_locals.insert(p.name.clone());
             self.current_params.insert(p.name.clone());
+        }
+        // Block-local variables (Phase 21a): fresh locals scoped to the
+        // block body.  Declared so VarRefs resolve, but NOT params —
+        // they shadow outer bindings and start unbound.
+        for name in &block_locals {
+            self.declared_locals.insert(name.clone());
         }
 
         // Body statements: every direct `statement` child of the
@@ -3824,6 +3848,27 @@ impl Lowerer {
         let value = value.unwrap_or(Expr::NilLit {
             span: self.span_of(inner),
         });
+
+        // Phase 21a (FC) — materialize block-local variables.  Each
+        // block-local needs an explicit `LetBinding <name> = nil` at the
+        // top of the body so the SIR validator knows the name exists
+        // (otherwise VarRefs to it report "references unknown name").
+        // They initialize to nil (unbound) — Ruby block-locals start nil.
+        if !block_locals.is_empty() {
+            let mut prefix: Vec<Stmt> = block_locals
+                .iter()
+                .map(|name| Stmt::LetBinding {
+                    name: name.clone(),
+                    sir_type: None,
+                    value: Expr::NilLit {
+                        span: self.span_of(inner),
+                    },
+                    span: self.span_of(inner),
+                })
+                .collect();
+            prefix.append(&mut stmts_out);
+            stmts_out = prefix;
+        }
 
         // Restore outer scope.
         self.declared_locals = saved_locals;


### PR DESCRIPTION
## Phase 21a (FC) — block-local variables `{ |x; y| … }`

Ruby blocks may declare **block-local variables** after a `;` in the pipe
header: `{ |x; y, z| … }` declares `x` as a block parameter and `y`,`z`
as fresh locals scoped to the block body. They shadow any same-named
outer binding, start unbound (nil), and never bind to a block argument.

### Grammar

`grammars/ruby.grammar` (then `_grammar.rs` regenerated via grammar-tools):

```
block_params = "|" NAME { COMMA NAME } [ ";" NAME { COMMA NAME } ] "|" ;
```

The `;` is a `Semicolon` token (already emitted by the lexer), so only
the grammar rule + regen were needed on the parser side.

### Lowering (`ruby-to-semantic-ir/src/lower.rs`)

The block lowerer walks the pipe tokens, flipping a flag at the `;`:

- names **before** `;` → block parameters (`Scope::Param`);
- names **after** `;` → block-locals: declared in the block's local
  scope (VarRefs resolve `Scope::Local`, not `Scope::Param`), excluded
  from the synthetic function's param list, and materialized as explicit
  `LetBinding <name> = NilLit` statements prepended to the body so the
  SIR validator recognizes them.

### Parser pins (+3, 229 → 232)

- `test_parse_brace_block_with_one_block_local` — `{ |x; y| x }` (Semicolon token + names `x`,`y`)
- `test_parse_do_block_with_two_block_locals` — `do |a; b, c|` (names `a`,`b`,`c`)
- `test_parse_block_without_locals_has_no_semicolon` — regression: plain `|x, y|` has no Semicolon

### Lowering pins (+3, 283 → 286)

- `block_local_is_not_a_param` — `do |x; y|` → `__block_0.params == [x]`
- `block_local_varref_resolves_as_local_not_param` — `y` VarRef is `Scope::Local`
- `block_with_block_local_passes_sir_validator` — validator end-to-end

### Verification

- `cargo test -p coding-adventures-ruby-lexer -p coding-adventures-ruby-parser -p ruby-to-semantic-ir` — all green (lexer 173, parser 232, IR 286).
- `/security-review` — PASSED (no unsafe/I/O; scope save/restore correct; bounded AST iteration).

### Changelogs

- `coding-adventures-ruby-parser` 0.65.0 → 0.66.0
- `ruby-to-semantic-ir` 0.68.0 → 0.69.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
