### PR TITLE
feat(ruby): add defined? operator (Phase 23b FC)

### DIFF
--- a/code/grammars/ruby.grammar
+++ b/code/grammars/ruby.grammar
@@ -25,7 +25,7 @@
 # than PUTS, TRUE, FALSE, NIL as token types.
 
 program      = { statement } ;
-statement    = endless_def_statement | def_statement | class_statement | module_statement | if_statement | unless_statement | while_statement | until_statement | case_statement | begin_statement | return_statement | break_statement | next_statement | redo_statement | retry_statement | yield_statement | super_statement | multi_assignment | modifier_statement | rightward_assignment | assignment | method_with_block | method_call | method_call_no_paren | expression_stmt ;
+statement    = endless_def_statement | def_statement | class_statement | module_statement | if_statement | unless_statement | while_statement | until_statement | case_statement | begin_statement | return_statement | break_statement | next_statement | redo_statement | retry_statement | yield_statement | super_statement | multi_assignment | modifier_statement | rightward_assignment | assignment | defined_expression | method_with_block | method_call | method_call_no_paren | expression_stmt ;
 # Phase 6r — multiple assignment `a, b = 1, 2`.
 #
 # Placed BEFORE `modifier_statement` and `assignment` so the multi-LHS
@@ -567,7 +567,7 @@ term         = factor { ( STAR | SLASH ) factor } ;
 # leaving `(1).bar` unconsumed.  When no parens follow the name, the
 # method_call alternative fails (requires LPAREN) and we fall through to
 # the bare-NAME branch.
-factor       = ( lambda_literal | method_call | NUMBER | STRING | NAME | KEYWORD | symbol_literal | array_literal | hash_literal | LPAREN expression RPAREN | unary_minus ) { dot_call | scope_resolution } ;
+factor       = ( defined_expression | lambda_literal | method_call | NUMBER | STRING | NAME | KEYWORD | symbol_literal | array_literal | hash_literal | LPAREN expression RPAREN | unary_minus ) { dot_call | scope_resolution } ;
 # Phase 6w — arrow-lambda literal `->(params){body}` / `->{body}`.
 #
 # Ruby 1.9+ shorthand for creating a `Proc`/`Lambda`.  The parameter
@@ -588,6 +588,17 @@ factor       = ( lambda_literal | method_call | NUMBER | STRING | NAME | KEYWORD
 # downstream emitters a single closure-construction shape.
 lambda_literal = "->" [ LPAREN [ params ] RPAREN ] block ;
 unary_minus  = MINUS factor ;
+# Phase 23b — Ruby `defined?` operator.  `defined?(expr)` / `defined? expr`
+# returns a description string of the operand (or nil if undefined); the
+# operand is never raised on.  The lexer emits `defined?` as a single
+# KEYWORD token (trailing `?` included), so we match it by VALUE.  The
+# operand is a `factor`, which covers both the parenthesised form
+# (`defined?(x)` → `LPAREN expression RPAREN`) and the bare tight form
+# (`defined? x` → NAME).  Placed FIRST in the `factor` alternation so the
+# leading `defined?` keyword wins over the bare `KEYWORD` alternative
+# (which would otherwise match `defined?` alone and leave the operand
+# unconsumed).
+defined_expression = "defined?" factor ;
 # Phase 15d (FC) — the colon is matched by the literal ":" (by VALUE)
 # rather than the COLON token reference (by TYPE).  The lexer emits both
 # `:` and `::` as `Colon`-typed tokens distinguished only by value, so a

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.69.0] - 2026-06-01
+
+### Added (Phase 23b (FC) — `defined?` operator)
+
+New grammar rule `defined_expression = "defined?" factor`, added as the
+first alternative of `factor` (so the `defined?` keyword wins over the
+bare `KEYWORD` alternative that would otherwise leave the operand
+unconsumed) and also to the `statement` alternation before `method_call`
+(so a bare `defined?(x)` statement parses as `defined_expression` rather
+than being swallowed as a `method_call` to a callee named `defined?`).
+The lexer already emits `defined?` as a single `KEYWORD` token (trailing
+`?` included), matched here by value. `_grammar.rs` regenerated.
+
+Covers both `defined?(x)` (operand = `LPAREN expression RPAREN`) and the
+bare tight form `defined? x` (operand = NAME). New parser pins:
+`test_parse_defined_with_parens`, `test_parse_defined_without_parens`,
+`test_parse_defined_statement_position`. Test count: 238 → 241.
+
 ## [0.68.0] - 2026-05-31
 
 ### Added (Phase 21c (FC) — implicit `it` block parameter, Ruby 3.4)

--- a/code/packages/rust/ruby-parser/src/_grammar.rs
+++ b/code/packages/rust/ruby-parser/src/_grammar.rs
@@ -39,6 +39,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"modifier_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"rightward_assignment"#.to_string() },
                 GrammarElement::RuleReference { name: r#"assignment"#.to_string() },
+                GrammarElement::RuleReference { name: r#"defined_expression"#.to_string() },
                 GrammarElement::RuleReference { name: r#"method_with_block"#.to_string() },
                 GrammarElement::RuleReference { name: r#"method_call"#.to_string() },
                 GrammarElement::RuleReference { name: r#"method_call_no_paren"#.to_string() },
@@ -875,6 +876,7 @@ pub fn parser_grammar() -> ParserGrammar {
             name: r#"factor"#.to_string(),
             body: GrammarElement::Sequence { elements: vec![
                 GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                        GrammarElement::RuleReference { name: r#"defined_expression"#.to_string() },
                         GrammarElement::RuleReference { name: r#"lambda_literal"#.to_string() },
                         GrammarElement::RuleReference { name: r#"method_call"#.to_string() },
                         GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
@@ -920,6 +922,14 @@ pub fn parser_grammar() -> ParserGrammar {
             line_number: 590,
         },
         GrammarRule {
+            name: r#"defined_expression"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"defined?"#.to_string() },
+                GrammarElement::RuleReference { name: r#"factor"#.to_string() },
+            ] },
+            line_number: 601,
+        },
+        GrammarRule {
             name: r#"symbol_literal"#.to_string(),
             body: GrammarElement::Sequence { elements: vec![
                 GrammarElement::Literal { value: r#":"#.to_string() },
@@ -929,7 +939,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 597,
+            line_number: 608,
         },
         GrammarRule {
             name: r#"array_literal"#.to_string(),
@@ -944,7 +954,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 598,
+            line_number: 609,
         },
         GrammarRule {
             name: r#"hash_literal"#.to_string(),
@@ -959,7 +969,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 599,
+            line_number: 610,
         },
         GrammarRule {
             name: r#"hash_entry"#.to_string(),
@@ -979,7 +989,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                 ] },
             ] },
-            line_number: 600,
+            line_number: 611,
         },
     ],
         version: 1,

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -3750,6 +3750,57 @@ mod tests {
     // to the block-bodied def.
     // -----------------------------------------------------------------------
 
+    // -----------------------------------------------------------------------
+    // Phase 23b — `defined?` operator
+    //
+    // The lexer emits `defined?` as a single KEYWORD token (trailing `?`
+    // included).  Grammar: `defined_expression = "defined?" factor`,
+    // placed first in the `factor` alternation so the keyword wins over
+    // the bare-KEYWORD alternative.  Covers both the parenthesised form
+    // `defined?(x)` and the bare tight form `defined? x`.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_defined_with_parens() {
+        // `x = defined?(y)` — parenthesised operand on an assignment RHS.
+        let ast = parse_ruby("x = defined?(y)\n");
+        assert!(
+            find_descendant(&ast, "assignment").is_some(),
+            "expected assignment node"
+        );
+        assert!(
+            find_descendant(&ast, "defined_expression").is_some(),
+            "expected defined_expression node"
+        );
+        assert!(
+            tree_has_token_value(&ast, "defined?"),
+            "expected the `defined?` keyword token in the tree"
+        );
+    }
+
+    #[test]
+    fn test_parse_defined_without_parens() {
+        // `x = defined? y` — bare tight form (operand is a NAME factor).
+        let ast = parse_ruby("x = defined? y\n");
+        let d = find_descendant(&ast, "defined_expression")
+            .expect("expected defined_expression node");
+        // The operand `y` is present as a Name token under the node.
+        assert!(
+            tree_has_token_value(d, "y"),
+            "expected operand `y` under defined_expression"
+        );
+    }
+
+    #[test]
+    fn test_parse_defined_statement_position() {
+        // `defined?(x)` as a bare expression statement (no assignment).
+        let ast = parse_ruby("defined?(x)\n");
+        assert!(
+            find_descendant(&ast, "defined_expression").is_some(),
+            "expected defined_expression node in statement position"
+        );
+    }
+
     #[test]
     fn test_parse_endless_def_no_params() {
         // `def hello = 1` — endless method with no parameters.

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.77.0] - 2026-06-01
+
+### Added (Phase 23b (FC) — `defined?` operator lowering)
+
+A `defined_expression` node (`defined?(x)` / `defined? x`) lowers to
+`BuiltinCall("defined?", [operand])` with `EffectSet::PURE` — `defined?`
+inspects whether its operand is defined, never raises, and has no side
+effects.  Handled in both expression position (`lower_expression`, e.g.
+an assignment RHS) and statement position (the statement dispatch wraps
+it in `Stmt::ExprStmt`).  The operand is carried as a lowered argument so
+a downstream emitter can reconstruct the source; a faithful backend does
+not evaluate it.
+
+v0 limitation: the operand lowers like any expression, so
+`defined?(undefined_local)` produces a `VarRef` the validator rejects as
+an unknown name — `defined?` on a never-bound bare local is not
+representable yet (operands are bound names, calls, or literals in
+practice).
+
+New lowering pins: `defined_with_parens_lowers_to_builtin_call`,
+`defined_of_literal_lowers_with_literal_operand`,
+`defined_in_statement_position_is_expr_stmt`,
+`defined_expression_validates_e2e`. Test count: 307 → 311.
+
 ## [0.76.0] - 2026-06-01
 
 ### Changed (Phase 13b (FC) — nested array patterns lower structurally)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -6183,6 +6183,85 @@ b = "y"
         );
     }
 
+    // -----------------------------------------------------------------------
+    // Phase 23b — `defined?` operator
+    //
+    // `defined?(expr)` / `defined? expr` lowers to
+    // `BuiltinCall("defined?", [operand])` (PURE).  Works in both
+    // expression position (assignment RHS) and statement position.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn defined_with_parens_lowers_to_builtin_call() {
+        // `y = defined?(x)` → LetBinding(y, BuiltinCall("defined?", [VarRef x])).
+        let m = lower("x = 1\ny = defined?(x)\n");
+        let b = main_body(&m);
+        let value = match &b.stmts[1] {
+            Stmt::LetBinding { name, value, .. } if name == "y" => value,
+            other => panic!("expected LetBinding y, got {:?}", other),
+        };
+        match value {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "defined?");
+                assert_eq!(args.len(), 1);
+                assert!(matches!(&args[0], Expr::VarRef { name, .. } if name == "x"));
+            }
+            other => panic!("expected BuiltinCall(defined?, [x]), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn defined_of_literal_lowers_with_literal_operand() {
+        // `y = defined?(1)` → operand is an IntLit (no parens-vs-bare diff
+        // at the SIR level).
+        let m = lower("y = defined?(1)\n");
+        let b = main_body(&m);
+        let value = match &b.stmts[0] {
+            Stmt::LetBinding { value, .. } => value,
+            other => panic!("expected LetBinding, got {:?}", other),
+        };
+        match value {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "defined?");
+                assert!(matches!(&args[0], Expr::IntLit { value: 1, .. }));
+            }
+            other => panic!("expected BuiltinCall(defined?, [1]), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn defined_in_statement_position_is_expr_stmt() {
+        // `defined?(x)` as a bare statement → Stmt::ExprStmt wrapping the
+        // BuiltinCall (the grammar routes it via the statement-level
+        // `defined_expression` alternative, not `method_call`).
+        let m = lower("x = 1\ndefined?(x)\n");
+        let b = main_body(&m);
+        match &b.stmts[1] {
+            Stmt::ExprStmt { expr, .. } => match expr {
+                Expr::BuiltinCall { name, args, .. } => {
+                    assert_eq!(name, "defined?");
+                    assert!(matches!(&args[0], Expr::VarRef { name, .. } if name == "x"));
+                }
+                other => panic!("expected BuiltinCall(defined?, …), got {:?}", other),
+            },
+            other => panic!("expected ExprStmt for bare defined?, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn defined_expression_validates_e2e() {
+        // Phase 23b (FC) — end-to-end: `defined?(x)` in trailing-value
+        // position (so the operand VarRef sees the prior binding) lowers
+        // to a PURE BuiltinCall that round-trips the SIR validator.
+        let m = lower("x = 1\ndefined?(x)\n");
+        let result = semantic_ir::validate(&m);
+        assert!(
+            result.is_ok(),
+            "validator rejected defined?-using module: {:?}",
+            result
+        );
+    }
+
     #[test]
     fn case_in_array_pattern_validates_e2e() {
         // Phase 13a (FC) — end-to-end: a binding array pattern lowers to

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -737,6 +737,17 @@ impl Lowerer {
         match node.rule_name.as_str() {
             "assignment" => self.lower_assignment(node),
             "rightward_assignment" => self.lower_rightward_assignment(node),
+            // Phase 23b (FC) — `defined?(x)` in statement position (the
+            // grammar lists `defined_expression` in the statement
+            // alternation so a bare `defined?(x)` doesn't get swallowed
+            // by `method_call`).  Wrap the lowered operator in ExprStmt.
+            "defined_expression" => {
+                let expr = self.lower_defined_expression(node)?;
+                Ok(Stmt::ExprStmt {
+                    expr,
+                    span: self.span_of(node),
+                })
+            }
             "method_call" => {
                 let expr = self.lower_method_call(node)?;
                 Ok(Stmt::ExprStmt {
@@ -4530,6 +4541,9 @@ impl Lowerer {
                     span: self.span_of(node),
                 })
             }
+            // Phase 23b (FC) — `defined?(x)` in expression position
+            // (assignment RHS, condition, …).
+            "defined_expression" => self.lower_defined_expression(node),
             "array_literal" => self.lower_array_literal(node),
             "hash_literal" => self.lower_hash_literal(node),
             "symbol_literal" => self.lower_symbol_literal(node),
@@ -5747,6 +5761,40 @@ impl Lowerer {
         })();
         self.interp_depth -= 1;
         result
+    }
+
+    /// Phase 23b (FC) — lower a `defined_expression` node
+    /// (`defined? <operand>` / `defined?(<operand>)`) to
+    /// `BuiltinCall("defined?", [operand])`.
+    ///
+    /// Effects are `PURE`: `defined?` inspects whether its operand is
+    /// defined and never raises (even on an undefined name) and has no
+    /// side effects.  The operand is carried as a lowered argument so a
+    /// downstream emitter can reconstruct the source; a faithful backend
+    /// does NOT evaluate it (Ruby's `defined?(foo.bar)` does not call
+    /// `foo.bar`).
+    ///
+    /// v0 limitation: the operand is lowered like any expression, so
+    /// `defined?(undefined_local)` lowers to a `VarRef` the SIR validator
+    /// will reject as an unknown name — `defined?` on a never-bound bare
+    /// local is not representable yet.  In practice the operand is a
+    /// bound name, a method call, or a literal.
+    fn lower_defined_expression(
+        &mut self,
+        node: &GrammarASTNode,
+    ) -> Result<Expr, RubyLowerError> {
+        let operand_node = self.first_node_child(node).ok_or_else(|| RubyLowerError {
+            message: "defined_expression missing operand".to_string(),
+            line: node.start_line.unwrap_or(0),
+            column: node.start_column.unwrap_or(0),
+        })?;
+        let operand = self.lower_expression(operand_node)?;
+        Ok(Expr::BuiltinCall {
+            name: "defined?".to_string(),
+            args: vec![operand],
+            effects: EffectSet::PURE,
+            span: self.span_of(node),
+        })
     }
 
     fn lower_factor(&mut self, node: &GrammarASTNode) -> Result<Expr, RubyLowerError> {


### PR DESCRIPTION
## Phase 23b (FC) — `defined?` operator

Part of the Ruby 3.4 frontend full-coverage effort. First grammar-level
feature after the lowering-only chunks — a full vertical slice
(grammar + regen + parser + lower).

### What

Ruby `defined?(expr)` / `defined? expr` now parses and lowers to
`BuiltinCall("defined?", [operand])` (`EffectSet::PURE`).

### Grammar (parser 0.68.0 → 0.69.0)

- New rule `defined_expression = "defined?" factor`, added as the **first**
  alternative of `factor` (so the `defined?` keyword wins over the bare
  `KEYWORD` alternative, which would otherwise leave the operand
  unconsumed) and to the `statement` alternation **before** `method_call`
  (so a bare `defined?(x)` statement parses as `defined_expression`
  rather than a `method_call` to a callee named `defined?`).
- The lexer already emits `defined?` as a single `KEYWORD` token (trailing
  `?` included); matched by value. `_grammar.rs` regenerated.
- Covers `defined?(x)` (operand = `LPAREN expression RPAREN`) and bare
  `defined? x` (operand = NAME).

### Lowering (IR 0.76.0 → 0.77.0)

- `defined_expression` → `BuiltinCall("defined?", [operand])` (PURE — never
  raises, no side effects) in both expression position and statement
  position (wrapped in `Stmt::ExprStmt`). The operand is carried lowered
  so a downstream emitter can reconstruct the source; a faithful backend
  does not evaluate it.
- v0 limitation: an undefined bare-local operand lowers to a `VarRef` the
  validator rejects — operands are bound names / calls / literals in
  practice.

### Tests

parser +3 (`with_parens`, `without_parens`, `statement_position`); IR +4
(`with_parens`, `literal_operand`, `statement_ExprStmt`, `validator_E2E`).
lexer 173 / parser 238 → 241 / ruby-IR 307 → 311 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
