### PR TITLE
board-vm: check firmware eject summary parity

### DIFF
--- a/code/packages/rust/board-vm-uno-r4-firmware/README.md
+++ b/code/packages/rust/board-vm-uno-r4-firmware/README.md
@@ -56,7 +56,9 @@ ejected blink metadata before flashing hardware.
 The firmware crate also exposes a compact ejected-artifact summary, letting
 board-specific startup paths inspect the embedded program id, slot, boot policy,
 module metadata, CRC, capability count, and byte length without parsing the raw
-generated constants.
+generated constants. Host-side tests compare that firmware summary against the
+target-independent `board-vm-eject` artifact summary, so the board-specific view
+cannot drift from the Rust-owned eject contract.
 
 The ejected artifact stays board-agnostic; this firmware binary is the Uno R4
 backend that decides how to validate and execute it.

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/lib.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/lib.rs
@@ -423,6 +423,43 @@ mod tests {
     }
 
     #[test]
+    fn ejected_blink_summary_matches_eject_generator_summary() {
+        let program = EjectedFirmwareProgram::blink();
+        let mut generated_module = [0u8; EMBEDDED_BLINK_MODULE.len()];
+
+        let artifact = build_blink_eject_artifact(
+            BlinkProgram::onboard_led(),
+            EjectOptions::new(program.program_id)
+                .slot(program.slot)
+                .boot_policy(program.boot_policy),
+            &mut generated_module,
+        )
+        .unwrap();
+        let firmware_summary = program.summary();
+        let eject_summary = artifact.summary();
+
+        assert_eq!(firmware_summary.program_id, eject_summary.program_id);
+        assert_eq!(firmware_summary.slot, eject_summary.slot);
+        assert_eq!(firmware_summary.boot_policy, eject_summary.boot_policy);
+        assert_eq!(
+            firmware_summary.program_format,
+            eject_summary.program_format.as_u8()
+        );
+        assert_eq!(
+            firmware_summary.module_version,
+            eject_summary.module_version
+        );
+        assert_eq!(firmware_summary.module_flags, eject_summary.module_flags);
+        assert_eq!(firmware_summary.max_stack, eject_summary.max_stack);
+        assert_eq!(firmware_summary.module_crc32, eject_summary.module_crc32);
+        assert_eq!(
+            firmware_summary.required_capability_count,
+            eject_summary.required_capability_count
+        );
+        assert_eq!(firmware_summary.module_len, eject_summary.module_len);
+    }
+
+    #[test]
     fn ejected_blink_boot_policy_runs_without_host() {
         assert_eq!(
             ejected_boot_action(EjectedFirmwareProgram::blink()).unwrap(),


### PR DESCRIPTION
## Summary
- add a host-side Uno R4 firmware test comparing the embedded blink firmware summary with the target-independent `board-vm-eject` summary
- keep the board-specific summary pinned to the Rust-owned eject artifact contract for program identity, slot, boot policy, module metadata, CRC, capability count, and byte length
- document that firmware summary parity check in the Uno R4 firmware README

## Validation
- cargo fmt -p board-vm-uno-r4-firmware
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-firmware-core-summary-parity cargo test -p board-vm-uno-r4-firmware
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-firmware-core-summary-parity cargo test -p board-vm-protocol -p board-vm-ir -p board-vm-host -p board-vm-device -p board-vm-loopback -p board-vm-client -p board-vm-eject -p board-vm-uno-r4-firmware -p board-vm-cli
- git diff --check
- git diff --cached --check