### PR TITLE
feat(ruby-fc): Phase 21c — implicit `it` block parameter (Ruby 3.4)

### DIFF
--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.68.0] - 2026-05-31
+
+### Added (Phase 21c (FC) — implicit `it` block parameter, Ruby 3.4)
+
+No grammar change.  A header-less block may use a bare `it` in its body
+as the first block argument.  Parser-side, `it` lexes as a plain `Name`
+token (it is not a Ruby keyword), so such blocks already parse — these
+pins confirm it.
+
+New parse pins (+3): `test_parse_block_with_implicit_it_parses`
+(`each { puts(it) }` — no block_params, `it` token present),
+`test_parse_do_block_with_implicit_it_parses`
+(`each do\n puts(it)\nend`), `test_parse_block_with_it_dot_method_parses`
+(`each { puts(it.foo) }` — `it` as receiver).  Test count: 235 → 238.
+
 ## [0.67.0] - 2026-05-31
 
 ### Added (Phase 21b (FC) — implicit numbered block parameters `_1`..`_9`)

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -1172,6 +1172,43 @@ mod tests {
         assert!(tree_has_token_value(mwb, "_1"));
     }
 
+    // -----------------------------------------------------------------------
+    // Phase 21c (FC) — implicit `it` block parameter (Ruby 3.4).
+    //
+    // A header-less block may use a bare `it` in its body as the first
+    // block argument.  Parser-side `it` lexes as a plain Name token;
+    // these pins confirm such blocks parse with no block_params header
+    // and the `it` Name token reaches the body.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_block_with_implicit_it_parses() {
+        let ast = parse_ruby("each { puts(it) }");
+        let mwb = find_statement_inner(&ast, "method_with_block")
+            .expect("expected method_with_block");
+        assert!(find_descendant(mwb, "block_params").is_none());
+        assert!(tree_has_token_value(mwb, "it"));
+    }
+
+    #[test]
+    fn test_parse_do_block_with_implicit_it_parses() {
+        let ast = parse_ruby("each do\n  puts(it)\nend");
+        let mwb = find_statement_inner(&ast, "method_with_block")
+            .expect("expected method_with_block");
+        assert!(find_descendant(mwb, "do_block").is_some());
+        assert!(tree_has_token_value(mwb, "it"));
+    }
+
+    #[test]
+    fn test_parse_block_with_it_dot_method_parses() {
+        // `it.foo` — `it` as a receiver still parses; the `it` token is
+        // present in the block body.
+        let ast = parse_ruby("each { puts(it.foo) }");
+        let mwb = find_statement_inner(&ast, "method_with_block")
+            .expect("expected method_with_block");
+        assert!(tree_has_token_value(mwb, "it"));
+    }
+
     #[test]
     fn test_parse_method_call_with_args_and_block() {
         let ast = parse_ruby("each(1, 2) { puts 1 }");

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.71.0] - 2026-05-31
+
+### Added (Phase 21c (FC) — implicit `it` block parameter, Ruby 3.4)
+
+When a block has NO explicit `|...|` header, no block-locals, and no
+numbered params, the lowerer now detects a bare `it` reference in the
+body and synthesizes a single positional parameter named `it`
+(`Scope::Param`).
+
+Detection (`block_uses_implicit_it`) flattens the block body's tokens in
+source order — pruning nested `block` nodes — and treats an `it` `Name`
+token as the implicit parameter ONLY when it is neither immediately
+preceded by `.` (method name: `obj.it`) nor immediately followed by `(`
+(call: `it(x)`).  So `it.foo`, `it + 1`, and `puts(it)` qualify, while
+`it(1)` and `obj.it` do not.  Numbered params (`_N`) take precedence;
+Ruby forbids mixing them with `it` anyway.
+
+New lowering pins (+3): `implicit_it_synthesizes_single_param`
+(`each { puts(it) }` → `__block_0.params == [it]`),
+`implicit_it_method_call_does_not_synthesize_param`
+(`each { it(1) }` → zero params), `implicit_it_passes_sir_validator`
+(validator end-to-end).  Test count: 289 → 292.
+
 ## [0.70.0] - 2026-05-31
 
 ### Added (Phase 21b (FC) — implicit numbered block parameters `_1`..`_9`)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -1502,6 +1502,47 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
+    // Phase 21c (FC) — implicit `it` block parameter (Ruby 3.4).
+    //
+    // A header-less block referencing a bare `it` gets a single
+    // synthesized parameter named `it`.  Guard: `it` adjacent to a
+    // preceding `.` (method name) or a following `(` (call) does NOT
+    // trigger the implicit param.  Numbered params take precedence.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn implicit_it_synthesizes_single_param() {
+        let m = lower("each { puts(it) }");
+        let block_fn = m
+            .functions
+            .iter()
+            .find(|f| f.name == "__block_0")
+            .expect("expected __block_0");
+        assert_eq!(block_fn.params.len(), 1);
+        assert_eq!(block_fn.params[0].name, "it");
+    }
+
+    #[test]
+    fn implicit_it_method_call_does_not_synthesize_param() {
+        // `it(1)` is a real method call, NOT the implicit param → the
+        // block should have zero synthesized params.
+        let m = lower("each { it(1) }");
+        let block_fn = m
+            .functions
+            .iter()
+            .find(|f| f.name == "__block_0")
+            .expect("expected __block_0");
+        assert!(block_fn.params.is_empty(), "got {:?}", block_fn.params);
+    }
+
+    #[test]
+    fn implicit_it_passes_sir_validator() {
+        let m = lower("each { puts(it) }");
+        let result = semantic_ir::validate(&m);
+        assert!(result.is_ok(), "validator rejected our output: {:?}", result);
+    }
+
+    // -----------------------------------------------------------------
     // Phase 6h — paren-less method calls (`puts 1`, `puts 1, 2`).
     // -----------------------------------------------------------------
 

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -482,6 +482,52 @@ fn collect_max_numbered_block_param(node: &GrammarASTNode, max: &mut u8) {
     }
 }
 
+/// Phase 21c (FC) — flatten a subtree's tokens into source order,
+/// pruning nested `block` nodes (their tokens belong to the inner
+/// block's own implicit-parameter scope).  Used to detect the implicit
+/// `it` parameter with reliable left/right adjacency.
+fn flatten_block_tokens<'a>(node: &'a GrammarASTNode, out: &mut Vec<&'a Token>) {
+    for child in &node.children {
+        match child {
+            ASTNodeOrToken::Token(t) => out.push(t),
+            ASTNodeOrToken::Node(n) => {
+                if n.rule_name != "block" {
+                    flatten_block_tokens(n, out);
+                }
+            }
+        }
+    }
+}
+
+/// Phase 21c (FC) — does this block body use the implicit `it`
+/// parameter (Ruby 3.4)?  A bare `it` with no explicit `|...|` header
+/// is the first block argument.  We treat an `it` Name token as the
+/// implicit param ONLY when it is:
+///   - NOT immediately preceded by `.` (else it's a method name:
+///     `obj.it`), and
+///   - NOT immediately followed by `(` (else it's a call: `it(x)`).
+/// `it.foo`, `it + 1`, `puts(it)` all qualify (the `.`/`(` there are
+/// not adjacent in the disqualifying position).  This is a heuristic;
+/// an `it` used as a local (`it = …`) or parenless callee is a rare
+/// edge not handled in v0.
+fn block_uses_implicit_it(inner: &GrammarASTNode) -> bool {
+    let mut toks: Vec<&Token> = Vec::new();
+    flatten_block_tokens(inner, &mut toks);
+    for (i, t) in toks.iter().enumerate() {
+        if !matches!(t.type_, TokenType::Name) || t.value != "it" {
+            continue;
+        }
+        let prev_is_dot = i > 0 && matches!(toks[i - 1].type_, TokenType::Dot);
+        let next_is_lparen = toks
+            .get(i + 1)
+            .is_some_and(|n| matches!(n.type_, TokenType::LParen));
+        if !prev_is_dot && !next_is_lparen {
+            return true;
+        }
+    }
+    false
+}
+
 // ---------------------------------------------------------------------------
 // Lowerer
 // ---------------------------------------------------------------------------
@@ -3830,6 +3876,17 @@ impl Lowerer {
                         span: self.span_of(inner),
                     });
                 }
+            } else if block_uses_implicit_it(inner) {
+                // Phase 21c (FC) — implicit `it` parameter (Ruby 3.4).
+                // A header-less block referencing bare `it` gets a single
+                // synthesized parameter named `it`.  Mutually exclusive
+                // with numbered params (`_N` takes precedence above; Ruby
+                // forbids mixing them anyway).
+                params.push(Param {
+                    name: "it".to_string(),
+                    sir_type: None,
+                    span: self.span_of(inner),
+                });
             }
         }
 


### PR DESCRIPTION
## Phase 21c (FC) — implicit `it` block parameter (Ruby 3.4)

Ruby 3.4 lets a header-less block reference a bare `it` as the first
block argument — the named spelling of `_1`.

### No grammar change — lowering-only

`it` lexes as a plain `Name` token (it is not a Ruby keyword), so such
blocks already parse. The work is entirely in the lowerer.

### Lowering (`ruby-to-semantic-ir/src/lower.rs`)

When a hoisted block has no explicit `|...|` header, no `;` block-locals,
and no `_N` numbered params, `block_uses_implicit_it` flattens the block
body's tokens in source order (pruning nested `block` nodes) and treats
an `it` `Name` token as the implicit parameter **only** when it is
neither immediately preceded by `.` (method name: `obj.it`) nor
immediately followed by `(` (call: `it(x)`). Qualifying uses
(`puts(it)`, `it.foo`, `it + 1`) synthesize a single param `it`
(`Scope::Param`). Numbered params take precedence; Ruby forbids mixing
`_N` and `it`.

### Parser pins (+3, 235 → 238)

- `test_parse_block_with_implicit_it_parses` — `each { puts(it) }`
- `test_parse_do_block_with_implicit_it_parses` — `each do\n puts(it)\nend`
- `test_parse_block_with_it_dot_method_parses` — `each { puts(it.foo) }`

### Lowering pins (+3, 289 → 292)

- `implicit_it_synthesizes_single_param` — `each { puts(it) }` → `__block_0.params == [it]`
- `implicit_it_method_call_does_not_synthesize_param` — `each { it(1) }` → zero params
- `implicit_it_passes_sir_validator` — validator end-to-end

### Verification

- `cargo test -p coding-adventures-ruby-lexer -p coding-adventures-ruby-parser -p ruby-to-semantic-ir` — all green (lexer 173, parser 238, IR 292).
- `/security-review` — PASSED (no unsafe/I/O; index access guarded; recursion bounded by AST depth, nested blocks pruned).

### Changelogs

- `coding-adventures-ruby-parser` 0.67.0 → 0.68.0
- `ruby-to-semantic-ir` 0.70.0 → 0.71.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
