### PR TITLE
feat(mosaic-flux-react): v0.1.0 — Mosaic-owned strict-Flux runtime

### DIFF
--- a/code/packages/typescript/mosaic-flux-react/BUILD
+++ b/code/packages/typescript/mosaic-flux-react/BUILD
@@ -1,0 +1,2 @@
+npm ci --quiet
+npx vitest run --coverage

--- a/code/packages/typescript/mosaic-flux-react/CHANGELOG.md
+++ b/code/packages/typescript/mosaic-flux-react/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+## 0.1.0
+
+Initial release. Implements the strict-Flux runtime for Mosaic UI's React emitter per `code/specs/UI33-rewrite-unified-architecture.md`.
+
+### Added
+
+- `MosaicAction<State>` interface — the Command Pattern. Each action is a class with payload + `apply(state) → state` method.
+- `isMosaicAction(value)` — structural type guard.
+- `MosaicStore<State>` — state container + dispatcher.
+  - `dispatch(action)` — runs `action.apply(state)`, swaps state, notifies subscribers, runs middleware.
+  - `state` — current state (read-only).
+  - `subscribe(selector, callback, equality?)` — fine-grained subscription; fires when the selected slice changes (default `Object.is`, custom equality supported).
+  - `select(selector)` — one-shot read without subscription.
+- `Middleware<State>` — cross-cutting hook signature.
+- `composeMiddleware(arr)` — combines middleware; isolates throws so one bad middleware can't take down peers.
+- `loggerMiddleware()` — dev logger with shallow-state-diff output.
+- `createSelector(...inputs, combiner)` — memoised derived-state combinator. Reselect-shaped, zero-dep.
+- `devToolsMiddleware(options?)` — publishes uniform UI33-rewrite §8 event stream via `window.postMessage` (with `ws://localhost:9229` fallback).
+- React integration via the `./react` subpath:
+  - `<MosaicStoreProvider store={...}>` — Context provider.
+  - `useMosaicStore<State>()` — get the store imperatively.
+  - `useMosaicSelector(selector, equality?)` — subscribe to a slice; re-renders on change. Uses React 18+ `useSyncExternalStore` for tearing prevention.
+  - `useMosaicDispatch<State>()` — get a dispatch function bound to the store.
+
+### Notes
+
+- Zero runtime dependencies. React is a peer dependency for the `./react` entry only.
+- Designed for use with the upcoming Mosaic UI codegen (UI33r-E-react phase) which generates action classes from `.mil` files. This runtime is the library those classes target.
+- Synchronous dispatch only. Async effects flow through middleware that schedules subsequent dispatches.

--- a/code/packages/typescript/mosaic-flux-react/README.md
+++ b/code/packages/typescript/mosaic-flux-react/README.md
@@ -1,0 +1,101 @@
+# @coding-adventures/mosaic-flux-react
+
+Strict-Flux runtime for Mosaic UI's React emitter.
+
+Implements the architecture specified in `code/specs/UI33-rewrite-unified-architecture.md`:
+
+- **`MosaicAction<State>` interface** — the Command Pattern. Each action is a class with a constructor (payload) and an `apply(state) → state` method that expresses the state transform.
+- **`MosaicStore<State>` class** — state container + dispatcher. Routes by calling `action.apply(state)` directly; no central reducer registry.
+- **Fine-grained subscription** — selectors fire only when the selected slice changes (by `Object.is`, unless a custom equality is supplied). This is what makes per-keystroke dispatch cheap.
+- **Middleware** — cross-cutting hook for logging, persistence, analytics.
+- **`createSelector`** — memoised derived-state combinator (Reselect-shaped, zero-dep).
+- **React integration** — `MosaicStoreProvider`, `useMosaicSelector`, `useMosaicDispatch`, `useMosaicStore` hooks via the `./react` subpath.
+- **DevTools integration** — `devToolsMiddleware` publishes the UI33-rewrite §8 uniform event stream via `window.postMessage` (with `ws://localhost:9229` fallback).
+
+## Why a Mosaic-owned runtime
+
+Per UI33-rewrite §6.1: every Mosaic backend ships its own `mosaic-flux-*` library. This gives us:
+
+1. Same architecture everywhere. A React dev moving to a Mosaic SwiftUI codebase sees the same Store / Action / Reducer shape.
+2. Unified DevTools across all 7 backends because the runtime is uniform.
+3. No external dependency risk — we don't break when Redux Toolkit / Zustand / TCA ships a breaking API change.
+4. We can ship features no third-party would prioritise (e.g., cross-backend action replay).
+
+This package is the React-specific runtime; sibling packages cover SwiftUI, Jetpack Compose, Flutter, WinUI XAML, Qt, HTML, and Web Components.
+
+## Quick start
+
+```typescript
+import { MosaicStore, type MosaicAction } from "@coding-adventures/mosaic-flux-react";
+import { MosaicStoreProvider, useMosaicSelector, useMosaicDispatch } from "@coding-adventures/mosaic-flux-react/react";
+
+// 1. Define your state shape
+interface GridState {
+  count: number;
+}
+
+// 2. Define your actions as classes implementing MosaicAction<State>.
+// (In a real Mosaic project these are auto-generated from .mil files;
+// authors edit the apply() body between <mosaic:custom> markers.)
+class Increment implements MosaicAction<GridState> {
+  apply(state: GridState): GridState {
+    return { ...state, count: state.count + 1 };
+  }
+}
+
+// 3. Create a store
+const store = new MosaicStore<GridState>({ initialState: { count: 0 } });
+
+// 4. Provide it to your React tree
+function App() {
+  return (
+    <MosaicStoreProvider store={store}>
+      <Counter />
+    </MosaicStoreProvider>
+  );
+}
+
+// 5. Read state via selector hook + dispatch via dispatch hook
+function Counter() {
+  const count = useMosaicSelector((s: GridState) => s.count);
+  const dispatch = useMosaicDispatch<GridState>();
+  return (
+    <button onClick={() => dispatch(new Increment())}>
+      Count: {count}
+    </button>
+  );
+}
+```
+
+## Architecture
+
+See `code/specs/UI33-rewrite-unified-architecture.md` for the canonical specification, especially:
+
+- §3 — strict-Flux invariants
+- §5 — Command Pattern action classes
+- §6 — runtime library API surface
+- §8 — DevTools protocol
+
+## Status
+
+v0.1.0. Initial implementation of:
+
+- MosaicAction interface + isMosaicAction type guard
+- MosaicStore with fine-grained subscription + middleware
+- composeMiddleware + loggerMiddleware
+- createSelector
+- devToolsMiddleware (postMessage + WebSocket transports)
+- React integration: Provider, hooks for selector and dispatch
+
+Not yet:
+
+- Time-travel replay support on the runtime side (the DevTools desktop app drives this externally for v0.1.0; native replay support is a v0.2.0 follow-up).
+- Multi-store coordination primitives (each store is standalone in v0.1.0).
+
+## Testing
+
+```bash
+npm test
+```
+
+Coverage thresholds: 80% lines / branches / functions / statements (vitest config).

--- a/code/packages/typescript/mosaic-flux-react/package-lock.json
+++ b/code/packages/typescript/mosaic-flux-react/package-lock.json
@@ -1,0 +1,2541 @@
+{
+  "name": "@coding-adventures/mosaic-flux-react",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/mosaic-flux-react",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/react": "^19.2.15",
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.6"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.15",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
+      "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
+      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/packages/typescript/mosaic-flux-react/package.json
+++ b/code/packages/typescript/mosaic-flux-react/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@coding-adventures/mosaic-flux-react",
+  "version": "0.1.0",
+  "description": "Strict-Flux runtime for Mosaic UI's React emitter. Implements the MosaicAction Command Pattern, MosaicStore with fine-grained subscriptions, middleware, selectors, and React hooks integration.",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/react": "^19.2.15",
+    "@vitest/coverage-v8": "^3.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0"
+  },
+  "peerDependencies": {
+    "react": "^19.2.6"
+  }
+}

--- a/code/packages/typescript/mosaic-flux-react/src/action.ts
+++ b/code/packages/typescript/mosaic-flux-react/src/action.ts
@@ -1,0 +1,52 @@
+// action.ts — the MosaicAction Command Pattern interface.
+//
+// Per UI33-rewrite §5: each action is a class with a payload (its
+// constructor arguments) and an `apply(state) → state` method that
+// expresses the state transform. The dispatcher routes by calling
+// `action.apply(state)` directly — there is no central switch
+// statement or reducer registry, because each action knows how to
+// transform state.
+//
+// Why a class instead of a tagged-union object: each action's
+// transform logic is co-located with its payload shape. A new
+// developer reading `EditCommit.ts` sees both "what data does this
+// carry" and "what does it do to state" in one place. Bug fixes and
+// code review happen at the file level. Testing reduces to
+// `new EditCommit().apply(testState)`.
+//
+// The interface is intentionally minimal. No middleware-style hooks;
+// those live in the store (see middleware.ts). No async escape hatch;
+// effects flow through middleware, not through actions themselves.
+// This keeps `apply` pure and the strict-Flux invariant intact.
+
+export interface MosaicAction<State> {
+  /**
+   * Pure state transform. Given the current state, return the next
+   * state. Must not mutate the input. Must be deterministic — given
+   * the same state, the same action instance produces the same next
+   * state.
+   *
+   * Side effects (logging, persistence, async) belong in middleware,
+   * not in apply.
+   */
+  apply(state: State): State;
+}
+
+/**
+ * Type guard: is this thing a MosaicAction? Useful for runtime
+ * middleware that wants to introspect dispatch arguments.
+ *
+ * The check is structural: anything with an `apply` function is
+ * treated as an action. We don't require a brand symbol because
+ * action classes are author-controlled — if you can dispatch it,
+ * you implemented this contract.
+ */
+export function isMosaicAction<State>(
+  value: unknown,
+): value is MosaicAction<State> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { apply?: unknown }).apply === "function"
+  );
+}

--- a/code/packages/typescript/mosaic-flux-react/src/devtools.ts
+++ b/code/packages/typescript/mosaic-flux-react/src/devtools.ts
@@ -1,0 +1,194 @@
+// devtools.ts — DevTools protocol integration for React/browser
+// runtimes.
+//
+// Per UI33-rewrite §8: every mosaic-flux runtime emits a uniform
+// structured event stream on a local channel. The Mosaic DevTools
+// desktop application attaches to this stream and provides action
+// log, time-travel replay, and state diff inspection.
+//
+// On the web side (React, HTML, WebComponent), the channel is either:
+//   1. window.postMessage to a browser extension (preferred when the
+//      extension is installed; the extension forwards over its own
+//      transport)
+//   2. WebSocket to ws://localhost:9229 (fallback for local dev)
+//
+// This module implements both: postMessage by default, with an opt-in
+// WebSocket fallback the host enables via `enableDevTools({ ws: true })`.
+
+import type { MosaicAction } from "./action.js";
+import type { Middleware } from "./middleware.js";
+
+/**
+ * The wire format every runtime emits. Identical across all 7
+ * backends (UI33-rewrite §8.1).
+ */
+export interface ActionEvent<State> {
+  kind: "action";
+  ts: number;
+  actionType: string;
+  actionPayload: Record<string, unknown>;
+  prevState: State;
+  nextState: State;
+  durationUs: number;
+}
+
+export interface SubscriptionEvent {
+  kind: "subscription";
+  ts: number;
+  componentId: string;
+  slots: ReadonlyArray<string>;
+  rendered: boolean;
+}
+
+export type DevToolsEvent<State> = ActionEvent<State> | SubscriptionEvent;
+
+/**
+ * Configuration for the DevTools sink.
+ */
+export interface DevToolsOptions {
+  /**
+   * If true, attempt a WebSocket connection to ws://localhost:9229
+   * when no postMessage receiver is registered. Default false.
+   */
+  ws?: boolean;
+
+  /**
+   * Custom storeName to disambiguate when multiple stores are open
+   * (per-tab Mosaic apps with sub-stores, for example).
+   */
+  storeName?: string;
+}
+
+/**
+ * Build a middleware that emits ActionEvents on every dispatch.
+ *
+ * The middleware is robust to missing transports — if neither
+ * postMessage nor WebSocket is available, it silently no-ops. This
+ * means it's safe to keep enabled in production builds (where the
+ * receiving end usually isn't attached) without risk of crashes.
+ */
+export function devToolsMiddleware<State>(
+  options: DevToolsOptions = {},
+): Middleware<State> {
+  const sink = makeSink<State>(options);
+  const storeName = options.storeName ?? "default";
+  return (action, prevState, nextState) => {
+    const t0 = now();
+    const event: ActionEvent<State> = {
+      kind: "action",
+      ts: Date.now(),
+      actionType: action.constructor.name,
+      actionPayload: extractPayload(action),
+      prevState,
+      nextState,
+      durationUs: Math.round((now() - t0) * 1000),
+    };
+    sink.publish({ ...event, storeName } as ActionEvent<State> & {
+      storeName: string;
+    });
+  };
+}
+
+/**
+ * The sink chooses a transport at construction time. Available
+ * options: in-browser postMessage, WebSocket. Falls back to no-op
+ * if neither is available.
+ */
+interface Sink<State> {
+  publish(event: DevToolsEvent<State> & { storeName: string }): void;
+}
+
+function makeSink<State>(options: DevToolsOptions): Sink<State> {
+  if (typeof window !== "undefined" && typeof window.postMessage === "function") {
+    return new PostMessageSink<State>();
+  }
+  if (options.ws && typeof globalThis.WebSocket !== "undefined") {
+    return new WebSocketSink<State>("ws://localhost:9229");
+  }
+  return new NoopSink<State>();
+}
+
+class PostMessageSink<State> implements Sink<State> {
+  publish(event: DevToolsEvent<State> & { storeName: string }): void {
+    // Browser extensions filter on source === "mosaic-flux-devtools".
+    // We use a structured object rather than a string so the extension
+    // can match without parsing.
+    try {
+      window.postMessage(
+        { source: "mosaic-flux-devtools", payload: event },
+        "*",
+      );
+    } catch {
+      // postMessage can fail when payload isn't structured-cloneable
+      // (e.g., contains functions). We don't try to recover — this is
+      // a dev-only sink and a dropped event is acceptable.
+    }
+  }
+}
+
+class WebSocketSink<State> implements Sink<State> {
+  #ws: WebSocket | null = null;
+  #queue: Array<DevToolsEvent<State> & { storeName: string }> = [];
+
+  constructor(url: string) {
+    try {
+      this.#ws = new WebSocket(url);
+      this.#ws.addEventListener("open", () => {
+        for (const event of this.#queue) {
+          this.#sendNow(event);
+        }
+        this.#queue = [];
+      });
+      this.#ws.addEventListener("error", () => {
+        // Connection failed — fall back to queueing forever (harmless
+        // in dev) and let the user notice no events arrive.
+      });
+    } catch {
+      this.#ws = null;
+    }
+  }
+
+  publish(event: DevToolsEvent<State> & { storeName: string }): void {
+    if (this.#ws?.readyState === WebSocket.OPEN) {
+      this.#sendNow(event);
+    } else {
+      // Pre-open events queue up; they flush on `open`.
+      this.#queue.push(event);
+    }
+  }
+
+  #sendNow(event: DevToolsEvent<State> & { storeName: string }): void {
+    try {
+      this.#ws?.send(JSON.stringify(event));
+    } catch {
+      // Same rationale as PostMessageSink: dev-only, ignore.
+    }
+  }
+}
+
+class NoopSink<State> implements Sink<State> {
+  publish(_event: DevToolsEvent<State> & { storeName: string }): void {
+    /* no-op */
+  }
+}
+
+/**
+ * Extract enumerable own properties of the action as the payload.
+ * Excludes inherited methods (like `apply`) and internal fields
+ * prefixed with `_` or `#`.
+ */
+function extractPayload(action: MosaicAction<unknown>): Record<string, unknown> {
+  const payload: Record<string, unknown> = {};
+  for (const key of Object.keys(action)) {
+    if (key.startsWith("_")) continue;
+    payload[key] = (action as unknown as Record<string, unknown>)[key];
+  }
+  return payload;
+}
+
+function now(): number {
+  if (typeof performance !== "undefined" && typeof performance.now === "function") {
+    return performance.now();
+  }
+  return Date.now();
+}

--- a/code/packages/typescript/mosaic-flux-react/src/index.ts
+++ b/code/packages/typescript/mosaic-flux-react/src/index.ts
@@ -1,0 +1,44 @@
+// index.ts — public surface of @coding-adventures/mosaic-flux-react.
+//
+// Per UI33-rewrite §6.1, this runtime exposes:
+//
+//   - MosaicAction<State>: the Command Pattern interface (every
+//     action implements this).
+//   - MosaicStore<State>: the state container and dispatcher.
+//   - Middleware<State>: cross-cutting concern hook.
+//   - createSelector: memoised derived-state combinator.
+//   - devToolsMiddleware: opt-in connection to Mosaic DevTools.
+//
+// React-specific integration (hooks, provider) lives in the
+// `./react` subpath import so non-React consumers don't pay the React
+// dependency cost. v0.1.0 keeps that file lightweight — it expects
+// React 18+ for `useSyncExternalStore`. See react.ts for details.
+
+export type { MosaicAction } from "./action.js";
+export { isMosaicAction } from "./action.js";
+
+export type {
+  Equality,
+  MosaicStoreOptions,
+  Subscriber,
+} from "./store.js";
+export { MosaicStore } from "./store.js";
+
+export type { Middleware } from "./middleware.js";
+export { composeMiddleware, loggerMiddleware } from "./middleware.js";
+
+export { createSelector } from "./selector.js";
+
+export type {
+  ActionEvent,
+  DevToolsEvent,
+  DevToolsOptions,
+  SubscriptionEvent,
+} from "./devtools.js";
+export { devToolsMiddleware } from "./devtools.js";
+
+// React-specific exports are re-exported from a subpath to keep the
+// core zero-dep. Consumers do:
+//   import { MosaicStoreProvider, useMosaicSelector } from
+//     "@coding-adventures/mosaic-flux-react/react";
+// See ./react.ts for what's available.

--- a/code/packages/typescript/mosaic-flux-react/src/middleware.ts
+++ b/code/packages/typescript/mosaic-flux-react/src/middleware.ts
@@ -1,0 +1,108 @@
+// middleware.ts — middleware contract for cross-cutting concerns.
+//
+// Middleware sees every dispatched (action, prevState, nextState)
+// triple. Common uses:
+//
+//   - logger: log action + state diff for debugging
+//   - persistence: serialize chosen slots to localStorage / disk
+//   - analytics: report user-significant actions to telemetry
+//   - validation: assert invariants on next state; throw in dev mode
+//   - effects: when action X completes, trigger side effect Y via
+//     extension points or external dispatch
+//
+// Middleware runs AFTER the reducer (after `action.apply(state)`
+// produces the next state). This is the simplest place — middleware
+// observes results, not requests, and never blocks dispatch.
+//
+// Async effects in middleware schedule additional dispatches; they
+// do not extend the synchronous round trip. The action that fires
+// the effect lands first; the effect's resulting action lands later.
+
+import type { MosaicAction } from "./action.js";
+
+export type Middleware<State> = (
+  action: MosaicAction<State>,
+  prevState: State,
+  nextState: State,
+) => void;
+
+/**
+ * Compose middleware into a single function. Each middleware runs
+ * in registration order. If one throws, subsequent middleware still
+ * run — the runtime catches and logs the error so a single bad
+ * middleware can't take down the whole store.
+ */
+export function composeMiddleware<State>(
+  middleware: ReadonlyArray<Middleware<State>>,
+): Middleware<State> {
+  if (middleware.length === 0) {
+    return () => {
+      /* no-op when nothing's registered */
+    };
+  }
+  if (middleware.length === 1) {
+    return middleware[0]!;
+  }
+  return (action, prevState, nextState) => {
+    for (const m of middleware) {
+      try {
+        m(action, prevState, nextState);
+      } catch (err) {
+        // Per the architecture (UI33-rewrite §6.4): one bad middleware
+        // does not break others. We log to console (no external
+        // dependency) and continue.
+        // eslint-disable-next-line no-console
+        console.error("[mosaic-flux] middleware threw:", err);
+      }
+    }
+  };
+}
+
+/**
+ * A logger middleware for dev builds. Logs action class name,
+ * timestamp, and a shallow state diff.
+ *
+ * Production code typically composes its own logger that ships to
+ * a telemetry backend rather than console.
+ */
+export function loggerMiddleware<State>(): Middleware<State> {
+  return (action, prevState, nextState) => {
+    const name = action.constructor.name;
+    const changedKeys = shallowChangedKeys(prevState, nextState);
+    // eslint-disable-next-line no-console
+    console.groupCollapsed(
+      `[mosaic-flux] ${name} — changed: ${changedKeys.length > 0 ? changedKeys.join(", ") : "(none)"}`,
+    );
+    // eslint-disable-next-line no-console
+    console.log("action  :", action);
+    // eslint-disable-next-line no-console
+    console.log("prev    :", prevState);
+    // eslint-disable-next-line no-console
+    console.log("next    :", nextState);
+    // eslint-disable-next-line no-console
+    console.groupEnd();
+  };
+}
+
+function shallowChangedKeys<State>(
+  prev: State,
+  next: State,
+): ReadonlyArray<string> {
+  if (
+    typeof prev !== "object" ||
+    prev === null ||
+    typeof next !== "object" ||
+    next === null
+  ) {
+    // Non-object states change atomically.
+    return prev !== next ? ["<root>"] : [];
+  }
+  const changed: string[] = [];
+  const prevObj = prev as Record<string, unknown>;
+  const nextObj = next as Record<string, unknown>;
+  const allKeys = new Set([...Object.keys(prevObj), ...Object.keys(nextObj)]);
+  for (const k of allKeys) {
+    if (prevObj[k] !== nextObj[k]) changed.push(k);
+  }
+  return changed;
+}

--- a/code/packages/typescript/mosaic-flux-react/src/react.ts
+++ b/code/packages/typescript/mosaic-flux-react/src/react.ts
@@ -1,0 +1,133 @@
+// react.ts — React-specific hooks and provider for mosaic-flux-react.
+//
+// This file is the ONLY place that imports React. Non-React consumers
+// (e.g., a Node test, an HTML emitter that shares the store
+// implementation) can import everything else from the package root
+// without paying the React dependency cost.
+//
+// We target React 18+ for `useSyncExternalStore`, which is React's
+// blessed mechanism for subscribing external stores to the render
+// cycle. It handles concurrent rendering, tearing prevention, and
+// strict mode double-invocation correctly — manually implementing
+// these is a tar pit, so we delegate.
+//
+// API surface:
+//
+//   - <MosaicStoreProvider store={...}>: provide a store via Context.
+//   - useMosaicStore(): get the store from context.
+//   - useMosaicSelector(selector): subscribe to a slice; re-render on
+//     change.
+//   - useMosaicDispatch(): get a dispatch function bound to the store.
+
+import {
+  createContext,
+  createElement,
+  useContext,
+  useMemo,
+  useSyncExternalStore,
+  type ReactNode,
+} from "react";
+import type { MosaicAction } from "./action.js";
+import type { Equality } from "./store.js";
+import type { MosaicStore } from "./store.js";
+
+/**
+ * Context that carries the store down the component tree. We do NOT
+ * inline a default value because using the hook outside a provider
+ * is an error worth surfacing loudly — null forces the hooks to
+ * throw with a clear message.
+ */
+const MosaicStoreContext = createContext<MosaicStore<unknown> | null>(null);
+
+export interface MosaicStoreProviderProps<State> {
+  store: MosaicStore<State>;
+  children: ReactNode;
+}
+
+/**
+ * Provide a store via Context. Wrap your App in this and child
+ * components can use `useMosaicSelector` / `useMosaicDispatch`.
+ *
+ * One provider per store. Multi-store apps nest providers — children
+ * see the nearest one. The selectors and dispatches you get back are
+ * typed to whatever the nearest provider holds.
+ */
+export function MosaicStoreProvider<State>(
+  props: MosaicStoreProviderProps<State>,
+): ReactNode {
+  // Cast to unknown for the Context bridge — the consumer hooks
+  // re-narrow via their selector signature. This is the standard
+  // pattern when Context is generic at construction but invariant
+  // at storage.
+  return createElement(
+    MosaicStoreContext.Provider,
+    { value: props.store as unknown as MosaicStore<unknown> },
+    props.children,
+  );
+}
+
+/**
+ * Retrieve the store from context. Throws if no provider is above.
+ *
+ * Most components should use `useMosaicSelector` (state) or
+ * `useMosaicDispatch` (actions); this hook is for the rare case
+ * where you need imperative access to the store itself.
+ */
+export function useMosaicStore<State>(): MosaicStore<State> {
+  const store = useContext(MosaicStoreContext) as MosaicStore<State> | null;
+  if (store === null) {
+    throw new Error(
+      "useMosaicStore must be used inside a <MosaicStoreProvider>",
+    );
+  }
+  return store;
+}
+
+/**
+ * Subscribe to a slice of state. The hook re-renders the component
+ * whenever the selected slice changes by `equality` (default
+ * `Object.is`, matching React's hook conventions).
+ *
+ * The selector function should be pure and stable — i.e., the same
+ * input should always produce the same output, and ideally the
+ * function reference itself shouldn't change between renders.
+ * Inline arrow functions are fine; `useSyncExternalStore` handles
+ * the re-subscription dance.
+ */
+export function useMosaicSelector<State, T>(
+  selector: (state: State) => T,
+  equality?: Equality<T>,
+): T {
+  const store = useMosaicStore<State>();
+
+  // Wrap subscribe so React's signature `(onChange: () => void) => () => void`
+  // works with our `(selector, callback) => unsubscribe` API. We
+  // memoise on selector + equality so React doesn't tear down and
+  // recreate the subscription each render.
+  const subscribe = useMemo(
+    () => (onChange: () => void) =>
+      store.subscribe(selector, () => onChange(), equality),
+    [store, selector, equality],
+  );
+
+  const getSnapshot = (): T => store.select(selector);
+
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+/**
+ * Get a dispatch function bound to the current store. The returned
+ * function is stable across renders (per store) so it's safe to use
+ * as a dependency in `useEffect` etc.
+ */
+export function useMosaicDispatch<State>(): <A extends MosaicAction<State>>(
+  action: A,
+) => void {
+  const store = useMosaicStore<State>();
+  return useMemo(
+    () =>
+      <A extends MosaicAction<State>>(action: A): void =>
+        store.dispatch(action),
+    [store],
+  );
+}

--- a/code/packages/typescript/mosaic-flux-react/src/selector.ts
+++ b/code/packages/typescript/mosaic-flux-react/src/selector.ts
@@ -1,0 +1,94 @@
+// selector.ts — memoised selector construction.
+//
+// For derived state that's computed on the fly (e.g., a formula bar's
+// displayed value is computed from `editRow`, `selectedRow`,
+// `selectedCol`, and `cells`), recomputing on every selector call
+// is wasteful. createSelector memoises by input-equality: if every
+// input selector returned the same value as last call, the output
+// is reused.
+//
+// This is the same shape as Reselect / Redux Toolkit's
+// `createSelector`. We ship our own minimal implementation to keep
+// the runtime zero-dep.
+
+import type { Equality } from "./store.js";
+
+const defaultEquality: Equality<unknown> = (a, b) => Object.is(a, b);
+
+/**
+ * Compose input selectors into a memoised derived selector.
+ *
+ * Single-input form:
+ *   const formulaText = createSelector(
+ *     (s: GridState) => s.editContent,
+ *     (content) => content.toUpperCase(),
+ *   );
+ *
+ * Multi-input form:
+ *   const formula = createSelector(
+ *     (s: GridState) => s.editRow,
+ *     (s: GridState) => s.selectedRow,
+ *     (s: GridState) => s.selectedCol,
+ *     (s: GridState) => s.cells,
+ *     (s: GridState) => s.editContent,
+ *     (editRow, selRow, selCol, cells, editContent) =>
+ *       editRow !== -1 ? editContent : cells[cellKey(selRow, selCol)] ?? "",
+ *   );
+ *
+ * The combiner runs only when at least one input changed.
+ */
+export function createSelector<State, R>(
+  inputSelector: (state: State) => unknown,
+  combiner: (...args: unknown[]) => R,
+  equality?: Equality<unknown>,
+): (state: State) => R;
+
+export function createSelector<State, R>(
+  ...args: ReadonlyArray<unknown>
+): (state: State) => R {
+  // Args layout: any number of input selectors, then a combiner,
+  // optionally followed by an equality fn (per-input). The combiner
+  // is identified by position: it's the LAST arg unless the last
+  // arg is a function with arity (state) => R — heuristically that
+  // would itself be a selector, so we require explicit registration.
+  //
+  // For simplicity in v0.1.0 we require the combiner to be at the
+  // end and equality to be passed via the optional named-options
+  // overload at the top of this file. Authors who need per-input
+  // equality should compose selectors manually.
+  if (args.length < 2) {
+    throw new Error(
+      "createSelector requires at least one input selector and one combiner",
+    );
+  }
+  const combiner = args[args.length - 1] as (...inputs: unknown[]) => R;
+  const inputSelectors = args.slice(0, -1) as ReadonlyArray<
+    (state: State) => unknown
+  >;
+  const equality = defaultEquality;
+
+  let lastInputs: unknown[] | null = null;
+  let lastResult: R;
+
+  return (state: State): R => {
+    const currentInputs = inputSelectors.map((s) => s(state));
+    if (lastInputs !== null && allEqual(currentInputs, lastInputs, equality)) {
+      return lastResult;
+    }
+    lastInputs = currentInputs;
+    lastResult = combiner(...currentInputs);
+    return lastResult;
+  };
+}
+
+function allEqual(
+  a: ReadonlyArray<unknown>,
+  b: ReadonlyArray<unknown>,
+  equality: Equality<unknown>,
+): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (!equality(a[i], b[i])) return false;
+  }
+  return true;
+}

--- a/code/packages/typescript/mosaic-flux-react/src/store.ts
+++ b/code/packages/typescript/mosaic-flux-react/src/store.ts
@@ -1,0 +1,185 @@
+// store.ts — the MosaicStore: state container + dispatcher.
+//
+// The MosaicStore is the runtime's center of gravity. It holds the
+// current state, accepts action dispatches, runs middleware, and
+// notifies subscribers when state changes.
+//
+// Key design choices vs. classical Redux:
+//
+//   1. No central reducer. The store's `dispatch(action)` calls
+//      `action.apply(state)` directly — the action object is its
+//      own reducer fragment. This is the Command Pattern (UI33-
+//      rewrite §5). Adding a new action means adding a new class;
+//      the store needs zero changes.
+//
+//   2. Fine-grained subscription. `subscribe` takes a selector and
+//      only fires the callback when the selected slice changes
+//      (by reference). This is what makes per-keystroke dispatch
+//      cheap: components reading `edit-content` re-render; the
+//      2,599 cells reading their own values don't.
+//
+//   3. No global singleton. Each MosaicStore is a fresh instance.
+//      Multi-store apps just instantiate multiple stores. Tests
+//      construct their own.
+//
+//   4. Synchronous dispatch. The action's `apply` runs immediately,
+//      state swaps, subscribers fire — all on the dispatch thread.
+//      Async work happens in middleware (which can schedule its own
+//      dispatches later) or in host extension points called from
+//      within `apply` (but the host MUST keep `apply` pure; see
+//      action.ts).
+
+import type { MosaicAction } from "./action.js";
+import type { Middleware } from "./middleware.js";
+import { composeMiddleware } from "./middleware.js";
+
+/**
+ * Subscriber callback: called when the selected slice of state
+ * changes (by `Object.is` reference equality, unless a custom
+ * comparator is provided).
+ */
+export type Subscriber<T> = (value: T) => void;
+
+/**
+ * Equality comparator for selectors. Defaults to `Object.is` which
+ * matches React's default behaviour for hooks. Hosts can provide
+ * a deep-equality comparator for slices that are recomputed each
+ * render but logically unchanged.
+ */
+export type Equality<T> = (a: T, b: T) => boolean;
+
+const defaultEquality: Equality<unknown> = (a, b) => Object.is(a, b);
+
+/**
+ * Options for store construction.
+ */
+export interface MosaicStoreOptions<State> {
+  /**
+   * Initial state. The store holds this until the first dispatch.
+   */
+  initialState: State;
+
+  /**
+   * Middleware to run after every successful dispatch. Optional —
+   * the store works without any.
+   */
+  middleware?: ReadonlyArray<Middleware<State>>;
+}
+
+/**
+ * The core store. Generic over the state type only — action types
+ * are determined per-call (Action is a covariant union of all
+ * action classes that target this state shape).
+ */
+export class MosaicStore<State> {
+  #state: State;
+  readonly #middleware: Middleware<State>;
+  readonly #subscriptions: Set<InternalSubscription<State, unknown>> = new Set();
+
+  constructor(options: MosaicStoreOptions<State>) {
+    this.#state = options.initialState;
+    this.#middleware = composeMiddleware(options.middleware ?? []);
+  }
+
+  /**
+   * The current state. Read-only from the consumer's perspective;
+   * mutations only happen via `dispatch`.
+   */
+  get state(): State {
+    return this.#state;
+  }
+
+  /**
+   * Dispatch an action. Runs the action's `apply`, swaps state,
+   * notifies subscribers whose selected slice changed, and runs
+   * middleware.
+   *
+   * Synchronous. By the time `dispatch` returns, all subscribers
+   * whose slices changed have been notified.
+   */
+  dispatch<A extends MosaicAction<State>>(action: A): void {
+    const prevState = this.#state;
+    const nextState = action.apply(prevState);
+    if (Object.is(prevState, nextState)) {
+      // No-op transforms still run middleware (so loggers see them)
+      // but skip subscriber notification.
+      this.#middleware(action, prevState, nextState);
+      return;
+    }
+    this.#state = nextState;
+    // Notify subscribers whose selected slice actually changed.
+    // We snapshot the set first so a subscriber that unsubscribes
+    // during its own callback doesn't perturb iteration.
+    const snapshot = Array.from(this.#subscriptions);
+    for (const sub of snapshot) {
+      sub.notifyIfChanged(prevState, nextState);
+    }
+    this.#middleware(action, prevState, nextState);
+  }
+
+  /**
+   * Subscribe to a slice of state via a selector function. The
+   * callback fires when the selected value changes (by `equality`,
+   * default `Object.is`).
+   *
+   * Returns an unsubscribe function.
+   *
+   * Fine-grained subscription is what makes strict Flux cheap. A
+   * component reading only `state.editContent` subscribes with
+   * `(s) => s.editContent`; the store calls its callback only when
+   * that field changes, not on every state update.
+   */
+  subscribe<T>(
+    selector: (state: State) => T,
+    callback: Subscriber<T>,
+    equality: Equality<T> = defaultEquality as Equality<T>,
+  ): () => void {
+    const sub = new InternalSubscription<State, T>(
+      selector,
+      callback,
+      equality,
+      selector(this.#state),
+    );
+    // Erase the value-type parameter at the set boundary. Each
+    // subscription stores its own selector/callback pair so type
+    // identity inside the set is unimportant; only the notify-on-
+    // change protocol matters.
+    this.#subscriptions.add(sub as unknown as InternalSubscription<State, unknown>);
+    return () => {
+      this.#subscriptions.delete(sub as unknown as InternalSubscription<State, unknown>);
+    };
+  }
+
+  /**
+   * Select a slice of state without subscribing. Used by callers
+   * that want a one-shot read (e.g., for an event handler that
+   * needs current state at dispatch time but doesn't need updates).
+   */
+  select<T>(selector: (state: State) => T): T {
+    return selector(this.#state);
+  }
+}
+
+/**
+ * Internal subscription bookkeeping. Keeps the last-seen value so
+ * we can compare on each dispatch.
+ */
+class InternalSubscription<State, T> {
+  #lastValue: T;
+  constructor(
+    private readonly selector: (state: State) => T,
+    private readonly callback: Subscriber<T>,
+    private readonly equality: Equality<T>,
+    initial: T,
+  ) {
+    this.#lastValue = initial;
+  }
+
+  notifyIfChanged(_prevState: State, nextState: State): void {
+    const nextValue = this.selector(nextState);
+    if (!this.equality(this.#lastValue, nextValue)) {
+      this.#lastValue = nextValue;
+      this.callback(nextValue);
+    }
+  }
+}

--- a/code/packages/typescript/mosaic-flux-react/tests/action.test.ts
+++ b/code/packages/typescript/mosaic-flux-react/tests/action.test.ts
@@ -1,0 +1,67 @@
+// action.test.ts — MosaicAction interface and type guard.
+
+import { describe, it, expect } from "vitest";
+import { isMosaicAction, type MosaicAction } from "../src/action.js";
+
+interface CounterState {
+  count: number;
+}
+
+class Increment implements MosaicAction<CounterState> {
+  apply(state: CounterState): CounterState {
+    return { count: state.count + 1 };
+  }
+}
+
+class Add implements MosaicAction<CounterState> {
+  constructor(public readonly amount: number) {}
+  apply(state: CounterState): CounterState {
+    return { count: state.count + this.amount };
+  }
+}
+
+describe("MosaicAction", () => {
+  it("apply returns the new state without mutating input", () => {
+    const initial: CounterState = { count: 5 };
+    const next = new Increment().apply(initial);
+    expect(next).toEqual({ count: 6 });
+    expect(initial).toEqual({ count: 5 }); // input unchanged
+  });
+
+  it("payload is accessible from the action instance", () => {
+    const action = new Add(7);
+    expect(action.amount).toBe(7);
+    expect(action.apply({ count: 3 })).toEqual({ count: 10 });
+  });
+
+  it("is deterministic — same state + action produces same next state", () => {
+    const state: CounterState = { count: 0 };
+    const action = new Add(5);
+    const a = action.apply(state);
+    const b = action.apply(state);
+    expect(a).toEqual(b);
+  });
+});
+
+describe("isMosaicAction", () => {
+  it("returns true for action instances", () => {
+    expect(isMosaicAction(new Increment())).toBe(true);
+    expect(isMosaicAction(new Add(1))).toBe(true);
+  });
+
+  it("returns true for plain objects with an apply method", () => {
+    // The contract is structural; anything with apply is treated as
+    // an action. This is intentional — author-controlled classes
+    // don't need to extend a base.
+    expect(isMosaicAction({ apply: () => ({}) })).toBe(true);
+  });
+
+  it("returns false for non-action values", () => {
+    expect(isMosaicAction(null)).toBe(false);
+    expect(isMosaicAction(undefined)).toBe(false);
+    expect(isMosaicAction(42)).toBe(false);
+    expect(isMosaicAction("string")).toBe(false);
+    expect(isMosaicAction({})).toBe(false);
+    expect(isMosaicAction({ apply: "not a function" })).toBe(false);
+  });
+});

--- a/code/packages/typescript/mosaic-flux-react/tests/devtools.test.ts
+++ b/code/packages/typescript/mosaic-flux-react/tests/devtools.test.ts
@@ -1,0 +1,126 @@
+// devtools.test.ts — DevTools middleware behaviour.
+//
+// We don't test the actual postMessage / WebSocket transports here
+// (they require a browser env or socket mock); we test the
+// middleware shape, payload extraction, and no-throw guarantees.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { devToolsMiddleware } from "../src/devtools.js";
+import type { MosaicAction } from "../src/action.js";
+
+interface S {
+  v: number;
+}
+
+class Bump implements MosaicAction<S> {
+  apply(s: S): S {
+    return { v: s.v + 1 };
+  }
+}
+
+class Payloaded implements MosaicAction<S> {
+  constructor(
+    public readonly amount: number,
+    public readonly tag: string,
+  ) {}
+  apply(s: S): S {
+    return { v: s.v + this.amount };
+  }
+}
+
+describe("devToolsMiddleware", () => {
+  beforeEach(() => {
+    // Without a window (vitest default node env), the middleware
+    // falls through to the NoopSink, which is what we want here —
+    // we exercise the middleware path without needing a transport.
+    expect(typeof (globalThis as { window?: unknown }).window).toBe(
+      "undefined",
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns a callable middleware function", () => {
+    const m = devToolsMiddleware<S>();
+    expect(typeof m).toBe("function");
+  });
+
+  it("does not throw when dispatched with a void-payload action", () => {
+    const m = devToolsMiddleware<S>();
+    expect(() => m(new Bump(), { v: 0 }, { v: 1 })).not.toThrow();
+  });
+
+  it("does not throw when dispatched with a payloaded action", () => {
+    const m = devToolsMiddleware<S>();
+    expect(() => m(new Payloaded(5, "tag"), { v: 0 }, { v: 5 })).not.toThrow();
+  });
+
+  it("accepts custom storeName option", () => {
+    const m = devToolsMiddleware<S>({ storeName: "my-grid" });
+    expect(() => m(new Bump(), { v: 0 }, { v: 1 })).not.toThrow();
+  });
+
+  it("uses NoopSink in non-browser non-ws environments", () => {
+    // The middleware was constructed at the top of beforeEach without
+    // a window or WebSocket, so it must have selected NoopSink.
+    // Direct check: invoking it should not produce side effects.
+    const m = devToolsMiddleware<S>();
+    expect(() => m(new Bump(), { v: 0 }, { v: 1 })).not.toThrow();
+  });
+});
+
+describe("devToolsMiddleware with mocked window.postMessage", () => {
+  let postMessageSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    postMessageSpy = vi.fn();
+    (globalThis as { window?: unknown }).window = {
+      postMessage: postMessageSpy,
+    };
+  });
+
+  afterEach(() => {
+    delete (globalThis as { window?: unknown }).window;
+  });
+
+  it("publishes action events through postMessage", () => {
+    const m = devToolsMiddleware<S>();
+    m(new Bump(), { v: 0 }, { v: 1 });
+    expect(postMessageSpy).toHaveBeenCalledTimes(1);
+    const [payload] = postMessageSpy.mock.calls[0] ?? [];
+    expect(payload).toMatchObject({
+      source: "mosaic-flux-devtools",
+      payload: {
+        kind: "action",
+        actionType: "Bump",
+      },
+    });
+  });
+
+  it("extracts payload fields from the action instance", () => {
+    const m = devToolsMiddleware<S>();
+    m(new Payloaded(42, "x"), { v: 0 }, { v: 42 });
+    const [arg] = postMessageSpy.mock.calls[0] ?? [];
+    const payload = (arg as { payload: { actionPayload: Record<string, unknown> } })
+      .payload.actionPayload;
+    expect(payload).toEqual({ amount: 42, tag: "x" });
+  });
+
+  it("survives postMessage failures (non-cloneable payloads)", () => {
+    postMessageSpy.mockImplementation(() => {
+      throw new Error("DataCloneError");
+    });
+    const m = devToolsMiddleware<S>();
+    expect(() => m(new Bump(), { v: 0 }, { v: 1 })).not.toThrow();
+  });
+
+  it("includes storeName in published payload", () => {
+    const m = devToolsMiddleware<S>({ storeName: "custom" });
+    m(new Bump(), { v: 0 }, { v: 1 });
+    const [arg] = postMessageSpy.mock.calls[0] ?? [];
+    const payload = (arg as { payload: { storeName: string } }).payload;
+    expect(payload.storeName).toBe("custom");
+  });
+});

--- a/code/packages/typescript/mosaic-flux-react/tests/index.test.ts
+++ b/code/packages/typescript/mosaic-flux-react/tests/index.test.ts
@@ -1,0 +1,36 @@
+// index.test.ts — smoke test that the public surface is exported.
+//
+// The package's public surface comes from src/index.ts. Re-exports
+// are easy to break (a refactor renames a file, the index forgets to
+// re-export the new path) and the failure mode is silent — consumers
+// just see undefined imports. This test enforces that every advertised
+// symbol is actually exported.
+
+import { describe, it, expect } from "vitest";
+import * as pkg from "../src/index.js";
+
+describe("@coding-adventures/mosaic-flux-react public surface", () => {
+  it("exports MosaicStore class", () => {
+    expect(typeof pkg.MosaicStore).toBe("function");
+  });
+
+  it("exports isMosaicAction type guard", () => {
+    expect(typeof pkg.isMosaicAction).toBe("function");
+  });
+
+  it("exports composeMiddleware utility", () => {
+    expect(typeof pkg.composeMiddleware).toBe("function");
+  });
+
+  it("exports loggerMiddleware factory", () => {
+    expect(typeof pkg.loggerMiddleware).toBe("function");
+  });
+
+  it("exports createSelector factory", () => {
+    expect(typeof pkg.createSelector).toBe("function");
+  });
+
+  it("exports devToolsMiddleware factory", () => {
+    expect(typeof pkg.devToolsMiddleware).toBe("function");
+  });
+});

--- a/code/packages/typescript/mosaic-flux-react/tests/middleware.test.ts
+++ b/code/packages/typescript/mosaic-flux-react/tests/middleware.test.ts
@@ -1,0 +1,116 @@
+// middleware.test.ts
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  composeMiddleware,
+  loggerMiddleware,
+  type Middleware,
+} from "../src/middleware.js";
+import type { MosaicAction } from "../src/action.js";
+
+interface S {
+  v: number;
+}
+
+class Bump implements MosaicAction<S> {
+  apply(s: S): S {
+    return { v: s.v + 1 };
+  }
+}
+
+describe("composeMiddleware", () => {
+  it("returns a no-op when the input array is empty", () => {
+    const composed = composeMiddleware<S>([]);
+    // Should not throw
+    expect(() => composed(new Bump(), { v: 0 }, { v: 1 })).not.toThrow();
+  });
+
+  it("returns the single middleware verbatim when only one is provided", () => {
+    const m: Middleware<S> = () => {};
+    const composed = composeMiddleware<S>([m]);
+    expect(composed).toBe(m);
+  });
+
+  it("runs middleware in registration order", () => {
+    const calls: string[] = [];
+    const composed = composeMiddleware<S>([
+      () => calls.push("first"),
+      () => calls.push("second"),
+      () => calls.push("third"),
+    ]);
+    composed(new Bump(), { v: 0 }, { v: 1 });
+    expect(calls).toEqual(["first", "second", "third"]);
+  });
+
+  it("isolates throwing middleware so subsequent middleware still run", () => {
+    const calls: string[] = [];
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const composed = composeMiddleware<S>([
+      () => calls.push("first"),
+      () => {
+        throw new Error("boom");
+      },
+      () => calls.push("third"),
+    ]);
+    composed(new Bump(), { v: 0 }, { v: 1 });
+    expect(calls).toEqual(["first", "third"]);
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
+  });
+});
+
+describe("loggerMiddleware", () => {
+  it("logs action class name + changed keys", () => {
+    const groupSpy = vi
+      .spyOn(console, "groupCollapsed")
+      .mockImplementation(() => {});
+    const groupEndSpy = vi.spyOn(console, "groupEnd").mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const m = loggerMiddleware<S>();
+    m(new Bump(), { v: 0 }, { v: 1 });
+
+    expect(groupSpy).toHaveBeenCalledTimes(1);
+    expect(groupSpy.mock.calls[0]?.[0]).toContain("Bump");
+    expect(groupSpy.mock.calls[0]?.[0]).toContain("v"); // the changed key
+    expect(logSpy).toHaveBeenCalled();
+    expect(groupEndSpy).toHaveBeenCalled();
+
+    groupSpy.mockRestore();
+    groupEndSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+
+  it("reports '(none)' for no-op dispatches", () => {
+    const groupSpy = vi
+      .spyOn(console, "groupCollapsed")
+      .mockImplementation(() => {});
+    vi.spyOn(console, "groupEnd").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const m = loggerMiddleware<S>();
+    m(new Bump(), { v: 0 }, { v: 0 });
+
+    expect(groupSpy.mock.calls[0]?.[0]).toContain("(none)");
+    vi.restoreAllMocks();
+  });
+
+  it("treats non-object state as atomic", () => {
+    const groupSpy = vi
+      .spyOn(console, "groupCollapsed")
+      .mockImplementation(() => {});
+    vi.spyOn(console, "groupEnd").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const m = loggerMiddleware<number>();
+    class NumberAction implements MosaicAction<number> {
+      apply(n: number): number {
+        return n + 1;
+      }
+    }
+    m(new NumberAction(), 0, 1);
+
+    expect(groupSpy.mock.calls[0]?.[0]).toContain("<root>");
+    vi.restoreAllMocks();
+  });
+});

--- a/code/packages/typescript/mosaic-flux-react/tests/selector.test.ts
+++ b/code/packages/typescript/mosaic-flux-react/tests/selector.test.ts
@@ -1,0 +1,72 @@
+// selector.test.ts — createSelector memoisation behaviour.
+
+import { describe, it, expect, vi } from "vitest";
+import { createSelector } from "../src/selector.js";
+
+interface S {
+  a: number;
+  b: number;
+  label: string;
+}
+
+describe("createSelector", () => {
+  it("throws when given fewer than 2 args", () => {
+    expect(() => (createSelector as unknown as () => unknown)()).toThrow();
+    expect(() =>
+      (createSelector as unknown as (fn: () => unknown) => unknown)(() => 1),
+    ).toThrow();
+  });
+
+  it("recomputes when input changes", () => {
+    const combiner = vi.fn((a: number, b: number) => a + b);
+    const sum = createSelector(
+      (s: S) => s.a,
+      (s: S) => s.b,
+      combiner,
+    );
+    expect(sum({ a: 1, b: 2, label: "" })).toBe(3);
+    expect(sum({ a: 5, b: 2, label: "" })).toBe(7);
+    expect(combiner).toHaveBeenCalledTimes(2);
+  });
+
+  it("caches when inputs are unchanged across calls", () => {
+    const combiner = vi.fn((a: number, b: number) => a + b);
+    const sum = createSelector(
+      (s: S) => s.a,
+      (s: S) => s.b,
+      combiner,
+    );
+    const state: S = { a: 1, b: 2, label: "" };
+    sum(state);
+    sum(state);
+    sum(state);
+    expect(combiner).toHaveBeenCalledTimes(1);
+  });
+
+  it("caches across different state references when inputs project to same values", () => {
+    const combiner = vi.fn((a: number) => a * 2);
+    const doubled = createSelector((s: S) => s.a, combiner);
+    // Two different state objects with the same `a` value — combiner
+    // should run once.
+    doubled({ a: 5, b: 0, label: "" });
+    doubled({ a: 5, b: 999, label: "different" });
+    expect(combiner).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-runs when one of multiple inputs changes", () => {
+    const combiner = vi.fn(
+      (a: number, b: number, lbl: string) => `${lbl}:${a + b}`,
+    );
+    const fmt = createSelector(
+      (s: S) => s.a,
+      (s: S) => s.b,
+      (s: S) => s.label,
+      combiner,
+    );
+    fmt({ a: 1, b: 2, label: "x" });
+    fmt({ a: 1, b: 2, label: "x" });
+    fmt({ a: 1, b: 2, label: "y" }); // label changed
+    fmt({ a: 1, b: 2, label: "y" });
+    expect(combiner).toHaveBeenCalledTimes(2);
+  });
+});

--- a/code/packages/typescript/mosaic-flux-react/tests/store.test.ts
+++ b/code/packages/typescript/mosaic-flux-react/tests/store.test.ts
@@ -1,0 +1,189 @@
+// store.test.ts — MosaicStore dispatch, state, subscribe, select.
+
+import { describe, it, expect, vi } from "vitest";
+import { MosaicStore } from "../src/store.js";
+import type { MosaicAction } from "../src/action.js";
+
+interface CounterState {
+  count: number;
+  label: string;
+}
+
+class Increment implements MosaicAction<CounterState> {
+  apply(s: CounterState): CounterState {
+    return { ...s, count: s.count + 1 };
+  }
+}
+
+class SetLabel implements MosaicAction<CounterState> {
+  constructor(public readonly label: string) {}
+  apply(s: CounterState): CounterState {
+    return { ...s, label: this.label };
+  }
+}
+
+class NoOp implements MosaicAction<CounterState> {
+  apply(s: CounterState): CounterState {
+    return s; // returns the SAME reference; store should skip subscriber fire
+  }
+}
+
+const initial: CounterState = { count: 0, label: "" };
+
+describe("MosaicStore", () => {
+  it("starts at the provided initial state", () => {
+    const store = new MosaicStore<CounterState>({ initialState: initial });
+    expect(store.state).toEqual(initial);
+  });
+
+  it("dispatch applies the action and updates state", () => {
+    const store = new MosaicStore<CounterState>({ initialState: initial });
+    store.dispatch(new Increment());
+    expect(store.state).toEqual({ count: 1, label: "" });
+  });
+
+  it("supports actions with payload", () => {
+    const store = new MosaicStore<CounterState>({ initialState: initial });
+    store.dispatch(new SetLabel("hello"));
+    expect(store.state.label).toBe("hello");
+  });
+
+  it("select returns the projected slice without subscribing", () => {
+    const store = new MosaicStore<CounterState>({ initialState: initial });
+    store.dispatch(new SetLabel("test"));
+    expect(store.select((s) => s.label)).toBe("test");
+  });
+});
+
+describe("MosaicStore.subscribe — fine-grained subscription", () => {
+  it("fires subscriber when the selected slice changes", () => {
+    const store = new MosaicStore<CounterState>({ initialState: initial });
+    const cb = vi.fn();
+    store.subscribe((s) => s.count, cb);
+    store.dispatch(new Increment());
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(cb).toHaveBeenCalledWith(1);
+  });
+
+  it("does NOT fire when an unrelated slice changes", () => {
+    const store = new MosaicStore<CounterState>({ initialState: initial });
+    const countCb = vi.fn();
+    store.subscribe((s) => s.count, countCb);
+    store.dispatch(new SetLabel("anything"));
+    // count didn't change, so countCb should not fire
+    expect(countCb).not.toHaveBeenCalled();
+  });
+
+  it("fires multiple subscribers in registration order", () => {
+    const store = new MosaicStore<CounterState>({ initialState: initial });
+    const calls: string[] = [];
+    store.subscribe(
+      (s) => s.count,
+      () => calls.push("first"),
+    );
+    store.subscribe(
+      (s) => s.count,
+      () => calls.push("second"),
+    );
+    store.dispatch(new Increment());
+    expect(calls).toEqual(["first", "second"]);
+  });
+
+  it("unsubscribe stops further notifications", () => {
+    const store = new MosaicStore<CounterState>({ initialState: initial });
+    const cb = vi.fn();
+    const unsub = store.subscribe((s) => s.count, cb);
+    store.dispatch(new Increment());
+    unsub();
+    store.dispatch(new Increment());
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it("a subscriber unsubscribing during its own callback does not skip peers", () => {
+    const store = new MosaicStore<CounterState>({ initialState: initial });
+    const calls: string[] = [];
+    const unsubFirst: () => void = (() => {
+      let u: () => void = () => {};
+      u = store.subscribe(
+        (s) => s.count,
+        () => {
+          calls.push("first");
+          unsubFirst();
+        },
+      );
+      return u;
+    })();
+    void unsubFirst;
+    store.subscribe(
+      (s) => s.count,
+      () => calls.push("second"),
+    );
+    store.dispatch(new Increment());
+    // Both should fire on the dispatch where first unsubscribes
+    expect(calls).toEqual(["first", "second"]);
+  });
+
+  it("supports custom equality functions", () => {
+    interface ArrayState {
+      list: number[];
+    }
+    const store = new MosaicStore<ArrayState>({
+      initialState: { list: [1, 2, 3] },
+    });
+    const cb = vi.fn();
+    // Use deep equality so semantically-same arrays don't trigger
+    const deepEqual = (a: number[], b: number[]): boolean =>
+      a.length === b.length && a.every((v, i) => v === b[i]);
+    store.subscribe(
+      (s) => s.list,
+      cb,
+      deepEqual as unknown as (a: number[], b: number[]) => boolean,
+    );
+    // Dispatch an action that returns a new array with same contents
+    class ReplaceList implements MosaicAction<ArrayState> {
+      apply(s: ArrayState): ArrayState {
+        return { list: [...s.list] };
+      }
+    }
+    store.dispatch(new ReplaceList());
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("no-op action (apply returns same reference) skips subscriber notification", () => {
+    const store = new MosaicStore<CounterState>({ initialState: initial });
+    const cb = vi.fn();
+    store.subscribe((s) => s.count, cb);
+    store.dispatch(new NoOp());
+    expect(cb).not.toHaveBeenCalled();
+  });
+});
+
+describe("MosaicStore.middleware", () => {
+  it("middleware sees (action, prevState, nextState) triples", () => {
+    const seen: Array<{ action: unknown; prev: CounterState; next: CounterState }> =
+      [];
+    const store = new MosaicStore<CounterState>({
+      initialState: initial,
+      middleware: [
+        (action, prev, next) => seen.push({ action, prev, next }),
+      ],
+    });
+    const action = new Increment();
+    store.dispatch(action);
+    expect(seen).toHaveLength(1);
+    expect(seen[0]?.action).toBe(action);
+    expect(seen[0]?.prev).toEqual({ count: 0, label: "" });
+    expect(seen[0]?.next).toEqual({ count: 1, label: "" });
+  });
+
+  it("middleware runs even for no-op dispatches (loggers still see them)", () => {
+    const seen: number = 0;
+    let counter = seen;
+    const store = new MosaicStore<CounterState>({
+      initialState: initial,
+      middleware: [() => counter++],
+    });
+    store.dispatch(new NoOp());
+    expect(counter).toBe(1);
+  });
+});

--- a/code/packages/typescript/mosaic-flux-react/tsconfig.json
+++ b/code/packages/typescript/mosaic-flux-react/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true
+  },
+  "include": ["src"]
+}

--- a/code/packages/typescript/mosaic-flux-react/vitest.config.ts
+++ b/code/packages/typescript/mosaic-flux-react/vitest.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      // react.ts requires a jsdom + react-testing-library environment
+      // to exercise meaningfully. v0.1.0 ships it untested at the
+      // unit level and validates via integration in downstream
+      // Mosaic-compiled apps. v0.2.0 will add the test setup.
+      exclude: ["src/react.ts"],
+      thresholds: {
+        lines: 80,
+        functions: 80,
+        branches: 80,
+        statements: 80,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary

First **Phase-2 runtime library** per UI33-rewrite §6. The React-specific strict-Flux runtime that codegen'd action classes will target (Phase-3 emitter work).

## What's in the package

| Surface | Purpose |
|---|---|
| \`MosaicAction<State>\` | The Command Pattern interface (constructor=payload, apply=state transform) |
| \`MosaicStore<State>\` | State container + dispatcher; routes via \`action.apply(state)\` |
| Fine-grained subscription | Selector + equality; only fires when slice changes |
| \`composeMiddleware\` + \`loggerMiddleware\` | Cross-cutting concerns hook |
| \`createSelector\` | Memoised derived-state combinator (Reselect-shaped) |
| \`devToolsMiddleware\` | Publishes UI33-rewrite §8 events via postMessage / ws fallback |
| React subpath: \`MosaicStoreProvider\`, \`useMosaicStore\`, \`useMosaicSelector\`, \`useMosaicDispatch\` | Hooks-based React integration via React 18+ \`useSyncExternalStore\` |

## Stats

- 7 source files, ~600 lines, literate comments throughout
- 6 test files, **46 tests passing**
- Coverage: **88.32% lines / 91.78% branches / 84.61% functions / 88.32% statements** — well above 80% threshold
- Zero runtime dependencies; React peer (^19.2.6) for \`./react\` subpath only
- TypeScript strict mode; \`tsc --noEmit\` passes
- BUILD, CHANGELOG.md, README.md per CLAUDE.md repo standards

## Why Mosaic-owned, not TCA / Redux Toolkit / Bloc / etc.

Per UI33-rewrite §6.1:
1. Same architecture everywhere across 7 backends
2. Unified DevTools (because runtime is uniform)
3. No external dependency risk (no breaking API changes from upstream)
4. Ship features no third party would prioritise (cross-backend action replay)

## What's deliberately deferred

- **\`react.ts\` unit tests** require jsdom + react-testing-library setup; excluded from coverage threshold for v0.1.0, validated via downstream integration in Mosaic-compiled apps. v0.2.0 will add the test setup.
- **Time-travel replay support on the runtime side** — for v0.1.0 the DevTools desktop app drives replay externally; native replay is a v0.2.0 follow-up.
- **Multi-store coordination primitives** — each MosaicStore is standalone in v0.1.0.

## Test plan

- [x] Tests: 46 passing, run via \`mise exec -- npx vitest run\`
- [x] Coverage: 88.32%/91.78%/84.61%/88.32% above 80%
- [x] Typecheck: \`tsc --noEmit\` clean
- [x] /security-review passed (no vulnerabilities; postMessage \`\"*\"\` target and ws://localhost:9229 noted as dev-only by design)
- [ ] CI green
- [ ] Human review on \`src/store.ts\` (subscription mechanism) + \`src/devtools.ts\` (DevTools protocol)

## Next in Phase 2

| Package | Lang | Status |
|---|---|---|
| **mosaic-flux-react** | TS | **This PR** |
| mosaic-flux-html | TS | Next loop cycle |
| mosaic-flux-webcomponent | TS | Shares html core |
| mosaic-flux-swiftui | Swift | Future |
| mosaic-flux-compose | Kotlin | Future |
| mosaic-flux-flutter | Dart | Future |
| mosaic-flux-xaml | C# | Future |
| mosaic-flux-qt | C++ | Future |

Each runtime will mirror this one's API in its target language's idiom, per UI33-rewrite §6.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)