### PR TITLE
feat(mosaic-flux-webcomponent): v0.1.0 — strict-Flux runtime for Web Components

### DIFF
--- a/code/packages/typescript/mosaic-flux-webcomponent/BUILD
+++ b/code/packages/typescript/mosaic-flux-webcomponent/BUILD
@@ -1,0 +1,2 @@
+npm ci --quiet
+npx vitest run --coverage

--- a/code/packages/typescript/mosaic-flux-webcomponent/CHANGELOG.md
+++ b/code/packages/typescript/mosaic-flux-webcomponent/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+## 0.1.0
+
+Initial release. Web Component strict-Flux runtime for Mosaic UI per `code/specs/UI33-rewrite-unified-architecture.md`.
+
+### Added
+
+- All core types from `mosaic-flux-html` (duplicated in this package per UI33-rewrite §6.1 "standalone runtimes" policy):
+  - `MosaicAction<State>` + `isMosaicAction` guard
+  - `MosaicStore<State>` with `dispatch` / `state` / `subscribe` / `select`
+  - `Middleware<State>` + `composeMiddleware` + `loggerMiddleware`
+  - `createSelector` memoised derived-state combinator
+  - `devToolsMiddleware` (postMessage + ws fallback)
+  - DOM binding helpers: `bindText` / `bindAttr` / `bindClass` / `bindStyle` / `bindList`
+- **`MosaicHostElement<State>` base class** — custom-element base with managed binding lifecycle:
+  - `attachShadowIfNeeded()` — idempotent open-shadow attachment
+  - `track(unsubscribe)` — register cleanup; auto-disposed on `disconnectedCallback`
+  - `dispatch(action)` shortcut delegating to the bound store
+  - `connectedCallback` invokes subclass `bindStore(store)` when a store is set
+  - `disconnectedCallback` invokes every tracked unsubscribe
+  - Setting `element.store = s` after connection triggers rebind (disposes old bindings, calls `bindStore(s)`)
+  - Setting `element.store = null` disposes existing bindings
+  - Bad unsubscribes are isolated (one throwing unsubscribe doesn't prevent others from running)
+- **`defineMosaicElement(tagName, class, options?)`** — idempotent `customElements.define` wrapper. Second call with same tag is a no-op (first definition wins). Throws if `customElements` is unavailable. Module reload / HMR safe.
+
+### Future direction
+
+- v0.2.0 may extract the shared core into `mosaic-flux-core` once all 7 backends ship and the architecture has settled. Until then, the duplicated core is intentional per UI33-rewrite §6.1.
+
+### Tests
+
+- 75 unit tests via vitest (jsdom env)
+- Coverage: 92.39% lines / 95.16% branches / 88.88% funcs / 92.39% statements
+- `element.ts` (the unique surface) at 100% on every metric

--- a/code/packages/typescript/mosaic-flux-webcomponent/README.md
+++ b/code/packages/typescript/mosaic-flux-webcomponent/README.md
@@ -1,0 +1,110 @@
+# @coding-adventures/mosaic-flux-webcomponent
+
+Strict-Flux runtime for Mosaic UI's Web Component emitter.
+
+Same core types as `mosaic-flux-html` (`MosaicAction`, `MosaicStore`, middleware, `createSelector`, `devToolsMiddleware`, DOM bindings) plus a `MosaicHostElement` base class and `defineMosaicElement` helper for lifecycle-managed custom elements.
+
+Implements the architecture specified in `code/specs/UI33-rewrite-unified-architecture.md`.
+
+## Why a separate package from mosaic-flux-html
+
+Per UI33-rewrite §6.1, each runtime ships standalone to avoid coupling release cadences. v0.1.0 duplicates the shared core; a future `mosaic-flux-core` may extract it once the design has settled and all backends are shipping.
+
+## The Web-Component-specific surface
+
+### `MosaicHostElement<State>` base class
+
+Subclass it to write custom elements that bind to a `MosaicStore`. The base class handles the lifecycle so you don't have to remember binding cleanup:
+
+```typescript
+import {
+  MosaicHostElement,
+  defineMosaicElement,
+  bindText,
+  type MosaicStore,
+  type MosaicAction,
+} from "@coding-adventures/mosaic-flux-webcomponent";
+
+interface CounterState { count: number; }
+
+class Increment implements MosaicAction<CounterState> {
+  apply(s: CounterState): CounterState {
+    return { ...s, count: s.count + 1 };
+  }
+}
+
+class CounterDisplay extends MosaicHostElement<CounterState> {
+  private span: HTMLSpanElement;
+
+  constructor() {
+    super();
+    const shadow = this.attachShadowIfNeeded();
+    this.span = document.createElement("span");
+    shadow.appendChild(this.span);
+  }
+
+  protected bindStore(store: MosaicStore<CounterState>): void {
+    // track() registers the unsubscribe for automatic cleanup on
+    // disconnectedCallback.
+    this.track(bindText(this.span, store, (s) => String(s.count)));
+  }
+}
+
+defineMosaicElement("counter-display", CounterDisplay);
+
+// Usage:
+const counter = document.createElement("counter-display") as CounterDisplay;
+counter.store = myStore;
+document.body.appendChild(counter);
+
+counter.dispatch(new Increment()); // shortcut, throws if no store bound
+```
+
+Lifecycle:
+
+| Event | What happens |
+|---|---|
+| `constructor` | Subclass typically attaches shadow DOM and assembles child nodes |
+| Setting `element.store = s` | Stores the reference; if already connected, disposes old bindings and calls `bindStore(s)` |
+| `connectedCallback` | If a store is set, calls `bindStore(store)` |
+| `bindStore(store)` | Subclass override; register bindings via `this.track(unsubscribe)` |
+| `disconnectedCallback` | Calls every tracked unsubscribe; you can move the element and reconnect to re-bind |
+
+The `track()` mechanism eliminates a common memory-leak class: bindings registered with the store would otherwise outlive the element after it's removed from the DOM. With `MosaicHostElement`, every binding is automatically disposed on disconnect.
+
+### `defineMosaicElement(tagName, elementClass, options?)`
+
+Thin wrapper around `customElements.define`. Idempotent — calling twice with the same tag is a no-op (the first definition wins) instead of throwing. This makes module reloads / HMR safe.
+
+```typescript
+defineMosaicElement("my-counter", MyCounter);
+```
+
+## Core surface (same as mosaic-flux-html)
+
+| Export | Purpose |
+|---|---|
+| `MosaicAction<State>` | Command Pattern interface |
+| `MosaicStore<State>` | State container + dispatcher |
+| `composeMiddleware` / `loggerMiddleware` | Middleware utilities |
+| `createSelector` | Memoised derived state |
+| `devToolsMiddleware` | DevTools protocol (postMessage + ws fallback) |
+| `bindText` / `bindAttr` / `bindClass` / `bindStyle` / `bindList` | Vanilla-DOM binding helpers (work inside shadow roots) |
+
+See `mosaic-flux-html`'s README for the core API details. The DOM binding helpers work identically inside an open shadow root.
+
+### Sanitisation contract
+
+Same as `mosaic-flux-html`: `bindAttr` and `bindStyle` do not sanitise URLs or event-handler attributes. The host (or the Mosaic codegen) is responsible for validating these before they reach the binding. `bindText` (`textContent`) and `bindClass` (`classList`) are always safe.
+
+## Status
+
+v0.1.0. Initial release.
+
+## Testing
+
+```bash
+npm test
+```
+
+Coverage thresholds: 80% lines/branches/functions/statements. jsdom environment provides `customElements`, shadow DOM, and HTMLElement.

--- a/code/packages/typescript/mosaic-flux-webcomponent/package-lock.json
+++ b/code/packages/typescript/mosaic-flux-webcomponent/package-lock.json
@@ -1,0 +1,3279 @@
+{
+  "name": "@coding-adventures/mosaic-flux-webcomponent",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/mosaic-flux-webcomponent",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "jsdom": "^25.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
+      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/code/packages/typescript/mosaic-flux-webcomponent/package.json
+++ b/code/packages/typescript/mosaic-flux-webcomponent/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@coding-adventures/mosaic-flux-webcomponent",
+  "version": "0.1.0",
+  "description": "Strict-Flux runtime for Mosaic UI's Web Component emitter. Same core types as mosaic-flux-html (MosaicAction, MosaicStore, middleware, createSelector, devToolsMiddleware, DOM bindings) plus MosaicHostElement base class + defineMosaicElement helper for custom-element lifecycle integration with the store.",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0",
+    "@vitest/coverage-v8": "^3.0.0",
+    "jsdom": "^25.0.0"
+  }
+}

--- a/code/packages/typescript/mosaic-flux-webcomponent/src/action.ts
+++ b/code/packages/typescript/mosaic-flux-webcomponent/src/action.ts
@@ -1,0 +1,35 @@
+// action.ts — the MosaicAction Command Pattern interface.
+//
+// Per UI33-rewrite §5: each action is a class with a payload (its
+// constructor arguments) and an `apply(state) → state` method that
+// expresses the state transform. The dispatcher routes by calling
+// `action.apply(state)` directly — there is no central switch
+// statement or reducer registry.
+//
+// This interface is identical to the one in mosaic-flux-react.
+// Eventually we may extract the shared core into mosaic-flux-core
+// and depend on it across HTML / WebComponent / React; v0.1.0 keeps
+// the packages standalone to avoid coupling release cadences while
+// the design is still settling.
+
+export interface MosaicAction<State> {
+  /**
+   * Pure state transform. Must not mutate input. Must be deterministic.
+   * Side effects belong in middleware, not apply.
+   */
+  apply(state: State): State;
+}
+
+/**
+ * Structural type guard: anything with an apply function is treated
+ * as an action.
+ */
+export function isMosaicAction<State>(
+  value: unknown,
+): value is MosaicAction<State> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { apply?: unknown }).apply === "function"
+  );
+}

--- a/code/packages/typescript/mosaic-flux-webcomponent/src/devtools.ts
+++ b/code/packages/typescript/mosaic-flux-webcomponent/src/devtools.ts
@@ -1,0 +1,138 @@
+// devtools.ts — DevTools protocol middleware for browser hosts.
+
+import type { MosaicAction } from "./action.js";
+import type { Middleware } from "./middleware.js";
+
+export interface ActionEvent<State> {
+  kind: "action";
+  ts: number;
+  actionType: string;
+  actionPayload: Record<string, unknown>;
+  prevState: State;
+  nextState: State;
+  durationUs: number;
+}
+
+export interface SubscriptionEvent {
+  kind: "subscription";
+  ts: number;
+  componentId: string;
+  slots: ReadonlyArray<string>;
+  rendered: boolean;
+}
+
+export type DevToolsEvent<State> = ActionEvent<State> | SubscriptionEvent;
+
+export interface DevToolsOptions {
+  ws?: boolean;
+  storeName?: string;
+}
+
+export function devToolsMiddleware<State>(
+  options: DevToolsOptions = {},
+): Middleware<State> {
+  const sink = makeSink<State>(options);
+  const storeName = options.storeName ?? "default";
+  return (action, prevState, nextState) => {
+    const t0 = now();
+    const event: ActionEvent<State> = {
+      kind: "action",
+      ts: Date.now(),
+      actionType: action.constructor.name,
+      actionPayload: extractPayload(action),
+      prevState,
+      nextState,
+      durationUs: Math.round((now() - t0) * 1000),
+    };
+    sink.publish({ ...event, storeName } as ActionEvent<State> & {
+      storeName: string;
+    });
+  };
+}
+
+interface Sink<State> {
+  publish(event: DevToolsEvent<State> & { storeName: string }): void;
+}
+
+function makeSink<State>(options: DevToolsOptions): Sink<State> {
+  if (typeof window !== "undefined" && typeof window.postMessage === "function") {
+    return new PostMessageSink<State>();
+  }
+  if (options.ws && typeof globalThis.WebSocket !== "undefined") {
+    return new WebSocketSink<State>("ws://localhost:9229");
+  }
+  return new NoopSink<State>();
+}
+
+class PostMessageSink<State> implements Sink<State> {
+  publish(event: DevToolsEvent<State> & { storeName: string }): void {
+    try {
+      window.postMessage(
+        { source: "mosaic-flux-devtools", payload: event },
+        "*",
+      );
+    } catch {
+      /* dev-only sink; ignore non-cloneable payloads */
+    }
+  }
+}
+
+class WebSocketSink<State> implements Sink<State> {
+  #ws: WebSocket | null = null;
+  #queue: Array<DevToolsEvent<State> & { storeName: string }> = [];
+
+  constructor(url: string) {
+    try {
+      this.#ws = new WebSocket(url);
+      this.#ws.addEventListener("open", () => {
+        for (const event of this.#queue) {
+          this.#sendNow(event);
+        }
+        this.#queue = [];
+      });
+      this.#ws.addEventListener("error", () => {
+        /* fail silently in dev */
+      });
+    } catch {
+      this.#ws = null;
+    }
+  }
+
+  publish(event: DevToolsEvent<State> & { storeName: string }): void {
+    if (this.#ws?.readyState === WebSocket.OPEN) {
+      this.#sendNow(event);
+    } else {
+      this.#queue.push(event);
+    }
+  }
+
+  #sendNow(event: DevToolsEvent<State> & { storeName: string }): void {
+    try {
+      this.#ws?.send(JSON.stringify(event));
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+class NoopSink<State> implements Sink<State> {
+  publish(_event: DevToolsEvent<State> & { storeName: string }): void {
+    /* no-op */
+  }
+}
+
+function extractPayload(action: MosaicAction<unknown>): Record<string, unknown> {
+  const payload: Record<string, unknown> = {};
+  for (const key of Object.keys(action)) {
+    if (key.startsWith("_")) continue;
+    payload[key] = (action as unknown as Record<string, unknown>)[key];
+  }
+  return payload;
+}
+
+function now(): number {
+  if (typeof performance !== "undefined" && typeof performance.now === "function") {
+    return performance.now();
+  }
+  return Date.now();
+}

--- a/code/packages/typescript/mosaic-flux-webcomponent/src/dom.ts
+++ b/code/packages/typescript/mosaic-flux-webcomponent/src/dom.ts
@@ -1,0 +1,174 @@
+// dom.ts — vanilla-DOM binding helpers.
+//
+// The HTML emitter produces static-ish DOM trees where dynamic
+// content comes from store selectors. These helpers wire a selector
+// to a DOM update so the emitter doesn't have to write subscribe +
+// callback boilerplate everywhere.
+//
+// Each bind* function returns an unsubscribe function for cleanup.
+// Callers (typically the emitted hydrator code) accumulate them and
+// invoke all unsubscribes on detach.
+//
+// Why no virtual DOM, no diffing engine, no template compiler:
+// strict-Flux + fine-grained subscriptions makes targeted DOM updates
+// trivial. A text node bound to a state slice updates that text node
+// ONLY when the slice changes. A 100-row list bound to a selector
+// updates ONLY the rows whose data changed (when bindList is given a
+// key function). The whole-DOM-diff approach React/Vue/etc. take is
+// solving a problem we don't have because our updates are already
+// scoped.
+
+import type { MosaicStore } from "./store.js";
+
+/**
+ * Bind the textContent of an element to a string selector.
+ *
+ * Updates only when the selected string changes (by Object.is).
+ */
+export function bindText<State>(
+  el: Element,
+  store: MosaicStore<State>,
+  selector: (state: State) => string,
+): () => void {
+  el.textContent = store.select(selector);
+  return store.subscribe(selector, (value) => {
+    el.textContent = value;
+  });
+}
+
+/**
+ * Bind an element attribute to a string selector. Setting the
+ * attribute to `null` removes it (matching the convention where
+ * absence is meaningful, e.g., `disabled`, `aria-expanded`).
+ */
+export function bindAttr<State>(
+  el: Element,
+  attrName: string,
+  store: MosaicStore<State>,
+  selector: (state: State) => string | null,
+): () => void {
+  applyAttr(el, attrName, store.select(selector));
+  return store.subscribe(selector, (value) => applyAttr(el, attrName, value));
+}
+
+function applyAttr(el: Element, attrName: string, value: string | null): void {
+  if (value === null) {
+    el.removeAttribute(attrName);
+  } else {
+    el.setAttribute(attrName, value);
+  }
+}
+
+/**
+ * Bind a class to a boolean selector. Adds the class when the
+ * predicate is true; removes it when false. Multiple class names
+ * separated by spaces are supported.
+ */
+export function bindClass<State>(
+  el: Element,
+  className: string,
+  store: MosaicStore<State>,
+  predicate: (state: State) => boolean,
+): () => void {
+  applyClass(el, className, store.select(predicate));
+  return store.subscribe(predicate, (value) => applyClass(el, className, value));
+}
+
+function applyClass(el: Element, className: string, present: boolean): void {
+  const classes = className.split(/\s+/).filter(Boolean);
+  for (const c of classes) {
+    if (present) {
+      el.classList.add(c);
+    } else {
+      el.classList.remove(c);
+    }
+  }
+}
+
+/**
+ * Bind an inline style property to a selector. Setting the value to
+ * `null` removes the property.
+ */
+export function bindStyle<State>(
+  el: HTMLElement,
+  prop: string,
+  store: MosaicStore<State>,
+  selector: (state: State) => string | null,
+): () => void {
+  applyStyle(el, prop, store.select(selector));
+  return store.subscribe(selector, (value) => applyStyle(el, prop, value));
+}
+
+function applyStyle(el: HTMLElement, prop: string, value: string | null): void {
+  if (value === null) {
+    el.style.removeProperty(prop);
+  } else {
+    el.style.setProperty(prop, value);
+  }
+}
+
+/**
+ * Bind a container's children to a list selector with key-based
+ * reconciliation.
+ *
+ * On each list change, the helper computes a key-keyed diff and:
+ *   - inserts a freshly-rendered child for new keys
+ *   - moves existing children to match new ordering
+ *   - removes children whose keys are gone
+ *   - leaves children with unchanged keys in place (no re-render)
+ *
+ * This is the cheapest list update strategy that maintains DOM
+ * identity for unchanged items (so focus, selection, scroll, and
+ * event listeners survive).
+ *
+ * @param container - The element whose children mirror the list
+ * @param store - The MosaicStore providing reactivity
+ * @param listSelector - Returns the current list
+ * @param keyFn - Returns a stable string key per item (must be unique)
+ * @param renderItem - Renders a fresh DOM node for an item
+ * @returns Unsubscribe function
+ */
+export function bindList<State, Item>(
+  container: Element,
+  store: MosaicStore<State>,
+  listSelector: (state: State) => ReadonlyArray<Item>,
+  keyFn: (item: Item, index: number) => string,
+  renderItem: (item: Item) => Node,
+): () => void {
+  // Map from key → existing rendered DOM node
+  const existing = new Map<string, Node>();
+
+  const reconcile = (list: ReadonlyArray<Item>): void => {
+    const seen = new Set<string>();
+    let cursor: Node | null = container.firstChild;
+    list.forEach((item, index) => {
+      const key = keyFn(item, index);
+      seen.add(key);
+      let node = existing.get(key);
+      if (node === undefined) {
+        node = renderItem(item);
+        existing.set(key, node);
+      }
+      if (cursor === node) {
+        cursor = node.nextSibling;
+      } else {
+        container.insertBefore(node, cursor);
+        // Note: insertBefore moves the node if it's already mounted.
+        // cursor is unchanged because we inserted *before* it.
+      }
+    });
+    // Remove anything past the cursor that no longer belongs.
+    while (cursor !== null) {
+      const next: Node | null = cursor.nextSibling;
+      container.removeChild(cursor);
+      cursor = next;
+    }
+    // Clean up the existing-map for keys no longer in the list.
+    for (const k of existing.keys()) {
+      if (!seen.has(k)) existing.delete(k);
+    }
+  };
+
+  reconcile(store.select(listSelector));
+  return store.subscribe(listSelector, reconcile);
+}

--- a/code/packages/typescript/mosaic-flux-webcomponent/src/element.ts
+++ b/code/packages/typescript/mosaic-flux-webcomponent/src/element.ts
@@ -1,0 +1,202 @@
+// element.ts — MosaicHostElement base class + defineMosaicElement
+// helper for custom-element lifecycle integration.
+//
+// The HTML emitter targets a flat DOM tree where the host wires
+// bindings on initialisation. The Web Component emitter targets the
+// same architecture but encapsulated inside a custom element with
+// (typically) a shadow root. The lifecycle is different:
+//
+//   1. The element is constructed (constructor)
+//   2. The browser inserts it into the DOM (connectedCallback)
+//   3. The element may move within the DOM (disconnect+connect again)
+//   4. The browser removes it from the DOM (disconnectedCallback)
+//
+// MosaicHostElement standardises the binding lifecycle:
+//
+//   * Subclass extends MosaicHostElement
+//   * Subclass overrides bindStore(store) to wire bindings; it
+//     accumulates returned unsubscribe fns via this.track(...)
+//   * The base class invokes bindStore in connectedCallback when a
+//     store has been set, and tears down all tracked unsubscribes
+//     in disconnectedCallback
+//
+// This means subclasses never have to remember to manage cleanup —
+// every binding registered via this.track() is automatically
+// disposed when the element leaves the DOM, eliminating a common
+// memory-leak class.
+
+import type { MosaicStore } from "./store.js";
+import type { MosaicAction } from "./action.js";
+
+/**
+ * Cleanup function returned by binding helpers.
+ */
+export type Unsubscribe = () => void;
+
+/**
+ * Base class for Mosaic-aware custom elements.
+ *
+ * Lifecycle:
+ *
+ *   const el = new SomeMosaicElement();         // constructor
+ *   el.store = myStore;                          // set the store
+ *   document.body.appendChild(el);               // → connectedCallback → bindStore
+ *   document.body.removeChild(el);               // → disconnectedCallback → cleanup
+ *
+ * Or via attribute / property:
+ *
+ *   const el = document.createElement("my-mosaic-element");
+ *   (el as SomeMosaicElement).store = myStore;
+ *   document.body.appendChild(el);
+ *
+ * Subclasses override bindStore(store) to register bindings.
+ * Use this.track(unsubscribe) for each binding so it's cleaned up
+ * automatically when the element disconnects.
+ */
+export abstract class MosaicHostElement<State> extends HTMLElement {
+  #store: MosaicStore<State> | null = null;
+  #unsubscribes: Unsubscribe[] = [];
+  #connected = false;
+  #shadow: ShadowRoot | null = null;
+
+  /**
+   * The bound store. Setting this property after the element has
+   * connected triggers a rebind (old bindings disposed, bindStore
+   * re-invoked).
+   */
+  get store(): MosaicStore<State> | null {
+    return this.#store;
+  }
+
+  set store(value: MosaicStore<State> | null) {
+    if (this.#store === value) return;
+    if (this.#connected) {
+      this.#cleanup();
+    }
+    this.#store = value;
+    if (this.#connected && value !== null) {
+      this.bindStore(value);
+    }
+  }
+
+  /**
+   * Attach an open shadow root if one hasn't been attached yet.
+   * Returns the shadow root. Idempotent — calling repeatedly returns
+   * the same root.
+   *
+   * Subclasses typically call this once in connectedCallback (before
+   * super.connectedCallback(), or via override of bindStore).
+   */
+  attachShadowIfNeeded(): ShadowRoot {
+    if (this.#shadow !== null) {
+      return this.#shadow;
+    }
+    // shadowRoot may already exist if a subclass attached one
+    // independently; respect that.
+    if (this.shadowRoot !== null) {
+      this.#shadow = this.shadowRoot;
+      return this.#shadow;
+    }
+    this.#shadow = this.attachShadow({ mode: "open" });
+    return this.#shadow;
+  }
+
+  /**
+   * Register an unsubscribe to be invoked on disconnect. Returns the
+   * unsubscribe for chaining or immediate invocation if desired.
+   */
+  track(unsubscribe: Unsubscribe): Unsubscribe {
+    this.#unsubscribes.push(unsubscribe);
+    return unsubscribe;
+  }
+
+  /**
+   * Dispatch shortcut. Throws if no store is bound.
+   */
+  dispatch<A extends MosaicAction<State>>(action: A): void {
+    if (this.#store === null) {
+      throw new Error(
+        `${this.constructor.name}: cannot dispatch without a store. Set element.store first.`,
+      );
+    }
+    this.#store.dispatch(action);
+  }
+
+  /**
+   * Subclasses implement this to wire bindings against the store.
+   * Use this.track(...) for every unsubscribe returned by a binding
+   * helper.
+   *
+   * Called once per connect-with-store cycle: when the element is
+   * connected with a store set, or when the store is reassigned
+   * while connected.
+   */
+  protected abstract bindStore(store: MosaicStore<State>): void;
+
+  /**
+   * Native lifecycle hook. Subclasses calling super.connectedCallback
+   * preserve the auto-bind behaviour. Subclasses that don't call
+   * super must implement their own bindStore invocation.
+   */
+  connectedCallback(): void {
+    this.#connected = true;
+    if (this.#store !== null) {
+      this.bindStore(this.#store);
+    }
+  }
+
+  /**
+   * Native lifecycle hook. Disposes all bindings registered via
+   * this.track().
+   */
+  disconnectedCallback(): void {
+    this.#connected = false;
+    this.#cleanup();
+  }
+
+  #cleanup(): void {
+    const toRun = this.#unsubscribes;
+    this.#unsubscribes = [];
+    for (const u of toRun) {
+      try {
+        u();
+      } catch {
+        // A bad unsubscribe shouldn't prevent the others from running.
+        // This is rare (most just remove from a Set), but defending
+        // here means a buggy custom binding can't leak the rest.
+      }
+    }
+  }
+}
+
+/**
+ * Register a custom element class with `customElements.define`.
+ *
+ * Calling defineMosaicElement is idempotent per tag name: if the
+ * tag is already registered (for example because a previous bundle
+ * ran), the existing definition wins and no error is thrown.
+ *
+ * @param tagName - The custom element tag (must contain a hyphen)
+ * @param elementClass - The class extending MosaicHostElement
+ * @param options - Optional ElementDefinitionOptions (e.g., extends)
+ */
+export function defineMosaicElement(
+  tagName: string,
+  elementClass: CustomElementConstructor,
+  options?: ElementDefinitionOptions,
+): void {
+  // customElements.get returns the existing constructor if any.
+  // We don't overwrite — the first definition wins. This matches
+  // the browser's behaviour (a second define() throws), but we
+  // swallow the duplicate-registration to keep idempotent dev-time
+  // builds working under HMR/module re-execution.
+  if (typeof customElements === "undefined") {
+    throw new Error(
+      "defineMosaicElement: customElements is not available in this environment.",
+    );
+  }
+  if (customElements.get(tagName) !== undefined) {
+    return;
+  }
+  customElements.define(tagName, elementClass, options);
+}

--- a/code/packages/typescript/mosaic-flux-webcomponent/src/index.ts
+++ b/code/packages/typescript/mosaic-flux-webcomponent/src/index.ts
@@ -1,0 +1,41 @@
+// index.ts — public surface of @coding-adventures/mosaic-flux-webcomponent.
+//
+// Re-exports the same core types as mosaic-flux-html (so consumers
+// see one consistent API surface) plus the WebComponent-specific
+// MosaicHostElement base class and defineMosaicElement helper for
+// custom-element lifecycle integration.
+
+export type { MosaicAction } from "./action.js";
+export { isMosaicAction } from "./action.js";
+
+export type {
+  Equality,
+  MosaicStoreOptions,
+  Subscriber,
+} from "./store.js";
+export { MosaicStore } from "./store.js";
+
+export type { Middleware } from "./middleware.js";
+export { composeMiddleware, loggerMiddleware } from "./middleware.js";
+
+export { createSelector } from "./selector.js";
+
+export type {
+  ActionEvent,
+  DevToolsEvent,
+  DevToolsOptions,
+  SubscriptionEvent,
+} from "./devtools.js";
+export { devToolsMiddleware } from "./devtools.js";
+
+export {
+  bindAttr,
+  bindClass,
+  bindList,
+  bindStyle,
+  bindText,
+} from "./dom.js";
+
+// WebComponent-specific surface
+export type { Unsubscribe } from "./element.js";
+export { MosaicHostElement, defineMosaicElement } from "./element.js";

--- a/code/packages/typescript/mosaic-flux-webcomponent/src/middleware.ts
+++ b/code/packages/typescript/mosaic-flux-webcomponent/src/middleware.ts
@@ -1,0 +1,80 @@
+// middleware.ts — middleware contract.
+
+import type { MosaicAction } from "./action.js";
+
+export type Middleware<State> = (
+  action: MosaicAction<State>,
+  prevState: State,
+  nextState: State,
+) => void;
+
+/**
+ * Compose middleware into one function. Errors in any middleware are
+ * caught and logged; subsequent middleware still run.
+ */
+export function composeMiddleware<State>(
+  middleware: ReadonlyArray<Middleware<State>>,
+): Middleware<State> {
+  if (middleware.length === 0) {
+    return () => {
+      /* no-op */
+    };
+  }
+  if (middleware.length === 1) {
+    return middleware[0]!;
+  }
+  return (action, prevState, nextState) => {
+    for (const m of middleware) {
+      try {
+        m(action, prevState, nextState);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error("[mosaic-flux] middleware threw:", err);
+      }
+    }
+  };
+}
+
+/**
+ * Dev logger with shallow-state-diff output.
+ */
+export function loggerMiddleware<State>(): Middleware<State> {
+  return (action, prevState, nextState) => {
+    const name = action.constructor.name;
+    const changedKeys = shallowChangedKeys(prevState, nextState);
+    // eslint-disable-next-line no-console
+    console.groupCollapsed(
+      `[mosaic-flux] ${name} — changed: ${changedKeys.length > 0 ? changedKeys.join(", ") : "(none)"}`,
+    );
+    // eslint-disable-next-line no-console
+    console.log("action  :", action);
+    // eslint-disable-next-line no-console
+    console.log("prev    :", prevState);
+    // eslint-disable-next-line no-console
+    console.log("next    :", nextState);
+    // eslint-disable-next-line no-console
+    console.groupEnd();
+  };
+}
+
+function shallowChangedKeys<State>(
+  prev: State,
+  next: State,
+): ReadonlyArray<string> {
+  if (
+    typeof prev !== "object" ||
+    prev === null ||
+    typeof next !== "object" ||
+    next === null
+  ) {
+    return prev !== next ? ["<root>"] : [];
+  }
+  const changed: string[] = [];
+  const prevObj = prev as Record<string, unknown>;
+  const nextObj = next as Record<string, unknown>;
+  const allKeys = new Set([...Object.keys(prevObj), ...Object.keys(nextObj)]);
+  for (const k of allKeys) {
+    if (prevObj[k] !== nextObj[k]) changed.push(k);
+  }
+  return changed;
+}

--- a/code/packages/typescript/mosaic-flux-webcomponent/src/selector.ts
+++ b/code/packages/typescript/mosaic-flux-webcomponent/src/selector.ts
@@ -1,0 +1,51 @@
+// selector.ts — memoised derived-state combinator.
+
+import type { Equality } from "./store.js";
+
+const defaultEquality: Equality<unknown> = (a, b) => Object.is(a, b);
+
+export function createSelector<State, R>(
+  inputSelector: (state: State) => unknown,
+  combiner: (...args: unknown[]) => R,
+  equality?: Equality<unknown>,
+): (state: State) => R;
+
+export function createSelector<State, R>(
+  ...args: ReadonlyArray<unknown>
+): (state: State) => R {
+  if (args.length < 2) {
+    throw new Error(
+      "createSelector requires at least one input selector and one combiner",
+    );
+  }
+  const combiner = args[args.length - 1] as (...inputs: unknown[]) => R;
+  const inputSelectors = args.slice(0, -1) as ReadonlyArray<
+    (state: State) => unknown
+  >;
+  const equality = defaultEquality;
+
+  let lastInputs: unknown[] | null = null;
+  let lastResult: R;
+
+  return (state: State): R => {
+    const currentInputs = inputSelectors.map((s) => s(state));
+    if (lastInputs !== null && allEqual(currentInputs, lastInputs, equality)) {
+      return lastResult;
+    }
+    lastInputs = currentInputs;
+    lastResult = combiner(...currentInputs);
+    return lastResult;
+  };
+}
+
+function allEqual(
+  a: ReadonlyArray<unknown>,
+  b: ReadonlyArray<unknown>,
+  equality: Equality<unknown>,
+): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (!equality(a[i], b[i])) return false;
+  }
+  return true;
+}

--- a/code/packages/typescript/mosaic-flux-webcomponent/src/store.ts
+++ b/code/packages/typescript/mosaic-flux-webcomponent/src/store.ts
@@ -1,0 +1,91 @@
+// store.ts — MosaicStore: state container + dispatcher.
+
+import type { MosaicAction } from "./action.js";
+import type { Middleware } from "./middleware.js";
+import { composeMiddleware } from "./middleware.js";
+
+export type Subscriber<T> = (value: T) => void;
+export type Equality<T> = (a: T, b: T) => boolean;
+
+const defaultEquality: Equality<unknown> = (a, b) => Object.is(a, b);
+
+export interface MosaicStoreOptions<State> {
+  initialState: State;
+  middleware?: ReadonlyArray<Middleware<State>>;
+}
+
+/**
+ * The core store. Synchronous dispatch; fine-grained subscriptions
+ * via selectors. Middleware sees every (action, prevState, nextState)
+ * triple even when state didn't change (so loggers see no-ops).
+ */
+export class MosaicStore<State> {
+  #state: State;
+  readonly #middleware: Middleware<State>;
+  readonly #subscriptions: Set<InternalSubscription<State, unknown>> = new Set();
+
+  constructor(options: MosaicStoreOptions<State>) {
+    this.#state = options.initialState;
+    this.#middleware = composeMiddleware(options.middleware ?? []);
+  }
+
+  get state(): State {
+    return this.#state;
+  }
+
+  dispatch<A extends MosaicAction<State>>(action: A): void {
+    const prevState = this.#state;
+    const nextState = action.apply(prevState);
+    if (Object.is(prevState, nextState)) {
+      this.#middleware(action, prevState, nextState);
+      return;
+    }
+    this.#state = nextState;
+    const snapshot = Array.from(this.#subscriptions);
+    for (const sub of snapshot) {
+      sub.notifyIfChanged(prevState, nextState);
+    }
+    this.#middleware(action, prevState, nextState);
+  }
+
+  subscribe<T>(
+    selector: (state: State) => T,
+    callback: Subscriber<T>,
+    equality: Equality<T> = defaultEquality as Equality<T>,
+  ): () => void {
+    const sub = new InternalSubscription<State, T>(
+      selector,
+      callback,
+      equality,
+      selector(this.#state),
+    );
+    this.#subscriptions.add(sub as unknown as InternalSubscription<State, unknown>);
+    return () => {
+      this.#subscriptions.delete(sub as unknown as InternalSubscription<State, unknown>);
+    };
+  }
+
+  select<T>(selector: (state: State) => T): T {
+    return selector(this.#state);
+  }
+}
+
+class InternalSubscription<State, T> {
+  #lastValue: T;
+  constructor(
+    private readonly selector: (state: State) => T,
+    private readonly callback: Subscriber<T>,
+    private readonly equality: Equality<T>,
+    initial: T,
+  ) {
+    this.#lastValue = initial;
+  }
+
+  notifyIfChanged(_prevState: State, nextState: State): void {
+    const nextValue = this.selector(nextState);
+    if (!this.equality(this.#lastValue, nextValue)) {
+      this.#lastValue = nextValue;
+      this.callback(nextValue);
+    }
+  }
+}

--- a/code/packages/typescript/mosaic-flux-webcomponent/tests/action.test.ts
+++ b/code/packages/typescript/mosaic-flux-webcomponent/tests/action.test.ts
@@ -1,0 +1,61 @@
+// action.test.ts
+
+import { describe, it, expect } from "vitest";
+import { isMosaicAction, type MosaicAction } from "../src/action.js";
+
+interface CounterState {
+  count: number;
+}
+
+class Increment implements MosaicAction<CounterState> {
+  apply(state: CounterState): CounterState {
+    return { count: state.count + 1 };
+  }
+}
+
+class Add implements MosaicAction<CounterState> {
+  constructor(public readonly amount: number) {}
+  apply(state: CounterState): CounterState {
+    return { count: state.count + this.amount };
+  }
+}
+
+describe("MosaicAction", () => {
+  it("apply returns next state without mutating input", () => {
+    const initial: CounterState = { count: 5 };
+    expect(new Increment().apply(initial)).toEqual({ count: 6 });
+    expect(initial).toEqual({ count: 5 });
+  });
+
+  it("payload accessible from instance", () => {
+    const action = new Add(7);
+    expect(action.amount).toBe(7);
+    expect(action.apply({ count: 3 })).toEqual({ count: 10 });
+  });
+
+  it("deterministic", () => {
+    const state: CounterState = { count: 0 };
+    const action = new Add(5);
+    expect(action.apply(state)).toEqual(action.apply(state));
+  });
+});
+
+describe("isMosaicAction", () => {
+  it("true for action instances", () => {
+    expect(isMosaicAction(new Increment())).toBe(true);
+    expect(isMosaicAction(new Add(1))).toBe(true);
+  });
+
+  it("true for plain objects with apply function (structural)", () => {
+    expect(isMosaicAction({ apply: () => ({}) })).toBe(true);
+  });
+
+  it("false for non-actions", () => {
+    expect(isMosaicAction(null)).toBe(false);
+    expect(isMosaicAction(undefined)).toBe(false);
+    expect(isMosaicAction(42)).toBe(false);
+    expect(isMosaicAction("s")).toBe(false);
+    expect(isMosaicAction({})).toBe(false);
+    expect(isMosaicAction({ apply: "not a fn" })).toBe(false);
+  });
+});

--- a/code/packages/typescript/mosaic-flux-webcomponent/tests/devtools.test.ts
+++ b/code/packages/typescript/mosaic-flux-webcomponent/tests/devtools.test.ts
@@ -1,0 +1,83 @@
+// devtools.test.ts
+//
+// In jsdom env, window IS defined, so the PostMessageSink path
+// runs. We mock postMessage and verify the payload format.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { devToolsMiddleware } from "../src/devtools.js";
+import type { MosaicAction } from "../src/action.js";
+
+interface S {
+  v: number;
+}
+
+class Bump implements MosaicAction<S> {
+  apply(s: S): S {
+    return { v: s.v + 1 };
+  }
+}
+
+class Payloaded implements MosaicAction<S> {
+  constructor(
+    public readonly amount: number,
+    public readonly tag: string,
+  ) {}
+  apply(s: S): S {
+    return { v: s.v + this.amount };
+  }
+}
+
+describe("devToolsMiddleware (jsdom postMessage path)", () => {
+  let postMessageSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    postMessageSpy = vi.fn();
+    Object.defineProperty(window, "postMessage", {
+      configurable: true,
+      writable: true,
+      value: postMessageSpy,
+    });
+  });
+
+  it("returns a callable middleware", () => {
+    const m = devToolsMiddleware<S>();
+    expect(typeof m).toBe("function");
+  });
+
+  it("publishes action events via postMessage", () => {
+    const m = devToolsMiddleware<S>();
+    m(new Bump(), { v: 0 }, { v: 1 });
+    expect(postMessageSpy).toHaveBeenCalledTimes(1);
+    const [arg] = postMessageSpy.mock.calls[0] ?? [];
+    expect(arg).toMatchObject({
+      source: "mosaic-flux-devtools",
+      payload: { kind: "action", actionType: "Bump" },
+    });
+  });
+
+  it("extracts payload from action instance", () => {
+    const m = devToolsMiddleware<S>();
+    m(new Payloaded(42, "t"), { v: 0 }, { v: 42 });
+    const [arg] = postMessageSpy.mock.calls[0] ?? [];
+    const payload = (arg as { payload: { actionPayload: Record<string, unknown> } })
+      .payload.actionPayload;
+    expect(payload).toEqual({ amount: 42, tag: "t" });
+  });
+
+  it("survives postMessage failure", () => {
+    postMessageSpy.mockImplementation(() => {
+      throw new Error("clone");
+    });
+    const m = devToolsMiddleware<S>();
+    expect(() => m(new Bump(), { v: 0 }, { v: 1 })).not.toThrow();
+  });
+
+  it("respects custom storeName", () => {
+    const m = devToolsMiddleware<S>({ storeName: "my-store" });
+    m(new Bump(), { v: 0 }, { v: 1 });
+    const [arg] = postMessageSpy.mock.calls[0] ?? [];
+    expect((arg as { payload: { storeName: string } }).payload.storeName).toBe(
+      "my-store",
+    );
+  });
+});

--- a/code/packages/typescript/mosaic-flux-webcomponent/tests/dom.test.ts
+++ b/code/packages/typescript/mosaic-flux-webcomponent/tests/dom.test.ts
@@ -1,0 +1,300 @@
+// dom.test.ts — vanilla-DOM binding helpers (jsdom).
+
+import { describe, it, expect } from "vitest";
+import { MosaicStore } from "../src/store.js";
+import type { MosaicAction } from "../src/action.js";
+import {
+  bindAttr,
+  bindClass,
+  bindList,
+  bindStyle,
+  bindText,
+} from "../src/dom.js";
+
+interface S {
+  text: string;
+  count: number;
+  disabled: boolean;
+  highlight: boolean;
+  color: string;
+  items: { id: string; label: string }[];
+}
+
+const initial: S = {
+  text: "hello",
+  count: 0,
+  disabled: false,
+  highlight: false,
+  color: "red",
+  items: [
+    { id: "a", label: "Alpha" },
+    { id: "b", label: "Beta" },
+  ],
+};
+
+class SetText implements MosaicAction<S> {
+  constructor(public readonly text: string) {}
+  apply(s: S): S {
+    return { ...s, text: this.text };
+  }
+}
+
+class ToggleDisabled implements MosaicAction<S> {
+  apply(s: S): S {
+    return { ...s, disabled: !s.disabled };
+  }
+}
+
+class ToggleHighlight implements MosaicAction<S> {
+  apply(s: S): S {
+    return { ...s, highlight: !s.highlight };
+  }
+}
+
+class SetColor implements MosaicAction<S> {
+  constructor(public readonly color: string) {}
+  apply(s: S): S {
+    return { ...s, color: this.color };
+  }
+}
+
+class ClearColor implements MosaicAction<S> {
+  apply(s: S): S {
+    return { ...s, color: "" };
+  }
+}
+
+class SetItems implements MosaicAction<S> {
+  constructor(public readonly items: { id: string; label: string }[]) {}
+  apply(s: S): S {
+    return { ...s, items: this.items };
+  }
+}
+
+const makeStore = (over?: Partial<S>): MosaicStore<S> =>
+  new MosaicStore<S>({ initialState: { ...initial, ...over } });
+
+describe("bindText", () => {
+  it("sets initial textContent from selector", () => {
+    const el = document.createElement("span");
+    const store = makeStore();
+    bindText(el, store, (s) => s.text);
+    expect(el.textContent).toBe("hello");
+  });
+
+  it("updates textContent on store change", () => {
+    const el = document.createElement("span");
+    const store = makeStore();
+    bindText(el, store, (s) => s.text);
+    store.dispatch(new SetText("world"));
+    expect(el.textContent).toBe("world");
+  });
+
+  it("unsubscribe stops updates", () => {
+    const el = document.createElement("span");
+    const store = makeStore();
+    const unsub = bindText(el, store, (s) => s.text);
+    unsub();
+    store.dispatch(new SetText("ignored"));
+    expect(el.textContent).toBe("hello");
+  });
+});
+
+describe("bindAttr", () => {
+  it("sets attribute when value is a string", () => {
+    const el = document.createElement("button");
+    const store = makeStore({ disabled: true });
+    bindAttr(el, "disabled", store, (s) => (s.disabled ? "true" : null));
+    expect(el.getAttribute("disabled")).toBe("true");
+  });
+
+  it("removes attribute when value is null", () => {
+    const el = document.createElement("button");
+    el.setAttribute("disabled", "true");
+    const store = makeStore({ disabled: false });
+    bindAttr(el, "disabled", store, (s) => (s.disabled ? "true" : null));
+    expect(el.hasAttribute("disabled")).toBe(false);
+  });
+
+  it("toggles in response to dispatch", () => {
+    const el = document.createElement("button");
+    const store = makeStore();
+    bindAttr(el, "disabled", store, (s) => (s.disabled ? "true" : null));
+    expect(el.hasAttribute("disabled")).toBe(false);
+    store.dispatch(new ToggleDisabled());
+    expect(el.getAttribute("disabled")).toBe("true");
+    store.dispatch(new ToggleDisabled());
+    expect(el.hasAttribute("disabled")).toBe(false);
+  });
+});
+
+describe("bindClass", () => {
+  it("adds class when predicate is true", () => {
+    const el = document.createElement("div");
+    const store = makeStore({ highlight: true });
+    bindClass(el, "highlighted", store, (s) => s.highlight);
+    expect(el.classList.contains("highlighted")).toBe(true);
+  });
+
+  it("removes class when predicate becomes false", () => {
+    const el = document.createElement("div");
+    const store = makeStore({ highlight: true });
+    bindClass(el, "highlighted", store, (s) => s.highlight);
+    store.dispatch(new ToggleHighlight());
+    expect(el.classList.contains("highlighted")).toBe(false);
+  });
+
+  it("supports multiple class names separated by space", () => {
+    const el = document.createElement("div");
+    const store = makeStore({ highlight: true });
+    bindClass(el, "a b c", store, (s) => s.highlight);
+    expect(el.classList.contains("a")).toBe(true);
+    expect(el.classList.contains("b")).toBe(true);
+    expect(el.classList.contains("c")).toBe(true);
+    store.dispatch(new ToggleHighlight());
+    expect(el.classList.contains("a")).toBe(false);
+    expect(el.classList.contains("b")).toBe(false);
+    expect(el.classList.contains("c")).toBe(false);
+  });
+});
+
+describe("bindStyle", () => {
+  it("sets style property", () => {
+    const el = document.createElement("div");
+    const store = makeStore();
+    bindStyle(el, "color", store, (s) => s.color);
+    expect(el.style.color).toBe("red");
+    store.dispatch(new SetColor("blue"));
+    expect(el.style.color).toBe("blue");
+  });
+
+  it("removes property when selector returns null", () => {
+    const el = document.createElement("div");
+    el.style.setProperty("color", "red");
+    const store = makeStore();
+    bindStyle(el, "color", store, (s) => (s.color === "" ? null : s.color));
+    expect(el.style.color).toBe("red");
+    store.dispatch(new ClearColor());
+    expect(el.style.color).toBe("");
+  });
+});
+
+describe("bindList", () => {
+  it("renders initial list", () => {
+    const container = document.createElement("ul");
+    const store = makeStore();
+    bindList(
+      container,
+      store,
+      (s) => s.items,
+      (item) => item.id,
+      (item) => {
+        const li = document.createElement("li");
+        li.textContent = item.label;
+        return li;
+      },
+    );
+    expect(container.children.length).toBe(2);
+    expect(container.children[0]?.textContent).toBe("Alpha");
+    expect(container.children[1]?.textContent).toBe("Beta");
+  });
+
+  it("preserves DOM identity on stable keys", () => {
+    const container = document.createElement("ul");
+    const store = makeStore();
+    bindList(
+      container,
+      store,
+      (s) => s.items,
+      (item) => item.id,
+      (item) => {
+        const li = document.createElement("li");
+        li.textContent = item.label;
+        return li;
+      },
+    );
+    const liAlpha = container.children[0];
+    const liBeta = container.children[1];
+    // Re-dispatch with same items (different object refs, same ids)
+    store.dispatch(
+      new SetItems([
+        { id: "a", label: "Alpha" },
+        { id: "b", label: "Beta" },
+      ]),
+    );
+    expect(container.children[0]).toBe(liAlpha);
+    expect(container.children[1]).toBe(liBeta);
+  });
+
+  it("inserts new items", () => {
+    const container = document.createElement("ul");
+    const store = makeStore();
+    bindList(
+      container,
+      store,
+      (s) => s.items,
+      (item) => item.id,
+      (item) => {
+        const li = document.createElement("li");
+        li.textContent = item.label;
+        return li;
+      },
+    );
+    store.dispatch(
+      new SetItems([
+        { id: "a", label: "Alpha" },
+        { id: "b", label: "Beta" },
+        { id: "c", label: "Charlie" },
+      ]),
+    );
+    expect(container.children.length).toBe(3);
+    expect(container.children[2]?.textContent).toBe("Charlie");
+  });
+
+  it("removes items whose keys are gone", () => {
+    const container = document.createElement("ul");
+    const store = makeStore();
+    bindList(
+      container,
+      store,
+      (s) => s.items,
+      (item) => item.id,
+      (item) => {
+        const li = document.createElement("li");
+        li.textContent = item.label;
+        return li;
+      },
+    );
+    store.dispatch(new SetItems([{ id: "a", label: "Alpha" }]));
+    expect(container.children.length).toBe(1);
+    expect(container.children[0]?.textContent).toBe("Alpha");
+  });
+
+  it("reorders items on key shuffle", () => {
+    const container = document.createElement("ul");
+    const store = makeStore();
+    bindList(
+      container,
+      store,
+      (s) => s.items,
+      (item) => item.id,
+      (item) => {
+        const li = document.createElement("li");
+        li.textContent = item.label;
+        return li;
+      },
+    );
+    const originalA = container.children[0];
+    const originalB = container.children[1];
+    // Swap order
+    store.dispatch(
+      new SetItems([
+        { id: "b", label: "Beta" },
+        { id: "a", label: "Alpha" },
+      ]),
+    );
+    // Same DOM nodes, swapped positions
+    expect(container.children[0]).toBe(originalB);
+    expect(container.children[1]).toBe(originalA);
+  });
+});

--- a/code/packages/typescript/mosaic-flux-webcomponent/tests/element.test.ts
+++ b/code/packages/typescript/mosaic-flux-webcomponent/tests/element.test.ts
@@ -1,0 +1,277 @@
+// element.test.ts — MosaicHostElement + defineMosaicElement.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MosaicStore } from "../src/store.js";
+import type { MosaicAction } from "../src/action.js";
+import {
+  MosaicHostElement,
+  defineMosaicElement,
+} from "../src/element.js";
+import { bindText } from "../src/dom.js";
+
+interface S {
+  text: string;
+  count: number;
+}
+
+class SetText implements MosaicAction<S> {
+  constructor(public readonly text: string) {}
+  apply(s: S): S {
+    return { ...s, text: this.text };
+  }
+}
+
+class Increment implements MosaicAction<S> {
+  apply(s: S): S {
+    return { ...s, count: s.count + 1 };
+  }
+}
+
+const initial: S = { text: "hello", count: 0 };
+
+/**
+ * Test subclass: renders a single text span bound to state.text in
+ * its shadow root, plus exposes a publicDispatch wrapper so tests
+ * can call dispatch from outside.
+ */
+class TextElement extends MosaicHostElement<S> {
+  span: HTMLSpanElement;
+  bindStoreCallCount = 0;
+
+  constructor() {
+    super();
+    const shadow = this.attachShadowIfNeeded();
+    this.span = document.createElement("span");
+    shadow.appendChild(this.span);
+  }
+
+  protected bindStore(store: MosaicStore<S>): void {
+    this.bindStoreCallCount++;
+    this.track(bindText(this.span, store, (s) => s.text));
+  }
+
+  publicDispatch(action: MosaicAction<S>): void {
+    this.dispatch(action);
+  }
+}
+
+let tagCounter = 0;
+const uniqueTag = (): string => `mosaic-test-${++tagCounter}-${Date.now()}`;
+
+describe("MosaicHostElement", () => {
+  let tagName: string;
+  let store: MosaicStore<S>;
+
+  beforeEach(() => {
+    tagName = uniqueTag();
+    customElements.define(tagName, class extends TextElement {});
+    store = new MosaicStore<S>({ initialState: { ...initial } });
+  });
+
+  it("does not bind before connection", () => {
+    const el = document.createElement(tagName) as TextElement;
+    el.store = store;
+    // Not connected yet
+    expect(el.bindStoreCallCount).toBe(0);
+  });
+
+  it("invokes bindStore on connection when store is set", () => {
+    const el = document.createElement(tagName) as TextElement;
+    el.store = store;
+    document.body.appendChild(el);
+    expect(el.bindStoreCallCount).toBe(1);
+    expect(el.span.textContent).toBe("hello");
+  });
+
+  it("does not invoke bindStore on connection without a store", () => {
+    const el = document.createElement(tagName) as TextElement;
+    document.body.appendChild(el);
+    expect(el.bindStoreCallCount).toBe(0);
+    el.remove();
+  });
+
+  it("invokes bindStore when store is set AFTER connection", () => {
+    const el = document.createElement(tagName) as TextElement;
+    document.body.appendChild(el);
+    expect(el.bindStoreCallCount).toBe(0);
+    el.store = store;
+    expect(el.bindStoreCallCount).toBe(1);
+  });
+
+  it("rebinds when store is reassigned while connected", () => {
+    const el = document.createElement(tagName) as TextElement;
+    el.store = store;
+    document.body.appendChild(el);
+    expect(el.bindStoreCallCount).toBe(1);
+    const store2 = new MosaicStore<S>({ initialState: { text: "two", count: 0 } });
+    el.store = store2;
+    expect(el.bindStoreCallCount).toBe(2);
+    expect(el.span.textContent).toBe("two");
+  });
+
+  it("disposes bindings on disconnect", () => {
+    const el = document.createElement(tagName) as TextElement;
+    el.store = store;
+    document.body.appendChild(el);
+    store.dispatch(new SetText("world"));
+    expect(el.span.textContent).toBe("world");
+    el.remove();
+    // After disconnect, further dispatches should NOT update the
+    // element's text content (the binding has been disposed).
+    store.dispatch(new SetText("ignored"));
+    expect(el.span.textContent).toBe("world");
+  });
+
+  it("reconnect after disconnect rebinds (no stale bindings)", () => {
+    const el = document.createElement(tagName) as TextElement;
+    el.store = store;
+    document.body.appendChild(el);
+    expect(el.bindStoreCallCount).toBe(1);
+    el.remove();
+    document.body.appendChild(el);
+    expect(el.bindStoreCallCount).toBe(2);
+    store.dispatch(new SetText("after-reconnect"));
+    expect(el.span.textContent).toBe("after-reconnect");
+  });
+
+  it("attachShadowIfNeeded is idempotent", () => {
+    const el = document.createElement(tagName) as TextElement;
+    const shadow1 = el.attachShadowIfNeeded();
+    const shadow2 = el.attachShadowIfNeeded();
+    expect(shadow1).toBe(shadow2);
+  });
+
+  it("attachShadowIfNeeded respects pre-existing shadow root", () => {
+    // Define a separate test class that DOESN'T attach a shadow in
+    // its constructor, to exercise the "subclass attached one
+    // independently" branch.
+    class BareElement extends MosaicHostElement<S> {
+      protected bindStore(_store: MosaicStore<S>): void {
+        // no-op
+      }
+    }
+    const bareTag = uniqueTag();
+    customElements.define(bareTag, BareElement);
+    const el = document.createElement(bareTag) as BareElement;
+    const preAttached = el.attachShadow({ mode: "open" });
+    const fromHelper = el.attachShadowIfNeeded();
+    expect(fromHelper).toBe(preAttached);
+  });
+
+  it("dispatch shortcut delegates to the store", () => {
+    const el = document.createElement(tagName) as TextElement;
+    el.store = store;
+    document.body.appendChild(el);
+    el.publicDispatch(new SetText("from-dispatch"));
+    expect(store.state.text).toBe("from-dispatch");
+    expect(el.span.textContent).toBe("from-dispatch");
+  });
+
+  it("dispatch throws when no store is bound", () => {
+    const el = document.createElement(tagName) as TextElement;
+    expect(() => el.publicDispatch(new Increment())).toThrow(/cannot dispatch/);
+  });
+
+  it("setting store to the same reference is a no-op", () => {
+    const el = document.createElement(tagName) as TextElement;
+    el.store = store;
+    document.body.appendChild(el);
+    const before = el.bindStoreCallCount;
+    el.store = store;
+    expect(el.bindStoreCallCount).toBe(before);
+  });
+
+  it("setting store to null disposes existing bindings while connected", () => {
+    const el = document.createElement(tagName) as TextElement;
+    el.store = store;
+    document.body.appendChild(el);
+    store.dispatch(new SetText("present"));
+    expect(el.span.textContent).toBe("present");
+    el.store = null;
+    store.dispatch(new SetText("after-null"));
+    expect(el.span.textContent).toBe("present");
+  });
+
+  it("a bad unsubscribe doesn't prevent other unsubscribes from running", () => {
+    class BadUnsubElement extends MosaicHostElement<S> {
+      otherUnsubRan = false;
+      protected bindStore(_s: MosaicStore<S>): void {
+        this.track(() => {
+          throw new Error("first one throws");
+        });
+        this.track(() => {
+          this.otherUnsubRan = true;
+        });
+      }
+    }
+    const badTag = uniqueTag();
+    customElements.define(badTag, BadUnsubElement);
+    const el = document.createElement(badTag) as BadUnsubElement;
+    el.store = store;
+    document.body.appendChild(el);
+    el.remove(); // triggers cleanup
+    expect(el.otherUnsubRan).toBe(true);
+  });
+
+  it("store getter returns null before any store is assigned", () => {
+    const el = document.createElement(tagName) as TextElement;
+    expect(el.store).toBe(null);
+  });
+
+  it("store getter returns the assigned store", () => {
+    const el = document.createElement(tagName) as TextElement;
+    el.store = store;
+    expect(el.store).toBe(store);
+  });
+});
+
+describe("defineMosaicElement", () => {
+  it("registers a class with customElements.define", () => {
+    const tag = uniqueTag();
+    class E extends MosaicHostElement<S> {
+      protected bindStore(_s: MosaicStore<S>): void {}
+    }
+    defineMosaicElement(tag, E);
+    expect(customElements.get(tag)).toBe(E);
+  });
+
+  it("is idempotent — second call with same tag is a no-op", () => {
+    const tag = uniqueTag();
+    class E1 extends MosaicHostElement<S> {
+      protected bindStore(_s: MosaicStore<S>): void {}
+    }
+    class E2 extends MosaicHostElement<S> {
+      protected bindStore(_s: MosaicStore<S>): void {}
+    }
+    defineMosaicElement(tag, E1);
+    defineMosaicElement(tag, E2); // should not throw
+    // First definition wins
+    expect(customElements.get(tag)).toBe(E1);
+  });
+
+  it("throws when customElements is undefined", () => {
+    const original = (globalThis as { customElements?: unknown }).customElements;
+    (globalThis as { customElements?: unknown }).customElements = undefined;
+    try {
+      class E extends MosaicHostElement<S> {
+        protected bindStore(_s: MosaicStore<S>): void {}
+      }
+      expect(() => defineMosaicElement(uniqueTag(), E)).toThrow(
+        /customElements is not available/,
+      );
+    } finally {
+      (globalThis as { customElements?: unknown }).customElements = original;
+    }
+  });
+
+  it("accepts ElementDefinitionOptions third argument", () => {
+    const tag = uniqueTag();
+    class E extends MosaicHostElement<S> {
+      protected bindStore(_s: MosaicStore<S>): void {}
+    }
+    const spy = vi.spyOn(customElements, "define");
+    defineMosaicElement(tag, E, {});
+    expect(spy).toHaveBeenCalledWith(tag, E, {});
+    spy.mockRestore();
+  });
+});

--- a/code/packages/typescript/mosaic-flux-webcomponent/tests/index.test.ts
+++ b/code/packages/typescript/mosaic-flux-webcomponent/tests/index.test.ts
@@ -1,0 +1,28 @@
+// index.test.ts — public surface smoke test.
+
+import { describe, it, expect } from "vitest";
+import * as pkg from "../src/index.js";
+
+describe("@coding-adventures/mosaic-flux-webcomponent public surface", () => {
+  it("exports core types (same as mosaic-flux-html)", () => {
+    expect(typeof pkg.MosaicStore).toBe("function");
+    expect(typeof pkg.isMosaicAction).toBe("function");
+    expect(typeof pkg.composeMiddleware).toBe("function");
+    expect(typeof pkg.loggerMiddleware).toBe("function");
+    expect(typeof pkg.createSelector).toBe("function");
+    expect(typeof pkg.devToolsMiddleware).toBe("function");
+  });
+
+  it("exports DOM binding helpers", () => {
+    expect(typeof pkg.bindText).toBe("function");
+    expect(typeof pkg.bindAttr).toBe("function");
+    expect(typeof pkg.bindClass).toBe("function");
+    expect(typeof pkg.bindStyle).toBe("function");
+    expect(typeof pkg.bindList).toBe("function");
+  });
+
+  it("exports WebComponent-specific surface", () => {
+    expect(typeof pkg.MosaicHostElement).toBe("function");
+    expect(typeof pkg.defineMosaicElement).toBe("function");
+  });
+});

--- a/code/packages/typescript/mosaic-flux-webcomponent/tests/middleware.test.ts
+++ b/code/packages/typescript/mosaic-flux-webcomponent/tests/middleware.test.ts
@@ -1,0 +1,93 @@
+// middleware.test.ts
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  composeMiddleware,
+  loggerMiddleware,
+  type Middleware,
+} from "../src/middleware.js";
+import type { MosaicAction } from "../src/action.js";
+
+interface S {
+  v: number;
+}
+
+class Bump implements MosaicAction<S> {
+  apply(s: S): S {
+    return { v: s.v + 1 };
+  }
+}
+
+describe("composeMiddleware", () => {
+  it("no-op when empty", () => {
+    const c = composeMiddleware<S>([]);
+    expect(() => c(new Bump(), { v: 0 }, { v: 1 })).not.toThrow();
+  });
+
+  it("returns the single middleware verbatim", () => {
+    const m: Middleware<S> = () => {};
+    expect(composeMiddleware<S>([m])).toBe(m);
+  });
+
+  it("runs in order", () => {
+    const calls: string[] = [];
+    const c = composeMiddleware<S>([
+      () => calls.push("a"),
+      () => calls.push("b"),
+      () => calls.push("c"),
+    ]);
+    c(new Bump(), { v: 0 }, { v: 1 });
+    expect(calls).toEqual(["a", "b", "c"]);
+  });
+
+  it("isolates throws", () => {
+    const calls: string[] = [];
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const c = composeMiddleware<S>([
+      () => calls.push("a"),
+      () => {
+        throw new Error("boom");
+      },
+      () => calls.push("c"),
+    ]);
+    c(new Bump(), { v: 0 }, { v: 1 });
+    expect(calls).toEqual(["a", "c"]);
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});
+
+describe("loggerMiddleware", () => {
+  it("logs action name + changed keys", () => {
+    const g = vi.spyOn(console, "groupCollapsed").mockImplementation(() => {});
+    vi.spyOn(console, "groupEnd").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    loggerMiddleware<S>()(new Bump(), { v: 0 }, { v: 1 });
+    expect(g.mock.calls[0]?.[0]).toContain("Bump");
+    expect(g.mock.calls[0]?.[0]).toContain("v");
+    vi.restoreAllMocks();
+  });
+
+  it("'(none)' for no-op", () => {
+    const g = vi.spyOn(console, "groupCollapsed").mockImplementation(() => {});
+    vi.spyOn(console, "groupEnd").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    loggerMiddleware<S>()(new Bump(), { v: 0 }, { v: 0 });
+    expect(g.mock.calls[0]?.[0]).toContain("(none)");
+    vi.restoreAllMocks();
+  });
+
+  it("atomic for non-object state", () => {
+    const g = vi.spyOn(console, "groupCollapsed").mockImplementation(() => {});
+    vi.spyOn(console, "groupEnd").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    class NA implements MosaicAction<number> {
+      apply(n: number): number {
+        return n + 1;
+      }
+    }
+    loggerMiddleware<number>()(new NA(), 0, 1);
+    expect(g.mock.calls[0]?.[0]).toContain("<root>");
+    vi.restoreAllMocks();
+  });
+});

--- a/code/packages/typescript/mosaic-flux-webcomponent/tests/selector.test.ts
+++ b/code/packages/typescript/mosaic-flux-webcomponent/tests/selector.test.ts
@@ -1,0 +1,70 @@
+// selector.test.ts
+
+import { describe, it, expect, vi } from "vitest";
+import { createSelector } from "../src/selector.js";
+
+interface S {
+  a: number;
+  b: number;
+  label: string;
+}
+
+describe("createSelector", () => {
+  it("throws when too few args", () => {
+    expect(() => (createSelector as unknown as () => unknown)()).toThrow();
+    expect(() =>
+      (createSelector as unknown as (fn: () => unknown) => unknown)(() => 1),
+    ).toThrow();
+  });
+
+  it("recomputes when input changes", () => {
+    const combiner = vi.fn((a: number, b: number) => a + b);
+    const sum = createSelector(
+      (s: S) => s.a,
+      (s: S) => s.b,
+      combiner,
+    );
+    expect(sum({ a: 1, b: 2, label: "" })).toBe(3);
+    expect(sum({ a: 5, b: 2, label: "" })).toBe(7);
+    expect(combiner).toHaveBeenCalledTimes(2);
+  });
+
+  it("caches on stable inputs", () => {
+    const combiner = vi.fn((a: number, b: number) => a + b);
+    const sum = createSelector(
+      (s: S) => s.a,
+      (s: S) => s.b,
+      combiner,
+    );
+    const state: S = { a: 1, b: 2, label: "" };
+    sum(state);
+    sum(state);
+    sum(state);
+    expect(combiner).toHaveBeenCalledTimes(1);
+  });
+
+  it("caches across different state refs with same projected inputs", () => {
+    const combiner = vi.fn((a: number) => a * 2);
+    const doubled = createSelector((s: S) => s.a, combiner);
+    doubled({ a: 5, b: 0, label: "" });
+    doubled({ a: 5, b: 99, label: "different" });
+    expect(combiner).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-runs when one of multiple inputs changes", () => {
+    const combiner = vi.fn(
+      (a: number, b: number, lbl: string) => `${lbl}:${a + b}`,
+    );
+    const fmt = createSelector(
+      (s: S) => s.a,
+      (s: S) => s.b,
+      (s: S) => s.label,
+      combiner,
+    );
+    fmt({ a: 1, b: 2, label: "x" });
+    fmt({ a: 1, b: 2, label: "x" });
+    fmt({ a: 1, b: 2, label: "y" });
+    fmt({ a: 1, b: 2, label: "y" });
+    expect(combiner).toHaveBeenCalledTimes(2);
+  });
+});

--- a/code/packages/typescript/mosaic-flux-webcomponent/tests/store.test.ts
+++ b/code/packages/typescript/mosaic-flux-webcomponent/tests/store.test.ts
@@ -1,0 +1,169 @@
+// store.test.ts
+
+import { describe, it, expect, vi } from "vitest";
+import { MosaicStore } from "../src/store.js";
+import type { MosaicAction } from "../src/action.js";
+
+interface S {
+  count: number;
+  label: string;
+}
+
+class Increment implements MosaicAction<S> {
+  apply(s: S): S {
+    return { ...s, count: s.count + 1 };
+  }
+}
+
+class SetLabel implements MosaicAction<S> {
+  constructor(public readonly label: string) {}
+  apply(s: S): S {
+    return { ...s, label: this.label };
+  }
+}
+
+class NoOp implements MosaicAction<S> {
+  apply(s: S): S {
+    return s;
+  }
+}
+
+const initial: S = { count: 0, label: "" };
+
+describe("MosaicStore", () => {
+  it("starts at initial state", () => {
+    const store = new MosaicStore<S>({ initialState: initial });
+    expect(store.state).toEqual(initial);
+  });
+
+  it("dispatch applies action", () => {
+    const store = new MosaicStore<S>({ initialState: initial });
+    store.dispatch(new Increment());
+    expect(store.state).toEqual({ count: 1, label: "" });
+  });
+
+  it("payloaded actions work", () => {
+    const store = new MosaicStore<S>({ initialState: initial });
+    store.dispatch(new SetLabel("hi"));
+    expect(store.state.label).toBe("hi");
+  });
+
+  it("select returns projection without subscribing", () => {
+    const store = new MosaicStore<S>({ initialState: initial });
+    store.dispatch(new SetLabel("t"));
+    expect(store.select((s) => s.label)).toBe("t");
+  });
+});
+
+describe("MosaicStore — fine-grained subscription", () => {
+  it("fires on changed slice", () => {
+    const store = new MosaicStore<S>({ initialState: initial });
+    const cb = vi.fn();
+    store.subscribe((s) => s.count, cb);
+    store.dispatch(new Increment());
+    expect(cb).toHaveBeenCalledWith(1);
+  });
+
+  it("does NOT fire on unrelated slice change", () => {
+    const store = new MosaicStore<S>({ initialState: initial });
+    const cb = vi.fn();
+    store.subscribe((s) => s.count, cb);
+    store.dispatch(new SetLabel("x"));
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("multiple subscribers fire in order", () => {
+    const store = new MosaicStore<S>({ initialState: initial });
+    const calls: string[] = [];
+    store.subscribe(
+      (s) => s.count,
+      () => calls.push("a"),
+    );
+    store.subscribe(
+      (s) => s.count,
+      () => calls.push("b"),
+    );
+    store.dispatch(new Increment());
+    expect(calls).toEqual(["a", "b"]);
+  });
+
+  it("unsubscribe stops notifications", () => {
+    const store = new MosaicStore<S>({ initialState: initial });
+    const cb = vi.fn();
+    const unsub = store.subscribe((s) => s.count, cb);
+    store.dispatch(new Increment());
+    unsub();
+    store.dispatch(new Increment());
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-entrant unsubscribe doesn't skip peers", () => {
+    const store = new MosaicStore<S>({ initialState: initial });
+    const calls: string[] = [];
+    let unsubFirst: () => void = () => {};
+    unsubFirst = store.subscribe(
+      (s) => s.count,
+      () => {
+        calls.push("first");
+        unsubFirst();
+      },
+    );
+    store.subscribe(
+      (s) => s.count,
+      () => calls.push("second"),
+    );
+    store.dispatch(new Increment());
+    expect(calls).toEqual(["first", "second"]);
+  });
+
+  it("custom equality respected", () => {
+    interface AS {
+      list: number[];
+    }
+    const store = new MosaicStore<AS>({ initialState: { list: [1, 2] } });
+    const cb = vi.fn();
+    const deep = (a: number[], b: number[]) =>
+      a.length === b.length && a.every((v, i) => v === b[i]);
+    store.subscribe((s) => s.list, cb, deep as (a: number[], b: number[]) => boolean);
+    class Replace implements MosaicAction<AS> {
+      apply(s: AS): AS {
+        return { list: [...s.list] };
+      }
+    }
+    store.dispatch(new Replace());
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("no-op dispatch skips subscriber notification", () => {
+    const store = new MosaicStore<S>({ initialState: initial });
+    const cb = vi.fn();
+    store.subscribe((s) => s.count, cb);
+    store.dispatch(new NoOp());
+    expect(cb).not.toHaveBeenCalled();
+  });
+});
+
+describe("MosaicStore — middleware", () => {
+  it("sees (action, prev, next) triple", () => {
+    const seen: Array<{ a: unknown; p: S; n: S }> = [];
+    const store = new MosaicStore<S>({
+      initialState: initial,
+      middleware: [(a, p, n) => seen.push({ a, p, n })],
+    });
+    const action = new Increment();
+    store.dispatch(action);
+    expect(seen[0]?.a).toBe(action);
+    expect(seen[0]?.p.count).toBe(0);
+    expect(seen[0]?.n.count).toBe(1);
+  });
+
+  it("runs on no-op dispatches", () => {
+    let count = 0;
+    const store = new MosaicStore<S>({
+      initialState: initial,
+      middleware: [() => count++],
+    });
+    store.dispatch(new NoOp());
+    expect(count).toBe(1);
+  });
+});

--- a/code/packages/typescript/mosaic-flux-webcomponent/tsconfig.json
+++ b/code/packages/typescript/mosaic-flux-webcomponent/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true
+  },
+  "include": ["src"]
+}

--- a/code/packages/typescript/mosaic-flux-webcomponent/vitest.config.ts
+++ b/code/packages/typescript/mosaic-flux-webcomponent/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    // jsdom provides customElements, shadow DOM, and HTMLElement
+    // for testing MosaicHostElement + defineMosaicElement.
+    environment: "jsdom",
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      thresholds: {
+        lines: 80,
+        functions: 80,
+        branches: 80,
+        statements: 80,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Third **Phase-2 runtime library** per UI33-rewrite §6. Web Component variant — same core as \`mosaic-flux-html\`, plus a \`MosaicHostElement\` base class + \`defineMosaicElement\` helper for lifecycle-managed custom elements.

## What's new vs. mosaic-flux-html

The core types are byte-identical duplicates (per UI33-rewrite §6.1 standalone-runtime policy). The unique surface is **\`src/element.ts\`**:

### \`MosaicHostElement<State>\` base class

Subclass it to write custom elements that bind to a \`MosaicStore\`. The base class manages the binding lifecycle so you don't have to remember cleanup:

\`\`\`typescript
class CounterDisplay extends MosaicHostElement<CounterState> {
  private span: HTMLSpanElement;

  constructor() {
    super();
    const shadow = this.attachShadowIfNeeded();
    this.span = document.createElement("span");
    shadow.appendChild(this.span);
  }

  protected bindStore(store: MosaicStore<CounterState>): void {
    // track() registers the unsubscribe for auto-cleanup on disconnect
    this.track(bindText(this.span, store, (s) => String(s.count)));
  }
}

defineMosaicElement("counter-display", CounterDisplay);

const counter = document.createElement("counter-display") as CounterDisplay;
counter.store = myStore;
document.body.appendChild(counter);  // → bindStore invoked
counter.dispatch(new Increment());   // shortcut, throws if no store

document.body.removeChild(counter);  // → all tracked unsubscribes invoked
\`\`\`

### Lifecycle invariant

Every binding registered via \`this.track()\` is automatically disposed when the element leaves the DOM. **This eliminates a common memory-leak class** where store subscriptions outlive their elements.

### Edge cases handled

- Setting \`element.store = currentStore\` is a no-op (no rebind thrash)
- Setting \`element.store = null\` while connected disposes existing bindings
- Reassigning \`element.store\` while connected: disposes old bindings, calls \`bindStore(new)\`
- Reconnect after disconnect rebinds cleanly (no stale bindings)
- One throwing unsubscribe doesn't prevent others from running
- Private fields use true \`#\` syntax — no cross-element state leakage possible

### \`defineMosaicElement(tagName, class, options?)\`

Idempotent \`customElements.define\` wrapper. Second call with same tag is a **no-op** (first definition wins) instead of throwing — HMR / module-reload safe. Throws cleanly if \`customElements\` is unavailable (SSR env).

## Stats

- 8 source files, ~900 LOC, literate comments
- 8 test files, **75 tests passing**
- Coverage: **92.39% lines / 95.16% branches / 88.88% funcs / 92.39% statements**
- \`element.ts\` (the unique surface) at **100% on every metric**
- Zero runtime deps; jsdom as devDep for testing
- TypeScript strict mode; \`tsc --noEmit\` clean
- BUILD, CHANGELOG.md, README.md per CLAUDE.md repo standards

## Test plan

- [x] Tests: 75 passing
- [x] Coverage: above 80% across the board
- [x] Typecheck: \`tsc --noEmit\` clean
- [x] /security-review passed (no vulnerabilities; verified core is byte-identical to mosaic-flux-html; element.ts manages lifecycle/cleanup correctly with isolated unsubscribe failures)
- [ ] CI green
- [ ] Human review on \`src/element.ts\` (MosaicHostElement lifecycle) + \`tests/element.test.ts\` (20 tests covering the lifecycle)

## Loop progress

| Cycle | Package | PR | Status |
|---|---|---|---|
| 1 | mosaic-flux-react | #4699 | ✅ MERGED |
| 2 | mosaic-flux-html | #4702 | ✅ MERGED |
| **3** | **mosaic-flux-webcomponent** | **(this)** | **Just opened** |
| 4 | mosaic-flux-swiftui | — | Next wakeup |
| 5-7 | compose / flutter / xaml / qt | — | Later |

🤖 Generated with [Claude Code](https://claude.com/claude-code)