### PR TITLE
feat(closure-pass-constant-fold): CLOC12.09 — close gap-005 typeof literal fold

### DIFF
--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,68 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.5.0] - 2026-06-01
+
+### Added — CLOC12.09: close gap-005 typeof literal fold
+
+Implements `typeof <primitive literal>` constant-folding per the
+ECMAScript §UnaryTypeofExpression table:
+
+| Operand                  | Folded result |
+|--------------------------|---------------|
+| `NumericLiteral`         | `"number"`    |
+| `StringLiteral`          | `"string"`    |
+| `BooleanLiteral`         | `"boolean"`   |
+| `NullLiteral`            | `"object"`    |
+
+The `NullLiteral → "object"` case preserves the famous JavaScript quirk
+where `typeof null === "object"` (a historical bug baked into the spec).
+
+The four remaining `typeof` cases stay deferred:
+
+- `typeof undefined → "undefined"` — gated on gap-001 (no
+  `UndefinedLiteral` AST variant yet).
+- `typeof <BigIntLiteral> → "bigint"` — gated on gap-021 (no
+  `BigIntLiteral` AST variant yet).
+- `typeof <function expression> → "function"` — Phase 1.x AST work.
+- `typeof <Identifier>` — left alone (identifier may bind to anything at
+  runtime; matches upstream `testSame` lines).
+
+### gap-005 → RESOLVED via CLOC12.09
+
+The CLOC12.02 ignored port `test_typeof_lines_from_string_string_comparison`
+is replaced by three focused tests:
+
+| New test | Status |
+|----------|--------|
+| `test_typeof_literal_comparison_folds` | **passing** (`typeof 3 > typeof 4` → `false`) |
+| `test_typeof_identifier_is_left_alone` | **passing** (`testSame` shape) |
+| `test_typeof_identifier_identity_fold` | `#[ignore]` on **new gap-029** |
+
+### gap-029 — identity-of-typeof-same-identifier fold (NEW)
+
+Upstream folds `typeof a === typeof a` → `true` and
+`typeof a !== typeof a` → `false` because the two sub-expressions are
+structurally identical. Implementing that requires a *structural
+equality* check between operands, which is conceptually distinct from
+value-substitution folding. Filed as gap-029 for a future PR.
+
+### Port score (this crate)
+
+|             | passing | ignored |
+|-------------|---------|---------|
+| CLOC12.03   | 7       | 5       |
+| **CLOC12.09** | **9** | **5**   |
+
+(Net +2 passing, 0 net change to ignored. The previously-ignored
+`test_typeof_lines_from_string_string_comparison` stub got replaced
+by 2 new passing tests + 1 new `#[ignore]`-d gap-029 test, so total
+test count went 12 → 14.)
+
+### Version bump
+
+`0.4.0` → `0.5.0`.
+
 ## [0.4.0] - 2026-05-31
 
 ### Added — CLOC12.03: close gap-007 and gap-008

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -748,8 +748,40 @@ fn fold_unary(u: &UnaryExpression, st: &mut FoldState) -> Expression {
                 _ => None,
             }
         }
-        // Skipped: BitNot (int32 coercion), TypeOf (need undefined),
-        // Void (need undefined), Delete (side effects).
+        UnaryOperator::TypeOf => {
+            // `typeof <primitive literal>` → corresponding string,
+            // per the ECMAScript §UnaryTypeofExpression table:
+            //
+            //   typeof <NumericLiteral>   →  "number"
+            //   typeof <StringLiteral>    →  "string"
+            //   typeof <BooleanLiteral>   →  "boolean"
+            //   typeof <NullLiteral>      →  "object"   (the famous JS quirk)
+            //   typeof <undefined>        →  "undefined" (gap-001: no
+            //                                            UndefinedLiteral
+            //                                            variant yet)
+            //   typeof <BigIntLiteral>    →  "bigint"   (gap-021: no
+            //                                            BigIntLiteral
+            //                                            variant yet)
+            //   typeof <function expr>    →  "function" (Phase 1.x; not
+            //                                            in v0.4.0's
+            //                                            fold-set)
+            //
+            // Closes CLOC12 gap-005 for the four primitive-literal cases
+            // we can already model. The identifier-typeof identity-fold
+            // (`typeof a === typeof a` → `true`) is structurally a
+            // *different* operation — it requires equality between two
+            // syntactically-identical operands, not a value-substitution
+            // fold. That part stays gated under the new gap-029.
+            match &arg {
+                Expression::NumericLiteral(_) => Some(FoldedLiteral::String("number".to_string())),
+                Expression::StringLiteral(_) => Some(FoldedLiteral::String("string".to_string())),
+                Expression::BooleanLiteral(_) => Some(FoldedLiteral::String("boolean".to_string())),
+                Expression::NullLiteral(_) => Some(FoldedLiteral::String("object".to_string())),
+                _ => None,
+            }
+        }
+        // Skipped: BitNot (int32 coercion), Void (need undefined),
+        // Delete (side effects).
         _ => None,
     };
 

--- a/code/packages/rust/closure-pass-constant-fold/tests/upstream/peephole_fold_constants_test.rs
+++ b/code/packages/rust/closure-pass-constant-fold/tests/upstream/peephole_fold_constants_test.rs
@@ -307,14 +307,78 @@ fn test_basic_number_comparisons() {
     assert_fold(b(n(2.0), BinaryOperator::StrictEq, n(1.0)), bool_(false));
 }
 
-/// Upstream `testStringStringComparison` `testSame` lines using
-/// `typeof` are deferred to gap-005 (no `typeof` constant fold).
+/// Upstream `testStringStringComparison` line:
+///
+///   test("typeof 3 > typeof 4", "false")
+///
+/// `typeof <NumericLiteral>` folds to `"number"`, and `"number" >
+/// "number"` is `false` (string comparison via the existing
+/// string-vs-string branch). **gap-005 closed in CLOC12.09** for the
+/// primitive-literal-typeof cases.
 #[test]
-#[ignore = "blocked on gap-005: `typeof` operator constant-fold not implemented"]
-fn test_typeof_lines_from_string_string_comparison() {
-    // `typeof a < 'a'` → leave alone (unknown identifier);
-    // `typeof 3 > typeof 4` → 'number' > 'number' → false (fold-able);
-    // `typeof a === typeof a` → true (fold-able by identity).
+fn test_typeof_literal_comparison_folds() {
+    use coding_adventures_javascript_ast::{UnaryExpression, UnaryOperator};
+    let typeof_lit = |arg: Expression| {
+        Expression::UnaryExpression(UnaryExpression {
+            cv: None,
+            operator: UnaryOperator::TypeOf,
+            prefix: true,
+            argument: Box::new(arg),
+        })
+    };
+    // typeof 3 > typeof 4  →  "number" > "number"  →  false
+    assert_fold(
+        b(typeof_lit(n(3.0)), BinaryOperator::Gt, typeof_lit(n(4.0))),
+        bool_(false),
+    );
+}
+
+/// Upstream `testStringStringComparison` lines:
+///
+///   testSame("typeof a < 'a'")
+///   testSame("'a' >= typeof a")
+///
+/// `typeof <identifier>` is *not* foldable — the identifier may bind to
+/// anything at runtime. **gap-005 closed in CLOC12.09**: our pass
+/// leaves these alone, which is exactly what upstream `testSame`
+/// asserts.
+#[test]
+fn test_typeof_identifier_is_left_alone() {
+    use coding_adventures_javascript_ast::{Identifier, UnaryExpression, UnaryOperator};
+    let ident_expr = |name: &str| {
+        Expression::Identifier(Identifier {
+            cv: None,
+            name: name.to_string(),
+        })
+    };
+    let typeof_a = Expression::UnaryExpression(UnaryExpression {
+        cv: None,
+        operator: UnaryOperator::TypeOf,
+        prefix: true,
+        argument: Box::new(ident_expr("a")),
+    });
+    // typeof a < "a"  →  leave alone (identifier means runtime-unknown)
+    assert_same(b(typeof_a.clone(), BinaryOperator::Lt, s("a")));
+    // "a" >= typeof a  →  same shape, flipped
+    assert_same(b(s("a"), BinaryOperator::GtEq, typeof_a));
+}
+
+/// Upstream `testStringStringComparison` lines using
+/// `typeof <identifier> === typeof <SAME identifier>`:
+///
+///   test("typeof a === typeof a", "true");
+///   test("typeof a !== typeof a", "false");
+///
+/// Folding these requires recognising that the two sub-expressions are
+/// *structurally identical* (same operator, same identifier name), not
+/// just folding each side independently. That's a different kind of
+/// fold rule — see gap-029. Stays `#[ignore]`-ed here.
+#[test]
+#[ignore = "blocked on gap-029: identity-of-typeof-same-identifier fold not implemented"]
+fn test_typeof_identifier_identity_fold() {
+    // Would assert:
+    //   typeof a === typeof a  →  true
+    //   typeof a !== typeof a  →  false
 }
 
 /// Upstream "and similar" lines that boil down to plain arithmetic on

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -58,11 +58,10 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-005 — `typeof` operator constant-fold not implemented
 
-- **Status:** OPEN
+- **Status:** RESOLVED in CLOC12.09 (literal-typeof cases) — residual identity-fold tracked as gap-029
 - **Upstream test:** `PeepholeFoldConstantsTest::testStringStringComparison` (lines using `typeof`)
 - **Ported file:** `closure-pass-constant-fold/tests/upstream/peephole_fold_constants_test.rs`
-- **Why it fails:** Crate-level docs already flag `typeof` as deferred. `typeof <literal>` → corresponding string literal needs no runtime info; identity-comparison fold (`typeof x === typeof x` → `true`) is a separate optimization.
-- **What it needs:** Implement `UnaryExpression { op: TypeOf, argument: literal }` → corresponding `StringLiteral` ("number" / "string" / "boolean" / "object" / "undefined" / "function").
+- **Resolution:** Added a `UnaryOperator::TypeOf` branch to `fold_unary` that pattern-matches the argument against the four Phase 1 primitive literals and returns the corresponding string: `NumericLiteral → "number"`, `StringLiteral → "string"`, `BooleanLiteral → "boolean"`, `NullLiteral → "object"` (the JS quirk). The remaining cases (`undefined`, BigInt, function expression, identifier) stay deferred per their respective gaps (gap-001, gap-021, Phase 1.x AST, runtime-unknown). The identity-comparison fold (`typeof x === typeof x` → `true`) is conceptually different — see gap-029.
 
 ### gap-007 — `NullLiteral OP NullLiteral` fold not implemented
 
@@ -245,3 +244,11 @@ historical context with status `RESOLVED` and a link to the fix PR.
 - **Ported file:** `closure-source-map/tests/upstream/source_map_generator_v3_test.rs`
 - **Why it fails:** Our `SourceMapBuilder` v0.1.0 accumulates raw `(line, column, cv_id)` mappings but the `build()` step produces a `SourceMap` with `mappings: String::new()` — VLQ encoding is documented as v2 work in the crate's source. Upstream tests assert specific VLQ strings like `"A,aAAAA,QAASA,UAAS,EAAG;"` and need the encoder to produce them.
 - **What it needs:** Implement the VLQ encoder per the source-map v3 spec. The encoder receives per-token `(generated_line, generated_column)` paired with `cv_id`, resolves each `cv_id` to `(source_index, original_line, original_column)` via the `CVLog`, and emits the standard base64-VLQ delta-encoded `mappings` string. Once it lands, the seven `#[ignore]`-ed ports in `source_map_generator_v3_test.rs` flip to real assertions and we re-port the rest of upstream's `SourceMapGeneratorV3Test`.
+
+### gap-029 — identity-of-typeof-same-identifier fold not implemented
+
+- **Status:** OPEN
+- **Upstream test:** `PeepholeFoldConstantsTest::testStringStringComparison` (`typeof a === typeof a` lines)
+- **Ported file:** `closure-pass-constant-fold/tests/upstream/peephole_fold_constants_test.rs`
+- **Why it fails:** Upstream folds `typeof a === typeof a` → `true` and `typeof a !== typeof a` → `false` because the two sub-expressions are *structurally identical*. Our constant-fold pass folds by *value substitution* — it doesn't compare two expressions for structural equality.
+- **What it needs:** A new fold rule on `BinaryExpression` with `StrictEq`/`StrictNotEq` that, when neither side is foldable to a literal, tests whether the two sides are syntactically equivalent. If both sides are the same `UnaryExpression { op: TypeOf, argument: <pure expression> }` shape with `argument` being the same identifier, fold to `true`/`false` respectively. Care needed: only fire when the argument is provably side-effect-free (an `Identifier` or another literal). Roughly 30-40 lines in `try_fold_binary_op`.


### PR DESCRIPTION
## Summary

Adds a `UnaryOperator::TypeOf` branch to `fold_unary` that folds `typeof <primitive literal>` per the ECMAScript spec table:

| Operand | Folded result |
|---------|---------------|
| `NumericLiteral` | `\"number\"` |
| `StringLiteral` | `\"string\"` |
| `BooleanLiteral` | `\"boolean\"` |
| `NullLiteral` | `\"object\"` ← the famous JS quirk |

The remaining cases stay deferred per their respective gaps:
- `typeof undefined → \"undefined\"` — gap-001 (no `UndefinedLiteral` AST yet)
- `typeof <BigIntLiteral> → \"bigint\"` — gap-021 (no `BigIntLiteral` AST yet)
- `typeof <function expr> → \"function\"` — Phase 1.x AST work
- `typeof <Identifier>` — left alone (binds to anything at runtime)

## gap-005 → RESOLVED

The CLOC12.02 ignored port `test_typeof_lines_from_string_string_comparison` is replaced by three focused tests:

| New test | Status |
|----------|--------|
| `test_typeof_literal_comparison_folds` | **passing** (`typeof 3 > typeof 4` → `false`) |
| `test_typeof_identifier_is_left_alone` | **passing** (`testSame` shape) |
| `test_typeof_identifier_identity_fold` | `#[ignore]` on **new gap-029** |

## gap-029 — NEW

Identity-of-typeof-same-identifier fold (`typeof a === typeof a` → `true`). Requires *structural equality* comparison between operands — conceptually distinct from value-substitution folding. ~30-40 lines in a future PR.

## Port score (this crate)

|             | passing | ignored | total |
|-------------|---------|---------|-------|
| CLOC12.03   | 7       | 5       | 12    |
| **CLOC12.09** | **9** | **5**   | **14** |

## Version

closure-pass-constant-fold `0.4.0` → `0.5.0`.

## Test plan

- [x] \`cargo test\` — 27 inline + 9 upstream pass, 5 ignored, 0 fail
- [x] Pure pattern matching, no unsafe, no IO/network/process
- [x] gap-005 marked RESOLVED in `code/specs/CLOC12-gaps.md`; gap-029 entry added
- [x] Security review: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)