### PR TITLE
board-vm: summarize eject artifacts in core

### DIFF
--- a/code/packages/rust/board-vm-cli/src/lib.rs
+++ b/code/packages/rust/board-vm-cli/src/lib.rs
@@ -1503,18 +1503,19 @@ pub fn render_blink_eject(options: &EjectBlinkOptions) -> Result<(String, EjectR
     write_embedded_rust_constants(&artifact, RustConstNames::board_vm_defaults(), &mut source)
         .map_err(|error| CliError::Eject(format!("{error:?}")))?;
 
+    let summary = artifact.summary();
     let report = EjectReport {
         output: options.output.clone(),
-        program_id: artifact.program_id,
-        slot: artifact.slot,
-        boot_policy: artifact.boot_policy,
-        program_format: artifact.format,
-        module_version: artifact.module_version,
-        module_flags: artifact.module_flags,
-        max_stack: artifact.max_stack,
+        program_id: summary.program_id,
+        slot: summary.slot,
+        boot_policy: summary.boot_policy,
+        program_format: summary.program_format,
+        module_version: summary.module_version,
+        module_flags: summary.module_flags,
+        max_stack: summary.max_stack,
         required_capabilities: artifact.required_capabilities.to_vec(),
-        module_len: artifact.module_len(),
-        module_crc32: artifact.module_crc32,
+        module_len: summary.module_len,
+        module_crc32: summary.module_crc32,
     };
     Ok((source, report))
 }

--- a/code/packages/rust/board-vm-eject/README.md
+++ b/code/packages/rust/board-vm-eject/README.md
@@ -15,3 +15,9 @@ mismatches, keeping frontend-owned metadata thin over the Rust-owned bytecode
 contract. The blink helper remains as the MVP program generator, but the generic
 builder is the path for REPL sessions and non-JS frontends once they emit
 bytecode directly.
+
+Each packaged artifact can produce a compact summary covering program identity,
+slot, boot policy, BVM module metadata, CRC, required-capability count, and byte
+length. CLI reports and board-specific firmware crates should use that
+Rust-owned summary instead of reparsing generated constants or reassembling the
+metadata contract themselves.

--- a/code/packages/rust/board-vm-eject/src/lib.rs
+++ b/code/packages/rust/board-vm-eject/src/lib.rs
@@ -86,9 +86,38 @@ pub struct EjectedProgram<'a> {
     pub required_capabilities: &'static [u16],
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EjectedProgramSummary {
+    pub program_id: u16,
+    pub slot: u8,
+    pub boot_policy: u8,
+    pub program_format: ProgramFormat,
+    pub module_version: u8,
+    pub module_flags: u8,
+    pub max_stack: u8,
+    pub module_crc32: u32,
+    pub required_capability_count: usize,
+    pub module_len: usize,
+}
+
 impl<'a> EjectedProgram<'a> {
     pub const fn module_len(self) -> usize {
         self.module.len()
+    }
+
+    pub const fn summary(self) -> EjectedProgramSummary {
+        EjectedProgramSummary {
+            program_id: self.program_id,
+            slot: self.slot,
+            boot_policy: self.boot_policy,
+            program_format: self.format,
+            module_version: self.module_version,
+            module_flags: self.module_flags,
+            max_stack: self.max_stack,
+            module_crc32: self.module_crc32,
+            required_capability_count: self.required_capabilities.len(),
+            module_len: self.module.len(),
+        }
     }
 }
 
@@ -276,6 +305,33 @@ mod tests {
         assert_eq!(artifact.module_crc32, crc32_ieee(artifact.module));
         assert_eq!(artifact.required_capabilities, BLINK_REQUIRED_CAPABILITIES);
         parse_module(artifact.module).unwrap();
+    }
+
+    #[test]
+    fn summarizes_blink_eject_artifact_contract() {
+        let mut module = [0u8; BLINK_MODULE_LEN];
+        let artifact = build_blink_eject_artifact(
+            BlinkProgram::onboard_led(),
+            EjectOptions::new(DEFAULT_PROGRAM_ID).slot(2),
+            &mut module,
+        )
+        .unwrap();
+
+        assert_eq!(
+            artifact.summary(),
+            EjectedProgramSummary {
+                program_id: DEFAULT_PROGRAM_ID,
+                slot: 2,
+                boot_policy: BOOT_RUN_IF_NO_HOST,
+                program_format: ProgramFormat::BvmModule,
+                module_version: MODULE_VERSION,
+                module_flags: 1,
+                max_stack: 4,
+                module_crc32: 0xBAD6_949E,
+                required_capability_count: 3,
+                module_len: BLINK_MODULE_LEN,
+            }
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a target-independent `EjectedProgramSummary` to `board-vm-eject`
- expose `EjectedProgram::summary()` for program identity, slot, boot policy, BVM module metadata, CRC, capability count, and byte length
- route the CLI eject report through the Rust-owned artifact summary instead of reassembling those fields directly

## Validation
- cargo fmt -p board-vm-eject -p board-vm-cli
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-eject-artifact-summary-core cargo test -p board-vm-eject -p board-vm-cli
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-eject-artifact-summary-core cargo test -p board-vm-protocol -p board-vm-ir -p board-vm-host -p board-vm-device -p board-vm-loopback -p board-vm-client -p board-vm-eject -p board-vm-uno-r4-firmware -p board-vm-cli
- git diff --check
- git diff --cached --check