### PR TITLE
feat(ruby-ir): lower fixed-arity array patterns structurally (Phase 13a FC)

### DIFF
--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.75.0] - 2026-06-01
+
+### Changed (Phase 13a (FC) — fixed-arity array patterns lower structurally)
+
+`case/in` array patterns whose elements are all simple (`literal_pattern`
+or `binding_pattern`) now lower to a real structural match instead of the
+v0 `BuiltinCall("__pattern_match__", …)` marker:
+
+```text
+case x
+in [1, b, 3] then …    # cond:   ((len(x) == 3) && (x[0] == 1)) && (x[2] == 3)
+                       # prefix: let b = x[1]   (runs only in the match arm)
+```
+
+The length check (`SeqLen == N`) leads the short-circuiting `&&`
+(`Expr::LogicalAnd`) chain so every `x[i]` (`Expr::SeqIndex`) is in bounds
+before evaluation, and binding `LetBinding`s run only in the match body
+(where the whole condition already held).  `Feature::Sequences` is
+requested for the new sequence nodes.
+
+Nested sub-patterns (`in [[1], 2]`) and all hash patterns keep the v0
+`__pattern_match__` marker (refactored into a shared
+`pattern_match_marker` helper) — to be replaced in a later phase per the
+Tier-3 marker-replacement convention.
+
+New / updated lowering pins:
+`case_in_literal_array_pattern_lowers_to_structural_match` (replaces the
+old marker assertion), `case_in_array_pattern_binds_name_elements`
+(`in [a, b]` → element bindings), `case_in_nested_array_pattern_keeps_marker_fallback`,
+`case_in_array_pattern_validates_e2e` (manifest + validator round-trip).
+Test count: 301 → 304.
+
 ## [0.74.0] - 2026-06-01
 
 ### Changed (Phase 17a (FC) — heredoc bodies interpolate)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -5922,7 +5922,10 @@ b = "y"
     // Patterns covered here:
     //   literal_pattern  → `==` comparison cond, no bindings
     //   binding_pattern  → `BoolLit(true)` cond + LetBinding prefix
-    //   array_pattern    → `__pattern_match__` marker, no bindings
+    //   array_pattern    → Phase 13a: fixed-arity literal/binding
+    //                      elements lower structurally (`len(s)==N &&
+    //                      s[i]==lit …` + element LetBindings); nested
+    //                      sub-patterns keep the `__pattern_match__` marker
     //   hash_pattern     → `__pattern_match__` marker, no bindings
     // -----------------------------------------------------------------------
 
@@ -6008,9 +6011,12 @@ b = "y"
     }
 
     #[test]
-    fn case_in_array_pattern_lowers_to_pattern_match_marker() {
-        // `case x; in [1, 2]; "pair"; end` — array pattern lowers as
-        // `BuiltinCall("__pattern_match__", [scrut, StrLit("<raw>")])`.
+    fn case_in_literal_array_pattern_lowers_to_structural_match() {
+        // Phase 13a (FC) — `case x; in [1, 2]; "pair"; end` — a
+        // fixed-arity all-literal array pattern lowers structurally to
+        // `((len(x) == 2) && (x[0] == 1)) && (x[1] == 2)` (an AND-chain
+        // of a length check and per-element equality), no longer the
+        // `__pattern_match__` marker.
         let m = lower("x = 1\ncase x\nin [1, 2]\n  \"pair\"\nend\n");
         let b = main_body(&m);
         let if_expr = extract_case_if(b);
@@ -6018,24 +6024,109 @@ b = "y"
             Expr::If { cond, .. } => cond,
             other => panic!("expected If, got {:?}", other),
         };
-        match cond.as_ref() {
-            Expr::BuiltinCall { name, args, .. } => {
-                assert_eq!(name, "__pattern_match__");
-                assert_eq!(args.len(), 2);
-                // args[1] is StrLit with the raw pattern text.
-                match &args[1] {
-                    Expr::StrLit { value, .. } => {
-                        assert!(
-                            value.contains('1') && value.contains('2'),
-                            "expected raw text to contain `1` and `2`, got `{}`",
-                            value
-                        );
-                    }
-                    other => panic!("expected StrLit raw pattern, got {:?}", other),
-                }
+        // Outermost node is the final `&& (x[1] == 2)`.
+        let (lhs, rhs) = match cond.as_ref() {
+            Expr::LogicalAnd { lhs, rhs, .. } => (lhs, rhs),
+            other => panic!("expected LogicalAnd cond, got {:?}", other),
+        };
+        // rhs: x[1] == 2
+        match rhs.as_ref() {
+            Expr::BuiltinCall { name, args, .. } if name == "==" => {
+                assert!(matches!(&args[0], Expr::SeqIndex { .. }));
+                assert!(matches!(&args[1], Expr::IntLit { value: 2, .. }));
             }
-            other => panic!("expected __pattern_match__ BuiltinCall, got {:?}", other),
+            other => panic!("expected `x[1] == 2`, got {:?}", other),
         }
+        // lhs: (len(x) == 2) && (x[0] == 1)
+        let (len_chk, first) = match lhs.as_ref() {
+            Expr::LogicalAnd { lhs, rhs, .. } => (lhs, rhs),
+            other => panic!("expected nested LogicalAnd, got {:?}", other),
+        };
+        match len_chk.as_ref() {
+            Expr::BuiltinCall { name, args, .. } if name == "==" => {
+                assert!(matches!(&args[0], Expr::SeqLen { .. }), "expected len() check");
+                assert!(matches!(&args[1], Expr::IntLit { value: 2, .. }));
+            }
+            other => panic!("expected `len(x) == 2`, got {:?}", other),
+        }
+        assert!(
+            matches!(first.as_ref(), Expr::BuiltinCall { name, .. } if name == "=="),
+            "expected `x[0] == 1`, got {:?}", first
+        );
+    }
+
+    #[test]
+    fn case_in_array_pattern_binds_name_elements() {
+        // Phase 13a (FC) — `in [a, b]` matches any 2-element sequence and
+        // binds `a = x[0]`, `b = x[1]` as prefix LetBindings in the body.
+        // Cond is just the length check (no per-element equality).
+        let m = lower("x = 1\ncase x\nin [a, b]\n  puts(a)\nend\n");
+        let b = main_body(&m);
+        let if_expr = extract_case_if(b);
+        let (cond, then_branch) = match if_expr {
+            Expr::If { cond, then_branch, .. } => (cond, then_branch),
+            other => panic!("expected If, got {:?}", other),
+        };
+        // Cond: len(x) == 2 (no element equality for pure bindings).
+        match cond.as_ref() {
+            Expr::BuiltinCall { name, args, .. } if name == "==" => {
+                assert!(matches!(&args[0], Expr::SeqLen { .. }));
+                assert!(matches!(&args[1], Expr::IntLit { value: 2, .. }));
+            }
+            other => panic!("expected `len(x) == 2` cond, got {:?}", other),
+        }
+        // Body prefix: let a = x[0]; let b = x[1].
+        let names: Vec<&str> = then_branch
+            .stmts
+            .iter()
+            .filter_map(|s| match s {
+                Stmt::LetBinding { name, value, .. }
+                    if matches!(value, Expr::SeqIndex { .. }) =>
+                {
+                    Some(name.as_str())
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(names, vec!["a", "b"], "expected element bindings a, b");
+    }
+
+    #[test]
+    fn case_in_nested_array_pattern_keeps_marker_fallback() {
+        // Phase 13a (FC) — a nested sub-pattern (`[[1], 2]`) is not yet
+        // supported structurally, so the whole pattern keeps the v0
+        // `__pattern_match__` marker.
+        let m = lower("x = 1\ncase x\nin [[1], 2]\n  \"nested\"\nend\n");
+        let b = main_body(&m);
+        let if_expr = extract_case_if(b);
+        let cond = match if_expr {
+            Expr::If { cond, .. } => cond,
+            other => panic!("expected If, got {:?}", other),
+        };
+        assert!(
+            matches!(cond.as_ref(), Expr::BuiltinCall { name, .. } if name == "__pattern_match__"),
+            "expected __pattern_match__ marker for nested pattern, got {:?}",
+            cond
+        );
+    }
+
+    #[test]
+    fn case_in_array_pattern_validates_e2e() {
+        // Phase 13a (FC) — end-to-end: a binding array pattern lowers to
+        // real SIR (`SeqLen`/`SeqIndex` + `LetBinding`) that round-trips
+        // the SIR validator, and declares `Feature::Sequences`.
+        let m = lower("x = 1\ncase x\nin [a, b]\n  puts(a)\nend\n");
+        assert!(
+            m.manifest.contains(semantic_ir::Feature::Sequences),
+            "expected Sequences feature; got {:?}",
+            m.manifest
+        );
+        let result = semantic_ir::validate(&m);
+        assert!(
+            result.is_ok(),
+            "validator rejected array-pattern module: {:?}",
+            result
+        );
     }
 
     #[test]

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -1570,29 +1570,40 @@ impl Lowerer {
                 };
                 Ok((Expr::BoolLit { value: true, span }, vec![prefix]))
             }
-            "array_pattern" | "hash_pattern" => {
-                // v0 marker: emit `BuiltinCall("__pattern_match__",
-                // [scrutinee, StrLit(<raw pattern text>)])`.  The raw
-                // text is reconstructed by joining the immediate Token
-                // children of the pattern node — good enough for
-                // round-tripping the pattern back to a Ruby emitter.
-                let raw = self.pattern_node_raw_text(inner);
-                self.features_used.insert(Feature::Strings);
-                Ok((
-                    Expr::BuiltinCall {
-                        name: "__pattern_match__".to_string(),
-                        args: vec![
-                            scrutinee.clone(),
-                            Expr::StrLit {
-                                value: raw,
-                                span: span.clone(),
-                            },
-                        ],
-                        effects: EffectSet::PURE,
-                        span,
-                    },
-                    Vec::new(),
-                ))
+            "array_pattern" => {
+                // Phase 13a (FC) — a fixed-arity array pattern whose
+                // elements are all simple (literal_pattern /
+                // binding_pattern) lowers to a real structural match:
+                // a length check ANDed with per-element equality
+                // checks, plus a `LetBinding` for every binding element.
+                // Nested array/hash elements are not yet supported and
+                // fall back to the v0 `__pattern_match__` marker (kept
+                // for one phase per the Tier-3 marker-replacement
+                // convention).
+                let elem_patterns: Vec<&GrammarASTNode> = inner
+                    .children
+                    .iter()
+                    .filter_map(|c| match c {
+                        ASTNodeOrToken::Node(n) if n.rule_name == "pattern" => Some(n),
+                        _ => None,
+                    })
+                    .collect();
+                let all_simple = elem_patterns.iter().all(|p| {
+                    matches!(
+                        self.first_node_child(p).map(|n| n.rule_name.as_str()),
+                        Some("literal_pattern") | Some("binding_pattern")
+                    )
+                });
+                if all_simple {
+                    self.lower_fixed_array_pattern(&elem_patterns, scrutinee, span)
+                } else {
+                    Ok(self.pattern_match_marker(inner, scrutinee, span))
+                }
+            }
+            "hash_pattern" => {
+                // v0 marker (unchanged): hash patterns keep the
+                // `__pattern_match__` marker pending a future phase.
+                Ok(self.pattern_match_marker(inner, scrutinee, span))
             }
             other => Err(RubyLowerError {
                 message: format!("unknown pattern kind `{}` in in_clause", other),
@@ -1600,6 +1611,155 @@ impl Lowerer {
                 column: inner.start_column.unwrap_or(0),
             }),
         }
+    }
+
+    /// Phase 13a (FC) — the v0 `__pattern_match__` marker for patterns
+    /// we cannot yet lower structurally (hash patterns, array patterns
+    /// with nested sub-patterns).  Emits
+    /// `BuiltinCall("__pattern_match__", [scrutinee, StrLit(<raw text>)])`
+    /// — the raw text round-trips the pattern back to a Ruby emitter.
+    /// Returns no body-prefix statements (the marker binds nothing).
+    fn pattern_match_marker(
+        &mut self,
+        inner: &GrammarASTNode,
+        scrutinee: &Expr,
+        span: Span,
+    ) -> (Expr, Vec<Stmt>) {
+        let raw = self.pattern_node_raw_text(inner);
+        self.features_used.insert(Feature::Strings);
+        (
+            Expr::BuiltinCall {
+                name: "__pattern_match__".to_string(),
+                args: vec![
+                    scrutinee.clone(),
+                    Expr::StrLit {
+                        value: raw,
+                        span: span.clone(),
+                    },
+                ],
+                effects: EffectSet::PURE,
+                span,
+            },
+            Vec::new(),
+        )
+    }
+
+    /// Phase 13a (FC) — lower a fixed-arity array pattern whose elements
+    /// are all `literal_pattern` or `binding_pattern` into a real
+    /// structural match.
+    ///
+    /// `in [1, x, 3]` against scrutinee `s` produces:
+    ///
+    /// ```text
+    /// cond   = ((len(s) == 3) && (s[0] == 1)) && (s[2] == 3)
+    /// prefix = [ let x = s[1] ]
+    /// ```
+    ///
+    /// The length check leads so the short-circuiting `&&`
+    /// (`Expr::LogicalAnd`) guarantees every `s[i]` index is in bounds
+    /// before it is evaluated, and the binding `LetBinding`s run only in
+    /// the match arm's body (where the whole condition already held), so
+    /// they too are in bounds.  `Feature::Sequences` is requested for the
+    /// `SeqLen` / `SeqIndex` nodes.
+    fn lower_fixed_array_pattern(
+        &mut self,
+        elems: &[&GrammarASTNode],
+        scrutinee: &Expr,
+        span: Span,
+    ) -> Result<(Expr, Vec<Stmt>), RubyLowerError> {
+        self.features_used.insert(Feature::Sequences);
+
+        // Length check: `len(scrutinee) == elems.len()`.
+        let mut cond = Expr::BuiltinCall {
+            name: "==".to_string(),
+            args: vec![
+                Expr::SeqLen {
+                    seq: Box::new(scrutinee.clone()),
+                    span: span.clone(),
+                },
+                Expr::IntLit {
+                    value: elems.len() as i64,
+                    span: span.clone(),
+                },
+            ],
+            effects: EffectSet::PURE,
+            span: span.clone(),
+        };
+
+        let mut prefix: Vec<Stmt> = Vec::new();
+        for (i, p) in elems.iter().enumerate() {
+            // `first_node_child` is guaranteed `Some` and one of
+            // literal_pattern / binding_pattern because the caller only
+            // routes here when `all_simple` held.
+            let elem_inner = self.first_node_child(p).ok_or_else(|| RubyLowerError {
+                message: "array_pattern element missing inner pattern".to_string(),
+                line: p.start_line.unwrap_or(0),
+                column: p.start_column.unwrap_or(0),
+            })?;
+            let index = Expr::SeqIndex {
+                seq: Box::new(scrutinee.clone()),
+                index: Box::new(Expr::IntLit {
+                    value: i as i64,
+                    span: span.clone(),
+                }),
+                span: span.clone(),
+            };
+            match elem_inner.rule_name.as_str() {
+                "literal_pattern" => {
+                    // Append `s[i] == lit` to the AND-chain.
+                    let lit = self.lower_pattern_literal(elem_inner)?;
+                    let eq = Expr::BuiltinCall {
+                        name: "==".to_string(),
+                        args: vec![index, lit],
+                        effects: EffectSet::PURE,
+                        span: span.clone(),
+                    };
+                    cond = Expr::LogicalAnd {
+                        lhs: Box::new(cond),
+                        rhs: Box::new(eq),
+                        span: span.clone(),
+                    };
+                }
+                "binding_pattern" => {
+                    // Bind `name = s[i]` (runs in the match body only).
+                    let name_tok = elem_inner
+                        .children
+                        .iter()
+                        .find_map(|c| match c {
+                            ASTNodeOrToken::Token(t)
+                                if matches!(t.type_, TokenType::Name) =>
+                            {
+                                Some(t)
+                            }
+                            _ => None,
+                        })
+                        .ok_or_else(|| RubyLowerError {
+                            message: "binding_pattern missing Name token".to_string(),
+                            line: elem_inner.start_line.unwrap_or(0),
+                            column: elem_inner.start_column.unwrap_or(0),
+                        })?;
+                    let bind_name = name_tok.value.clone();
+                    self.declared_locals.insert(bind_name.clone());
+                    prefix.push(Stmt::LetBinding {
+                        name: bind_name,
+                        sir_type: None,
+                        value: index,
+                        span: self.span_of_token(name_tok),
+                    });
+                }
+                other => {
+                    return Err(RubyLowerError {
+                        message: format!(
+                            "lower_fixed_array_pattern reached non-simple element `{}`",
+                            other
+                        ),
+                        line: elem_inner.start_line.unwrap_or(0),
+                        column: elem_inner.start_column.unwrap_or(0),
+                    });
+                }
+            }
+        }
+        Ok((cond, prefix))
     }
 
     /// Lower a `literal_pattern` Node into its `Expr` form.  Mirrors


### PR DESCRIPTION
## Phase 13a (FC) — fixed-arity array patterns lower structurally

Part of the Ruby 3.4 frontend full-coverage effort. `case/in` pattern
matching (Phase 7d) already lowered literal and bare-name patterns, but
**array and hash patterns fell back to an opaque
`BuiltinCall("__pattern_match__", [scrutinee, StrLit(raw)])` marker**.

### What

An array pattern whose elements are all simple (`literal_pattern` or
`binding_pattern`) now lowers to a **real structural match**:

```text
case x
in [1, b, 3] then …
#   cond:   ((len(x) == 3) && (x[0] == 1)) && (x[2] == 3)
#   prefix: let b = x[1]     (runs only in the match arm body)
```

- Length check `SeqLen(x) == N` leads the short-circuiting `&&`
  (`Expr::LogicalAnd`) chain, so every `x[i]` (`Expr::SeqIndex`) is in
  bounds before it's evaluated.
- Binding elements become `LetBinding`s prepended to the match arm body
  (which only runs when the whole condition — including the length
  check — held), so they're in bounds too.
- `Feature::Sequences` is requested for the new sequence nodes.

### Scope / fallback

Nested sub-patterns (`in [[1], 2]`) and **all hash patterns** keep the v0
`__pattern_match__` marker (refactored into a shared
`pattern_match_marker` helper) — to be replaced in a later phase per the
Tier-3 marker-replacement convention. Lowering-only
(`ruby-to-semantic-ir`); lexer/parser/grammar untouched (case/in already
parses).

### Tests

`case_in_literal_array_pattern_lowers_to_structural_match` (replaces the
old marker assertion), `case_in_array_pattern_binds_name_elements`
(`in [a, b]` → element bindings), `case_in_nested_array_pattern_keeps_marker_fallback`,
`case_in_array_pattern_validates_e2e` (manifest + validator round-trip).
lexer 173 / parser 238 / ruby-IR 301 → 304 green. CHANGELOG 0.74.0 →
0.75.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
