### PR TITLE
Track browser form select descriptors

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -724,6 +724,25 @@ def check_browser_expected_lists(
                 require_optional_nullable_string(option_path, option, "label", errors)
                 require_string(option_path, option, "text", errors)
                 require_optional_boolean(option_path, option, "disabled", errors)
+        require_optional_object_list(form_path, form, "selects", errors)
+        for select_index, select in enumerate(object_list_items(form, "selects")):
+            select_path = f"{form_path}.selects[{select_index}]"
+            for field in ("id", "name", "form_owner", "accessible_name", "size", "value"):
+                require_optional_nullable_string(select_path, select, field, errors)
+            require_optional_string_list(select_path, select, "labels", errors)
+            for field in ("disabled", "required", "multiple"):
+                require_optional_boolean(select_path, select, field, errors)
+            require_optional_string_list(select_path, select, "selected_options", errors)
+            require_optional_object_list(select_path, select, "options", errors)
+            for option_index, option in enumerate(object_list_items(select, "options")):
+                option_path = f"{select_path}.options[{option_index}]"
+                require_string(option_path, option, "value", errors)
+                require_optional_nullable_string(option_path, option, "label", errors)
+                require_string(option_path, option, "text", errors)
+                require_optional_boolean(option_path, option, "selected", errors)
+                require_optional_boolean(option_path, option, "disabled", errors)
+                require_optional_nullable_string(option_path, option, "group_label", errors)
+            require_string(select_path, select, "text", errors)
         require_optional_object_list(form_path, form, "outputs", errors)
         for output_index, output in enumerate(object_list_items(form, "outputs")):
             output_path = f"{form_path}.outputs[{output_index}]"

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -1613,6 +1613,7 @@ pub struct BrowserForm {
     pub fieldsets: Vec<BrowserFormFieldset>,
     pub labels: Vec<BrowserFormLabel>,
     pub datalists: Vec<BrowserFormDatalist>,
+    pub selects: Vec<BrowserFormSelect>,
     pub outputs: Vec<BrowserFormOutput>,
     pub controls: Vec<BrowserFormControl>,
     pub submitters: Vec<BrowserFormSubmitter>,
@@ -1653,6 +1654,23 @@ pub struct BrowserDatalistOption {
     pub label: Option<String>,
     pub text: String,
     pub disabled: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserFormSelect {
+    pub id: Option<String>,
+    pub name: Option<String>,
+    pub form_owner: Option<String>,
+    pub labels: Vec<String>,
+    pub accessible_name: Option<String>,
+    pub disabled: bool,
+    pub required: bool,
+    pub multiple: bool,
+    pub size: Option<String>,
+    pub value: Option<String>,
+    pub selected_options: Vec<String>,
+    pub options: Vec<BrowserSelectOption>,
+    pub text: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -12715,6 +12733,7 @@ fn browser_form(
     let form_labels =
         collect_form_labels_for_form(body_root, element, element.attribute("id"), &controls);
     let datalists = browser_form_datalists(body_root, &controls);
+    let selects = browser_form_selects(&controls);
     let outputs = browser_form_outputs(&controls);
     let submitters = browser_form_submitters(
         &controls,
@@ -12755,6 +12774,7 @@ fn browser_form(
         fieldsets,
         labels: form_labels,
         datalists,
+        selects,
         outputs,
         controls,
         submitters,
@@ -13056,6 +13076,28 @@ fn browser_form_outputs(controls: &[BrowserFormControl]) -> Vec<BrowserFormOutpu
             form_owner: control.form_owner.clone(),
             for_tokens: control.output_for.clone(),
             value: control.value.clone(),
+            text: control.text.clone(),
+        })
+        .collect()
+}
+
+fn browser_form_selects(controls: &[BrowserFormControl]) -> Vec<BrowserFormSelect> {
+    controls
+        .iter()
+        .filter(|control| control.control_type == "select")
+        .map(|control| BrowserFormSelect {
+            id: control.id.clone(),
+            name: control.name.clone(),
+            form_owner: control.form_owner.clone(),
+            labels: control.labels.clone(),
+            accessible_name: control.accessible_name.clone(),
+            disabled: control.disabled,
+            required: control.required,
+            multiple: control.multiple,
+            size: control.size.clone(),
+            value: control.value.clone(),
+            selected_options: control.selected_options.clone(),
+            options: control.option_items.clone(),
             text: control.text.clone(),
         })
         .collect()

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -2,11 +2,11 @@ use coding_adventures_html_parser::{
     parse_browser_document, BrowserAnchor, BrowserComponentHydrationTarget, BrowserDataAttribute,
     BrowserDatalistOption, BrowserDocument, BrowserDocumentMetadata, BrowserEmbeddedContext,
     BrowserForm, BrowserFormControl, BrowserFormDatalist, BrowserFormFieldset, BrowserFormLabel,
-    BrowserFormOutput, BrowserFormSubmitter, BrowserHeading, BrowserHttpEquivHint, BrowserImage,
-    BrowserImageSource, BrowserInteractiveElement, BrowserLink, BrowserMedia, BrowserMeta,
-    BrowserMetadataDirective, BrowserRefresh, BrowserResource, BrowserResourceHint, BrowserScript,
-    BrowserSelectOption, BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet,
-    BrowserTable, BrowserTemplate, BrowserThemeColor,
+    BrowserFormOutput, BrowserFormSelect, BrowserFormSubmitter, BrowserHeading,
+    BrowserHttpEquivHint, BrowserImage, BrowserImageSource, BrowserInteractiveElement, BrowserLink,
+    BrowserMedia, BrowserMeta, BrowserMetadataDirective, BrowserRefresh, BrowserResource,
+    BrowserResourceHint, BrowserScript, BrowserSelectOption, BrowserStructuredItem,
+    BrowserStructuredProperty, BrowserStylesheet, BrowserTable, BrowserTemplate, BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -721,6 +721,8 @@ struct ExpectedForm {
     #[serde(default)]
     datalists: Vec<ExpectedFormDatalist>,
     #[serde(default)]
+    selects: Vec<ExpectedFormSelect>,
+    #[serde(default)]
     outputs: Vec<ExpectedFormOutput>,
     controls: Vec<ExpectedFormControl>,
     #[serde(default)]
@@ -779,6 +781,35 @@ struct ExpectedDatalistOption {
     text: String,
     #[serde(default)]
     disabled: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedFormSelect {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    form_owner: Option<String>,
+    #[serde(default)]
+    labels: Vec<String>,
+    #[serde(default)]
+    accessible_name: Option<String>,
+    #[serde(default)]
+    disabled: bool,
+    #[serde(default)]
+    required: bool,
+    #[serde(default)]
+    multiple: bool,
+    #[serde(default)]
+    size: Option<String>,
+    #[serde(default)]
+    value: Option<String>,
+    #[serde(default)]
+    selected_options: Vec<String>,
+    #[serde(default)]
+    options: Vec<ExpectedSelectOption>,
+    text: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1227,6 +1258,52 @@ fn browser_select_option_descriptor_metadata_tracks_values_labels_groups_and_sta
         actual.forms, expected.forms,
         "select controls should preserve option values, labels, optgroup labels, selected state, and disabled state",
     );
+}
+
+#[test]
+fn browser_form_select_descriptor_metadata_tracks_option_items_and_selection_state() {
+    let document = parse_browser_document(
+        "<form id=survey><label for=topic>Topic</label>\
+         <select id=topic name=topic required multiple size=4>\
+         <optgroup label=Primary><option value=rust selected>Rust<option value=html label=HTML>Markup</optgroup>\
+         <optgroup label=Archived disabled><option value=mosaic>Mosaic</optgroup>\
+         </select></form>\
+         <select id=external form=survey name=external><option>One<option selected>Two</select>",
+    )
+    .expect("form select descriptor fixture should parse");
+
+    let form = document
+        .forms
+        .first()
+        .expect("survey form should be summarized");
+    assert_eq!(form.selects.len(), 2);
+
+    let topic = &form.selects[0];
+    assert_eq!(topic.id.as_deref(), Some("topic"));
+    assert_eq!(topic.name.as_deref(), Some("topic"));
+    assert_eq!(topic.labels, vec!["Topic"]);
+    assert_eq!(topic.accessible_name.as_deref(), Some("Topic"));
+    assert!(topic.required);
+    assert!(topic.multiple);
+    assert_eq!(topic.size.as_deref(), Some("4"));
+    assert_eq!(topic.value.as_deref(), Some("rust"));
+    assert_eq!(topic.selected_options, vec!["rust"]);
+    assert_eq!(topic.text, "Rust Markup Mosaic");
+    assert_eq!(topic.options.len(), 3);
+    assert_eq!(topic.options[0].value, "rust");
+    assert_eq!(topic.options[0].group_label.as_deref(), Some("Primary"));
+    assert!(topic.options[0].selected);
+    assert_eq!(topic.options[1].label.as_deref(), Some("HTML"));
+    assert_eq!(topic.options[1].text, "Markup");
+    assert_eq!(topic.options[2].value, "mosaic");
+    assert_eq!(topic.options[2].group_label.as_deref(), Some("Archived"));
+    assert!(topic.options[2].disabled);
+
+    let external = &form.selects[1];
+    assert_eq!(external.id.as_deref(), Some("external"));
+    assert_eq!(external.form_owner.as_deref(), Some("survey"));
+    assert_eq!(external.selected_options, vec!["Two"]);
+    assert_eq!(external.options[1].value, "Two");
 }
 
 #[test]
@@ -2061,6 +2138,11 @@ impl ExpectedForm {
                 .into_iter()
                 .map(ExpectedFormDatalist::into_browser_form_datalist)
                 .collect(),
+            selects: self
+                .selects
+                .into_iter()
+                .map(ExpectedFormSelect::into_browser_form_select)
+                .collect(),
             outputs: self
                 .outputs
                 .into_iter()
@@ -2141,6 +2223,30 @@ impl ExpectedFormOutput {
             form_owner: self.form_owner,
             for_tokens: self.for_tokens,
             value: self.value,
+            text: self.text,
+        }
+    }
+}
+
+impl ExpectedFormSelect {
+    fn into_browser_form_select(self) -> BrowserFormSelect {
+        BrowserFormSelect {
+            id: self.id,
+            name: self.name,
+            form_owner: self.form_owner,
+            labels: self.labels,
+            accessible_name: self.accessible_name,
+            disabled: self.disabled,
+            required: self.required,
+            multiple: self.multiple,
+            size: self.size,
+            value: self.value,
+            selected_options: self.selected_options,
+            options: self
+                .options
+                .into_iter()
+                .map(ExpectedSelectOption::into_browser_select_option)
+                .collect(),
             text: self.text,
         }
     }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -74,6 +74,9 @@
             "enctype": "multipart/form-data",
             "target": "results",
             "effective_target": "results",
+            "selects": [
+              { "name": "section", "value": "manuals", "selected_options": ["manuals"], "options": [{ "value": "books", "text": "Books" }, { "value": "manuals", "text": "Manuals", "selected": true }], "text": "Books Manuals" }
+            ],
             "controls": [
               { "control_type": "text", "name": "q", "value": "rust html", "successful": true, "submission_values": ["rust html"], "disabled": false, "will_validate": true, "checked": false, "text": "", "options": [] },
               { "control_type": "hidden", "name": "page", "value": "1", "successful": true, "submission_values": ["1"], "disabled": false, "validation_barred_reason": "input-type-hidden", "checked": false, "text": "", "options": [] },
@@ -201,6 +204,9 @@
             ],
             "datalists": [
               { "id": "query-suggestions", "control_ids": ["q"], "control_names": ["q"], "options": [{ "value": "Rust", "text": "" }, { "value": "HTML", "label": "Markup", "text": "Markup" }, { "value": "Browser APIs", "text": "Browser APIs" }] }
+            ],
+            "selects": [
+              { "id": "kind", "name": "kind", "accessible_name": "Kind", "multiple": true, "size": "5", "value": "books", "selected_options": ["books"], "options": [{ "value": "books", "text": "Books", "selected": true, "group_label": "Print" }, { "value": "manuals", "label": "Manuals", "text": "Manuals", "group_label": "Print" }, { "value": "fiche", "text": "Microfiche", "disabled": true, "group_label": "Legacy" }], "text": "Books Manuals Microfiche" }
             ],
             "outputs": [
               { "id": "total", "name": "total", "for_tokens": ["q", "kind"], "value": "Ready", "text": "Ready" }


### PR DESCRIPTION
## Summary
- add form-level select descriptors to BrowserForm summaries
- surface select labels, selection state, size/multiple/required state, and option items
- update browser-readiness fixture schema and expected fixture data

## Tests
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- cargo test -p coding-adventures-html-parser browser_form_select_descriptor_metadata_tracks_option_items_and_selection_state
- cargo test -p coding-adventures-html-parser browser_form_
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser