### PR TITLE
feat(semantic-ir): add first-class StrConcat node (Phase 20b FC)

### DIFF
--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.73.0] - 2026-06-01
+
+### Changed (Phase 20b (FC) — interpolation lowers to first-class `StrConcat`)
+
+A multi-segment interpolated/concatenated string (`"a#{x}b"`) now lowers
+to the new `Expr::StrConcat` node instead of the v0
+`BuiltinCall("string_concat", …)` marker.  This is the marker→node
+counterpart of Phase 20a (which replaced the `__interp__` body marker
+with real recursive lowering): 20a turned each `#{…}` *body* into real
+SIR, and 20b turns the *concatenation wrapper* into a real SIR node.
+
+`lower_string_literal_with_interp` (shared by string **and** regex-pattern
+interpolation) keeps its result-shape selection — empty → empty `StrLit`,
+one segment → the bare segment, two-or-more → concat — but the 2+ case now
+emits `StrConcat { parts }` and declares the new
+`Feature::StringInterpolation` in the module manifest (alongside `Strings`
+for any `StrLit` parts).
+
+New / updated lowering pins:
+`interpolated_string_with_bare_name_lowers_to_str_concat`,
+`interpolated_string_with_expression_lowers_recursively`,
+`interpolated_string_with_multiple_expr_interps_lowers_each_recursively`,
+and the regex `regex_interpolation_lowers_pattern_to_concat` /
+`regex_interpolation_validates_e2e` all now assert the `StrConcat` shape.
+Added `adjacent_interps_with_no_literal_lower_to_str_concat_of_refs`
+(`"#{a}#{b}"` → two-`VarRef` concat) and
+`str_concat_module_declares_string_interpolation_feature` (manifest
+agreement).  Test count: 296 → 298.
+
 ## [0.72.0] - 2026-05-31
 
 ### Changed (Phase 20a (FC) — string interpolation lowers to real SIR)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -2798,27 +2798,30 @@ mod tests {
     // The `regex_body` lexer state captures `#{...}` markers verbatim
     // into the pattern, so the lowerer runs the pattern through the SAME
     // interpolation splitter strings use.  `args[0]` of the `regex`
-    // builtin therefore becomes a `string_concat` (or a bare `VarRef`
+    // builtin therefore becomes a `StrConcat` node (or a bare `VarRef`
     // for a single `#{x}` segment) when the pattern interpolates, and a
     // plain `StrLit` when it doesn't (the 19a shape, unchanged).
+    // Phase 20b replaced the v0 `string_concat` builtin with the
+    // first-class `Expr::StrConcat` node — regex patterns share the
+    // same interpolation splitter, so they pick up the new shape too.
     // -----------------------------------------------------------------
 
     #[test]
     fn regex_interpolation_lowers_pattern_to_concat() {
         // `def r(b) (/a#{b}c/) end` — pattern splits into
-        // [StrLit("a"), VarRef(b), StrLit("c")] under string_concat.
+        // [StrLit("a"), VarRef(b), StrLit("c")] under StrConcat.
         let m = lower("def r(b)\n  (/a#{b}c/)\nend\n");
         let f = m.functions.iter().find(|f| f.name == "r").unwrap();
         match &f.body.value {
             Expr::BuiltinCall { name, args, .. } if name == "regex" => {
                 match &args[0] {
-                    Expr::BuiltinCall { name, args: parts, .. } if name == "string_concat" => {
+                    Expr::StrConcat { parts, .. } => {
                         assert_eq!(parts.len(), 3, "expected 3 pattern segments");
                         assert!(matches!(&parts[0], Expr::StrLit { value, .. } if value == "a"));
                         assert!(matches!(&parts[1], Expr::VarRef { name, .. } if name == "b"));
                         assert!(matches!(&parts[2], Expr::StrLit { value, .. } if value == "c"));
                     }
-                    other => panic!("expected string_concat pattern, got {:?}", other),
+                    other => panic!("expected StrConcat pattern, got {:?}", other),
                 }
                 // Flags arg still present (empty here).
                 assert!(matches!(&args[1], Expr::StrLit { value, .. } if value.is_empty()));
@@ -2830,7 +2833,7 @@ mod tests {
     #[test]
     fn regex_interpolation_single_marker_is_bare_varref() {
         // `def r(b) (/#{b}/) end` — a lone `#{b}` pattern lowers to a
-        // single `VarRef` (no string_concat wrapper), mirroring `"#{b}"`.
+        // single `VarRef` (no StrConcat wrapper), mirroring `"#{b}"`.
         let m = lower("def r(b)\n  (/#{b}/)\nend\n");
         let f = m.functions.iter().find(|f| f.name == "r").unwrap();
         match &f.body.value {
@@ -2853,8 +2856,8 @@ mod tests {
         match &f.body.value {
             Expr::BuiltinCall { name, args, .. } if name == "regex" => {
                 assert!(
-                    matches!(&args[0], Expr::BuiltinCall { name, .. } if name == "string_concat"),
-                    "expected string_concat pattern; got {:?}", &args[0]
+                    matches!(&args[0], Expr::StrConcat { .. }),
+                    "expected StrConcat pattern; got {:?}", &args[0]
                 );
                 assert!(matches!(&args[1], Expr::StrLit { value, .. } if value == "i"));
             }
@@ -5174,15 +5177,18 @@ mod tests {
     // Output shapes covered:
     //   "plain"              → StrLit("plain")
     //   "#{x}"               → VarRef("x")
-    //   "hi #{name}"         → BuiltinCall("string_concat",
-    //                            [StrLit("hi "), VarRef("name")])
-    //   "sum=#{1+2}"         → BuiltinCall("string_concat",
-    //                            [StrLit("sum="),
-    //                             BuiltinCall("__interp__", [StrLit("1+2")])])
+    //   "hi #{name}"         → StrConcat([StrLit("hi "), VarRef("name")])
+    //   "sum=#{1+2}"         → StrConcat([StrLit("sum="),
+    //                                     BuiltinCall("+", [1, 2])])
+    //
+    // Phase 20b replaced the v0 `BuiltinCall("string_concat", …)` marker
+    // with the first-class `Expr::StrConcat` node (mirroring how 20a
+    // replaced the `__interp__` body marker with real lowering).
     //
     // Plus an end-to-end smoke test that an interpolated module passes
-    // the SIR validator (proves the BuiltinCall + StrLit shape is
-    // well-formed semantic IR).
+    // the SIR validator (proves the StrConcat + StrLit shape is
+    // well-formed semantic IR and the manifest declares
+    // `StringInterpolation`).
     // -----------------------------------------------------------------------
 
     #[test]
@@ -5201,8 +5207,8 @@ mod tests {
     }
 
     #[test]
-    fn interpolated_string_with_bare_name_lowers_to_string_concat() {
-        // `"hi #{name}"` → string_concat(StrLit("hi "), VarRef("name"))
+    fn interpolated_string_with_bare_name_lowers_to_str_concat() {
+        // `"hi #{name}"` → StrConcat([StrLit("hi "), VarRef("name")])
         //
         // The interpolated literal is in *trailing-value* position so
         // it sees the prior LetBinding (the validator's parallel-let
@@ -5216,20 +5222,19 @@ mod tests {
         assert_eq!(b.stmts.len(), 1);
         assert!(matches!(&b.stmts[0], Stmt::LetBinding { name, .. } if name == "name"));
         match &b.value {
-            Expr::BuiltinCall { name, args, .. } => {
-                assert_eq!(name, "string_concat");
-                assert_eq!(args.len(), 2, "expected 2 concat segments");
-                assert!(matches!(&args[0], Expr::StrLit { value, .. } if value == "hi "));
-                assert!(matches!(&args[1], Expr::VarRef { name, .. } if name == "name"));
+            Expr::StrConcat { parts, .. } => {
+                assert_eq!(parts.len(), 2, "expected 2 concat segments");
+                assert!(matches!(&parts[0], Expr::StrLit { value, .. } if value == "hi "));
+                assert!(matches!(&parts[1], Expr::VarRef { name, .. } if name == "name"));
             }
-            other => panic!("expected string_concat BuiltinCall, got {:?}", other),
+            other => panic!("expected StrConcat, got {:?}", other),
         }
     }
 
     #[test]
     fn interpolated_string_that_is_only_interp_unwraps_to_a_single_segment() {
         // `"#{name}"` has no literal text — the lowerer should hand back
-        // the single segment directly (no `string_concat` wrapper).
+        // the single segment directly (no `StrConcat` wrapper).
         // Trailing-value position so the VarRef sees the LetBinding.
         let m = lower(r##"name = "world"
 "#{name}"
@@ -5251,6 +5256,7 @@ mod tests {
         // the raw body text, the lowerer now re-parses the body and lowers
         // it into genuine SIR: the `+` operator becomes `BuiltinCall("+", …)`.
         // The marker survives only as a fallback for bodies we cannot parse.
+        // Phase 20b — the outer concat is now an `Expr::StrConcat` node.
         let m = lower(r##"x = "sum=#{1+2}""##);
         let b = main_body(&m);
         let value = match &b.stmts[0] {
@@ -5258,11 +5264,10 @@ mod tests {
             other => panic!("expected LetBinding, got {:?}", other),
         };
         match value {
-            Expr::BuiltinCall { name, args, .. } => {
-                assert_eq!(name, "string_concat");
-                assert_eq!(args.len(), 2);
-                assert!(matches!(&args[0], Expr::StrLit { value, .. } if value == "sum="));
-                match &args[1] {
+            Expr::StrConcat { parts, .. } => {
+                assert_eq!(parts.len(), 2);
+                assert!(matches!(&parts[0], Expr::StrLit { value, .. } if value == "sum="));
+                match &parts[1] {
                     Expr::BuiltinCall { name, args, .. } => {
                         assert_eq!(name, "+", "interp body 1+2 lowers to a real + call");
                         assert_eq!(args.len(), 2);
@@ -5272,7 +5277,7 @@ mod tests {
                     other => panic!("expected real `+` BuiltinCall, got {:?}", other),
                 }
             }
-            other => panic!("expected string_concat, got {:?}", other),
+            other => panic!("expected StrConcat, got {:?}", other),
         }
     }
 
@@ -5296,11 +5301,49 @@ puts("hi #{name}")
     }
 
     #[test]
+    fn adjacent_interps_with_no_literal_lower_to_str_concat_of_refs() {
+        // Phase 20b (FC) — `"#{a}#{b}"` has two interpolations and *no*
+        // literal text between them.  The concat still has two parts
+        // (both `VarRef`s), so it lowers to a two-part `StrConcat` — a
+        // concat is well-defined without any `StrLit` segment.
+        let m = lower(r##"a = "x"
+b = "y"
+"#{a}#{b}"
+"##);
+        let b = main_body(&m);
+        match &b.value {
+            Expr::StrConcat { parts, .. } => {
+                assert_eq!(parts.len(), 2);
+                assert!(matches!(&parts[0], Expr::VarRef { name, .. } if name == "a"));
+                assert!(matches!(&parts[1], Expr::VarRef { name, .. } if name == "b"));
+            }
+            other => panic!("expected StrConcat of two VarRefs, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn str_concat_module_declares_string_interpolation_feature() {
+        // Phase 20b (FC) — emitting a `StrConcat` must add
+        // `Feature::StringInterpolation` to the module manifest, or the
+        // validator would reject the module as using an undeclared
+        // feature.  This pins the manifest/observed agreement directly.
+        let m = lower(r##"name = "world"
+"hi #{name}"
+"##);
+        assert!(
+            m.manifest.contains(semantic_ir::Feature::StringInterpolation),
+            "manifest should declare string-interpolation; got {:?}",
+            m.manifest
+        );
+    }
+
+    #[test]
     fn interpolated_string_with_multiple_expr_interps_lowers_each_recursively() {
         // Phase 20a (FC) — `"a#{1}b#{2}c"` carries two expression
         // interpolations interleaved with three literal runs.  Each `#{…}`
         // body re-parses and lowers to a real `IntLit`, producing a
-        // five-segment `string_concat` (no `__interp__` markers anywhere).
+        // five-segment concat (no `__interp__` markers anywhere).
+        // Phase 20b — the concat is now an `Expr::StrConcat` node.
         let m = lower(r##"x = "a#{1}b#{2}c""##);
         let b = main_body(&m);
         let value = match &b.stmts[0] {
@@ -5308,16 +5351,15 @@ puts("hi #{name}")
             other => panic!("expected LetBinding, got {:?}", other),
         };
         match value {
-            Expr::BuiltinCall { name, args, .. } => {
-                assert_eq!(name, "string_concat");
-                assert_eq!(args.len(), 5, "a | 1 | b | 2 | c");
-                assert!(matches!(&args[0], Expr::StrLit { value, .. } if value == "a"));
-                assert!(matches!(args[1], Expr::IntLit { value: 1, .. }));
-                assert!(matches!(&args[2], Expr::StrLit { value, .. } if value == "b"));
-                assert!(matches!(args[3], Expr::IntLit { value: 2, .. }));
-                assert!(matches!(&args[4], Expr::StrLit { value, .. } if value == "c"));
+            Expr::StrConcat { parts, .. } => {
+                assert_eq!(parts.len(), 5, "a | 1 | b | 2 | c");
+                assert!(matches!(&parts[0], Expr::StrLit { value, .. } if value == "a"));
+                assert!(matches!(parts[1], Expr::IntLit { value: 1, .. }));
+                assert!(matches!(&parts[2], Expr::StrLit { value, .. } if value == "b"));
+                assert!(matches!(parts[3], Expr::IntLit { value: 2, .. }));
+                assert!(matches!(&parts[4], Expr::StrLit { value, .. } if value == "c"));
             }
-            other => panic!("expected string_concat, got {:?}", other),
+            other => panic!("expected StrConcat, got {:?}", other),
         }
     }
 

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -136,6 +136,10 @@ pub fn compile(program: &GrammarASTNode, module_name: &str) -> Result<Module, Ru
         // Phase 16a (FC) — `begin/rescue/ensure/end` (`Stmt::TryCatch`)
         // triggers the `Exceptions` feature.
         Feature::Exceptions,
+        // Phase 20b (FC) — a multi-segment interpolation/concat
+        // (`"a#{x}b"`) lowers to `Expr::StrConcat` and triggers the
+        // `StringInterpolation` feature.
+        Feature::StringInterpolation,
     ] {
         if lw.features_used.contains(&f) {
             manifest.add(f);
@@ -227,6 +231,10 @@ fn expr_references_any_name(expr: &Expr, names: &HashSet<String>) -> bool {
 
         Expr::LogicalAnd { lhs, rhs, .. } | Expr::LogicalOr { lhs, rhs, .. } => {
             expr_references_any_name(lhs, names) || expr_references_any_name(rhs, names)
+        }
+
+        Expr::StrConcat { parts, .. } => {
+            parts.iter().any(|p| expr_references_any_name(p, names))
         }
     }
 }
@@ -5359,7 +5367,11 @@ impl Lowerer {
         // - Empty string literal (`""`): emit a single empty `StrLit`.
         // - Exactly one segment: hand it back directly (no concat
         //   wrapper needed — keeps `"plain"` and `"#{x}"` lean).
-        // - Two or more segments: wrap in a `string_concat` builtin.
+        // - Two or more segments: wrap in a first-class `StrConcat`
+        //   node (Phase 20b).  This replaces the v0
+        //   `BuiltinCall("string_concat", …)` marker so backends can
+        //   emit native string building and the validator can track
+        //   interpolation usage via `Feature::StringInterpolation`.
         //
         // Any path that emits one or more segments needs the `Strings`
         // feature flag because we're producing `StrLit` data.
@@ -5373,10 +5385,12 @@ impl Lowerer {
         if segments.len() == 1 {
             return Ok(segments.into_iter().next().unwrap());
         }
-        Ok(Expr::BuiltinCall {
-            name: "string_concat".to_string(),
-            args: segments,
-            effects: EffectSet::PURE,
+        // 2+ segments → first-class concatenation node.  Declare the
+        // new feature so the manifest matches what the validator
+        // observes for the `StrConcat` node.
+        self.features_used.insert(Feature::StringInterpolation);
+        Ok(Expr::StrConcat {
+            parts: segments,
             span,
         })
     }

--- a/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.1.2 — SIR18 exhaustiveness (no behaviour change)
+
+semantic-ir 0.10.0 adds `Expr::StrConcat` (the SIR18 string-concat
+node).  This backend gains a `StrConcat` arm in its expression emitter
+so it stays exhaustive.  The arm joins the existing SIR16+ reject group
+and `panic!`s with a "capability check should have rejected it"
+message: `Feature::StringInterpolation` is not in this backend's
+accepted-feature set, so a concat-using module is rejected at the
+capability check before emit, making the arm unreachable.  No output or
+accepted-feature changes.
+
 ## 0.1.1 — SIR17 exhaustiveness (no behaviour change)
 
 semantic-ir 0.2.0 adds `Stmt::ClassDef` (the SIR17 class node).  This

--- a/code/packages/rust/semantic-ir-to-go/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/emit.rs
@@ -320,8 +320,9 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
         | Expr::MapLit { span, .. }
         | Expr::MapGet { span, .. }
         | Expr::LogicalAnd { span, .. }
-        | Expr::LogicalOr { span, .. } => {
-            panic!("go backend reached SIR16 expression at {} — capability check should have rejected it", span);
+        | Expr::LogicalOr { span, .. }
+        | Expr::StrConcat { span, .. } => {
+            panic!("go backend reached SIR16+ expression at {} — capability check should have rejected it", span);
         }
     }
 }

--- a/code/packages/rust/semantic-ir-to-python/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-python/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.1.2 — SIR18 exhaustiveness (no behaviour change)
+
+semantic-ir 0.10.0 adds `Expr::StrConcat` (the SIR18 string-concat
+node).  This backend gains a `StrConcat` arm in its expression emitter
+so it stays exhaustive.  The arm joins the existing SIR16+ reject group
+and `panic!`s with a "capability check should have rejected it"
+message: `Feature::StringInterpolation` is not in this backend's
+accepted-feature set, so a concat-using module is rejected at the
+capability check before emit, making the arm unreachable.  No output or
+accepted-feature changes.
+
 ## 0.1.1 — SIR17 exhaustiveness (no behaviour change)
 
 semantic-ir 0.2.0 adds `Stmt::ClassDef` (the SIR17 class node).  This

--- a/code/packages/rust/semantic-ir-to-python/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/emit.rs
@@ -271,8 +271,9 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
         | Expr::MapLit { span, .. }
         | Expr::MapGet { span, .. }
         | Expr::LogicalAnd { span, .. }
-        | Expr::LogicalOr { span, .. } => {
-            panic!("python backend reached SIR16 expression at {} — capability check should have rejected it", span);
+        | Expr::LogicalOr { span, .. }
+        | Expr::StrConcat { span, .. } => {
+            panic!("python backend reached SIR16+ expression at {} — capability check should have rejected it", span);
         }
     }
 }

--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.1.2 — SIR18 exhaustiveness (no behaviour change)
+
+semantic-ir 0.10.0 adds `Expr::StrConcat` (the SIR18 string-concat
+node).  This backend gains a `StrConcat` arm in its expression emitter
+so it stays exhaustive.  The arm joins the existing SIR16+ reject group
+and `panic!`s with a "capability check should have rejected it"
+message: `Feature::StringInterpolation` is not in this backend's
+accepted-feature set, so a concat-using module is rejected at the
+capability check before emit, making the arm unreachable.  No output or
+accepted-feature changes.
+
 ## 0.1.1 — SIR17 exhaustiveness (no behaviour change)
 
 semantic-ir 0.2.0 adds `Stmt::ClassDef` (the SIR17 class node).  This

--- a/code/packages/rust/semantic-ir-to-rust/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/emit.rs
@@ -261,8 +261,9 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
         | Expr::MapLit { span, .. }
         | Expr::MapGet { span, .. }
         | Expr::LogicalAnd { span, .. }
-        | Expr::LogicalOr { span, .. } => {
-            panic!("rust backend reached SIR16 expression at {} — capability check should have rejected it", span);
+        | Expr::LogicalOr { span, .. }
+        | Expr::StrConcat { span, .. } => {
+            panic!("rust backend reached SIR16+ expression at {} — capability check should have rejected it", span);
         }
     }
 }

--- a/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.1.2 — SIR18 exhaustiveness (no behaviour change)
+
+semantic-ir 0.10.0 adds `Expr::StrConcat` (the SIR18 string-concat
+node).  This backend gains a `StrConcat` arm in its expression emitter
+so it stays exhaustive.  The arm joins the existing SIR16+ reject group
+and `panic!`s with a "capability check should have rejected it"
+message: `Feature::StringInterpolation` is not in this backend's
+accepted-feature set, so a concat-using module is rejected at the
+capability check before emit, making the arm unreachable.  No output or
+accepted-feature changes.
+
 ## 0.1.1 — SIR17 exhaustiveness (no behaviour change)
 
 semantic-ir 0.2.0 adds `Stmt::ClassDef` (the SIR17 class node).  This

--- a/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
@@ -258,8 +258,9 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
         | Expr::MapLit { span, .. }
         | Expr::MapGet { span, .. }
         | Expr::LogicalAnd { span, .. }
-        | Expr::LogicalOr { span, .. } => {
-            panic!("ts backend reached SIR16 expression at {} — capability check should have rejected it", span);
+        | Expr::LogicalOr { span, .. }
+        | Expr::StrConcat { span, .. } => {
+            panic!("ts backend reached SIR16+ expression at {} — capability check should have rejected it", span);
         }
     }
 }

--- a/code/packages/rust/semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to the `semantic-ir` crate are documented here.
 
+## 0.10.0 — SIR18: string interpolation (`Expr::StrConcat`)
+
+Introduced by the Ruby frontend's Phase 20b (`"a#{x}b"` interpolation).
+
+### Added
+
+- `Expr::StrConcat { parts, span }` — a first-class string-concatenation
+  node that replaces the v0 `BuiltinCall("string_concat", parts)` marker
+  (the same marker→node move `Stmt::TryCatch` made for
+  `__rescue_marker__`).  A dedicated node lets backends emit native
+  string building (`format!` / template literals / f-strings) instead of
+  routing through a runtime helper.  Invariant: `parts.len() >= 2`.
+- `Feature::StringInterpolation` — observed whenever a module contains a
+  `StrConcat` node.  Distinct from `Feature::Strings` (a plain `StrLit`):
+  a backend may support string literals without yet knowing how to build
+  a concatenation, so the two capabilities are tracked separately.
+
+### Validator
+
+- `StrConcat` observes `Feature::StringInterpolation` and recursively
+  checks every part.  A concat with fewer than two parts is a hard error
+  (a frontend should emit the bare part instead).
+
+### Text format
+
+- `print_expr` renders `StrConcat` as `(str-concat <part…>)` (kind name
+  `str-concat`).  Span and visitor (`walker`) coverage extended to the
+  new node.
+
 ## 0.9.0 — SIR17: structured exception handling (`Stmt::TryCatch`)
 
 Introduced by the Ruby frontend's Phase 16a (`begin/rescue/ensure/end`).

--- a/code/packages/rust/semantic-ir/src/backend.rs
+++ b/code/packages/rust/semantic-ir/src/backend.rs
@@ -344,6 +344,12 @@ where
             walk_intrinsics_in_expr(lhs, f, depth + 1);
             walk_intrinsics_in_expr(rhs, f, depth + 1);
         }
+        // ── SIR18: string interpolation ────────────────────────────
+        Expr::StrConcat { parts, .. } => {
+            for p in parts {
+                walk_intrinsics_in_expr(p, f, depth + 1);
+            }
+        }
     }
 }
 

--- a/code/packages/rust/semantic-ir/src/manifest.rs
+++ b/code/packages/rust/semantic-ir/src/manifest.rs
@@ -25,6 +25,7 @@ use std::fmt;
 /// | `TailCalls`                | tail-call optimisation required       |
 /// | `Globals`                  | any top-level value `define`          |
 /// | `Intrinsics`               | any `Intrinsic` node                  |
+/// | `StringInterpolation`      | an `Expr::StrConcat` node             |
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Feature {
     Closures,
@@ -75,6 +76,16 @@ pub enum Feature {
     /// earlier `__rescue_marker__`/`__ensure_marker__` placeholder
     /// builtins with a first-class node.
     Exceptions,
+    // ── SIR18 (rich string handling) ─────────────────────────────────
+    /// Module contains at least one `Expr::StrConcat` node — string
+    /// concatenation / interpolation (Ruby `"a#{x}b"`).  Phase 20b
+    /// (Ruby) introduces this feature, replacing the v0
+    /// `BuiltinCall("string_concat", ...)` marker with a first-class
+    /// node.  Distinct from `Strings` (a plain `StrLit`): a backend may
+    /// support string literals yet not (yet) know how to build a
+    /// concatenation natively, so the two capabilities are tracked
+    /// separately.
+    StringInterpolation,
 }
 
 impl Feature {
@@ -102,6 +113,7 @@ impl Feature {
         Feature::ClassVars,
         Feature::Constants,
         Feature::Exceptions,
+        Feature::StringInterpolation,
     ];
 
     /// Kebab-case name for the SIR text format.
@@ -129,6 +141,7 @@ impl Feature {
             Feature::ClassVars => "class-vars",
             Feature::Constants => "constants",
             Feature::Exceptions => "exceptions",
+            Feature::StringInterpolation => "string-interpolation",
         }
     }
 

--- a/code/packages/rust/semantic-ir/src/nodes.rs
+++ b/code/packages/rust/semantic-ir/src/nodes.rs
@@ -543,6 +543,25 @@ pub enum Expr {
         rhs: Box<Expr>,
         span: Span,
     },
+
+    // ── SIR18: string interpolation ────────────────────────────────
+    /// String concatenation of two or more `parts`, evaluated left to
+    /// right and joined into a single string.  This is the first-class
+    /// replacement for the v0 `BuiltinCall("string_concat", parts)`
+    /// marker that Ruby's `"a#{x}b"` interpolation used to lower to —
+    /// the same relationship `SeqLen` has to `BuiltinCall("len", ...)`
+    /// or `TryCatch` has to the old `__rescue_marker__` builtin.
+    ///
+    /// Giving concatenation a dedicated node lets a backend emit native
+    /// string building (`format!` / template literals / f-strings)
+    /// instead of routing through a runtime helper, and lets the
+    /// validator track interpolation usage via
+    /// `Feature::StringInterpolation` distinctly from a plain `StrLit`.
+    ///
+    /// Invariant: `parts.len() >= 2`.  A zero- or one-part concat is
+    /// degenerate — frontends emit a bare `StrLit` (empty string) or the
+    /// single part directly rather than wrapping it.
+    StrConcat { parts: Vec<Expr>, span: Span },
 }
 
 /// A single capture provided to `MakeClosure`.  The `name` matches a
@@ -586,6 +605,7 @@ impl Expr {
             Expr::MapGet { span, .. } => span,
             Expr::LogicalAnd { span, .. } => span,
             Expr::LogicalOr { span, .. } => span,
+            Expr::StrConcat { span, .. } => span,
         }
     }
 
@@ -614,6 +634,7 @@ impl Expr {
             Expr::MapGet { .. } => "map-get",
             Expr::LogicalAnd { .. } => "and",
             Expr::LogicalOr { .. } => "or",
+            Expr::StrConcat { .. } => "str-concat",
         }
     }
 }
@@ -762,6 +783,16 @@ mod tests {
                     span: span.clone(),
                 },
                 "or",
+            ),
+            (
+                Expr::StrConcat {
+                    parts: vec![
+                        Expr::StrLit { value: "a".into(), span: span.clone() },
+                        Expr::StrLit { value: "b".into(), span: span.clone() },
+                    ],
+                    span: span.clone(),
+                },
+                "str-concat",
             ),
         ];
         for (e, expected) in &cases {

--- a/code/packages/rust/semantic-ir/src/text/printer.rs
+++ b/code/packages/rust/semantic-ir/src/text/printer.rs
@@ -430,6 +430,11 @@ fn print_expr_inline_depth(out: &mut String, e: &Expr, depth: usize) {
             print_expr_inline_depth(out, rhs, depth + 1);
             out.push(')');
         }
+        Expr::StrConcat { parts, .. } => {
+            let _ = write!(out, "(str-concat");
+            print_args(out, parts, depth);
+            out.push(')');
+        }
     }
 }
 
@@ -531,6 +536,20 @@ mod tests {
     fn print_negative_integer() {
         let e = Expr::IntLit { value: -7, span: s() };
         assert_eq!(print_expr(&e), "(int -7)");
+    }
+
+    #[test]
+    fn print_str_concat() {
+        // Phase 20b — `StrConcat` renders as `(str-concat <parts…>)`,
+        // each part printed inline like a builtin-call's args.
+        let e = Expr::StrConcat {
+            parts: vec![
+                Expr::StrLit { value: "hi ".into(), span: s() },
+                Expr::VarRef { name: "name".into(), scope: Scope::Local, span: s() },
+            ],
+            span: s(),
+        };
+        assert_eq!(print_expr(&e), "(str-concat (str \"hi \") (var-ref name local))");
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir/src/validator.rs
+++ b/code/packages/rust/semantic-ir/src/validator.rs
@@ -550,6 +550,25 @@ impl<'m> ValidatorState<'m> {
                 self.check_expr(lhs, env, depth + 1);
                 self.check_expr(rhs, env, depth + 1);
             }
+            // ── SIR18: string interpolation ────────────────────────
+            Expr::StrConcat { parts, span } => {
+                self.observed.add(Feature::StringInterpolation);
+                // A concat is only meaningful with at least two parts;
+                // a degenerate one-part concat signals a frontend bug
+                // (it should have emitted the bare part instead).
+                if parts.len() < 2 {
+                    self.error(
+                        format!(
+                            "str-concat needs at least 2 parts, got {}",
+                            parts.len()
+                        ),
+                        span,
+                    );
+                }
+                for p in parts {
+                    self.check_expr(p, env, depth + 1);
+                }
+            }
         }
     }
 
@@ -1169,6 +1188,64 @@ mod tests {
         });
         let r = validate(&m);
         assert!(r.is_ok(), "expected ok, got {:?}", r.issues);
+    }
+
+    #[test]
+    fn str_concat_observes_string_interpolation_feature() {
+        // Phase 20b — a well-formed two-part `StrConcat` validates when
+        // the manifest declares `StringInterpolation`.
+        let mut m =
+            empty_module(FeatureManifest::from_features(&[Feature::StringInterpolation, Feature::Strings]));
+        m.functions.push(Function {
+            name: "f".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![],
+                value: Expr::StrConcat {
+                    parts: vec![
+                        Expr::StrLit { value: "a".into(), span: s() },
+                        Expr::StrLit { value: "b".into(), span: s() },
+                    ],
+                    span: s(),
+                },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        });
+        let r = validate(&m);
+        assert!(r.is_ok(), "expected ok, got {:?}", r.issues);
+    }
+
+    #[test]
+    fn str_concat_with_fewer_than_two_parts_is_rejected() {
+        // Phase 20b — a one-part concat is degenerate; the frontend
+        // should have emitted the bare part instead.  The validator
+        // flags it so a buggy lowerer is caught early.
+        let mut m =
+            empty_module(FeatureManifest::from_features(&[Feature::StringInterpolation, Feature::Strings]));
+        m.functions.push(Function {
+            name: "f".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![],
+                value: Expr::StrConcat {
+                    parts: vec![Expr::StrLit { value: "lonely".into(), span: s() }],
+                    span: s(),
+                },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        });
+        let r = validate(&m);
+        assert!(!r.is_ok(), "expected error for 1-part str-concat, got ok");
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir/src/walker.rs
+++ b/code/packages/rust/semantic-ir/src/walker.rs
@@ -244,6 +244,12 @@ pub fn walk_expr_default<V: Visitor>(v: &mut V, e: &Expr) {
             v.visit_expr(lhs);
             v.visit_expr(rhs);
         }
+        // ── SIR18: string interpolation ────────────────────────────
+        Expr::StrConcat { parts, .. } => {
+            for p in parts {
+                v.visit_expr(p);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Phase 20b (FC) — string interpolation → first-class `StrConcat` SIR node

Part of the Ruby 3.4 frontend full-coverage effort. The marker→node
counterpart of Phase 20a: 20a turned each `#{…}` *body* into real SIR;
20b turns the *concatenation wrapper* into a real SIR node, replacing the
v0 `BuiltinCall("string_concat", parts)` marker. Mirrors how
`Stmt::TryCatch` replaced the `__rescue_marker__` builtin (Phase 16a).

### Core IR — `semantic-ir` (0.9.0 → 0.10.0)

- **New node** `Expr::StrConcat { parts, span }` (invariant
  `parts.len() >= 2`), threaded through `span()`, `kind_name()`
  (`"str-concat"`), the `walker` visitor, the `backend` intrinsic-walk,
  and the text printer (`(str-concat <parts…>)`).
- **New feature** `Feature::StringInterpolation`, observed by the
  validator on any `StrConcat`. Distinct from `Strings` (a plain
  `StrLit`) so a backend can support literals without yet supporting
  native concatenation. The validator rejects a `<2`-part concat.

### Ruby frontend — `ruby-to-semantic-ir` (0.72.0 → 0.73.0)

- `lower_string_literal_with_interp` (shared by string **and**
  regex-pattern interpolation) emits `StrConcat` for the 2+-segment case
  and declares `Feature::StringInterpolation` in the manifest. The empty
  → `StrLit("")` and single-segment → bare-segment fast paths are
  unchanged.
- Updated the string + regex interpolation pins to assert the new shape;
  added `adjacent_interps_with_no_literal_lower_to_str_concat_of_refs`
  (`"#{a}#{b}"` → two-`VarRef` concat) and
  `str_concat_module_declares_string_interpolation_feature`.

### Backends — `semantic-ir-to-{go,python,rust,typescript}` (0.1.1 → 0.1.2)

Each gains a `StrConcat` arm in its existing SIR16+ reject group to stay
exhaustive. `Feature::StringInterpolation` is in no backend's
`accepts_features()` allowlist, so a concat-using module is rejected at
the capability check (and again as an undeclared-feature validation
error) before emit — the arm is unreachable defense-in-depth, no output
or accepted-feature change. Matches the SIR17-exhaustiveness precedent.

### Tests

lexer 173 / parser 238 / ruby-IR 298 / semantic-ir 109 /
backends 20+19+35+35 — all green, no warnings. `cargo build --workspace`
clean (pre-existing `ir-to-jvm-class-file` Unix-only failure on Windows
is unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
