### PR TITLE
feat(ruby-fc): Phase 21b — implicit numbered block parameters `_1`..`_9`

### DIFF
--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.67.0] - 2026-05-31
+
+### Added (Phase 21b (FC) — implicit numbered block parameters `_1`..`_9`)
+
+No grammar change.  A block with NO explicit `|...|` header may use
+`_1`..`_9` in its body as positional parameters.  Parser-side, `_1`
+lexes as a plain `Name` token (the lexer flags it with
+`NUMBERED_BLOCK_PARAM_FLAG` but keeps the type), so such blocks already
+parse — these pins confirm it.
+
+New parse pins (+3): `test_parse_block_with_numbered_param_parses`
+(`each { puts(_1) }` — no block_params, `_1` token present),
+`test_parse_block_with_two_numbered_params_parses`
+(`each { puts(_1 + _2) }`), `test_parse_do_block_with_numbered_param_parses`
+(`each do\n puts(_1)\nend`).  Test count: 232 → 235.
+
 ## [0.66.0] - 2026-05-31
 
 ### Added (Phase 21a (FC) — block-local variables `{ |x; y| … }`)

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -1131,6 +1131,47 @@ mod tests {
         )));
     }
 
+    // -----------------------------------------------------------------------
+    // Phase 21b (FC) — implicit numbered block parameters `_1`..`_9`.
+    //
+    // A block with NO explicit `|...|` header may use `_1`..`_9` in its
+    // body as positional parameters.  Parser-side, `_1` lexes as a plain
+    // Name token (the lexer flags it with NUMBERED_BLOCK_PARAM_FLAG but
+    // keeps the type); these pins confirm such blocks parse and the
+    // `_N` Name token reaches the brace_block / do_block body with no
+    // block_params header.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_block_with_numbered_param_parses() {
+        let ast = parse_ruby("each { puts(_1) }");
+        let mwb = find_statement_inner(&ast, "method_with_block")
+            .expect("expected method_with_block");
+        // No explicit pipe header.
+        assert!(find_descendant(mwb, "block_params").is_none());
+        // The `_1` Name token reaches the block body.
+        assert!(tree_has_token_value(mwb, "_1"));
+    }
+
+    #[test]
+    fn test_parse_block_with_two_numbered_params_parses() {
+        let ast = parse_ruby("each { puts(_1 + _2) }");
+        let mwb = find_statement_inner(&ast, "method_with_block")
+            .expect("expected method_with_block");
+        assert!(find_descendant(mwb, "block_params").is_none());
+        assert!(tree_has_token_value(mwb, "_1"));
+        assert!(tree_has_token_value(mwb, "_2"));
+    }
+
+    #[test]
+    fn test_parse_do_block_with_numbered_param_parses() {
+        let ast = parse_ruby("each do\n  puts(_1)\nend");
+        let mwb = find_statement_inner(&ast, "method_with_block")
+            .expect("expected method_with_block");
+        assert!(find_descendant(mwb, "do_block").is_some());
+        assert!(tree_has_token_value(mwb, "_1"));
+    }
+
     #[test]
     fn test_parse_method_call_with_args_and_block() {
         let ast = parse_ruby("each(1, 2) { puts 1 }");

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.70.0] - 2026-05-31
+
+### Added (Phase 21b (FC) — implicit numbered block parameters `_1`..`_9`)
+
+When a block has NO explicit `|...|` header and no block-locals, the
+lowerer now scans the block body for `_1`..`_9` `Name` tokens, takes the
+highest index used, and synthesizes positional parameters `_1`..`_<max>`
+(`Scope::Param`).  Arity follows Ruby semantics: a body using `_2`
+implies arity 2 (params `_1, _2`), even if `_1` is unreferenced.
+
+The scan does NOT descend into nested `block` nodes — a `_N` inside an
+inner block belongs to that inner block's own implicit parameter scope.
+An explicit pipe header (or `;` block-locals) always wins; numbered
+params apply only when no header is present.
+
+New lowering pins (+3): `numbered_block_param_synthesizes_single_param`
+(`each { puts(_1) }` → `__block_0.params == [_1]`),
+`numbered_block_param_arity_is_highest_index` (`each { puts(_2) }` →
+params `_1, _2`), `numbered_block_param_passes_sir_validator`
+(validator end-to-end).  Test count: 286 → 289.
+
 ## [0.69.0] - 2026-05-31
 
 ### Added (Phase 21a (FC) — block-local variables `{ |x; y| … }`)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -1460,6 +1460,48 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
+    // Phase 21b (FC) — implicit numbered block parameters `_1`..`_9`.
+    //
+    // A block with NO explicit `|...|` header may reference `_1`..`_9`
+    // as positional parameters; arity = the highest index used.  The
+    // lowerer scans the body and synthesizes params `_1`..`_<max>`
+    // (Scope::Param), without descending into nested blocks.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn numbered_block_param_synthesizes_single_param() {
+        let m = lower("each { puts(_1) }");
+        let block_fn = m
+            .functions
+            .iter()
+            .find(|f| f.name == "__block_0")
+            .expect("expected __block_0");
+        assert_eq!(block_fn.params.len(), 1);
+        assert_eq!(block_fn.params[0].name, "_1");
+    }
+
+    #[test]
+    fn numbered_block_param_arity_is_highest_index() {
+        // Using `_2` implies arity 2 → params `_1, _2`, even though `_1`
+        // is not referenced.
+        let m = lower("each { puts(_2) }");
+        let block_fn = m
+            .functions
+            .iter()
+            .find(|f| f.name == "__block_0")
+            .expect("expected __block_0");
+        let names: Vec<&str> = block_fn.params.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(names, vec!["_1", "_2"]);
+    }
+
+    #[test]
+    fn numbered_block_param_passes_sir_validator() {
+        let m = lower("each { puts(_1) }");
+        let result = semantic_ir::validate(&m);
+        assert!(result.is_ok(), "validator rejected our output: {:?}", result);
+    }
+
+    // -----------------------------------------------------------------
     // Phase 6h — paren-less method calls (`puts 1`, `puts 1, 2`).
     // -----------------------------------------------------------------
 

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -444,6 +444,44 @@ fn is_constant_name(name: &str) -> bool {
     name.chars().next().is_some_and(|c| c.is_ascii_uppercase())
 }
 
+/// Phase 21b (FC) — is `s` a numbered block parameter `_1`..`_9`?
+/// (Two chars: `_` then a digit 1-9.  `_0` and `_10` are NOT numbered
+/// params in Ruby.)  Mirrors the lexer's `is_numbered_block_param`.
+fn numbered_block_param_index(s: &str) -> Option<u8> {
+    let b = s.as_bytes();
+    if b.len() == 2 && b[0] == b'_' && (b'1'..=b'9').contains(&b[1]) {
+        Some(b[1] - b'0')
+    } else {
+        None
+    }
+}
+
+/// Recursively walk an AST subtree, recording the highest numbered
+/// block parameter (`_1`..`_9`) that appears as a `Name` token.  Does
+/// NOT descend into nested `block` nodes — a `_N` inside an inner block
+/// belongs to that inner block's parameter scope, not the outer one.
+fn collect_max_numbered_block_param(node: &GrammarASTNode, max: &mut u8) {
+    for child in &node.children {
+        match child {
+            ASTNodeOrToken::Token(t) if matches!(t.type_, TokenType::Name) => {
+                if let Some(idx) = numbered_block_param_index(&t.value) {
+                    if idx > *max {
+                        *max = idx;
+                    }
+                }
+            }
+            ASTNodeOrToken::Node(n) => {
+                // Don't cross into a nested block — its `_N` refs are
+                // scoped to that block's own implicit parameters.
+                if n.rule_name != "block" {
+                    collect_max_numbered_block_param(n, max);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Lowerer
 // ---------------------------------------------------------------------------
@@ -3773,6 +3811,28 @@ impl Lowerer {
                 }
             }
         }
+        // Phase 21b (FC) — implicit numbered block parameters.  When a
+        // block has NO explicit `|...|` header, Ruby allows the body to
+        // reference `_1`..`_9` as positional parameters.  The arity is
+        // the highest numbered param used (e.g. a body using `_2` gets
+        // params `_1, _2`).  We scan the body tokens for `_1`..`_9`,
+        // take the max, and synthesize params `_1`..`_<max>`.  This
+        // only applies when no explicit params/block-locals were given
+        // (an explicit header always wins; numbered params can't mix).
+        if params.is_empty() && block_locals.is_empty() {
+            let mut max_numbered: u8 = 0;
+            collect_max_numbered_block_param(inner, &mut max_numbered);
+            if max_numbered > 0 {
+                for n in 1..=max_numbered {
+                    params.push(Param {
+                        name: format!("_{n}"),
+                        sir_type: None,
+                        span: self.span_of(inner),
+                    });
+                }
+            }
+        }
+
         // Block params are untyped → declare dynamic-typing.  Block-local
         // variables are likewise dynamically typed.
         if !params.is_empty() || !block_locals.is_empty() {


### PR DESCRIPTION
## Phase 21b (FC) — implicit numbered block parameters `_1`..`_9`

Ruby allows a block with **no** explicit `|...|` header to reference
`_1`..`_9` in its body as positional parameters. The block's arity is
the highest numbered param used — a body using `_2` implies arity 2
(params `_1, _2`), even if `_1` is unreferenced.

### No grammar change — lowering-only

The lexer already flags `_1`..`_9` (`NUMBERED_BLOCK_PARAM_FLAG`) while
keeping them as `Name` tokens, so such blocks already parse. The work is
entirely in the lowerer.

### Lowering (`ruby-to-semantic-ir/src/lower.rs`)

When a hoisted block has no explicit params **and** no `;` block-locals,
the lowerer scans the block body for `_1`..`_9` `Name` tokens
(`collect_max_numbered_block_param`), takes the highest index, and
synthesizes params `_1`..`_<max>` (`Scope::Param`). The scan does **not**
descend into nested `block` nodes — a `_N` inside an inner block belongs
to that inner block's own implicit parameter scope. An explicit pipe
header (or block-locals) always wins; numbered params apply only when no
header is present.

### Parser pins (+3, 232 → 235)

- `test_parse_block_with_numbered_param_parses` — `each { puts(_1) }` (no block_params, `_1` token present)
- `test_parse_block_with_two_numbered_params_parses` — `each { puts(_1 + _2) }`
- `test_parse_do_block_with_numbered_param_parses` — `each do\n puts(_1)\nend`

### Lowering pins (+3, 286 → 289)

- `numbered_block_param_synthesizes_single_param` — `each { puts(_1) }` → `__block_0.params == [_1]`
- `numbered_block_param_arity_is_highest_index` — `each { puts(_2) }` → params `_1, _2`
- `numbered_block_param_passes_sir_validator` — validator end-to-end

### Verification

- `cargo test -p coding-adventures-ruby-lexer -p coding-adventures-ruby-parser -p ruby-to-semantic-ir` — all green (lexer 173, parser 235, IR 289).
- `/security-review` — PASSED (no unsafe/I/O; `_N` index arithmetic cannot underflow; arity bounded 0..=9; recursion bounded by AST depth, nested blocks pruned).

### Changelogs

- `coding-adventures-ruby-parser` 0.66.0 → 0.67.0
- `ruby-to-semantic-ir` 0.69.0 → 0.70.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
