### PR TITLE
feat(ruby-ir): interpolate heredoc bodies (Phase 17a FC)

### DIFF
--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.74.0] - 2026-06-01
+
+### Changed (Phase 17a (FC) — heredoc bodies interpolate)
+
+A heredoc (`<<EOF` / `<<-EOF` / `<<~EOF`) interpolates `#{…}` like a
+double-quoted string, but `lower_heredoc_literal` previously emitted the
+extracted body as a single raw `StrLit` — so `<<EOF\nhi #{name}\nEOF`
+mis-lowered `#{name}` as literal text.  The lowerer now routes the
+extracted body through the shared `lower_string_literal_with_interp`
+splitter:
+
+- A body with no `#{…}` still lowers to one `StrLit` (unchanged — the
+  existing plain/`<<-`/`<<~` pins still hold).
+- An interpolating body lowers to a `StrConcat` of literal runs and the
+  lowered `#{…}` expressions, exactly as `"a#{x}b"` does (and so picks up
+  Phase 20a recursive expression lowering + Phase 20b `StrConcat` +
+  `Feature::StringInterpolation` for free).  A malformed-interp lowering
+  error falls back to the verbatim body as a plain `StrLit`, keeping
+  heredoc lowering infallible.
+
+New lowering pins (+3): `interpolated_heredoc_lowers_body_to_str_concat`
+(`<<EOF\nhi #{name}\nEOF` → 3-part `StrConcat`),
+`interpolated_tilde_heredoc_with_expression_lowers_recursively`
+(`<<~EOF` body `#{1 + 2}` → real `+` call),
+`interpolated_heredoc_validates_e2e_and_declares_feature` (manifest +
+validator round-trip).  Test count: 298 → 301.
+
 ## [0.73.0] - 2026-06-01
 
 ### Changed (Phase 20b (FC) — interpolation lowers to first-class `StrConcat`)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -5647,6 +5647,12 @@ b = "y"
     // value is the canonical `<<TAG\n<body>TAG` form (with `<<~TAG`
     // indent-stripping pre-applied).  The lowerer detects the `<<` prefix
     // and emits `StrLit(body)` — the inner body, tag suffix stripped.
+    //
+    // Phase 17a (FC): heredocs interpolate like double-quoted strings, so
+    // the extracted body is routed through the shared interpolation
+    // splitter.  A body with no `#{…}` still lowers to a single `StrLit`
+    // (the tests below), while an interpolating body lowers to a
+    // `StrConcat` of literal runs + lowered `#{…}` expressions.
     // -----------------------------------------------------------------------
 
     #[test]
@@ -5726,6 +5732,79 @@ b = "y"
         assert!(
             result.is_ok(),
             "validator rejected heredoc-using module: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn interpolated_heredoc_lowers_body_to_str_concat() {
+        // Phase 17a (FC) — a heredoc body interpolates like a
+        // double-quoted string.  `<<EOF\nhi #{name}\nEOF` → the body
+        // `hi #{name}\n` splits into ["hi ", VarRef(name), "\n"] under a
+        // three-part `StrConcat`.  `name` is bound first so it resolves
+        // as a local.
+        let m = lower("name = \"bob\"\ny = <<EOF\nhi #{name}\nEOF\n");
+        let b = main_body(&m);
+        // stmts[0] binds `name`; stmts[1] binds `y` to the heredoc.
+        let value = match &b.stmts[1] {
+            Stmt::LetBinding { name, value, .. } if name == "y" => value,
+            other => panic!("expected LetBinding y, got {:?}", other),
+        };
+        match value {
+            Expr::StrConcat { parts, .. } => {
+                assert_eq!(parts.len(), 3, "hi  | name | newline");
+                assert!(matches!(&parts[0], Expr::StrLit { value, .. } if value == "hi "));
+                assert!(matches!(&parts[1], Expr::VarRef { name, .. } if name == "name"));
+                assert!(matches!(&parts[2], Expr::StrLit { value, .. } if value == "\n"));
+            }
+            other => panic!("expected StrConcat, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn interpolated_tilde_heredoc_with_expression_lowers_recursively() {
+        // Phase 17a (FC) — interpolation works through the `<<~`
+        // indent-stripping form too, and the `#{1+2}` body lowers to a
+        // real `+` call (via Phase 20a recursive interp lowering).
+        let m = lower("x = <<~EOF\n  sum #{1 + 2}\n  EOF\n");
+        let b = main_body(&m);
+        let value = match &b.stmts[0] {
+            Stmt::LetBinding { value, .. } => value,
+            other => panic!("expected LetBinding, got {:?}", other),
+        };
+        match value {
+            Expr::StrConcat { parts, .. } => {
+                assert_eq!(parts.len(), 3, "sum  | 1+2 | newline");
+                assert!(matches!(&parts[0], Expr::StrLit { value, .. } if value == "sum "));
+                assert!(
+                    matches!(&parts[1], Expr::BuiltinCall { name, .. } if name == "+"),
+                    "expected real `+` call, got {:?}", &parts[1]
+                );
+                assert!(matches!(&parts[2], Expr::StrLit { value, .. } if value == "\n"));
+            }
+            other => panic!("expected StrConcat, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn interpolated_heredoc_validates_e2e_and_declares_feature() {
+        // Phase 17a (FC) — end-to-end: an interpolating heredoc lowers to
+        // a `StrConcat`, declares `Feature::StringInterpolation`, and the
+        // module round-trips the SIR validator.  The heredoc is the
+        // block's trailing value expression (not a `LetBinding` RHS) so
+        // its `#{name}` VarRef sees the prior binding under the
+        // validator's parallel-let rule — mirroring the double-quoted
+        // `interpolated_string_module_passes_sir_validator` test.
+        let m = lower("name = \"bob\"\n<<EOF\nhi #{name}\nEOF\n");
+        assert!(
+            m.manifest.contains(semantic_ir::Feature::StringInterpolation),
+            "expected string-interpolation feature; got {:?}",
+            m.manifest
+        );
+        let result = semantic_ir::validate(&m);
+        assert!(
+            result.is_ok(),
+            "validator rejected interpolating-heredoc module: {:?}",
             result
         );
     }

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -4952,7 +4952,13 @@ impl Lowerer {
     ///   state, so we treat every heredoc the same.
     /// - Escape sequences inside the body are kept literal (the lexer's
     ///   heredoc capture does not unescape; same v0 stance as backticks).
-    fn lower_heredoc_literal(&mut self, raw: &str, span: Span) -> Expr {
+    fn lower_heredoc_literal(
+        &mut self,
+        raw: &str,
+        span: Span,
+        err_line: usize,
+        err_column: usize,
+    ) -> Expr {
         // Step 1: strip the opener prefix.  Order matters — `<<~` and
         // `<<-` must be tried *before* `<<`, because `<<~`/`<<-` both
         // start with `<<`.
@@ -4982,8 +4988,23 @@ impl Lowerer {
             after_prefix.to_string()
         };
 
-        self.features_used.insert(Feature::Strings);
-        Expr::StrLit { value: body, span }
+        // Step 3 (Phase 17a FC): a plain / `<<-` / `<<~` heredoc
+        // interpolates like a double-quoted string, so route the
+        // extracted body through the shared interpolation splitter
+        // rather than treating it as fully literal.  Bodies with no
+        // `#{…}` come back as a single `StrLit` (the prior behaviour);
+        // bodies that interpolate become a `StrConcat` whose segments
+        // are the literal runs and the lowered `#{…}` expressions —
+        // exactly as `"a#{x}b"` lowers.  A lowering error (malformed
+        // interpolation body) falls back to the verbatim body as a
+        // plain `StrLit`, keeping heredoc lowering infallible.
+        match self.lower_string_literal_with_interp(&body, span.clone(), err_line, err_column) {
+            Ok(expr) => expr,
+            Err(_) => {
+                self.features_used.insert(Feature::Strings);
+                Expr::StrLit { value: body, span }
+            }
+        }
     }
 
     // -------------------------------------------------------------------
@@ -5583,6 +5604,8 @@ impl Lowerer {
                                 return Ok(self.lower_heredoc_literal(
                                     &tok.value,
                                     span,
+                                    tok.line,
+                                    tok.column,
                                 ));
                             }
                             // Phase 19d (FC) — `%r{...}` regex literal


### PR DESCRIPTION
## Phase 17a (FC) — heredoc bodies interpolate

Part of the Ruby 3.4 frontend full-coverage effort.

### What

Heredocs (`<<EOF`, `<<-EOF`, `<<~EOF`) interpolate `#{…}` like a
double-quoted string. The lexer (Phase 3c/4o) and parser (Phase 7b)
already handle every heredoc form, and `lower_heredoc_literal` already
extracts the body and strips the tag — but it emitted the body as a
**single raw `StrLit`**, so `<<EOF\nhi #{name}\nEOF` mis-lowered
`#{name}` as literal text.

### How

The extracted body is now routed through the shared
`lower_string_literal_with_interp` splitter (the same one double-quoted
strings use):

| Heredoc | Before | After |
|---|---|---|
| `<<EOF\nhello\nEOF` | `StrLit("hello\n")` | `StrLit("hello\n")` (unchanged) |
| `<<EOF\nhi #{name}\nEOF` | `StrLit("hi #{name}\n")` ❌ | `StrConcat([StrLit("hi "), VarRef(name), StrLit("\n")])` ✅ |
| `<<~EOF\n  sum #{1+2}\n  EOF` | `StrLit("sum #{1+2}\n")` ❌ | `StrConcat([StrLit("sum "), +(1,2), StrLit("\n")])` ✅ |

Interpolating bodies pick up Phase 20a recursive expression lowering,
Phase 20b `StrConcat`, and `Feature::StringInterpolation` for free. A
malformed-interp lowering error falls back to the verbatim body as a
plain `StrLit`, keeping heredoc lowering infallible. The dispatch site
threads `tok.line`/`tok.column` for interp-body error spans.

### Scope

Lowering-only (`ruby-to-semantic-ir`); lexer/parser/grammar untouched.
The recursive interp re-parse path remains bounded by Phase 20a's
`MAX_INTERP_DEPTH = 8`.

### Tests

`interpolated_heredoc_lowers_body_to_str_concat`,
`interpolated_tilde_heredoc_with_expression_lowers_recursively`,
`interpolated_heredoc_validates_e2e_and_declares_feature` (manifest +
validator round-trip; heredoc in trailing-value position per the
parallel-let rule). Existing plain/`<<-`/`<<~` pins unchanged. lexer 173
/ parser 238 / ruby-IR 298 → 301 green. CHANGELOG 0.73.0 → 0.74.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
