### PR TITLE
feat(ruby-ir): lower nested array patterns structurally (Phase 13b FC)

### DIFF
--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.76.0] - 2026-06-01
+
+### Changed (Phase 13b (FC) — nested array patterns lower structurally)
+
+`case/in` array patterns now lower **recursively**: a nested array
+sub-pattern (`in [[1], y]`) is matched structurally instead of dropping
+the whole pattern to the `__pattern_match__` marker.
+`lower_fixed_array_pattern` was generalized to `lower_array_pattern`,
+which takes a `target` expression (the scrutinee, or a `SeqIndex` into it
+for a nested level) and recurses on `array_pattern` elements:
+
+```text
+in [[1], y]   # cond:   ((len(x)==2) && ((len(x[0])==1) && (x[0][0]==1)))
+              # prefix: let y = x[1]
+```
+
+Each level's length check leads its sub-match in the short-circuiting
+`&&` (`Expr::LogicalAnd`) chain, so every `SeqIndex` is in bounds before
+evaluation (outer length → element → inner length → …). A new recursive
+`array_pattern_is_lowerable` gate decides marker-vs-structural: literal /
+binding / nested-array elements are lowerable; **hash sub-patterns at any
+depth** keep the whole pattern on the `__pattern_match__` marker.
+
+Also declares `Feature::ShortCircuit` whenever a structural pattern emits
+`Expr::LogicalAnd` (a literal or nested element) and adds it to the
+manifest builder allowlist — fixing a latent gap where a literal array
+pattern (`in [1, 2]`, Phase 13a) emitted `LogicalAnd` without declaring
+the feature (not previously exercised through the validator).
+
+New / updated lowering pins: `case_in_nested_array_pattern_lowers_structurally`
+(replaces the 13a marker assertion), `case_in_array_with_hash_element_keeps_marker_fallback`,
+`case_in_literal_array_pattern_validates_e2e` (ShortCircuit regression),
+`case_in_nested_array_pattern_validates_e2e`. Test count: 304 → 307.
+
 ## [0.75.0] - 2026-06-01
 
 ### Changed (Phase 13a (FC) — fixed-arity array patterns lower structurally)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -6092,11 +6092,46 @@ b = "y"
     }
 
     #[test]
-    fn case_in_nested_array_pattern_keeps_marker_fallback() {
-        // Phase 13a (FC) — a nested sub-pattern (`[[1], 2]`) is not yet
-        // supported structurally, so the whole pattern keeps the v0
-        // `__pattern_match__` marker.
-        let m = lower("x = 1\ncase x\nin [[1], 2]\n  \"nested\"\nend\n");
+    fn case_in_nested_array_pattern_lowers_structurally() {
+        // Phase 13b (FC) — a nested array sub-pattern (`[[1], y]`) now
+        // lowers structurally: the cond AND-chain contains an inner
+        // `len(x[0]) == 1` check (proving recursion into `x[0]`), and the
+        // body binds `y = x[1]`.
+        let m = lower("x = 1\ncase x\nin [[1], y]\n  puts(y)\nend\n");
+        let b = main_body(&m);
+        let if_expr = extract_case_if(b);
+        let (cond, then_branch) = match if_expr {
+            Expr::If { cond, then_branch, .. } => (cond, then_branch),
+            other => panic!("expected If, got {:?}", other),
+        };
+        // No __pattern_match__ marker anywhere in the cond tree.
+        let printed = format!("{:?}", cond);
+        assert!(
+            !printed.contains("__pattern_match__"),
+            "expected no marker in nested pattern cond, got {}",
+            printed
+        );
+        // The cond must contain a nested SeqLen over a SeqIndex
+        // (`len(x[0])`), which only the recursive lowering produces.
+        assert!(
+            printed.contains("SeqLen") && printed.contains("SeqIndex"),
+            "expected nested SeqLen(SeqIndex(..)) in cond, got {}",
+            printed
+        );
+        // Body binds `y = x[1]`.
+        let has_y = then_branch.stmts.iter().any(|s| {
+            matches!(s, Stmt::LetBinding { name, value, .. }
+                if name == "y" && matches!(value, Expr::SeqIndex { .. }))
+        });
+        assert!(has_y, "expected `let y = x[1]` binding in body");
+    }
+
+    #[test]
+    fn case_in_array_with_hash_element_keeps_marker_fallback() {
+        // Phase 13b (FC) — a hash sub-pattern is still unsupported, so an
+        // array pattern containing one (`[{a: 1}, 2]`) falls back to the
+        // whole-pattern `__pattern_match__` marker.
+        let m = lower("x = 1\ncase x\nin [{a: 1}, 2]\n  \"h\"\nend\n");
         let b = main_body(&m);
         let if_expr = extract_case_if(b);
         let cond = match if_expr {
@@ -6105,8 +6140,46 @@ b = "y"
         };
         assert!(
             matches!(cond.as_ref(), Expr::BuiltinCall { name, .. } if name == "__pattern_match__"),
-            "expected __pattern_match__ marker for nested pattern, got {:?}",
+            "expected __pattern_match__ marker for hash-in-array pattern, got {:?}",
             cond
+        );
+    }
+
+    #[test]
+    fn case_in_literal_array_pattern_validates_e2e() {
+        // Phase 13b (FC) — regression: a literal array pattern emits
+        // `Expr::LogicalAnd`, so the module observes `Feature::ShortCircuit`
+        // and the manifest must declare it (a gap not exercised through
+        // the validator by the Phase 13a binding-only E2E test).
+        let m = lower("x = 1\ncase x\nin [1, 2]\n  puts(x)\nend\n");
+        assert!(
+            m.manifest.contains(semantic_ir::Feature::ShortCircuit),
+            "expected ShortCircuit feature for literal array pattern; got {:?}",
+            m.manifest
+        );
+        let result = semantic_ir::validate(&m);
+        assert!(
+            result.is_ok(),
+            "validator rejected literal-array-pattern module: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn case_in_nested_array_pattern_validates_e2e() {
+        // Phase 13b (FC) — end-to-end: a nested binding array pattern
+        // lowers to real recursive SIR that round-trips the validator.
+        let m = lower("x = 1\ncase x\nin [[a], b]\n  puts(a)\nend\n");
+        assert!(
+            m.manifest.contains(semantic_ir::Feature::Sequences),
+            "expected Sequences feature; got {:?}",
+            m.manifest
+        );
+        let result = semantic_ir::validate(&m);
+        assert!(
+            result.is_ok(),
+            "validator rejected nested-array-pattern module: {:?}",
+            result
         );
     }
 

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -140,6 +140,10 @@ pub fn compile(program: &GrammarASTNode, module_name: &str) -> Result<Module, Ru
         // (`"a#{x}b"`) lowers to `Expr::StrConcat` and triggers the
         // `StringInterpolation` feature.
         Feature::StringInterpolation,
+        // Phase 13a/13b (FC) — a structural array pattern with a literal
+        // or nested element ANDs its checks via `Expr::LogicalAnd`, which
+        // triggers the `ShortCircuit` feature.
+        Feature::ShortCircuit,
     ] {
         if lw.features_used.contains(&f) {
             manifest.add(f);
@@ -1571,31 +1575,19 @@ impl Lowerer {
                 Ok((Expr::BoolLit { value: true, span }, vec![prefix]))
             }
             "array_pattern" => {
-                // Phase 13a (FC) — a fixed-arity array pattern whose
-                // elements are all simple (literal_pattern /
-                // binding_pattern) lowers to a real structural match:
-                // a length check ANDed with per-element equality
-                // checks, plus a `LetBinding` for every binding element.
-                // Nested array/hash elements are not yet supported and
-                // fall back to the v0 `__pattern_match__` marker (kept
-                // for one phase per the Tier-3 marker-replacement
+                // Phase 13a/13b (FC) — a fixed-arity array pattern whose
+                // every element is itself lowerable (literal_pattern,
+                // binding_pattern, or — Phase 13b — a nested
+                // `array_pattern` of the same kind) lowers to a real
+                // structural match: a length check ANDed with per-element
+                // equality checks and nested sub-conditions, plus a
+                // `LetBinding` for every binding element (at any depth).
+                // Hash sub-patterns are still unsupported and make the
+                // whole pattern fall back to the v0 `__pattern_match__`
+                // marker (kept per the Tier-3 marker-replacement
                 // convention).
-                let elem_patterns: Vec<&GrammarASTNode> = inner
-                    .children
-                    .iter()
-                    .filter_map(|c| match c {
-                        ASTNodeOrToken::Node(n) if n.rule_name == "pattern" => Some(n),
-                        _ => None,
-                    })
-                    .collect();
-                let all_simple = elem_patterns.iter().all(|p| {
-                    matches!(
-                        self.first_node_child(p).map(|n| n.rule_name.as_str()),
-                        Some("literal_pattern") | Some("binding_pattern")
-                    )
-                });
-                if all_simple {
-                    self.lower_fixed_array_pattern(&elem_patterns, scrutinee, span)
+                if self.array_pattern_is_lowerable(inner) {
+                    self.lower_array_pattern(inner, scrutinee, span)
                 } else {
                     Ok(self.pattern_match_marker(inner, scrutinee, span))
                 }
@@ -1644,37 +1636,76 @@ impl Lowerer {
         )
     }
 
-    /// Phase 13a (FC) — lower a fixed-arity array pattern whose elements
-    /// are all `literal_pattern` or `binding_pattern` into a real
-    /// structural match.
+    /// Phase 13b (FC) — collect the element `pattern` subnodes of an
+    /// `array_pattern` node, in source order.
+    fn array_pattern_elements<'a>(
+        &self,
+        array_inner: &'a GrammarASTNode,
+    ) -> Vec<&'a GrammarASTNode> {
+        array_inner
+            .children
+            .iter()
+            .filter_map(|c| match c {
+                ASTNodeOrToken::Node(n) if n.rule_name == "pattern" => Some(n),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Phase 13b (FC) — can this `array_pattern` node be lowered to a real
+    /// structural match?  True when every element is a `literal_pattern`,
+    /// a `binding_pattern`, or (recursively) a lowerable nested
+    /// `array_pattern`.  Hash sub-patterns (and any other shape) make the
+    /// whole pattern fall back to the `__pattern_match__` marker.
+    fn array_pattern_is_lowerable(&self, array_inner: &GrammarASTNode) -> bool {
+        self.array_pattern_elements(array_inner).iter().all(|p| {
+            match self.first_node_child(p) {
+                Some(elem) => match elem.rule_name.as_str() {
+                    "literal_pattern" | "binding_pattern" => true,
+                    "array_pattern" => self.array_pattern_is_lowerable(elem),
+                    _ => false,
+                },
+                None => false,
+            }
+        })
+    }
+
+    /// Phase 13a/13b (FC) — lower an `array_pattern` node into a real
+    /// structural match of `target` (the scrutinee, or a `SeqIndex` into
+    /// it for a nested pattern).
     ///
-    /// `in [1, x, 3]` against scrutinee `s` produces:
+    /// `in [1, x, [2, y]]` against `s` produces:
     ///
     /// ```text
-    /// cond   = ((len(s) == 3) && (s[0] == 1)) && (s[2] == 3)
-    /// prefix = [ let x = s[1] ]
+    /// cond   = (((len(s) == 3) && (s[0] == 1))
+    ///            && ((len(s[2]) == 2) && (s[2][0] == 2)))
+    /// prefix = [ let x = s[1], let y = s[2][1] ]
     /// ```
     ///
-    /// The length check leads so the short-circuiting `&&`
-    /// (`Expr::LogicalAnd`) guarantees every `s[i]` index is in bounds
-    /// before it is evaluated, and the binding `LetBinding`s run only in
-    /// the match arm's body (where the whole condition already held), so
-    /// they too are in bounds.  `Feature::Sequences` is requested for the
-    /// `SeqLen` / `SeqIndex` nodes.
-    fn lower_fixed_array_pattern(
+    /// Every length check leads its sub-match, and all checks are joined
+    /// with the short-circuiting `&&` (`Expr::LogicalAnd`) in the order
+    /// outer-length → element → (nested) inner-length → …, so each
+    /// `SeqIndex` is only evaluated once the enclosing length check has
+    /// held — keeping every index in bounds.  Binding `LetBinding`s run
+    /// only in the match arm's body (reached only when the whole
+    /// condition held), so they too are in bounds.  Assumes the caller
+    /// verified `array_pattern_is_lowerable`.  `Feature::Sequences` is
+    /// requested for the `SeqLen` / `SeqIndex` nodes.
+    fn lower_array_pattern(
         &mut self,
-        elems: &[&GrammarASTNode],
-        scrutinee: &Expr,
+        array_inner: &GrammarASTNode,
+        target: &Expr,
         span: Span,
     ) -> Result<(Expr, Vec<Stmt>), RubyLowerError> {
         self.features_used.insert(Feature::Sequences);
+        let elems = self.array_pattern_elements(array_inner);
 
-        // Length check: `len(scrutinee) == elems.len()`.
+        // Length check: `len(target) == elems.len()`.
         let mut cond = Expr::BuiltinCall {
             name: "==".to_string(),
             args: vec![
                 Expr::SeqLen {
-                    seq: Box::new(scrutinee.clone()),
+                    seq: Box::new(target.clone()),
                     span: span.clone(),
                 },
                 Expr::IntLit {
@@ -1688,16 +1719,15 @@ impl Lowerer {
 
         let mut prefix: Vec<Stmt> = Vec::new();
         for (i, p) in elems.iter().enumerate() {
-            // `first_node_child` is guaranteed `Some` and one of
-            // literal_pattern / binding_pattern because the caller only
-            // routes here when `all_simple` held.
             let elem_inner = self.first_node_child(p).ok_or_else(|| RubyLowerError {
                 message: "array_pattern element missing inner pattern".to_string(),
                 line: p.start_line.unwrap_or(0),
                 column: p.start_column.unwrap_or(0),
             })?;
+            // `target[i]` — reused for the equality check, the binding
+            // value, or the nested sub-match's target.
             let index = Expr::SeqIndex {
-                seq: Box::new(scrutinee.clone()),
+                seq: Box::new(target.clone()),
                 index: Box::new(Expr::IntLit {
                     value: i as i64,
                     span: span.clone(),
@@ -1706,7 +1736,7 @@ impl Lowerer {
             };
             match elem_inner.rule_name.as_str() {
                 "literal_pattern" => {
-                    // Append `s[i] == lit` to the AND-chain.
+                    // Append `target[i] == lit` to the AND-chain.
                     let lit = self.lower_pattern_literal(elem_inner)?;
                     let eq = Expr::BuiltinCall {
                         name: "==".to_string(),
@@ -1714,6 +1744,7 @@ impl Lowerer {
                         effects: EffectSet::PURE,
                         span: span.clone(),
                     };
+                    self.features_used.insert(Feature::ShortCircuit);
                     cond = Expr::LogicalAnd {
                         lhs: Box::new(cond),
                         rhs: Box::new(eq),
@@ -1721,7 +1752,7 @@ impl Lowerer {
                     };
                 }
                 "binding_pattern" => {
-                    // Bind `name = s[i]` (runs in the match body only).
+                    // Bind `name = target[i]` (runs in the match body only).
                     let name_tok = elem_inner
                         .children
                         .iter()
@@ -1747,10 +1778,26 @@ impl Lowerer {
                         span: self.span_of_token(name_tok),
                     });
                 }
+                "array_pattern" => {
+                    // Phase 13b — recurse: match `target[i]` against the
+                    // nested array pattern.  AND the sub-condition into
+                    // the chain (after this level's length check, so the
+                    // `target[i]` index is already in bounds) and append
+                    // any nested bindings to the prefix.
+                    let (sub_cond, sub_prefix) =
+                        self.lower_array_pattern(elem_inner, &index, span.clone())?;
+                    self.features_used.insert(Feature::ShortCircuit);
+                    cond = Expr::LogicalAnd {
+                        lhs: Box::new(cond),
+                        rhs: Box::new(sub_cond),
+                        span: span.clone(),
+                    };
+                    prefix.extend(sub_prefix);
+                }
                 other => {
                     return Err(RubyLowerError {
                         message: format!(
-                            "lower_fixed_array_pattern reached non-simple element `{}`",
+                            "lower_array_pattern reached non-lowerable element `{}`",
                             other
                         ),
                         line: elem_inner.start_line.unwrap_or(0),


### PR DESCRIPTION
## Phase 13b (FC) — nested array patterns lower structurally

Part of the Ruby 3.4 frontend full-coverage effort. Builds on Phase 13a
(fixed-arity array patterns). Previously a **nested** array sub-pattern
dropped the whole pattern to the `__pattern_match__` marker.

### What

`case/in` array patterns now lower **recursively**:

```text
case x
in [[1], y] then …
#   cond:   ((len(x) == 2) && ((len(x[0]) == 1) && (x[0][0] == 1)))
#   prefix: let y = x[1]
```

`lower_fixed_array_pattern` was generalized to `lower_array_pattern`,
which takes a `target` expression (the scrutinee, or a `SeqIndex` into it
for a nested level) and recurses on `array_pattern` elements. Each
level's length check leads its sub-match in the short-circuiting `&&`
(`Expr::LogicalAnd`) chain, so every `SeqIndex` is in bounds before
evaluation (outer length → element → inner length → …).

A recursive `array_pattern_is_lowerable` gate decides
marker-vs-structural: literal / binding / nested-array elements are
lowerable; **hash sub-patterns at any depth** keep the whole pattern on
the `__pattern_match__` marker (pending a future phase).

### Latent-gap fix

Declares `Feature::ShortCircuit` whenever a structural pattern emits
`Expr::LogicalAnd` (a literal or nested element) and adds it to the
manifest builder allowlist — fixing a gap where a literal array pattern
(`in [1, 2]`, Phase 13a) emitted `LogicalAnd` without declaring the
feature (the 13a binding-only validator-E2E test never exercised it).

### Scope / tests

Lowering-only (`ruby-to-semantic-ir`). `case_in_nested_array_pattern_lowers_structurally`
(replaces the 13a marker assertion), `case_in_array_with_hash_element_keeps_marker_fallback`,
`case_in_literal_array_pattern_validates_e2e` (ShortCircuit regression),
`case_in_nested_array_pattern_validates_e2e`. lexer 173 / parser 238 /
ruby-IR 304 → 307 green. CHANGELOG 0.75.0 → 0.76.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
