### PR TITLE
feat(ruby-ir): lower string interpolation to real SIR (Phase 20a FC)

### DIFF
--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -21,7 +21,15 @@ Per the Tier-3 marker-replacement convention, the `__interp__` marker is
 multi-statement bodies (`#{a; b}`), and anything that doesn't parse to a
 single expression statement still emit the verbatim marker.
 
-New lowering pins (+3, one existing marker test rewritten):
+**DoS guard.** Because a `#{…}` body may itself contain a nested
+interpolated string (`"#{ "#{x}" }"`), the recursive re-parse path could
+otherwise recurse without bound and exhaust the thread stack (an
+uncatchable abort) on adversarial input.  A new `interp_depth` counter on
+`Lowerer` caps re-parsing at `MAX_INTERP_DEPTH = 8` — far beyond any
+legitimate nesting — and falls back to the safe `__interp__` marker past
+the cap.
+
+New lowering pins (+4, one existing marker test rewritten):
 `interpolated_string_with_expression_lowers_recursively`
 (`"sum=#{1+2}"` → real `+` call, not a marker),
 `interpolated_string_with_multiple_expr_interps_lowers_each_recursively`
@@ -29,8 +37,10 @@ New lowering pins (+3, one existing marker test rewritten):
 `interpolated_string_with_binary_var_expr_lowers_recursively`
 (`"#{a + b}"` → `+` over two `VarRef`s),
 `interpolated_expression_string_validates_e2e`
-(`puts("sum is #{1 + 2}")` round-trips the SIR validator).
-Test count: 292 → 295.
+(`puts("sum is #{1 + 2}")` round-trips the SIR validator),
+`deeply_nested_interpolation_terminates_without_stack_overflow`
+(200-level nesting terminates via the depth cap).
+Test count: 292 → 296.
 
 ## [0.71.0] - 2026-05-31
 

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.72.0] - 2026-05-31
+
+### Changed (Phase 20a (FC) — string interpolation lowers to real SIR)
+
+Expression interpolations inside double-quoted strings now lower to
+genuine SIR instead of the v0 `__interp__` marker.  When a `#{…}` body
+re-parses to exactly one expression / method-call statement, the new
+`try_lower_interp_body` helper re-invokes `parse_ruby` on the body and
+lowers its tail expression **in the current scope** — so `"sum=#{1+2}"`
+becomes `string_concat([StrLit("sum="), BuiltinCall("+", [1, 2])])` and
+`"#{a + b}"` resolves `a`/`b` as `VarRef`s the same way surrounding code
+would.  Bare-name bodies (`"#{name}"`) keep their existing `VarRef`
+fast-path.
+
+Per the Tier-3 marker-replacement convention, the `__interp__` marker is
+**retained as a fallback** for one phase: empty bodies (`#{}`),
+multi-statement bodies (`#{a; b}`), and anything that doesn't parse to a
+single expression statement still emit the verbatim marker.
+
+New lowering pins (+3, one existing marker test rewritten):
+`interpolated_string_with_expression_lowers_recursively`
+(`"sum=#{1+2}"` → real `+` call, not a marker),
+`interpolated_string_with_multiple_expr_interps_lowers_each_recursively`
+(`"a#{1}b#{2}c"` → five-segment concat),
+`interpolated_string_with_binary_var_expr_lowers_recursively`
+(`"#{a + b}"` → `+` over two `VarRef`s),
+`interpolated_expression_string_validates_e2e`
+(`puts("sum is #{1 + 2}")` round-trips the SIR validator).
+Test count: 292 → 295.
+
 ## [0.71.0] - 2026-05-31
 
 ### Added (Phase 21c (FC) — implicit `it` block parameter, Ruby 3.4)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -5245,10 +5245,12 @@ mod tests {
     }
 
     #[test]
-    fn interpolated_string_with_expression_uses_interp_marker() {
-        // `"sum=#{1+2}"` — the interp body `1+2` is not a bare name, so
-        // it must lower as the v0 `__interp__` marker carrying the raw
-        // body text.  Same marker pattern as Phase 6v rescue/ensure.
+    fn interpolated_string_with_expression_lowers_recursively() {
+        // Phase 20a (FC) — `"sum=#{1+2}"` — the interp body `1+2` is a real
+        // expression.  Rather than emit the v0 `__interp__` marker carrying
+        // the raw body text, the lowerer now re-parses the body and lowers
+        // it into genuine SIR: the `+` operator becomes `BuiltinCall("+", …)`.
+        // The marker survives only as a fallback for bodies we cannot parse.
         let m = lower(r##"x = "sum=#{1+2}""##);
         let b = main_body(&m);
         let value = match &b.stmts[0] {
@@ -5262,14 +5264,12 @@ mod tests {
                 assert!(matches!(&args[0], Expr::StrLit { value, .. } if value == "sum="));
                 match &args[1] {
                     Expr::BuiltinCall { name, args, .. } => {
-                        assert_eq!(name, "__interp__");
-                        assert_eq!(args.len(), 1);
-                        assert!(
-                            matches!(&args[0], Expr::StrLit { value, .. } if value == "1+2"),
-                            "expected the raw interp body preserved in the marker"
-                        );
+                        assert_eq!(name, "+", "interp body 1+2 lowers to a real + call");
+                        assert_eq!(args.len(), 2);
+                        assert!(matches!(args[0], Expr::IntLit { value: 1, .. }));
+                        assert!(matches!(args[1], Expr::IntLit { value: 2, .. }));
                     }
-                    other => panic!("expected __interp__ marker, got {:?}", other),
+                    other => panic!("expected real `+` BuiltinCall, got {:?}", other),
                 }
             }
             other => panic!("expected string_concat, got {:?}", other),
@@ -5291,6 +5291,71 @@ puts("hi #{name}")
         assert!(
             result.is_ok(),
             "validator rejected interpolated-string module: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn interpolated_string_with_multiple_expr_interps_lowers_each_recursively() {
+        // Phase 20a (FC) — `"a#{1}b#{2}c"` carries two expression
+        // interpolations interleaved with three literal runs.  Each `#{…}`
+        // body re-parses and lowers to a real `IntLit`, producing a
+        // five-segment `string_concat` (no `__interp__` markers anywhere).
+        let m = lower(r##"x = "a#{1}b#{2}c""##);
+        let b = main_body(&m);
+        let value = match &b.stmts[0] {
+            Stmt::LetBinding { value, .. } => value,
+            other => panic!("expected LetBinding, got {:?}", other),
+        };
+        match value {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "string_concat");
+                assert_eq!(args.len(), 5, "a | 1 | b | 2 | c");
+                assert!(matches!(&args[0], Expr::StrLit { value, .. } if value == "a"));
+                assert!(matches!(args[1], Expr::IntLit { value: 1, .. }));
+                assert!(matches!(&args[2], Expr::StrLit { value, .. } if value == "b"));
+                assert!(matches!(args[3], Expr::IntLit { value: 2, .. }));
+                assert!(matches!(&args[4], Expr::StrLit { value, .. } if value == "c"));
+            }
+            other => panic!("expected string_concat, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn interpolated_string_with_binary_var_expr_lowers_recursively() {
+        // Phase 20a (FC) — `"#{a + b}"` is a sole interpolation whose body is
+        // a binary expression over two names.  It unwraps to the lowered
+        // `+` call directly (single-segment unwrap), with both operands as
+        // `VarRef`s — proving the recursive lowerer threads the current
+        // scope through, not a `__interp__` marker.
+        let m = lower(r##"x = "#{a + b}""##);
+        let b = main_body(&m);
+        let value = match &b.stmts[0] {
+            Stmt::LetBinding { value, .. } => value,
+            other => panic!("expected LetBinding, got {:?}", other),
+        };
+        match value {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "+", "single interp body unwraps to the real + call");
+                assert_eq!(args.len(), 2);
+                assert!(matches!(&args[0], Expr::VarRef { name, .. } if name == "a"));
+                assert!(matches!(&args[1], Expr::VarRef { name, .. } if name == "b"));
+            }
+            other => panic!("expected real `+` BuiltinCall, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn interpolated_expression_string_validates_e2e() {
+        // Phase 20a (FC) — end-to-end: an arithmetic interpolation lowers to
+        // real SIR (`string_concat([StrLit, BuiltinCall("+", …)])`) and that
+        // shape round-trips cleanly through the SIR validator.  Guards
+        // against effect/arg-shape regressions in the new recursive path.
+        let m = lower(r##"puts("sum is #{1 + 2}")"##);
+        let result = semantic_ir::validate(&m);
+        assert!(
+            result.is_ok(),
+            "validator rejected expression-interpolation module: {:?}",
             result
         );
     }

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -5360,6 +5360,27 @@ puts("hi #{name}")
         );
     }
 
+    #[test]
+    fn deeply_nested_interpolation_terminates_without_stack_overflow() {
+        // Phase 20a (FC) DoS guard — the recursive interp lowerer caps
+        // re-parsing at MAX_INTERP_DEPTH (8).  Build an interpolation
+        // nested *far* beyond that (200 levels) and confirm lowering
+        // simply terminates — past the cap the body is kept as the
+        // verbatim `__interp__` marker rather than recursing until the
+        // thread stack is exhausted.  Before the guard this input would
+        // abort the process with an uncatchable stack overflow.
+        let mut src = String::from("1");
+        for _ in 0..200 {
+            // each wrap adds one `"#{ … }"` interpolation level
+            src = format!("\"#{{{src}}}\"");
+        }
+        let code = format!("x = {src}");
+        // The assertion is simply that this returns at all (no panic /
+        // overflow); we touch the body to ensure a real module came back.
+        let m = lower(&code);
+        let _ = main_body(&m);
+    }
+
     // -----------------------------------------------------------------------
     // Phase 6z — float / hex / bin / oct numeric literal lowering
     //

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -5403,6 +5403,19 @@ impl Lowerer {
                 span,
             };
         }
+        // Phase 20a (FC) — recursively parse+lower the interpolation
+        // body so `#{1 + 2}`, `#{foo.bar}`, `#{a * b}` etc. become real
+        // SIR (a BuiltinCall/DirectCall/BinaryOp tree) instead of an
+        // opaque marker.  We re-invoke the Ruby parser on the trimmed
+        // body and lower its single tail expression in the CURRENT
+        // scope (so VarRefs to enclosing params/locals resolve
+        // correctly).  Anything that doesn't cleanly parse to exactly
+        // one expression/method-call statement falls back to the
+        // `__interp__` marker below (kept for one phase per the Tier-3
+        // marker-replacement convention).
+        if let Some(expr) = self.try_lower_interp_body(trimmed) {
+            return expr;
+        }
         // Fallback marker.  Triggers `Strings` because we embed the
         // raw text as a `StrLit`.
         self.features_used.insert(Feature::Strings);
@@ -5414,6 +5427,45 @@ impl Lowerer {
             }],
             effects: EffectSet::PURE,
             span,
+        }
+    }
+
+    /// Phase 20a (FC) — try to lower an interpolation body by
+    /// re-invoking the Ruby parser on it and lowering the resulting
+    /// single tail expression.  Returns `None` (→ marker fallback) if
+    /// the body is empty, doesn't parse to exactly one statement, or
+    /// that statement isn't a plain expression / method call.  Lowering
+    /// runs in the current scope so `#{x + 1}` resolves `x` the same way
+    /// the surrounding code would.
+    fn try_lower_interp_body(&mut self, body: &str) -> Option<Expr> {
+        if body.is_empty() {
+            return None;
+        }
+        let ast = coding_adventures_ruby_parser::parse_ruby(body);
+        if ast.rule_name != "program" {
+            return None;
+        }
+        let stmts: Vec<&GrammarASTNode> = ast
+            .children
+            .iter()
+            .filter_map(|c| match c {
+                ASTNodeOrToken::Node(n) if n.rule_name == "statement" => Some(n),
+                _ => None,
+            })
+            .collect();
+        // Exactly one statement; multi-statement bodies (`#{a; b}`) are
+        // rare and kept as the verbatim marker.
+        if stmts.len() != 1 {
+            return None;
+        }
+        let inner = self.first_node_child(stmts[0])?;
+        match inner.rule_name.as_str() {
+            "expression_stmt" => {
+                let expr_node = self.first_node_child(inner)?;
+                self.lower_expression(expr_node).ok()
+            }
+            "method_call" | "method_call_no_paren" => self.lower_method_call(inner).ok(),
+            _ => None,
         }
     }
 

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -71,6 +71,7 @@ pub fn compile(program: &GrammarASTNode, module_name: &str) -> Result<Module, Ru
         features_used: HashSet::new(),
         block_counter: 0,
         multi_assign_counter: 0,
+        interp_depth: 0,
     };
     // Phase 6a: hoist `def name(params) … end` declarations to
     // top-level Functions BEFORE walking the rest of the program so
@@ -567,7 +568,29 @@ struct Lowerer {
     /// temps so the original RHS values are captured *before* any LHS
     /// is rebound — matching Ruby's parallel-binding semantics.
     multi_assign_counter: usize,
+    /// Phase 20a (FC): current nesting depth of string-interpolation
+    /// re-parsing.  `try_lower_interp_body` re-invokes the Ruby parser
+    /// on each `#{…}` body, and a body may itself contain a nested
+    /// interpolated string (`"#{ "#{x}" }"`), which recurses back into
+    /// the same path.  Neither the parser nor the lowerer has its own
+    /// recursion limit, so without this counter an adversarial deeply
+    /// nested literal could exhaust the thread stack (an uncatchable
+    /// abort — a DoS for any host that compiles untrusted source).  We
+    /// stop recursing at `MAX_INTERP_DEPTH` and fall back to the safe
+    /// `__interp__` marker, which preserves correctness.
+    interp_depth: usize,
 }
+
+/// Phase 20a (FC): hard ceiling on nested string-interpolation
+/// re-parsing depth.  Real Ruby almost never nests interpolation more
+/// than a level or two (`"a#{ "b#{x}" }"` is already exotic), so 8 is
+/// far beyond any legitimate use.  We deliberately keep it small: each
+/// recursion level re-enters the full recursive-descent lowering stack
+/// (`lower_expression` → … → `try_lower_interp_body`), whose frames are
+/// large, so an over-generous cap could itself approach the thread
+/// stack limit.  Past the cap we fall back to the safe `__interp__`
+/// marker, bounding stack growth regardless of how deeply input nests.
+const MAX_INTERP_DEPTH: usize = 8;
 
 impl Lowerer {
     /// Build a `Span` from a node's recorded start/end positions.
@@ -5441,32 +5464,47 @@ impl Lowerer {
         if body.is_empty() {
             return None;
         }
-        let ast = coding_adventures_ruby_parser::parse_ruby(body);
-        if ast.rule_name != "program" {
+        // DoS guard (Phase 20a): a nested interpolated literal
+        // (`"#{ "#{x}" }"`) recurses back through this path on every
+        // level.  Beyond MAX_INTERP_DEPTH we stop re-parsing and let the
+        // caller fall back to the `__interp__` marker, bounding stack
+        // growth no matter how deeply an adversarial input nests.
+        if self.interp_depth >= MAX_INTERP_DEPTH {
             return None;
         }
-        let stmts: Vec<&GrammarASTNode> = ast
-            .children
-            .iter()
-            .filter_map(|c| match c {
-                ASTNodeOrToken::Node(n) if n.rule_name == "statement" => Some(n),
-                _ => None,
-            })
-            .collect();
-        // Exactly one statement; multi-statement bodies (`#{a; b}`) are
-        // rare and kept as the verbatim marker.
-        if stmts.len() != 1 {
-            return None;
-        }
-        let inner = self.first_node_child(stmts[0])?;
-        match inner.rule_name.as_str() {
-            "expression_stmt" => {
-                let expr_node = self.first_node_child(inner)?;
-                self.lower_expression(expr_node).ok()
+        self.interp_depth += 1;
+        // Run the parse+lower in a closure so a single `?`/early-return
+        // can't skip the depth decrement below.
+        let result = (|| {
+            let ast = coding_adventures_ruby_parser::parse_ruby(body);
+            if ast.rule_name != "program" {
+                return None;
             }
-            "method_call" | "method_call_no_paren" => self.lower_method_call(inner).ok(),
-            _ => None,
-        }
+            let stmts: Vec<&GrammarASTNode> = ast
+                .children
+                .iter()
+                .filter_map(|c| match c {
+                    ASTNodeOrToken::Node(n) if n.rule_name == "statement" => Some(n),
+                    _ => None,
+                })
+                .collect();
+            // Exactly one statement; multi-statement bodies (`#{a; b}`)
+            // are rare and kept as the verbatim marker.
+            if stmts.len() != 1 {
+                return None;
+            }
+            let inner = self.first_node_child(stmts[0])?;
+            match inner.rule_name.as_str() {
+                "expression_stmt" => {
+                    let expr_node = self.first_node_child(inner)?;
+                    self.lower_expression(expr_node).ok()
+                }
+                "method_call" | "method_call_no_paren" => self.lower_method_call(inner).ok(),
+                _ => None,
+            }
+        })();
+        self.interp_depth -= 1;
+        result
     }
 
     fn lower_factor(&mut self, node: &GrammarASTNode) -> Result<Expr, RubyLowerError> {


### PR DESCRIPTION
## Phase 20a (FC) — string interpolation lowers to real SIR

Part of the Ruby 3.4 frontend full-coverage effort.

### What

Expression interpolations inside double-quoted strings now lower to
**genuine SIR** instead of the v0 `__interp__` marker.

| Source | Before (v0 marker) | After (Phase 20a) |
|---|---|---|
| `"sum=#{1+2}"` | `string_concat([StrLit "sum=", __interp__("1+2")])` | `string_concat([StrLit "sum=", BuiltinCall("+", [1, 2])])` |
| `"#{a + b}"` | `__interp__("a + b")` | `BuiltinCall("+", [VarRef a, VarRef b])` |
| `"#{name}"` | `VarRef name` (unchanged) | `VarRef name` (unchanged) |

### How

A new `try_lower_interp_body` helper re-invokes `parse_ruby` on the
interpolation body. If it parses to exactly one expression /
method-call statement, the tail expression is lowered **in the current
scope** (so names resolve the same way the surrounding code would).
Otherwise it falls through to the marker.

Per the Tier-3 marker-replacement convention, `__interp__` is **retained
as a fallback** for one phase: empty bodies (`#{}`), multi-statement
bodies (`#{a; b}`), and anything not reducible to a single expression
statement still emit the verbatim marker.

### Scope

Lowering-only. The lexer already emits `"a#{x}b"` as a single `String`
token (Phase-3b state machine) and the parser already accepts it at the
factor position, so the grammar and parser are untouched — the parser
CHANGELOG stays at 0.68.0 (same pattern as Phase 21c).

### Tests

- Rewrote `interpolated_string_with_expression_uses_interp_marker` →
  `..._lowers_recursively` to assert the real `+` call.
- `interpolated_string_with_multiple_expr_interps_lowers_each_recursively`
  — `"a#{1}b#{2}c"` → five-segment concat.
- `interpolated_string_with_binary_var_expr_lowers_recursively` —
  `"#{a + b}"` → `+` over two `VarRef`s.
- `interpolated_expression_string_validates_e2e` — `puts("sum is #{1 +
  2}")` round-trips the SIR validator.

IR test count 292 → 295; lexer 173 / parser 238 green. IR CHANGELOG
0.71.0 → 0.72.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
