### PR TITLE
test(closure-emitter): CLOC12.07 — port upstream CodePrinterTest subset

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,68 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.3.0] - 2026-05-31
+
+### Added — CLOC12.07: port subset of upstream `CodePrinterTest`
+
+Fourth port under CLOC12, first one targeting the emitter rather than
+a transform pass.
+
+- `tests/upstream/UPSTREAM_SHA` — pins
+  `google/closure-compiler@5bb35ec1245dc1d3557481e5f8b4db344bcd1e6b`.
+- `tests/upstream/ATTRIBUTION.md` — Apache-2.0 attribution per
+  CLOC12.01 §5.
+- `tests/upstream/code_printer_test.rs` — 12 ported test methods.
+
+### Test breakdown
+
+|     | passing | ignored |
+|-----|---------|---------|
+| CLOC12.07 | **6** | **6** |
+
+**Passing (6):** literal-position emits and bare unary that match our
+current emitter output exactly:
+
+- `test_binary_addition_with_parens_is_current_behaviour` — `2 + 3` emits as `(2 + 3);` (paren-wrapped; pins current behaviour).
+- `test_string_concat_with_parens_is_current_behaviour` — `"a" + "b"` emits as `("a" + "b");`.
+- `test_unary_not_emits_without_space` — `!x` emits as `!x;`.
+- `test_boolean_literal_at_statement_position` — `true;` / `false;`.
+- `test_integer_literals_at_statement_position` — `0;`, `42;`, `1;`.
+- `test_string_literal_at_statement_position` — `"hello";`, `"a";`.
+
+Two of those (`test_*_is_current_behaviour`) deliberately pin our
+*current* paren-wrapping behaviour even though it diverges from
+upstream — they serve as regression markers so when gap-024 is closed
+and the wrapping comes off, the assertions can flip at the same time.
+
+**Ignored (6):** record upstream's broader scope:
+
+| Test | Gap | Blocker |
+|------|-----|---------|
+| `test_big_int` | gap-021 | `BigIntLiteral` not in Phase 1 AST |
+| `test_trailing_comma_in_array_and_object_with_pretty_print` | gap-022 | array/object trailing-comma policy not modelled |
+| `test_no_trailing_comma_in_empty_array_literal` | gap-023 | VariableDeclaration round-trip ports deferred |
+| `test_number_formatting_shortest_form` | gap-025 | numeric exponential-form / shortest-form not implemented |
+| `test_string_quote_choice_minimises_escapes` | gap-026 | quote-choice optimisation not implemented |
+| `test_operator_precedence_inserts_inner_parens` | gap-027 | precedence-aware paren insertion not implemented |
+
+Plus the meta-divergence:
+
+- gap-024 — `ExpressionStatement` paren-wrapping is unconditional in our emitter, whereas upstream only wraps when ambiguity demands it. Not strictly "blocked" (we choose to wrap), but tracked so the eventual byte-identical match can flip the two `_is_current_behaviour` ports.
+
+### Why the bulk of upstream is ignored
+
+`CodePrinterTest` has 263 `@Test` methods. Most cover Phase 2+ AST
+nodes (BigInt, optional chaining, template literals, classes,
+spread, async/await, regex) or formatting policies (quote choice,
+exponential-form numerics, precedence-aware parens) that aren't in
+our emitter's v0.2.0 body. Each future emitter slice can re-port
+the relevant subset and convert ignored markers into asserts.
+
+### Version bump
+
+`0.2.0` → `0.3.0`.
+
 ## [0.2.0] - 2026-05-24
 
 ### Added — real `emit` body (first real pipeline output)

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 
@@ -17,3 +17,10 @@ coding-adventures-javascript-tokens = { path = "../javascript-tokens" }
 # End-to-end pipeline tests: constant-fold + pipeline scheduler.
 coding-adventures-closure-pass-constant-fold = { path = "../closure-pass-constant-fold" }
 coding-adventures-closure-pass-pipeline = { path = "../closure-pass-pipeline" }
+
+# Upstream-test ports live under `tests/upstream/`; Cargo only
+# auto-discovers `tests/*.rs` one level deep, so each ported file
+# needs an explicit `[[test]]` entry. Per CLOC12.01 §3.
+[[test]]
+name = "upstream_code_printer"
+path = "tests/upstream/code_printer_test.rs"

--- a/code/packages/rust/closure-emitter/tests/upstream/ATTRIBUTION.md
+++ b/code/packages/rust/closure-emitter/tests/upstream/ATTRIBUTION.md
@@ -1,0 +1,53 @@
+# Attribution
+
+Tests in this directory are ported from the Google Closure Compiler
+under the Apache License, Version 2.0:
+
+    https://github.com/google/closure-compiler
+    LICENSE: https://www.apache.org/licenses/LICENSE-2.0
+
+## Files ported
+
+- `code_printer_test.rs`
+    - upstream: `test/com/google/javascript/jscomp/CodePrinterTest.java`
+    - blob SHA at port time: `64944e8e615c95b0cf845aab86f77d634776a5b1`
+    - tracked commit: see `UPSTREAM_SHA`
+
+## Translation notes
+
+Fourth port under CLOC12 (after `closure-pass-constant-fold` in
+CLOC12.02, `closure-pass-dce` in CLOC12.04, and
+`closure-pass-fold-control-flow` in CLOC12.05). First port that
+targets the *emitter* rather than a transform pass — the shape of
+assertions is "given AST, emit string equal to X" instead of "given
+AST, fold to AST'".
+
+- Upstream tests use `assertPrint(input_js, expected_js)` and
+  `assertPrintSame(js)` which both lex/parse the input through their
+  own compiler harness and pretty-print the result. Our `emit()`
+  takes a typed `Program` directly — there's no parser bridge yet.
+  Ports here hand-construct typed-AST inputs.
+- **Coverage scope is narrow today.** Upstream `CodePrinterTest` is
+  ~263 `@Test` methods covering BigInt, optional chaining,
+  trailing-comma policies, spread, async/await, classes, generators,
+  template literals, regex, and every operator precedence corner.
+  Most of these reference Phase 2+ AST node variants we don't have
+  yet (BigInt, OptionalCallExpression, TemplateLiteral, etc.).
+- **Our emitter unconditionally wraps every ExpressionStatement in
+  parens** — `(2 + 3);` instead of upstream's `2+3;`. That's a
+  deliberate Phase 1 simplification documented in the emitter's
+  crate-level docs. It means most upstream `assertPrintSame` tests
+  fail today — the input form they expect to be unchanged isn't what
+  our emitter produces. Each such case becomes a `#[ignore]` with
+  a gap describing the divergence rather than a behaviour bug.
+- Each ported test docstring records the upstream `assertPrint*`
+  line being modelled so a future re-port can diff cleanly.
+
+## Ignored tests
+
+See `code/specs/CLOC12-gaps.md` for `gap-NNN` entries that gate
+ignored ports.
+
+## Skipped (intentionally not ported)
+
+None yet.

--- a/code/packages/rust/closure-emitter/tests/upstream/UPSTREAM_SHA
+++ b/code/packages/rust/closure-emitter/tests/upstream/UPSTREAM_SHA
@@ -1,0 +1,13 @@
+# UPSTREAM_SHA
+#
+# Tracks google/closure-compiler at this commit. Every Rust file in
+# tests/upstream/ was ported from a Java file at this snapshot.
+#
+# Upgrade policy: bump this SHA only in a dedicated PR that re-ports
+# every Java source listed in ATTRIBUTION.md, diff-checks against the
+# previous port, and explicitly handles added / removed / renamed
+# tests per CLOC12 §4.
+
+commit:  5bb35ec1245dc1d3557481e5f8b4db344bcd1e6b
+date:    2026-05-28
+url:     https://github.com/google/closure-compiler/tree/5bb35ec1245dc1d3557481e5f8b4db344bcd1e6b

--- a/code/packages/rust/closure-emitter/tests/upstream/code_printer_test.rs
+++ b/code/packages/rust/closure-emitter/tests/upstream/code_printer_test.rs
@@ -1,0 +1,253 @@
+//! Ported from `CodePrinterTest.java` in `google/closure-compiler`,
+//! Apache-2.0. Upstream SHA: see `tests/upstream/UPSTREAM_SHA`.
+//!
+//! Translation policy: see
+//! `code/specs/CLOC12-upstream-test-suite-port.md`.
+//!
+//! Fourth port under CLOC12 — first one targeting the emitter rather
+//! than a transform pass. Most upstream `@Test` methods exercise
+//! Phase 2+ AST node variants we don't have yet (BigInt,
+//! OptionalCallExpression, TemplateLiteral, etc.) or use the upstream
+//! `assertPrintSame` round-trip which expects unparenthesised
+//! expression-statements like `2+3;` while our Phase 1 emitter
+//! deliberately wraps every ExpressionStatement in parens
+//! (`(2 + 3);`).
+//!
+//! So the bulk of this file is `#[ignore = "blocked on gap-NNN"]`
+//! placeholders that pin the upstream intent and document the
+//! divergence. The few non-ignored tests assert the byte-equal output
+//! our emitter actually produces today, matching the inline-test
+//! shapes in `closure-emitter`'s own `#[cfg(test)]` module.
+
+use coding_adventures_closure_emitter::{emit, EmitOptions};
+use coding_adventures_correlation_vector::CVLog;
+use coding_adventures_javascript_ast::{
+    BinaryExpression, BinaryOperator, BooleanLiteral, Expression, ExpressionStatement, Identifier,
+    NumericLiteral, Program, ProgramItem, SourceType, Statement, StringLiteral, UnaryExpression,
+    UnaryOperator,
+};
+use coding_adventures_javascript_tokens::EsVersion;
+use coding_adventures_type_sidecar::Sidecar;
+
+// =====================================================================
+// Test-support helpers
+// =====================================================================
+
+fn ident(name: &str) -> Expression {
+    Expression::Identifier(Identifier {
+        cv: None,
+        name: name.to_string(),
+    })
+}
+fn num(v: f64) -> Expression {
+    Expression::NumericLiteral(NumericLiteral {
+        cv: None,
+        value: v,
+        raw: if v.fract() == 0.0 && v.is_finite() {
+            format!("{}", v as i64)
+        } else {
+            v.to_string()
+        },
+    })
+}
+fn string(v: &str) -> Expression {
+    Expression::StringLiteral(StringLiteral {
+        cv: None,
+        value: v.to_string(),
+        raw: format!("\"{}\"", v),
+    })
+}
+fn boolean(v: bool) -> Expression {
+    Expression::BooleanLiteral(BooleanLiteral { cv: None, value: v })
+}
+
+fn stmt(expr: Expression) -> ProgramItem {
+    ProgramItem::Statement(Statement::expression_statement(ExpressionStatement {
+        cv: None,
+        expression: expr,
+    }))
+}
+
+fn program_with(item: ProgramItem) -> Program {
+    Program::new_untraced(EsVersion::Es2025, SourceType::Module).with_body(vec![item])
+}
+
+fn emit_default(prog: Program) -> String {
+    let sidecar = Sidecar::new();
+    let mut cv = CVLog::new(false);
+    emit(&prog, &sidecar, &mut cv, &EmitOptions::default())
+        .expect("emit failed")
+        .code
+}
+
+/// Upstream `assertPrint(input, expected)` reshaped for our AST
+/// surface: given an Expression that models the input, emit it as
+/// the body of a single-statement program and assert the resulting
+/// code equals `expected_emitted`.
+fn assert_emits(expr: Expression, expected_emitted: &str) {
+    let code = emit_default(program_with(stmt(expr)));
+    assert_eq!(
+        code, expected_emitted,
+        "emit output did not match expected\n  actual:   {:?}\n  expected: {:?}",
+        code, expected_emitted
+    );
+}
+
+// =====================================================================
+// Ported tests
+// =====================================================================
+
+/// Upstream `testBigInt`:
+///
+///   assertPrintSame("1n");
+///   assertPrint("0b10n", "2n");
+///   ...
+#[test]
+#[ignore = "blocked on gap-021: BigIntLiteral not in Phase 1 AST"]
+fn test_big_int() {
+    // Requires Expression::BigIntLiteral variant. Phase 1.x work.
+}
+
+/// Upstream `testTrailingCommaInArrayAndObjectWithPrettyPrint`:
+///
+///   languageMode = LanguageMode.ECMASCRIPT_2017;
+///   assertPrettyPrint("var x = [1,];", "var x = [1];\n");
+///   ...
+///
+/// Pretty-print + array/object trailing-comma policy. Our emitter
+/// doesn't model trailing commas explicitly yet.
+#[test]
+#[ignore = "blocked on gap-022: array/object trailing-comma policy not modelled"]
+fn test_trailing_comma_in_array_and_object_with_pretty_print() {
+    // ArrayExpression / ObjectExpression trailing-comma cases.
+}
+
+/// Upstream `testNoTrailingCommaInEmptyArrayLiteral`:
+///
+///   assertPrintSame("var x = [];");
+///
+/// Empty array literal. Our typed AST does have ArrayExpression but
+/// hand-constructing a VariableDeclaration here is verbose; the
+/// behaviour belongs in a dedicated declaration-emitter port.
+#[test]
+#[ignore = "blocked on gap-023: VariableDeclaration round-trip ports deferred"]
+fn test_no_trailing_comma_in_empty_array_literal() {
+    // Belongs in a future declarations-focused port file.
+}
+
+/// Upstream-style `assertPrint("2 + 3", "2+3")` line shape — checks
+/// that a `+` binary expression emits with the operator and both
+/// operands in the right order. Our Phase 1 emitter wraps the whole
+/// expression-statement in parens and pads the operator with spaces:
+///
+///   2 + 3   →  `(2 + 3);`
+///
+/// This isn't matching upstream's exact byte output today
+/// (`2+3;`), so it's filed as gap-024 and the assertion here pins
+/// what we actually produce so a future paren-policy fix has a
+/// regression target to flip.
+#[test]
+fn test_binary_addition_with_parens_is_current_behaviour() {
+    let e = Expression::BinaryExpression(BinaryExpression {
+        cv: None,
+        operator: BinaryOperator::Add,
+        left: Box::new(num(2.0)),
+        right: Box::new(num(3.0)),
+    });
+    assert_emits(e, "(2 + 3);");
+}
+
+/// Same shape as upstream `assertPrint("\"a\" + \"b\"", "\"a\"+\"b\"")`.
+/// We currently emit `("a" + "b");` — paren-wrapped, space-padded.
+#[test]
+fn test_string_concat_with_parens_is_current_behaviour() {
+    let e = Expression::BinaryExpression(BinaryExpression {
+        cv: None,
+        operator: BinaryOperator::Add,
+        left: Box::new(string("a")),
+        right: Box::new(string("b")),
+    });
+    assert_emits(e, "(\"a\" + \"b\");");
+}
+
+/// Upstream `assertPrintSame("!x")` — unary-not on identifier, no
+/// space between `!` and the argument. We emit `!x;` (no surrounding
+/// parens for a bare unary statement).
+#[test]
+fn test_unary_not_emits_without_space() {
+    let e = Expression::UnaryExpression(UnaryExpression {
+        cv: None,
+        operator: UnaryOperator::Not,
+        prefix: true,
+        argument: Box::new(ident("x")),
+    });
+    assert_emits(e, "!x;");
+}
+
+/// Upstream `assertPrintSame("true")` — boolean literal at statement
+/// position. Our emitter produces `true;` — bare boolean literal, no
+/// parens.
+#[test]
+fn test_boolean_literal_at_statement_position() {
+    assert_emits(boolean(true), "true;");
+    assert_emits(boolean(false), "false;");
+}
+
+/// Upstream `assertPrintSame("0")`, `assertPrintSame("42")`, etc. —
+/// integer numeric literal at statement position. Our emitter
+/// produces `0;`, `42;` etc.
+#[test]
+fn test_integer_literals_at_statement_position() {
+    assert_emits(num(0.0), "0;");
+    assert_emits(num(42.0), "42;");
+    assert_emits(num(1.0), "1;");
+}
+
+/// Upstream `assertPrintSame("\"hello\"")` — string literal at
+/// statement position. We emit `"hello";`.
+#[test]
+fn test_string_literal_at_statement_position() {
+    assert_emits(string("hello"), "\"hello\";");
+    assert_emits(string("a"), "\"a\";");
+}
+
+/// Upstream tests cover number formatting like
+/// `assertPrint("1000000000", "1E9")` — using `1E9` exponential
+/// notation as shorter. Our emitter formats `1000000000` as
+/// `1000000000` (no exponent collapse).
+#[test]
+#[ignore = "blocked on gap-025: number-formatting (shortest-form / exponential) not implemented"]
+fn test_number_formatting_shortest_form() {
+    // assertPrint("1000000000", "1E9");
+    // Belongs in a future emitter-numeric-formatter slice.
+}
+
+/// Upstream `testStringQuoteChoice`-style — pick the quote that
+/// minimises escapes:
+///
+///   assertPrint("var x = \"single 'quote'\";", "var x='single \\'quote\\''");
+///   assertPrint("var x = \"a\\nb\";", "var x=\"a\\nb\"");
+///
+/// Our emitter always uses double quotes and doesn't switch to
+/// single. Gap-026.
+#[test]
+#[ignore = "blocked on gap-026: quote-choice optimisation not implemented"]
+fn test_string_quote_choice_minimises_escapes() {
+    // Belongs in a future emitter-string-escape slice.
+}
+
+/// Upstream `testOperatorPrecedence`-style — when a higher-precedence
+/// operator contains a lower-precedence subexpression, the
+/// subexpression needs parens to preserve evaluation order:
+///
+///   assertPrint("(a+b)*c", "(a+b)*c");
+///   assertPrint("a*(b+c)", "a*(b+c)");
+///
+/// Our emitter doesn't model operator precedence — it doesn't emit
+/// inner parens, and it wraps the outer expression in parens
+/// unconditionally. Filed as gap-027.
+#[test]
+#[ignore = "blocked on gap-027: precedence-aware paren insertion not implemented"]
+fn test_operator_precedence_inserts_inner_parens() {
+    // Would assert that `a * (b + c)` emits with the inner parens.
+}

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -181,3 +181,59 @@ historical context with status `RESOLVED` and a link to the fix PR.
 - **Ported file:** `closure-pass-fold-control-flow/tests/upstream/peephole_minimize_conditions_test.rs`
 - **Why it fails:** No `ThrowStatement` variant in our typed AST.
 - **What it needs:** A Phase 1.x AST extension to model `throw expr;`. Then teach fold-control-flow that `if (x) foo() else throw 1` → `if (!x) throw 1; foo();` (the early-throw rearrangement).
+
+### gap-021 — `BigIntLiteral` not in Phase 1 AST
+
+- **Status:** OPEN
+- **Upstream test:** `CodePrinterTest::testBigInt`
+- **Ported file:** `closure-emitter/tests/upstream/code_printer_test.rs`
+- **Why it fails:** No `Expression::BigIntLiteral` variant — `1n`, `0x4n`, `-5n` etc. have no AST representation in Phase 1.
+- **What it needs:** Phase 1.x AST extension: `BigIntLiteral { value: ?, raw: String }`. Then teach the emitter to render the literal with the `n` suffix, including for the negative-literal case.
+
+### gap-022 — Array/object trailing-comma policy not modelled
+
+- **Status:** OPEN
+- **Upstream test:** `CodePrinterTest::testTrailingCommaInArrayAndObjectWithPrettyPrint` and ~6 sibling tests
+- **Ported file:** `closure-emitter/tests/upstream/code_printer_test.rs`
+- **Why it fails:** Our emitter doesn't model whether trailing commas are present in `[1,]` / `{a:1,}` — there's no `trailing_comma: bool` flag on the relevant AST nodes, and the emitter doesn't insert / preserve them.
+- **What it needs:** AST flag + emitter rule + (optional) pretty-print toggle.
+
+### gap-023 — `VariableDeclaration` round-trip ports deferred
+
+- **Status:** OPEN
+- **Upstream test:** Most `assertPrintSame("var x = …")` lines in `CodePrinterTest`
+- **Ported file:** `closure-emitter/tests/upstream/code_printer_test.rs`
+- **Why it fails:** Hand-constructing `VariableDeclaration` ASTs (with `VariableDeclarator`s, `id`, `init`, `kind`) for every upstream test is verbose. Deferred to a dedicated future port file that focuses on declaration round-trips.
+- **What it needs:** Either a parser bridge (so the upstream `var x = ...` source string can be used directly), or a focused declarations-port-file that pays the verbosity cost. Likely the former.
+
+### gap-024 — `ExpressionStatement` paren-wrapping diverges from upstream
+
+- **Status:** DOCUMENTED divergence (not strictly a "missing feature")
+- **Upstream test:** Every upstream `assertPrintSame("foo();")` / `assertPrint("a+b", "a+b")` line
+- **Ported file:** `closure-emitter/tests/upstream/code_printer_test.rs`
+- **Why it fails:** Our Phase 1 emitter wraps every `ExpressionStatement` body in parens for safety. Upstream only wraps when the expression at statement position would otherwise be ambiguous (e.g. an object literal that could be a block).
+- **What it needs:** A precedence- and ambiguity-aware emitter that wraps only when necessary. Closes when CLOC12.07's two `_is_current_behaviour` ports get their assertions flipped to upstream's exact bytes.
+
+### gap-025 — Numeric formatting (shortest-form / exponential) not implemented
+
+- **Status:** OPEN
+- **Upstream test:** `CodePrinterTest` lines like `assertPrint("1000000000", "1E9")`
+- **Ported file:** `closure-emitter/tests/upstream/code_printer_test.rs`
+- **Why it fails:** Upstream picks the shorter representation between decimal and exponential. Our emitter always uses the `raw` field on `NumericLiteral` (or a plain `f64.to_string()`).
+- **What it needs:** Add a "pick-shortest" numeric formatter and wire it into the `NumericLiteral` emit path.
+
+### gap-026 — String quote-choice optimisation not implemented
+
+- **Status:** OPEN
+- **Upstream test:** `CodePrinterTest` quote-choice lines
+- **Ported file:** `closure-emitter/tests/upstream/code_printer_test.rs`
+- **Why it fails:** Our emitter always uses double quotes. Upstream picks the quote style that minimises required escapes.
+- **What it needs:** Walk the string content, count `\"` vs `\'` escapes, pick the shorter side.
+
+### gap-027 — Precedence-aware paren insertion not implemented
+
+- **Status:** OPEN
+- **Upstream test:** `CodePrinterTest` operator-precedence lines (e.g. `a*(b+c)` keeps inner parens)
+- **Ported file:** `closure-emitter/tests/upstream/code_printer_test.rs`
+- **Why it fails:** Our emitter doesn't compare child operator precedence against parent operator precedence to decide whether to insert parens. Coupled with gap-024.
+- **What it needs:** Per-node precedence table + recursive emitter pass that checks parent vs. child precedence at every binary/unary/logical/conditional node.


### PR DESCRIPTION
## Summary

**Fourth pass crate** now has its `tests/upstream/` layout — and the first one targeting the **emitter** rather than a transform pass. Asserts on output strings instead of AST shape.

- Pinned to `google/closure-compiler@5bb35ec1245dc1d3557481e5f8b4db344bcd1e6b`. Apache-2.0 attribution complete.
- **12 ported test methods: 6 pass today, 6 are `#[ignore]`-ed citing gap-021 through gap-027.** (gap-024 is a DOCUMENTED divergence, not a missing feature.)

## Passing today (6)

| Test | Assertion |
|------|-----------|
| `test_binary_addition_with_parens_is_current_behaviour` | `2 + 3` → `(2 + 3);` |
| `test_string_concat_with_parens_is_current_behaviour` | `\"a\" + \"b\"` → `(\"a\" + \"b\");` |
| `test_unary_not_emits_without_space` | `!x` → `!x;` |
| `test_boolean_literal_at_statement_position` | `true;` / `false;` |
| `test_integer_literals_at_statement_position` | `0;`, `42;`, `1;` |
| `test_string_literal_at_statement_position` | `\"hello\";`, `\"a\";` |

The two `_is_current_behaviour` tests deliberately pin our paren-wrapping divergence from upstream — they serve as regression markers so when **gap-024** is closed and the wrapping comes off, both assertions can flip together to upstream's exact bytes.

## Ignored (6) + 1 divergence

| Test / Gap | What it'd need |
|------------|---------------|
| `test_big_int` / **gap-021** | `BigIntLiteral` AST variant (Phase 1.x) |
| `test_trailing_comma_*` / **gap-022** | Array/object trailing-comma policy in AST + emitter |
| `test_no_trailing_comma_in_empty_array_literal` / **gap-023** | `VariableDeclaration` round-trip ports deferred |
| (no test) / **gap-024** | DOCUMENTED — `ExpressionStatement` paren-wrapping diverges; closes when ambiguity-aware emitter lands |
| `test_number_formatting_shortest_form` / **gap-025** | Pick-shortest numeric formatter (exponential vs decimal) |
| `test_string_quote_choice_minimises_escapes` / **gap-026** | Quote-choice optimisation |
| `test_operator_precedence_inserts_inner_parens` / **gap-027** | Precedence-aware paren insertion |

## Why so much is ignored

`CodePrinterTest` has 263 `@Test` methods covering Phase 2+ AST node variants (BigInt, optional chaining, template literals, classes, spread, async/await, regex) plus formatting policies (quote choice, exponential-form numerics, precedence-aware parens) we haven't implemented yet. Future emitter slices can re-port the relevant subset and convert ignored markers into asserts.

## Test plan

- [x] \`cargo test --test upstream_code_printer\` — 6 pass / 6 ignored / 0 fail
- [x] Full crate sweep — 17 inline + 6 upstream pass, 6 ignored, 0 fail
- [x] Each `#[ignore]` cites a `gap-NNN` entry in `code/specs/CLOC12-gaps.md`
- [x] `UPSTREAM_SHA` + `ATTRIBUTION.md` per CLOC12.01 §§4-5
- [x] Security review: PASS — test-only, no unsafe, no IO/network/process, attribution complete, mirrors merged CLOC12.02 / CLOC12.04 / CLOC12.05 pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)