### PR TITLE
Track browser form successful control descriptors

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -750,6 +750,18 @@ def check_browser_expected_lists(
                 require_optional_nullable_string(output_path, output, field, errors)
             require_optional_string_list(output_path, output, "for_tokens", errors)
             require_string(output_path, output, "text", errors)
+        require_optional_object_list(form_path, form, "successful_controls", errors)
+        for successful_index, control in enumerate(
+            object_list_items(form, "successful_controls")
+        ):
+            successful_path = f"{form_path}.successful_controls[{successful_index}]"
+            require_optional_nullable_string(successful_path, control, "id", errors)
+            require_string(successful_path, control, "control_type", errors)
+            require_string(successful_path, control, "name", errors)
+            require_optional_nullable_string(successful_path, control, "form_owner", errors)
+            require_optional_string_list(
+                successful_path, control, "submission_values", errors
+            )
         require_object_list(form_path, form, "controls", errors)
         require_optional_object_list(form_path, form, "submitters", errors)
         for control_index, control in enumerate(object_list_items(form, "controls")):

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -1615,6 +1615,7 @@ pub struct BrowserForm {
     pub datalists: Vec<BrowserFormDatalist>,
     pub selects: Vec<BrowserFormSelect>,
     pub outputs: Vec<BrowserFormOutput>,
+    pub successful_controls: Vec<BrowserFormSuccessfulControl>,
     pub controls: Vec<BrowserFormControl>,
     pub submitters: Vec<BrowserFormSubmitter>,
 }
@@ -1681,6 +1682,15 @@ pub struct BrowserFormOutput {
     pub for_tokens: Vec<String>,
     pub value: Option<String>,
     pub text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserFormSuccessfulControl {
+    pub id: Option<String>,
+    pub control_type: String,
+    pub name: String,
+    pub form_owner: Option<String>,
+    pub submission_values: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -12735,6 +12745,7 @@ fn browser_form(
     let datalists = browser_form_datalists(body_root, &controls);
     let selects = browser_form_selects(&controls);
     let outputs = browser_form_outputs(&controls);
+    let successful_controls = browser_form_successful_controls(&controls);
     let submitters = browser_form_submitters(
         &controls,
         action.as_deref(),
@@ -12776,6 +12787,7 @@ fn browser_form(
         datalists,
         selects,
         outputs,
+        successful_controls,
         controls,
         submitters,
     }
@@ -13099,6 +13111,24 @@ fn browser_form_selects(controls: &[BrowserFormControl]) -> Vec<BrowserFormSelec
             selected_options: control.selected_options.clone(),
             options: control.option_items.clone(),
             text: control.text.clone(),
+        })
+        .collect()
+}
+
+fn browser_form_successful_controls(
+    controls: &[BrowserFormControl],
+) -> Vec<BrowserFormSuccessfulControl> {
+    controls
+        .iter()
+        .filter(|control| control.successful)
+        .filter_map(|control| {
+            Some(BrowserFormSuccessfulControl {
+                id: control.id.clone(),
+                control_type: control.control_type.clone(),
+                name: control.name.clone()?,
+                form_owner: control.form_owner.clone(),
+                submission_values: control.submission_values.clone(),
+            })
         })
         .collect()
 }

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -2,11 +2,12 @@ use coding_adventures_html_parser::{
     parse_browser_document, BrowserAnchor, BrowserComponentHydrationTarget, BrowserDataAttribute,
     BrowserDatalistOption, BrowserDocument, BrowserDocumentMetadata, BrowserEmbeddedContext,
     BrowserForm, BrowserFormControl, BrowserFormDatalist, BrowserFormFieldset, BrowserFormLabel,
-    BrowserFormOutput, BrowserFormSelect, BrowserFormSubmitter, BrowserHeading,
-    BrowserHttpEquivHint, BrowserImage, BrowserImageSource, BrowserInteractiveElement, BrowserLink,
-    BrowserMedia, BrowserMeta, BrowserMetadataDirective, BrowserRefresh, BrowserResource,
-    BrowserResourceHint, BrowserScript, BrowserSelectOption, BrowserStructuredItem,
-    BrowserStructuredProperty, BrowserStylesheet, BrowserTable, BrowserTemplate, BrowserThemeColor,
+    BrowserFormOutput, BrowserFormSelect, BrowserFormSubmitter, BrowserFormSuccessfulControl,
+    BrowserHeading, BrowserHttpEquivHint, BrowserImage, BrowserImageSource,
+    BrowserInteractiveElement, BrowserLink, BrowserMedia, BrowserMeta, BrowserMetadataDirective,
+    BrowserRefresh, BrowserResource, BrowserResourceHint, BrowserScript, BrowserSelectOption,
+    BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet, BrowserTable,
+    BrowserTemplate, BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -724,6 +725,8 @@ struct ExpectedForm {
     selects: Vec<ExpectedFormSelect>,
     #[serde(default)]
     outputs: Vec<ExpectedFormOutput>,
+    #[serde(default)]
+    successful_controls: Vec<ExpectedFormSuccessfulControl>,
     controls: Vec<ExpectedFormControl>,
     #[serde(default)]
     submitters: Vec<ExpectedFormSubmitter>,
@@ -825,6 +828,18 @@ struct ExpectedFormOutput {
     #[serde(default)]
     value: Option<String>,
     text: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedFormSuccessfulControl {
+    #[serde(default)]
+    id: Option<String>,
+    control_type: String,
+    name: String,
+    #[serde(default)]
+    form_owner: Option<String>,
+    #[serde(default)]
+    submission_values: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1197,6 +1212,59 @@ fn browser_form_successful_control_metadata_tracks_submission_values() {
     assert_eq!(
         actual.forms, expected.forms,
         "form controls should preserve successful-control and submission value metadata",
+    );
+}
+
+#[test]
+fn browser_form_successful_control_descriptor_metadata_tracks_submission_entries() {
+    let document = parse_browser_document(
+        "<form id=checkout>\
+         <input id=item name=item value=book>\
+         <input id=gift type=checkbox name=gift value=yes checked>\
+         <input id=skip type=checkbox name=skip value=yes>\
+         <input id=disabled name=disabled value=no disabled>\
+         <select id=shipping name=shipping><option value=ground>Ground<option value=air selected>Air</select>\
+         <textarea id=note name=note>Leave at desk</textarea>\
+         <input id=file type=file name=upload>\
+         <button name=go>Submit</button></form>\
+         <input id=outside form=checkout name=outside value=external>",
+    )
+    .expect("form successful-control descriptor fixture should parse");
+
+    let form = document
+        .forms
+        .first()
+        .expect("checkout form should be summarized");
+    let names: Vec<&str> = form
+        .successful_controls
+        .iter()
+        .map(|control| control.name.as_str())
+        .collect();
+    assert_eq!(
+        names,
+        vec!["item", "gift", "shipping", "note", "upload", "outside"]
+    );
+    assert_eq!(form.successful_controls[0].id.as_deref(), Some("item"));
+    assert_eq!(form.successful_controls[0].control_type, "text");
+    assert_eq!(form.successful_controls[0].submission_values, vec!["book"]);
+    assert_eq!(form.successful_controls[1].control_type, "checkbox");
+    assert_eq!(form.successful_controls[1].submission_values, vec!["yes"]);
+    assert_eq!(form.successful_controls[2].control_type, "select");
+    assert_eq!(form.successful_controls[2].submission_values, vec!["air"]);
+    assert_eq!(form.successful_controls[3].control_type, "textarea");
+    assert_eq!(
+        form.successful_controls[3].submission_values,
+        vec!["Leave at desk"]
+    );
+    assert_eq!(form.successful_controls[4].control_type, "file");
+    assert!(form.successful_controls[4].submission_values.is_empty());
+    assert_eq!(
+        form.successful_controls[5].form_owner.as_deref(),
+        Some("checkout")
+    );
+    assert_eq!(
+        form.successful_controls[5].submission_values,
+        vec!["external"]
     );
 }
 
@@ -2148,6 +2216,11 @@ impl ExpectedForm {
                 .into_iter()
                 .map(ExpectedFormOutput::into_browser_form_output)
                 .collect(),
+            successful_controls: self
+                .successful_controls
+                .into_iter()
+                .map(ExpectedFormSuccessfulControl::into_browser_form_successful_control)
+                .collect(),
             controls: self
                 .controls
                 .into_iter()
@@ -2224,6 +2297,18 @@ impl ExpectedFormOutput {
             for_tokens: self.for_tokens,
             value: self.value,
             text: self.text,
+        }
+    }
+}
+
+impl ExpectedFormSuccessfulControl {
+    fn into_browser_form_successful_control(self) -> BrowserFormSuccessfulControl {
+        BrowserFormSuccessfulControl {
+            id: self.id,
+            control_type: self.control_type,
+            name: self.name,
+            form_owner: self.form_owner,
+            submission_values: self.submission_values,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -77,6 +77,13 @@
             "selects": [
               { "name": "section", "value": "manuals", "selected_options": ["manuals"], "options": [{ "value": "books", "text": "Books" }, { "value": "manuals", "text": "Manuals", "selected": true }], "text": "Books Manuals" }
             ],
+            "successful_controls": [
+              { "control_type": "text", "name": "q", "submission_values": ["rust html"] },
+              { "control_type": "hidden", "name": "page", "submission_values": ["1"] },
+              { "control_type": "checkbox", "name": "in_stock", "submission_values": ["yes"] },
+              { "control_type": "select", "name": "section", "submission_values": ["manuals"] },
+              { "control_type": "textarea", "name": "notes", "submission_values": ["Line one Line two"] }
+            ],
             "controls": [
               { "control_type": "text", "name": "q", "value": "rust html", "successful": true, "submission_values": ["rust html"], "disabled": false, "will_validate": true, "checked": false, "text": "", "options": [] },
               { "control_type": "hidden", "name": "page", "value": "1", "successful": true, "submission_values": ["1"], "disabled": false, "validation_barred_reason": "input-type-hidden", "checked": false, "text": "", "options": [] },
@@ -210,6 +217,14 @@
             ],
             "outputs": [
               { "id": "total", "name": "total", "for_tokens": ["q", "kind"], "value": "Ready", "text": "Ready" }
+            ],
+            "successful_controls": [
+              { "id": "q", "control_type": "text", "name": "q", "submission_values": [""] },
+              { "id": "count", "control_type": "number", "name": "count", "submission_values": ["2"] },
+              { "id": "notes", "control_type": "textarea", "name": "notes", "submission_values": ["Keep me"] },
+              { "id": "kind", "control_type": "select", "name": "kind", "submission_values": ["books"] },
+              { "id": "upload", "control_type": "file", "name": "upload", "submission_values": [] },
+              { "id": "external", "control_type": "text", "name": "outside", "form_owner": "search", "submission_values": [""] }
             ],
             "controls": [
               { "id": "q", "control_type": "text", "name": "q", "labels": ["Query"], "accessible_name": "Query", "accessible_description": "Query", "placeholder": "Search terms", "autocomplete": "section-primary shipping search", "autocomplete_tokens": ["section-primary", "shipping", "search"], "autocapitalize": "words", "enterkeyhint": "search", "dirname": "q.dir", "spellcheck": "false", "autocorrect": "off", "inputmode": "search", "pattern": "[A-Za-z ]+", "minlength": "2", "maxlength": "80", "size": "40", "list": "query-suggestions", "datalist_options": ["Rust", "HTML", "Browser APIs"], "value": null, "successful": true, "submission_values": [""], "autofocus": true, "disabled": false, "required": true, "will_validate": true, "validation_attributes": ["required", "pattern", "minlength", "maxlength"], "checked": false, "text": "", "options": [] },


### PR DESCRIPTION
## Summary
- add form-level `successful_controls` descriptors for successful named controls and submission values
- cover external form-owned controls, skipped disabled/unchecked controls, and file inputs with empty submission values
- extend browser-readiness fixture schema and fixtures with the new descriptor metadata

## Tests
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py`
- `cargo test -p coding-adventures-html-parser browser_form_successful_control_descriptor_metadata_tracks_submission_entries`
- `cargo test -p coding-adventures-html-parser browser_form_`
- `cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts`
- `cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`