### PR TITLE
feat(oct-semantic-tokens): semantic-token extraction for Oct (OCT-ST01)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -671,6 +671,7 @@ members = [
     "basic-dap",
     "basic-semantic-tokens",
     "nib-semantic-tokens",
+    "oct-semantic-tokens",
     "nib-dap",
     "oct-dap",
     "twig-vm",

--- a/code/packages/rust/oct-semantic-tokens/BUILD
+++ b/code/packages/rust/oct-semantic-tokens/BUILD
@@ -1,0 +1,1 @@
+cargo test -p oct-semantic-tokens -- --nocapture

--- a/code/packages/rust/oct-semantic-tokens/CHANGELOG.md
+++ b/code/packages/rust/oct-semantic-tokens/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog — `oct-semantic-tokens`
+
+## 0.1.0 — 2026-06-01 (OCT-ST01 — initial Oct semantic tokens)
+
+Initial release.  Sibling of `basic-semantic-tokens` 0.1.0
+(PR #4717), `nib-semantic-tokens` 0.1.0 (PR #4718), and
+`twig-semantic-tokens` 0.2.0.  **Completes the syntax-highlighting
+phase** (task #40 — part 3 of 3).
+
+### What's here
+
+- `TokenKind` enum (`Keyword`, `Intrinsic`, `Boolean`, `Number`,
+  `Type`, `Variable`, `Operator`, `Punctuation`, `Comment`) with
+  stable LSP-aligned mnemonics.  `Intrinsic` is Oct-specific —
+  Oct's 8008 hardware-intrinsic keywords (`in`, `out`, `adc`,
+  `sbb`, `rlc`, `rrc`, `ral`, `rar`, `carry`, `parity`) get a
+  separate kind so themes can colour them like CPU mnemonics
+  rather than control flow.
+- `SemanticToken` struct — `(line, column, length, kind)` in
+  1-based monospace cells.
+- `semantic_tokens(source) -> Vec<SemanticToken>` — tokenise + classify.
+- `tokens_from(tokens) -> Vec<SemanticToken>` — reuse a lex pass.
+
+### Token classifications
+
+| Origin (oct-lexer)                                          | `TokenKind` |
+|-------------------------------------------------------------|-------------|
+| `type_name == "fn" / "let" / "static" / "if" / …`            | `Keyword`   |
+| `type_name == "in" / "out" / "adc" / "sbb" / "rlc" / "rrc" / "ral" / "rar" / "carry" / "parity"` | `Intrinsic` |
+| `type_name == "true" / "false"`                             | `Boolean`   |
+| `type_name == "INT_LIT" / "HEX_LIT" / "BIN_LIT"`            | `Number`    |
+| `NAME` matching `u8 / bool`                                  | `Type`      |
+| Other `NAME`                                                 | `Variable`  |
+| `PLUS / MINUS / AMP / PIPE / CARET / TILDE / BANG / LT / GT / EQ / EQ_EQ / NEQ / LEQ / GEQ / LAND / LOR` | `Operator` |
+| `COMMA / SEMICOLON / COLON / LPAREN / RPAREN / LBRACE / RBRACE / ARROW` | `Punctuation` |
+| `LINE_COMMENT`                                              | `Comment`   |
+| `WHITESPACE / Newline / Eof`                                | (skipped)   |
+
+### Tests
+
+- 10 unit tests covering each classification family.

--- a/code/packages/rust/oct-semantic-tokens/Cargo.toml
+++ b/code/packages/rust/oct-semantic-tokens/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "oct-semantic-tokens"
+version = "0.1.0"
+edition = "2021"
+description = "OCT-ST01 — semantic-token extraction for Oct.  Walks the oct-lexer's token stream and emits a typed token stream (keywords / booleans / numbers / names / types / operators / comments) suitable for LSP semantic-tokens, syntax highlighters, and editor extensions."
+
+[dependencies]
+coding-adventures-oct-lexer = { path = "../oct-lexer" }
+lexer                       = { path = "../lexer" }

--- a/code/packages/rust/oct-semantic-tokens/README.md
+++ b/code/packages/rust/oct-semantic-tokens/README.md
@@ -1,0 +1,48 @@
+# `oct-semantic-tokens` — semantic-token extraction for Oct
+
+Walks the `oct-lexer` token stream and emits a typed token stream
+— keywords / booleans / numbers / names / types / operators /
+comments — suitable for **LSP semantic-tokens**, syntax
+highlighters, and editor extensions.
+
+The Oct counterpart to `twig-semantic-tokens`,
+`basic-semantic-tokens`, and `nib-semantic-tokens`.  **Final piece**
+of the syntax-highlighting phase (task #40 part 3 of 3).
+
+## Public API
+
+- `semantic_tokens(source: &str) -> Vec<SemanticToken>` — tokenise + classify.
+- `tokens_from(tokens: &[Token]) -> Vec<SemanticToken>` — skip the
+  lex step when callers already have a `Vec<Token>` in hand.
+
+Tokens come back in **document order**.
+
+## Position model
+
+All positions are **1-based** `(line, column)` in monospace cell
+units.
+
+## Token classifications
+
+| Kind     | Examples                                                  |
+|----------|-----------------------------------------------------------|
+| Keyword  | `fn`, `let`, `static`, `if`, `else`, `while`, `loop`, `break`, `return` |
+| Intrinsic | `in`, `out`, `adc`, `sbb`, `rlc`, `rrc`, `ral`, `rar`, `carry`, `parity` — Oct's 8008 hardware intrinsics, distinguished from ordinary keywords so themes can colour hardware ops specially |
+| Boolean  | `true`, `false`                                           |
+| Number   | `42`, `0xFF`, `0b1010`                                    |
+| Type     | `u8`, `bool` (the known Oct types)                        |
+| Variable | NAME tokens that are not a recognised type                |
+| Operator | `+`, `-`, `&`, `\|`, `^`, `~`, `!`, `=`, `==`, `!=`, `<`, `<=`, `>`, `>=`, `&&`, `\|\|` |
+| Punctuation | `,`, `;`, `:`, `(`, `)`, `{`, `}`, `->`                |
+| Comment  | `// …` to end of line (if the lexer preserves it)         |
+
+## What this crate does NOT do
+
+- **No LSP encoding.**  Returns a typed `Vec<SemanticToken>`;
+  conversion to LSP's delta-encoded wire format is one level up.
+
+## Versions
+
+- `0.1.0` — initial release.
+
+See [CHANGELOG.md](./CHANGELOG.md) for details.

--- a/code/packages/rust/oct-semantic-tokens/src/lib.rs
+++ b/code/packages/rust/oct-semantic-tokens/src/lib.rs
@@ -1,0 +1,339 @@
+//! # `oct-semantic-tokens` — semantic-token extraction for Oct.
+//!
+//! Walks the [`coding_adventures_oct_lexer`] token stream and emits
+//! a typed token stream suitable for **LSP semantic-tokens**,
+//! syntax highlighters, and editor extensions.
+//!
+//! See [`README.md`](../README.md) for the API surface and the
+//! token-classification table.
+//!
+//! ## Oct-specific: hardware intrinsics
+//!
+//! Oct is a typed 8-bit systems language that originated targeting
+//! the Intel 8008.  The lexer's keyword set includes the 8008
+//! hardware intrinsics (`in`, `out`, `adc`, `sbb`, `rlc`, `rrc`,
+//! `ral`, `rar`, `carry`, `parity`).  Mixing those into the same
+//! `Keyword` bucket as control-flow keywords (`if`, `while`,
+//! `return`) hides a meaningful distinction.  We give them their
+//! own [`TokenKind::Intrinsic`] so editors can colour CPU ops
+//! distinctly — useful when reading Oct kernel/driver code.
+
+#![warn(missing_docs)]
+#![warn(rust_2018_idioms)]
+
+use std::fmt;
+
+use coding_adventures_oct_lexer::tokenize_oct;
+use lexer::token::{Token, TokenType};
+
+// ===========================================================================
+// TokenKind
+// ===========================================================================
+
+/// Semantic-token classifications surfaced by this crate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum TokenKind {
+    /// Reserved control-flow / declaration keyword: `fn`, `let`,
+    /// `static`, `if`, `else`, `while`, `loop`, `break`, `return`.
+    Keyword,
+    /// 8008 hardware intrinsic keyword: `in`, `out`, `adc`, `sbb`,
+    /// `rlc`, `rrc`, `ral`, `rar`, `carry`, `parity`.  Separated
+    /// from [`TokenKind::Keyword`] so editor themes can colour CPU
+    /// ops distinctly.
+    Intrinsic,
+    /// Boolean literal (`true`, `false`).
+    Boolean,
+    /// Integer literal — decimal (`42`), hex (`0xFF`), or binary
+    /// (`0b1010`).
+    Number,
+    /// Built-in type name (`u8`, `bool`).
+    Type,
+    /// User-defined identifier (function names, parameter names,
+    /// `let`-bound names, variable references).
+    Variable,
+    /// Arithmetic, relational, assignment, or bitwise operator.
+    Operator,
+    /// Grouping / separation punctuation.
+    Punctuation,
+    /// Line comment payload (`// …` to end of line).
+    Comment,
+}
+
+impl TokenKind {
+    /// Stable string mnemonic.
+    pub fn mnemonic(self) -> &'static str {
+        match self {
+            TokenKind::Keyword     => "keyword",
+            TokenKind::Intrinsic   => "macro",
+            TokenKind::Boolean     => "boolean",
+            TokenKind::Number      => "number",
+            TokenKind::Type        => "type",
+            TokenKind::Variable    => "variable",
+            TokenKind::Operator    => "operator",
+            TokenKind::Punctuation => "punctuation",
+            TokenKind::Comment     => "comment",
+        }
+    }
+}
+
+impl fmt::Display for TokenKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.mnemonic())
+    }
+}
+
+// ===========================================================================
+// SemanticToken
+// ===========================================================================
+
+/// One semantic token — a position + length + kind triple.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SemanticToken {
+    /// 1-based source line.
+    pub line: u32,
+    /// 1-based starting column.
+    pub column: u32,
+    /// Token width in monospace cells.
+    pub length: u32,
+    /// Classification.
+    pub kind: TokenKind,
+}
+
+// ===========================================================================
+// Oct keyword sets
+// ===========================================================================
+
+/// Control-flow / declaration keywords — get [`TokenKind::Keyword`].
+const OCT_KEYWORDS: &[&str] = &[
+    "fn", "let", "static",
+    "if", "else", "while", "loop", "break", "return",
+];
+
+/// 8008 hardware intrinsics — get [`TokenKind::Intrinsic`].  Oct
+/// classifies these as KEYWORD in the lexer (they're reserved
+/// words), but semantically they're closer to CPU ops than to
+/// control-flow keywords.
+const OCT_INTRINSICS: &[&str] = &[
+    "in", "out", "adc", "sbb", "rlc", "rrc", "ral", "rar",
+    "carry", "parity",
+];
+
+/// Built-in Oct types — get [`TokenKind::Type`].  Oct V1 has only
+/// `u8` and `bool` at the source level (narrower types like u4 are
+/// reserved for future versions); both come through as NAME tokens.
+const OCT_TYPES: &[&str] = &["u8", "bool"];
+
+fn is_oct_keyword(s: &str)   -> bool { OCT_KEYWORDS.contains(&s) }
+fn is_oct_intrinsic(s: &str) -> bool { OCT_INTRINSICS.contains(&s) }
+fn is_oct_type(s: &str)      -> bool { OCT_TYPES.contains(&s) }
+
+// ===========================================================================
+// Public entry points
+// ===========================================================================
+
+/// Tokenise `source` and return its semantic tokens in document
+/// order.
+pub fn semantic_tokens(source: &str) -> Vec<SemanticToken> {
+    let tokens = tokenize_oct(source);
+    tokens_from(&tokens)
+}
+
+/// Walk an already-tokenised stream and return its semantic tokens
+/// in document order.
+pub fn tokens_from(tokens: &[Token]) -> Vec<SemanticToken> {
+    let mut out: Vec<SemanticToken> = Vec::with_capacity(tokens.len());
+    for tok in tokens {
+        if let Some(kind) = classify(tok) {
+            out.push(SemanticToken {
+                line:   tok.line as u32,
+                column: tok.column as u32,
+                length: token_length(tok) as u32,
+                kind,
+            });
+        }
+    }
+    out
+}
+
+// ===========================================================================
+// Classification
+// ===========================================================================
+
+fn classify(tok: &Token) -> Option<TokenKind> {
+    // 1.  Built-in trivia tokens are skipped.
+    match tok.type_ {
+        TokenType::Newline | TokenType::Eof
+        | TokenType::Indent | TokenType::Dedent
+            => return None,
+        // Built-in operators / punctuation that come through with a
+        // standard TokenType (mostly fallbacks for the grammar's
+        // custom-named variants — Oct's grammar attaches custom
+        // names to almost every operator, so these rarely fire).
+        TokenType::Plus | TokenType::Minus
+        | TokenType::Star | TokenType::Slash
+        | TokenType::Equals | TokenType::Bang
+            => return Some(TokenKind::Operator),
+        TokenType::Comma | TokenType::Semicolon | TokenType::Colon
+            => return Some(TokenKind::Punctuation),
+        _ => {}
+    }
+
+    // 2.  Grammar-attached type names — the common path.
+    let etype = tok.effective_type_name();
+
+    // Booleans
+    if etype == "true" || etype == "false" {
+        return Some(TokenKind::Boolean);
+    }
+    // Intrinsics (checked before Keyword because the intersection is
+    // empty — there's no `in`/`out` in OCT_KEYWORDS — but listing
+    // intrinsics first makes the intent explicit).
+    if is_oct_intrinsic(etype) {
+        return Some(TokenKind::Intrinsic);
+    }
+    if is_oct_keyword(etype) {
+        return Some(TokenKind::Keyword);
+    }
+
+    match etype {
+        "INT_LIT" | "HEX_LIT" | "BIN_LIT" => Some(TokenKind::Number),
+        "NAME" => {
+            if is_oct_type(&tok.value) {
+                Some(TokenKind::Type)
+            } else {
+                Some(TokenKind::Variable)
+            }
+        }
+        "LINE_COMMENT" => Some(TokenKind::Comment),
+        // Custom-named operators
+        "EQ" | "EQ_EQ" | "NEQ" | "LEQ" | "GEQ" | "LT" | "GT"
+        | "LAND" | "LOR"
+        | "PLUS" | "MINUS" | "AMP" | "PIPE" | "CARET"
+        | "TILDE" | "BANG"
+            => Some(TokenKind::Operator),
+        // Custom-named punctuation
+        "ARROW" | "LBRACE" | "RBRACE" | "LPAREN" | "RPAREN"
+        | "COLON" | "SEMICOLON" | "COMMA"
+            => Some(TokenKind::Punctuation),
+        // Drop whitespace explicitly (it usually never reaches
+        // tokens_from but be defensive).
+        "WHITESPACE" => None,
+        _ => None,
+    }
+}
+
+fn token_length(tok: &Token) -> usize {
+    tok.value.chars().count()
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tokens_returns_in_document_order() {
+        let toks = semantic_tokens("fn main() { let x: u8 = 42; }");
+        let mut last = (0u32, 0u32);
+        for t in &toks {
+            let here = (t.line, t.column);
+            assert!(here >= last, "out of order: {last:?} -> {here:?}");
+            last = here;
+        }
+    }
+
+    #[test]
+    fn classifies_keywords() {
+        let toks = semantic_tokens("fn main() { if true { return; } }");
+        let keyword_count = toks.iter().filter(|t| t.kind == TokenKind::Keyword).count();
+        // `fn`, `if`, `return` — 3 keywords.
+        assert!(keyword_count >= 3, "expected at least 3 keywords; got {keyword_count}: {toks:?}");
+    }
+
+    #[test]
+    fn classifies_intrinsics() {
+        let toks = semantic_tokens("fn t() { out(1, 0); let c: bool = carry(); }");
+        // Should have at least 2 Intrinsics (`out`, `carry`).
+        let intrinsic_count = toks.iter().filter(|t| t.kind == TokenKind::Intrinsic).count();
+        assert!(intrinsic_count >= 2,
+            "expected at least 2 Intrinsics; got {intrinsic_count}: {toks:?}");
+    }
+
+    #[test]
+    fn classifies_true_false_as_boolean() {
+        let toks = semantic_tokens("fn t() -> bool { return true; }");
+        assert!(toks.iter().any(|t| t.kind == TokenKind::Boolean),
+            "expected a Boolean for `true`; got {toks:?}");
+        let toks2 = semantic_tokens("fn t() -> bool { return false; }");
+        assert!(toks2.iter().any(|t| t.kind == TokenKind::Boolean),
+            "expected a Boolean for `false`; got {toks2:?}");
+    }
+
+    #[test]
+    fn classifies_int_hex_bin_literals_as_number() {
+        for src in &[
+            "fn t() { let x: u8 = 42; }",
+            "fn t() { let x: u8 = 0xFF; }",
+            "fn t() { let x: u8 = 0b1010; }",
+        ] {
+            let toks = semantic_tokens(src);
+            assert!(toks.iter().any(|t| t.kind == TokenKind::Number),
+                "expected a Number in {src:?}; got {toks:?}");
+        }
+    }
+
+    #[test]
+    fn classifies_type_names() {
+        for ty in &["u8", "bool"] {
+            let src = format!("fn t() {{ let x: {ty} = 1; }}");
+            let toks = semantic_tokens(&src);
+            assert!(toks.iter().any(|t| t.kind == TokenKind::Type),
+                "expected Type for {ty}; got {toks:?}");
+        }
+    }
+
+    #[test]
+    fn classifies_user_name_as_variable() {
+        let toks = semantic_tokens("fn main() { let x: u8 = 1; }");
+        let vars: Vec<_> = toks.iter().filter(|t| t.kind == TokenKind::Variable).collect();
+        // `main` and `x` should both be Variables.
+        assert!(vars.len() >= 2, "expected at least 2 Variables; got {vars:?}");
+    }
+
+    #[test]
+    fn classifies_operators_and_punctuation() {
+        let toks = semantic_tokens("fn t() { let x: u8 = 1 + 2; if x == 3 { x = x - 1; } }");
+        assert!(toks.iter().any(|t| t.kind == TokenKind::Operator),
+            "expected Operator; got {toks:?}");
+        assert!(toks.iter().any(|t| t.kind == TokenKind::Punctuation),
+            "expected Punctuation; got {toks:?}");
+    }
+
+    #[test]
+    fn token_kind_mnemonic_stable() {
+        assert_eq!(TokenKind::Keyword.mnemonic(),     "keyword");
+        assert_eq!(TokenKind::Intrinsic.mnemonic(),   "macro");
+        assert_eq!(TokenKind::Boolean.mnemonic(),     "boolean");
+        assert_eq!(TokenKind::Number.mnemonic(),      "number");
+        assert_eq!(TokenKind::Type.mnemonic(),        "type");
+        assert_eq!(TokenKind::Variable.mnemonic(),    "variable");
+        assert_eq!(TokenKind::Operator.mnemonic(),    "operator");
+        assert_eq!(TokenKind::Punctuation.mnemonic(), "punctuation");
+        assert_eq!(TokenKind::Comment.mnemonic(),     "comment");
+    }
+
+    /// Intrinsic vs Keyword separation — both classes must appear in
+    /// the same program and be distinguished.
+    #[test]
+    fn keyword_and_intrinsic_are_distinct() {
+        let toks = semantic_tokens("fn t() { if true { out(1, 0); } }");
+        let has_kw  = toks.iter().any(|t| t.kind == TokenKind::Keyword);
+        let has_int = toks.iter().any(|t| t.kind == TokenKind::Intrinsic);
+        assert!(has_kw  && has_int,
+            "expected both Keyword AND Intrinsic in same program; got {toks:?}");
+    }
+}


### PR DESCRIPTION
## Summary

New \`oct-semantic-tokens\` crate — **completes the syntax-highlighting phase** across BASIC, Nib, and Oct (task #40 part 3 of 3).

## Surface

- \`TokenKind\` enum (Keyword, Intrinsic, Boolean, Number, Type, Variable, Operator, Punctuation, Comment).
- **\`Intrinsic\` is Oct-specific**: the 8008 hardware intrinsics (\`in\` / \`out\` / \`adc\` / \`sbb\` / \`rlc\` / \`rrc\` / \`ral\` / \`rar\` / \`carry\` / \`parity\`) are classified separately from ordinary control-flow keywords so editor themes can colour CPU ops distinctly.
- \`SemanticToken\` struct + \`semantic_tokens(source)\` and \`tokens_from(tokens)\` — same shape as basic-semantic-tokens / nib-semantic-tokens.

## Versions

- \`oct-semantic-tokens\` 0.1.0 (new crate)

## Test plan

- [x] 10 unit tests pass — covers each TokenKind variant plus the Keyword/Intrinsic separation invariant
- [x] \`/security-review\` passed — no vulnerabilities (pure library, no unsafe)

This is the final PR in the **syntax-highlighting phase**:
- task #38: basic-semantic-tokens (PR #4717)
- task #39: nib-semantic-tokens (PR #4718)
- task #40: oct-semantic-tokens (this PR)

Per the user's original priority order (JIT → AOT → debugger → syntax → LSP → formatter), all four early phases are now landed.  Next phase: LSP (basic-lsp-bridge / nib-lsp-bridge / oct-lsp-bridge, plus per-language completion / hover / document-symbols / folding-ranges crates as twig already has).

🤖 Generated with [Claude Code](https://claude.com/claude-code)