### PR TITLE
feat(closure-emitter): CLOC12.12 — number formatting shortest-form (closes gap-025)

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,62 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.6.0] - 2026-06-01
+
+### Added — CLOC12.12: number formatting shortest-form (closes gap-025)
+
+`format_js_number` now computes both decimal and exponential
+representations for finite non-zero numbers and returns whichever is
+shorter. Ties pick decimal (canonical). Matches upstream
+`CodePrinter`'s behaviour.
+
+| Value | Old emit | New emit |
+|-------|----------|----------|
+| `1` | `1` | `1` |
+| `100` | `100` | `100` (tie 3=3 → decimal) |
+| `1_000_000_000` | `1000000000` | `1E9` |
+| `5_000_000` | `5000000` | `5E6` |
+| `0.5` | `0.5` | `0.5` |
+| `1.5e-10` | `0.00000000015` | `1.5E-10` |
+| `NaN` | `NaN` | `NaN` |
+| `Infinity` | `Infinity` | `Infinity` |
+
+Exponential form follows JS / upstream conventions: uppercase `E`,
+no leading `+` for positive exponents, stripped trailing zeros in
+the mantissa (`1E9`, not `1.0E+9`).
+
+### New helper
+
+`format_exponential_uppercase(n: f64) -> String` — wraps Rust's
+`{:e}` formatter and uppercases the `E`.
+
+### New inline tests (5)
+
+- `number_shortest_form_small_integers_stay_decimal` — `0`, `1`, `42`, `100`, `-7`.
+- `number_shortest_form_big_integers_switch_to_exponential` — `1E9`, `5E6`.
+- `number_shortest_form_small_decimals_stay_decimal` — `0.5`, `3.14`.
+- `number_shortest_form_tiny_floats_switch_to_exponential` — `1.5E-10`.
+- `number_shortest_form_nan_and_infinity_unchanged` — sanity check.
+
+Plus `emit_number_value(v: f64) -> String` helper.
+
+### gap-025 → RESOLVED
+
+### Reconciles missing version bump from CLOC12.11
+
+CLOC12.11 (PR #4703) updated the CHANGELOG to `[0.5.0]` but the
+`Cargo.toml` change was dropped, leaving the published crate at
+`0.4.0`. This PR bumps directly `0.4.0` → `0.6.0`: the `0.5.0`
+CHANGELOG entry below stays valid as the description of quote-choice
+work; `0.6.0` is the first published version that actually includes
+both quote-choice (CLOC12.11) AND shortest-form number rendering
+(CLOC12.12).
+
+### Version
+
+`0.4.0` → `0.6.0` (skips `0.5.0` to absorb the missed CLOC12.11
+Cargo.toml bump).
+
 ## [0.5.0] - 2026-06-01
 
 ### Added — CLOC12.11: string quote-choice optimisation (closes gap-026)

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.4.0"
+version = "0.6.0"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 

--- a/code/packages/rust/closure-emitter/src/lib.rs
+++ b/code/packages/rust/closure-emitter/src/lib.rs
@@ -825,9 +825,20 @@ impl<'a> Emitter<'a> {
 // =====================================================================
 
 /// JavaScript-style number rendering — matches `String(x)` so
-/// emitted output round-trips numerically. Mirrors the helper of
-/// the same name in `closure-pass-constant-fold` so both crates
-/// produce consistent text for the same value.
+/// emitted output round-trips numerically. CLOC12.12 / gap-025:
+/// for finite non-zero numbers we now compute BOTH the decimal and
+/// exponential forms and return whichever is shorter. Ties pick
+/// decimal (canonical).
+///
+/// Examples:
+///
+///   1                 →  "1"      (decimal shorter)
+///   100               →  "100"    (tie → decimal)
+///   1000000000        →  "1E9"    (decimal 10 chars vs expo 3)
+///   0.5               →  "0.5"    (decimal shorter)
+///   1.5e-10           →  "1.5E-10" (decimal 13 chars vs expo 7)
+///   1e21              →  "1E21"   (expo shorter)
+///   NaN / Infinity    →  unchanged from JS String(x)
 fn format_js_number(n: f64) -> String {
     if n.is_nan() {
         return "NaN".to_string();
@@ -842,10 +853,34 @@ fn format_js_number(n: f64) -> String {
     if n == 0.0 {
         return "0".to_string();
     }
-    if n.fract() == 0.0 && n.abs() < 1e21 {
-        return format!("{}", n as i64);
+    let decimal = if n.fract() == 0.0 && n.abs() < 1e21 {
+        format!("{}", n as i64)
+    } else {
+        n.to_string()
+    };
+    let expo = format_exponential_uppercase(n);
+    if expo.len() < decimal.len() {
+        expo
+    } else {
+        decimal
     }
-    n.to_string()
+}
+
+/// Build the JS-style exponential form for a finite non-zero
+/// number. Rust's `{:e}` formatter produces `"1e9"` / `"1.5e-10"` /
+/// `"1.2345e4"`; we just uppercase the `e`. We do *not* emit a `+`
+/// for positive exponents — upstream's CodePrinter writes `1E9`,
+/// not `1E+9`.
+fn format_exponential_uppercase(n: f64) -> String {
+    // Rust's `{:e}` never inserts a `+` for positive exponents and
+    // strips trailing zeros from the mantissa fraction. So a direct
+    // `e → E` substitution is sufficient.
+    let mut s = format!("{:e}", n);
+    // Convert "1.5e-10" → "1.5E-10"
+    if let Some(pos) = s.find('e') {
+        s.replace_range(pos..pos + 1, "E");
+    }
+    s
 }
 
 // =====================================================================
@@ -1189,6 +1224,57 @@ mod tests {
             raw: String::new(),
         });
         emit_default(program().with_body(vec![stmt(s)])).code
+    }
+
+    // ---- number shortest-form (gap-025, CLOC12.12) ---------
+
+    /// Helper: emit a synthetic NumericLiteral and return the code
+    /// (without the trailing `;`).
+    fn emit_number_value(v: f64) -> String {
+        let n = Expression::NumericLiteral(NumericLiteral {
+            cv: None,
+            value: v,
+            raw: String::new(),
+        });
+        let code = emit_default(program().with_body(vec![stmt(n)])).code;
+        // strip trailing ";"
+        code.trim_end_matches(';').to_string()
+    }
+
+    #[test]
+    fn number_shortest_form_small_integers_stay_decimal() {
+        assert_eq!(emit_number_value(0.0), "0");
+        assert_eq!(emit_number_value(1.0), "1");
+        assert_eq!(emit_number_value(42.0), "42");
+        assert_eq!(emit_number_value(100.0), "100"); // tie 3=3 → decimal
+        assert_eq!(emit_number_value(-7.0), "-7");
+    }
+
+    #[test]
+    fn number_shortest_form_big_integers_switch_to_exponential() {
+        // 1000000000 (10 chars) vs 1E9 (3 chars) → 1E9
+        assert_eq!(emit_number_value(1_000_000_000.0), "1E9");
+        // 5_000_000 vs 5E6 → 5E6
+        assert_eq!(emit_number_value(5_000_000.0), "5E6");
+    }
+
+    #[test]
+    fn number_shortest_form_small_decimals_stay_decimal() {
+        assert_eq!(emit_number_value(0.5), "0.5");
+        assert_eq!(emit_number_value(3.14), "3.14");
+    }
+
+    #[test]
+    fn number_shortest_form_tiny_floats_switch_to_exponential() {
+        // 1.5e-10 → "0.00000000015" (13) vs "1.5E-10" (7)
+        assert_eq!(emit_number_value(1.5e-10), "1.5E-10");
+    }
+
+    #[test]
+    fn number_shortest_form_nan_and_infinity_unchanged() {
+        assert_eq!(emit_number_value(f64::NAN), "NaN");
+        assert_eq!(emit_number_value(f64::INFINITY), "Infinity");
+        assert_eq!(emit_number_value(f64::NEG_INFINITY), "-Infinity");
     }
 
     #[test]

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -214,11 +214,10 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-025 — Numeric formatting (shortest-form / exponential) not implemented
 
-- **Status:** OPEN
+- **Status:** RESOLVED in CLOC12.12
 - **Upstream test:** `CodePrinterTest` lines like `assertPrint("1000000000", "1E9")`
 - **Ported file:** `closure-emitter/tests/upstream/code_printer_test.rs`
-- **Why it fails:** Upstream picks the shorter representation between decimal and exponential. Our emitter always uses the `raw` field on `NumericLiteral` (or a plain `f64.to_string()`).
-- **What it needs:** Add a "pick-shortest" numeric formatter and wire it into the `NumericLiteral` emit path.
+- **Resolution:** `format_js_number` now computes both decimal and exponential forms for finite non-zero numbers and returns the shorter (ties → decimal). `format_exponential_uppercase` wraps Rust's `{:e}` formatter and uppercases the `e`. Examples: `1000000000` → `1E9`, `5000000` → `5E6`, `1.5e-10` → `1.5E-10`. Small integers and decimals stay decimal. NaN/Infinity unchanged. The `test_number_formatting_shortest_form` ignored placeholder in `tests/upstream/code_printer_test.rs` stays — to be re-port'd with real upstream `assertPrint` lines in a follow-up; the underlying emitter behaviour is in place.
 
 ### gap-026 — String quote-choice optimisation not implemented
 


### PR DESCRIPTION
## Summary

`format_js_number` now computes both decimal and exponential representations for finite non-zero numbers and returns whichever is shorter. Ties pick decimal (canonical). Matches upstream CodePrinter.

## Truth table

| Value | Old emit | New emit |
|-------|----------|----------|
| `1` | `1` | `1` |
| `100` | `100` | `100` (tie 3=3 → decimal) |
| `1_000_000_000` | `1000000000` | `1E9` |
| `5_000_000` | `5000000` | `5E6` |
| `0.5` | `0.5` | `0.5` |
| `1.5e-10` | `0.00000000015` | `1.5E-10` |
| `NaN` / `Infinity` | unchanged | unchanged |

Exponential form follows JS / upstream conventions: uppercase `E`, no leading `+` for positive exponents, stripped trailing zeros in the mantissa.

## New helper

`format_exponential_uppercase(n: f64) -> String` — wraps Rust's `{:e}` formatter and uppercases the `E`.

## New inline tests (5)

- `number_shortest_form_small_integers_stay_decimal`
- `number_shortest_form_big_integers_switch_to_exponential`
- `number_shortest_form_small_decimals_stay_decimal`
- `number_shortest_form_tiny_floats_switch_to_exponential`
- `number_shortest_form_nan_and_infinity_unchanged`

Plus `emit_number_value(v)` helper.

## Bookkeeping: reconciles missed CLOC12.11 Cargo bump

CLOC12.11 (PR #4703) updated CHANGELOG to `[0.5.0]` but the Cargo.toml change was dropped, leaving published crate at `0.4.0`. This PR bumps directly `0.4.0` → `0.6.0` to reconcile: the `0.5.0` CHANGELOG entry stays valid as the description of quote-choice work; `0.6.0` is the first version that actually includes both quote-choice and shortest-form number rendering.

## gap-025 → RESOLVED

## Version

closure-emitter `0.4.0` → `0.6.0` (skips `0.5.0`).

## Test plan

- [x] \`cargo test\` (emitter) — 27 inline + 6 upstream pass, 6 ignored, 0 fail
- [x] \`cargo test\` (closurec end-to-end) — no failures
- [x] Security review: PASS (pure safe Rust, ASCII-only string ops, no new deps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)