### PR TITLE
Track browser form label output descriptors

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -700,6 +700,22 @@ def check_browser_expected_lists(
             require_optional_boolean(fieldset_path, fieldset, "disabled", errors)
             require_optional_string_list(fieldset_path, fieldset, "control_ids", errors)
             require_optional_string_list(fieldset_path, fieldset, "control_names", errors)
+        require_optional_object_list(form_path, form, "labels", errors)
+        for label_index, label in enumerate(object_list_items(form, "labels")):
+            label_path = f"{form_path}.labels[{label_index}]"
+            require_optional_nullable_string(label_path, label, "id", errors)
+            require_optional_nullable_string(label_path, label, "for_control", errors)
+            require_string(label_path, label, "text", errors)
+            for field in ("control_id", "control_name", "control_type"):
+                require_optional_nullable_string(label_path, label, field, errors)
+            require_string(label_path, label, "association", errors)
+        require_optional_object_list(form_path, form, "outputs", errors)
+        for output_index, output in enumerate(object_list_items(form, "outputs")):
+            output_path = f"{form_path}.outputs[{output_index}]"
+            for field in ("id", "name", "form_owner", "value"):
+                require_optional_nullable_string(output_path, output, field, errors)
+            require_optional_string_list(output_path, output, "for_tokens", errors)
+            require_string(output_path, output, "text", errors)
         require_object_list(form_path, form, "controls", errors)
         require_optional_object_list(form_path, form, "submitters", errors)
         for control_index, control in enumerate(object_list_items(form, "controls")):

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -1611,6 +1611,8 @@ pub struct BrowserForm {
     pub rel_noreferrer: bool,
     pub novalidate: bool,
     pub fieldsets: Vec<BrowserFormFieldset>,
+    pub labels: Vec<BrowserFormLabel>,
+    pub outputs: Vec<BrowserFormOutput>,
     pub controls: Vec<BrowserFormControl>,
     pub submitters: Vec<BrowserFormSubmitter>,
 }
@@ -1623,6 +1625,27 @@ pub struct BrowserFormFieldset {
     pub disabled: bool,
     pub control_ids: Vec<String>,
     pub control_names: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserFormLabel {
+    pub id: Option<String>,
+    pub for_control: Option<String>,
+    pub text: String,
+    pub control_id: Option<String>,
+    pub control_name: Option<String>,
+    pub control_type: Option<String>,
+    pub association: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserFormOutput {
+    pub id: Option<String>,
+    pub name: Option<String>,
+    pub form_owner: Option<String>,
+    pub for_tokens: Vec<String>,
+    pub value: Option<String>,
+    pub text: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -11663,7 +11686,7 @@ fn browser_accessible_description(
 fn browser_form_owner(element: &Element) -> Option<String> {
     if matches!(
         element.name.as_str(),
-        "button" | "fieldset" | "input" | "object" | "select" | "textarea"
+        "button" | "fieldset" | "input" | "object" | "output" | "select" | "textarea"
     ) {
         element.attribute("form").map(ToOwned::to_owned)
     } else {
@@ -12647,6 +12670,9 @@ fn browser_form(
     let novalidate = element.attribute("novalidate").is_some();
     let controls = collect_form_controls_for_form(body_root, element, labels, id_texts, base_href);
     let fieldsets = collect_form_fieldsets_for_form(body_root, element, element.attribute("id"));
+    let form_labels =
+        collect_form_labels_for_form(body_root, element, element.attribute("id"), &controls);
+    let outputs = browser_form_outputs(&controls);
     let submitters = browser_form_submitters(
         &controls,
         action.as_deref(),
@@ -12684,8 +12710,144 @@ fn browser_form(
         rel_tokens,
         novalidate,
         fieldsets,
+        labels: form_labels,
+        outputs,
         controls,
         submitters,
+    }
+}
+
+fn collect_form_labels_for_form(
+    body_root: &[Node],
+    target_form: &Element,
+    target_form_id: Option<&str>,
+    controls: &[BrowserFormControl],
+) -> Vec<BrowserFormLabel> {
+    let mut labels = Vec::new();
+    collect_form_labels_for_form_into(
+        body_root,
+        &mut labels,
+        target_form as *const Element,
+        target_form_id,
+        None,
+        controls,
+    );
+    labels
+}
+
+fn collect_form_labels_for_form_into(
+    nodes: &[Node],
+    labels: &mut Vec<BrowserFormLabel>,
+    target_form: *const Element,
+    target_form_id: Option<&str>,
+    current_form: Option<*const Element>,
+    controls: &[BrowserFormControl],
+) {
+    for node in nodes {
+        let Node::Element(element) = node else {
+            continue;
+        };
+
+        let element_form = if element.name == "form" {
+            Some(element as *const Element)
+        } else {
+            current_form
+        };
+
+        if element.name == "label" {
+            if let Some(label) =
+                browser_form_label(element, target_form, target_form_id, element_form, controls)
+            {
+                labels.push(label);
+            }
+        }
+
+        collect_form_labels_for_form_into(
+            &element.children,
+            labels,
+            target_form,
+            target_form_id,
+            element_form,
+            controls,
+        );
+    }
+}
+
+fn browser_form_label(
+    element: &Element,
+    target_form: *const Element,
+    target_form_id: Option<&str>,
+    current_form: Option<*const Element>,
+    controls: &[BrowserFormControl],
+) -> Option<BrowserFormLabel> {
+    let text = visible_text_for_nodes(&element.children);
+    if text.is_empty() {
+        return None;
+    }
+
+    if let Some(for_control) = element.attribute("for") {
+        let control = controls
+            .iter()
+            .find(|control| control.id.as_deref() == Some(for_control))?;
+        return Some(BrowserFormLabel {
+            id: element.attribute("id").map(ToOwned::to_owned),
+            for_control: Some(for_control.to_string()),
+            text,
+            control_id: control.id.clone(),
+            control_name: control.name.clone(),
+            control_type: Some(control.control_type.clone()),
+            association: "explicit".to_string(),
+        });
+    }
+
+    let control_element = first_labelable_descendant(element)?;
+    if !form_control_associated_with_target(
+        control_element,
+        target_form,
+        target_form_id,
+        current_form,
+    ) {
+        return None;
+    }
+    let control_type = browser_content_control_type(control_element);
+    Some(BrowserFormLabel {
+        id: element.attribute("id").map(ToOwned::to_owned),
+        for_control: None,
+        text,
+        control_id: control_element.attribute("id").map(ToOwned::to_owned),
+        control_name: control_element.attribute("name").map(ToOwned::to_owned),
+        control_type,
+        association: "implicit".to_string(),
+    })
+}
+
+fn first_labelable_descendant(element: &Element) -> Option<&Element> {
+    for child in &element.children {
+        let Node::Element(child_element) = child else {
+            continue;
+        };
+
+        if is_browser_labelable_element(&child_element.name) {
+            return Some(child_element);
+        }
+
+        if let Some(descendant) = first_labelable_descendant(child_element) {
+            return Some(descendant);
+        }
+    }
+
+    None
+}
+
+fn form_control_associated_with_target(
+    element: &Element,
+    target_form: *const Element,
+    target_form_id: Option<&str>,
+    current_form: Option<*const Element>,
+) -> bool {
+    match browser_form_owner(element).as_deref() {
+        Some(owner) => target_form_id.is_some_and(|form_id| form_id == owner),
+        None => current_form.is_some_and(|form| form == target_form),
     }
 }
 
@@ -12796,6 +12958,21 @@ fn browser_form_submitters(
                 .or_else(|| base_target.map(ToOwned::to_owned)),
             novalidate: novalidate || control.form_novalidate,
             value: control.value.clone(),
+        })
+        .collect()
+}
+
+fn browser_form_outputs(controls: &[BrowserFormControl]) -> Vec<BrowserFormOutput> {
+    controls
+        .iter()
+        .filter(|control| control.control_type == "output")
+        .map(|control| BrowserFormOutput {
+            id: control.id.clone(),
+            name: control.name.clone(),
+            form_owner: control.form_owner.clone(),
+            for_tokens: control.output_for.clone(),
+            value: control.value.clone(),
+            text: control.text.clone(),
         })
         .collect()
 }
@@ -14336,6 +14513,41 @@ mod tests {
         assert_eq!(summary.forms[0].autocomplete_tokens, vec!["on"]);
         assert_eq!(summary.forms[0].rel.as_deref(), Some("noreferrer"));
         assert!(summary.forms[0].novalidate);
+        assert_eq!(summary.forms[0].labels.len(), 2);
+        assert_eq!(summary.forms[0].labels[0].id.as_deref(), Some("q-help"));
+        assert_eq!(summary.forms[0].labels[0].for_control.as_deref(), Some("q"));
+        assert_eq!(summary.forms[0].labels[0].text, "Query");
+        assert_eq!(summary.forms[0].labels[0].control_id.as_deref(), Some("q"));
+        assert_eq!(
+            summary.forms[0].labels[0].control_name.as_deref(),
+            Some("q")
+        );
+        assert_eq!(
+            summary.forms[0].labels[0].control_type.as_deref(),
+            Some("text")
+        );
+        assert_eq!(summary.forms[0].labels[0].association, "explicit");
+        assert_eq!(summary.forms[0].labels[1].for_control, None);
+        assert_eq!(summary.forms[0].labels[1].text, "NotesKeep me");
+        assert_eq!(
+            summary.forms[0].labels[1].control_id.as_deref(),
+            Some("notes")
+        );
+        assert_eq!(
+            summary.forms[0].labels[1].control_name.as_deref(),
+            Some("notes")
+        );
+        assert_eq!(
+            summary.forms[0].labels[1].control_type.as_deref(),
+            Some("textarea")
+        );
+        assert_eq!(summary.forms[0].labels[1].association, "implicit");
+        assert_eq!(summary.forms[0].outputs.len(), 1);
+        assert_eq!(summary.forms[0].outputs[0].id.as_deref(), Some("total"));
+        assert_eq!(summary.forms[0].outputs[0].name.as_deref(), Some("total"));
+        assert_eq!(summary.forms[0].outputs[0].for_tokens, vec!["q", "kind"]);
+        assert_eq!(summary.forms[0].outputs[0].value.as_deref(), Some("Ready"));
+        assert_eq!(summary.forms[0].outputs[0].text, "Ready");
         let controls = &summary.forms[0].controls;
         assert_eq!(controls[0].id.as_deref(), Some("q"));
         assert_eq!(controls[0].labels, vec!["Query"]);
@@ -14580,6 +14792,53 @@ mod tests {
                 .as_deref(),
             Some("Query")
         );
+    }
+
+    #[test]
+    fn browser_form_label_output_descriptor_metadata_tracks_external_associations() {
+        let document = parse_html(
+            "<form id=cart><label for=qty>Quantity</label><input id=qty name=qty>\
+             <output id=total name=total for=\"qty promo\">12</output></form>\
+             <label id=gift-label>Gift note<textarea id=gift form=cart name=gift>Thanks</textarea></label>\
+             <output id=external-total form=cart name=external-total for=gift>Saved</output>\
+             <form id=other><label for=ignored>Ignored</label><input id=ignored name=ignored></form>",
+        )
+        .unwrap();
+
+        let summary = BrowserDocument::from_document(&document);
+        let form = &summary.forms[0];
+        assert_eq!(form.id.as_deref(), Some("cart"));
+        assert_eq!(form.labels.len(), 2);
+        assert_eq!(form.labels[0].for_control.as_deref(), Some("qty"));
+        assert_eq!(form.labels[0].text, "Quantity");
+        assert_eq!(form.labels[0].control_id.as_deref(), Some("qty"));
+        assert_eq!(form.labels[0].control_name.as_deref(), Some("qty"));
+        assert_eq!(form.labels[0].control_type.as_deref(), Some("text"));
+        assert_eq!(form.labels[0].association, "explicit");
+        assert_eq!(form.labels[1].id.as_deref(), Some("gift-label"));
+        assert_eq!(form.labels[1].for_control, None);
+        assert_eq!(form.labels[1].text, "Gift noteThanks");
+        assert_eq!(form.labels[1].control_id.as_deref(), Some("gift"));
+        assert_eq!(form.labels[1].control_name.as_deref(), Some("gift"));
+        assert_eq!(form.labels[1].control_type.as_deref(), Some("textarea"));
+        assert_eq!(form.labels[1].association, "implicit");
+
+        assert_eq!(form.outputs.len(), 2);
+        assert_eq!(form.outputs[0].id.as_deref(), Some("total"));
+        assert_eq!(form.outputs[0].name.as_deref(), Some("total"));
+        assert_eq!(form.outputs[0].form_owner, None);
+        assert_eq!(form.outputs[0].for_tokens, vec!["qty", "promo"]);
+        assert_eq!(form.outputs[0].value.as_deref(), Some("12"));
+        assert_eq!(form.outputs[0].text, "12");
+        assert_eq!(form.outputs[1].id.as_deref(), Some("external-total"));
+        assert_eq!(form.outputs[1].form_owner.as_deref(), Some("cart"));
+        assert_eq!(form.outputs[1].for_tokens, vec!["gift"]);
+        assert_eq!(form.outputs[1].value.as_deref(), Some("Saved"));
+        assert_eq!(form.outputs[1].text, "Saved");
+
+        assert_eq!(summary.forms[1].id.as_deref(), Some("other"));
+        assert_eq!(summary.forms[1].labels.len(), 1);
+        assert_eq!(summary.forms[1].labels[0].text, "Ignored");
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -1,11 +1,12 @@
 use coding_adventures_html_parser::{
     parse_browser_document, BrowserAnchor, BrowserComponentHydrationTarget, BrowserDataAttribute,
     BrowserDocument, BrowserDocumentMetadata, BrowserEmbeddedContext, BrowserForm,
-    BrowserFormControl, BrowserFormFieldset, BrowserFormSubmitter, BrowserHeading,
-    BrowserHttpEquivHint, BrowserImage, BrowserImageSource, BrowserInteractiveElement, BrowserLink,
-    BrowserMedia, BrowserMeta, BrowserMetadataDirective, BrowserRefresh, BrowserResource,
-    BrowserResourceHint, BrowserScript, BrowserSelectOption, BrowserStructuredItem,
-    BrowserStructuredProperty, BrowserStylesheet, BrowserTable, BrowserTemplate, BrowserThemeColor,
+    BrowserFormControl, BrowserFormFieldset, BrowserFormLabel, BrowserFormOutput,
+    BrowserFormSubmitter, BrowserHeading, BrowserHttpEquivHint, BrowserImage, BrowserImageSource,
+    BrowserInteractiveElement, BrowserLink, BrowserMedia, BrowserMeta, BrowserMetadataDirective,
+    BrowserRefresh, BrowserResource, BrowserResourceHint, BrowserScript, BrowserSelectOption,
+    BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet, BrowserTable,
+    BrowserTemplate, BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -715,6 +716,10 @@ struct ExpectedForm {
     novalidate: bool,
     #[serde(default)]
     fieldsets: Vec<ExpectedFormFieldset>,
+    #[serde(default)]
+    labels: Vec<ExpectedFormLabel>,
+    #[serde(default)]
+    outputs: Vec<ExpectedFormOutput>,
     controls: Vec<ExpectedFormControl>,
     #[serde(default)]
     submitters: Vec<ExpectedFormSubmitter>,
@@ -734,6 +739,37 @@ struct ExpectedFormFieldset {
     control_ids: Vec<String>,
     #[serde(default)]
     control_names: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedFormLabel {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    for_control: Option<String>,
+    text: String,
+    #[serde(default)]
+    control_id: Option<String>,
+    #[serde(default)]
+    control_name: Option<String>,
+    #[serde(default)]
+    control_type: Option<String>,
+    association: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedFormOutput {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    form_owner: Option<String>,
+    #[serde(default)]
+    for_tokens: Vec<String>,
+    #[serde(default)]
+    value: Option<String>,
+    text: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1991,6 +2027,16 @@ impl ExpectedForm {
                 .into_iter()
                 .map(ExpectedFormFieldset::into_browser_form_fieldset)
                 .collect(),
+            labels: self
+                .labels
+                .into_iter()
+                .map(ExpectedFormLabel::into_browser_form_label)
+                .collect(),
+            outputs: self
+                .outputs
+                .into_iter()
+                .map(ExpectedFormOutput::into_browser_form_output)
+                .collect(),
             controls: self
                 .controls
                 .into_iter()
@@ -2014,6 +2060,33 @@ impl ExpectedFormFieldset {
             disabled: self.disabled,
             control_ids: self.control_ids,
             control_names: self.control_names,
+        }
+    }
+}
+
+impl ExpectedFormLabel {
+    fn into_browser_form_label(self) -> BrowserFormLabel {
+        BrowserFormLabel {
+            id: self.id,
+            for_control: self.for_control,
+            text: self.text,
+            control_id: self.control_id,
+            control_name: self.control_name,
+            control_type: self.control_type,
+            association: self.association,
+        }
+    }
+}
+
+impl ExpectedFormOutput {
+    fn into_browser_form_output(self) -> BrowserFormOutput {
+        BrowserFormOutput {
+            id: self.id,
+            name: self.name,
+            form_owner: self.form_owner,
+            for_tokens: self.for_tokens,
+            value: self.value,
+            text: self.text,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -193,6 +193,15 @@
             "fieldsets": [
               { "legend": "Options", "disabled": true, "control_ids": ["fast"], "control_names": ["fast"] }
             ],
+            "labels": [
+              { "id": "q-help", "for_control": "q", "text": "Query", "control_id": "q", "control_name": "q", "control_type": "text", "association": "explicit" },
+              { "text": "Count", "control_id": "count", "control_name": "count", "control_type": "number", "association": "implicit" },
+              { "text": "NotesKeep me", "control_id": "notes", "control_name": "notes", "control_type": "textarea", "association": "implicit" },
+              { "text": "Fast", "control_id": "fast", "control_name": "fast", "control_type": "checkbox", "association": "implicit" }
+            ],
+            "outputs": [
+              { "id": "total", "name": "total", "for_tokens": ["q", "kind"], "value": "Ready", "text": "Ready" }
+            ],
             "controls": [
               { "id": "q", "control_type": "text", "name": "q", "labels": ["Query"], "accessible_name": "Query", "accessible_description": "Query", "placeholder": "Search terms", "autocomplete": "section-primary shipping search", "autocomplete_tokens": ["section-primary", "shipping", "search"], "autocapitalize": "words", "enterkeyhint": "search", "dirname": "q.dir", "spellcheck": "false", "autocorrect": "off", "inputmode": "search", "pattern": "[A-Za-z ]+", "minlength": "2", "maxlength": "80", "size": "40", "list": "query-suggestions", "datalist_options": ["Rust", "HTML", "Browser APIs"], "value": null, "successful": true, "submission_values": [""], "autofocus": true, "disabled": false, "required": true, "will_validate": true, "validation_attributes": ["required", "pattern", "minlength", "maxlength"], "checked": false, "text": "", "options": [] },
               { "id": "count", "control_type": "number", "name": "count", "labels": ["Count"], "accessible_name": "Count", "min": "1", "max": "10", "step": "0.5", "value": "2", "successful": true, "submission_values": ["2"], "disabled": false, "required": true, "will_validate": true, "validation_attributes": ["required", "min", "max", "step"], "checked": false, "text": "", "options": [] },


### PR DESCRIPTION
## Summary
- add form-level label descriptors for explicit and implicit label associations
- add form-level output descriptors for output target tokens, values, and external form owners
- extend browser-readiness fixture schema and fixture expectations for label/output metadata

## Tests
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- cargo test -p coding-adventures-html-parser browser_form_label_output_descriptor_metadata_tracks_external_associations
- cargo test -p coding-adventures-html-parser browser_form_
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser