### PR TITLE
[codex] Check Board VM ejected artifact parity

### DIFF
--- a/code/packages/rust/board-vm-uno-r4-firmware/Cargo.toml
+++ b/code/packages/rust/board-vm-uno-r4-firmware/Cargo.toml
@@ -25,6 +25,7 @@ panic-halt = "0.2"
 board-vm-serial = { path = "../board-vm-serial" }
 
 [dev-dependencies]
+board-vm-eject = { path = "../board-vm-eject" }
 board-vm-host = { path = "../board-vm-host" }
 
 [lib]

--- a/code/packages/rust/board-vm-uno-r4-firmware/README.md
+++ b/code/packages/rust/board-vm-uno-r4-firmware/README.md
@@ -49,6 +49,10 @@ The constants match the output shape produced by:
 cargo run -p board-vm-cli --bin board-vm -- eject blink --out src/ejected_blink.rs
 ```
 
+Host-side tests re-run the Rust eject generator and compare the generated
+artifact against the embedded constants, so firmware changes catch stale
+ejected blink metadata before flashing hardware.
+
 The ejected artifact stays board-agnostic; this firmware binary is the Uno R4
 backend that decides how to validate and execute it.
 

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/lib.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/lib.rs
@@ -248,6 +248,8 @@ extern crate std;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use board_vm_eject::{build_blink_eject_artifact, EjectOptions};
+    use board_vm_host::BlinkProgram;
     use board_vm_ir::{
         parse_module, CapabilitySet, CAP_GPIO_OPEN, CAP_GPIO_WRITE, CAP_TIME_SLEEP_MS,
         FLAG_PROGRAM_MAY_RUN_FOREVER,
@@ -341,6 +343,35 @@ mod tests {
         );
         assert_eq!(program.module, &EMBEDDED_BLINK_MODULE);
         validate_ejected_blink_program(16).unwrap();
+    }
+
+    #[test]
+    fn ejected_blink_program_matches_eject_generator_output() {
+        let program = EjectedFirmwareProgram::blink();
+        let mut generated_module = [0u8; EMBEDDED_BLINK_MODULE.len()];
+
+        let artifact = build_blink_eject_artifact(
+            BlinkProgram::onboard_led(),
+            EjectOptions::new(program.program_id)
+                .slot(program.slot)
+                .boot_policy(program.boot_policy),
+            &mut generated_module,
+        )
+        .unwrap();
+
+        assert_eq!(program.program_id, artifact.program_id);
+        assert_eq!(program.slot, artifact.slot);
+        assert_eq!(program.boot_policy, artifact.boot_policy);
+        assert_eq!(program.program_format, artifact.format.as_u8());
+        assert_eq!(program.module_version, artifact.module_version);
+        assert_eq!(program.module_flags, artifact.module_flags);
+        assert_eq!(program.max_stack, artifact.max_stack);
+        assert_eq!(program.module_crc32, artifact.module_crc32);
+        assert_eq!(
+            program.required_capabilities,
+            artifact.required_capabilities
+        );
+        assert_eq!(program.module, artifact.module);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a host-side Uno R4 firmware test that re-runs the Rust eject generator for the blink artifact
- compare generated artifact metadata, required capabilities, CRC, and bytecode against the embedded ejected blink constants
- document that the firmware tests catch stale ejected artifact metadata before flashing hardware

## Validation
- cargo fmt -p board-vm-uno-r4-firmware
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-ejected-artifact-parity cargo test -p board-vm-uno-r4-firmware
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-ejected-artifact-parity cargo test -p board-vm-protocol -p board-vm-ir -p board-vm-host -p board-vm-device -p board-vm-loopback -p board-vm-client -p board-vm-eject -p board-vm-uno-r4-firmware -p board-vm-cli
- git diff --check
- git diff --cached --check