### PR TITLE
feat(ruby): add `undef name` method removal (Phase 24b FC)

### DIFF
--- a/code/.commit-msg-24b.txt
+++ b/code/.commit-msg-24b.txt
@@ -1,0 +1,24 @@
+feat(ruby): add `undef name` method removal (Phase 24b FC)
+
+Grammar: new rule `undef_statement = "undef" NAME`, inserted into the
+`statement` alternation right after `alias_statement` (i.e. BEFORE
+method_call/expression_stmt) so the leading `undef` keyword wins over
+the bare-KEYWORD `factor` alternative (the same shadowing hazard the
+Phase 23b `defined?` and Phase 24a `alias` rules document). The lexer
+already classifies `undef` as a Ruby keyword, so no lexer change was
+needed. `_grammar.rs` regenerated.
+
+Lowering: `undef name` lowers to a statement-position
+`BuiltinCall("undef", [StrLit(name)])` with `EffectSet::PURE`, mirroring
+the Phase 24a `alias` lowering exactly. The method name is surfaced as a
+`StrLit` (not a `VarRef`) since it is a method name, not a local; the
+lowerer declares `Feature::Strings` (already permitted by the manifest
+builder allowlist).
+
+Tests: 3 parser pins + 3 lowering tests (incl. lower -> validate E2E).
+Scope: canonical single-bare-name form; symbol (`undef :name`) and
+multi-name (`undef a, b`) operands are deliberate follow-up slices.
+
+Parser CHANGELOG 0.70.0 -> 0.71.0; IR CHANGELOG 0.78.0 -> 0.79.0.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

--- a/code/.pr-body-fc-24b.md
+++ b/code/.pr-body-fc-24b.md
@@ -1,0 +1,29 @@
+## Phase 24b (FC) — `undef name` method removal
+
+Adds Ruby's `undef name` statement to the Ruby 3.4 frontend (grammar + lowering), continuing the full-coverage convergence after Phase 24a (`alias`).
+
+### Grammar
+- New rule `undef_statement = "undef" NAME`, inserted into the `statement` alternation right after `alias_statement` (i.e. **before** `method_call`/`expression_stmt`).
+- The lexer already classifies `undef` as a Ruby `KEYWORD` (matched here by value), so **no lexer change** was needed.
+- Placement matters for the same reason the Phase 23b `defined?` and Phase 24a `alias` rules document: a bare leading `undef` would otherwise be matched by the `KEYWORD` alternative of `factor` (via `expression_stmt`), consuming only `undef` and leaving the name operand dangling.
+- `_grammar.rs` regenerated.
+
+### Lowering
+- `undef name` lowers to a statement-position `BuiltinCall("undef", [StrLit(name)])` with `EffectSet::PURE`, mirroring the Phase 24a `alias` lowering exactly.
+- The method name is surfaced as a `StrLit` — it is a method name, **not** a local variable, so emitting a `VarRef` would be wrong and the SIR validator would reject the never-bound name.
+- `Feature::Strings` is declared for the `StrLit` operand (already permitted by the manifest builder allowlist).
+- Effects are `PURE`, mirroring the other declaration-ish keyword statements (`redo`/`retry`/`defined?`/`alias`).
+
+### Scope
+This first slice covers the canonical single-bare-name form (`undef foo`). The symbol form (`undef :name`) and the multi-name form (`undef a, b`) are deliberate follow-up slices.
+
+### Tests
+- 3 parser pins: `test_parse_undef_basic`, `test_parse_undef_carries_name`, `test_parse_undef_not_shadowed_by_method_call`.
+- 3 lowering tests: `undef_lowers_to_builtin_call`, `undef_operand_is_string_literal`, `undef_is_pure_and_validates_e2e` (lower → validate round-trip).
+- Full lexer + parser + lowerer suites green (247 parser, 317 lowerer tests pass).
+
+### Versions
+- `coding-adventures-ruby-parser` CHANGELOG 0.70.0 → 0.71.0
+- `ruby-to-semantic-ir` CHANGELOG 0.78.0 → 0.79.0
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/code/grammars/ruby.grammar
+++ b/code/grammars/ruby.grammar
@@ -25,7 +25,7 @@
 # than PUTS, TRUE, FALSE, NIL as token types.
 
 program      = { statement } ;
-statement    = endless_def_statement | def_statement | class_statement | module_statement | if_statement | unless_statement | while_statement | until_statement | case_statement | begin_statement | return_statement | break_statement | next_statement | redo_statement | retry_statement | yield_statement | super_statement | alias_statement | multi_assignment | modifier_statement | rightward_assignment | assignment | defined_expression | method_with_block | method_call | method_call_no_paren | expression_stmt ;
+statement    = endless_def_statement | def_statement | class_statement | module_statement | if_statement | unless_statement | while_statement | until_statement | case_statement | begin_statement | return_statement | break_statement | next_statement | redo_statement | retry_statement | yield_statement | super_statement | alias_statement | undef_statement | multi_assignment | modifier_statement | rightward_assignment | assignment | defined_expression | method_with_block | method_call | method_call_no_paren | expression_stmt ;
 # Phase 6r — multiple assignment `a, b = 1, 2`.
 #
 # Placed BEFORE `modifier_statement` and `assignment` so the multi-LHS
@@ -181,6 +181,18 @@ retry_statement  = "retry" ;
 # two name operands would be left unconsumed (same shadowing hazard the
 # Phase 23b `defined?` rule documents).
 alias_statement  = "alias" NAME NAME ;
+# Phase 24b (FC) — `undef name` removes the method `name` from the current
+# class/module.  Like `alias`, the lexer already classifies `undef` as a
+# Ruby KEYWORD (matched here by VALUE), so no lexer change is needed.  The
+# single operand is a bare method-name identifier (a NAME token); the
+# symbol form (`undef :name`) and the multi-name form (`undef a, b`) are
+# deliberate follow-up slices.  Placed in the `statement` alternation
+# BEFORE `method_call`/`expression_stmt` (right after `alias_statement`)
+# so the leading `undef` keyword wins — otherwise a bare `undef` would be
+# matched by the `KEYWORD` alternative of `factor` (via `expression_stmt`)
+# and the name operand would be left unconsumed (same shadowing hazard the
+# Phase 23b `defined?` and Phase 24a `alias` rules document).
+undef_statement  = "undef" NAME ;
 # Phase 6t — `yield` keyword.  Inside a method body, `yield` invokes
 # the block argument supplied by the caller (if any), forwarding the
 # given arguments to it.  All three surface forms supported:

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.71.0] - 2026-06-01
+
+### Added (Phase 24b (FC) — `undef name` method removal)
+
+New grammar rule `undef_statement = "undef" NAME`, added to the
+`statement` alternation right after `alias_statement` (i.e. BEFORE
+`method_call`/`expression_stmt`).  Like `alias`, the lexer already
+classifies `undef` as a Ruby `KEYWORD` (matched here by value), so no
+lexer change was needed.  Placement matters for the same reason the
+Phase 23b `defined?` and Phase 24a `alias` rules document: a bare
+leading `undef` would otherwise be matched by the `KEYWORD` alternative
+of `factor` (via `expression_stmt`), consuming only `undef` and leaving
+the name operand dangling.  `_grammar.rs` regenerated.
+
+This first slice covers the canonical single-bare-name form (`undef
+foo`); the symbol form (`undef :name`) and the multi-name form (`undef
+a, b`) are deliberate follow-ups.  New parser pins:
+`test_parse_undef_basic`, `test_parse_undef_carries_name`,
+`test_parse_undef_not_shadowed_by_method_call`.
+
 ## [0.70.0] - 2026-06-01
 
 ### Added (Phase 24a (FC) — `alias new old` method aliasing)

--- a/code/packages/rust/ruby-parser/src/_grammar.rs
+++ b/code/packages/rust/ruby-parser/src/_grammar.rs
@@ -36,6 +36,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"yield_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"super_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"alias_statement"#.to_string() },
+                GrammarElement::RuleReference { name: r#"undef_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"multi_assignment"#.to_string() },
                 GrammarElement::RuleReference { name: r#"modifier_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"rightward_assignment"#.to_string() },
@@ -299,12 +300,20 @@ pub fn parser_grammar() -> ParserGrammar {
             line_number: 183,
         },
         GrammarRule {
+            name: r#"undef_statement"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"undef"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+            ] },
+            line_number: 195,
+        },
+        GrammarRule {
             name: r#"yield_statement"#.to_string(),
             body: GrammarElement::Sequence { elements: vec![
                 GrammarElement::Literal { value: r#"yield"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"yield_args"#.to_string() }) },
             ] },
-            line_number: 205,
+            line_number: 217,
         },
         GrammarRule {
             name: r#"yield_args"#.to_string(),
@@ -328,7 +337,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) },
                 ] },
             ] },
-            line_number: 206,
+            line_number: 218,
         },
         GrammarRule {
             name: r#"super_statement"#.to_string(),
@@ -336,7 +345,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"super"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"super_args"#.to_string() }) },
             ] },
-            line_number: 225,
+            line_number: 237,
         },
         GrammarRule {
             name: r#"super_args"#.to_string(),
@@ -360,7 +369,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) },
                 ] },
             ] },
-            line_number: 226,
+            line_number: 238,
         },
         GrammarRule {
             name: r#"params"#.to_string(),
@@ -374,7 +383,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) },
                 ] },
             ] },
-            line_number: 255,
+            line_number: 267,
         },
         GrammarRule {
             name: r#"param"#.to_string(),
@@ -385,7 +394,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
             ] },
-            line_number: 256,
+            line_number: 268,
         },
         GrammarRule {
             name: r#"if_statement"#.to_string(),
@@ -402,7 +411,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 257,
+            line_number: 269,
         },
         GrammarRule {
             name: r#"elsif_clause"#.to_string(),
@@ -416,7 +425,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 258,
+            line_number: 270,
         },
         GrammarRule {
             name: r#"else_clause"#.to_string(),
@@ -427,7 +436,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 259,
+            line_number: 271,
         },
         GrammarRule {
             name: r#"unless_statement"#.to_string(),
@@ -442,7 +451,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 260,
+            line_number: 272,
         },
         GrammarRule {
             name: r#"while_statement"#.to_string(),
@@ -455,7 +464,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 261,
+            line_number: 273,
         },
         GrammarRule {
             name: r#"until_statement"#.to_string(),
@@ -468,7 +477,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 262,
+            line_number: 274,
         },
         GrammarRule {
             name: r#"case_statement"#.to_string(),
@@ -482,7 +491,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 285,
+            line_number: 297,
         },
         GrammarRule {
             name: r#"when_clause"#.to_string(),
@@ -501,7 +510,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 286,
+            line_number: 298,
         },
         GrammarRule {
             name: r#"in_clause"#.to_string(),
@@ -516,7 +525,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 308,
+            line_number: 320,
         },
         GrammarRule {
             name: r#"pattern"#.to_string(),
@@ -526,7 +535,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"literal_pattern"#.to_string() },
                 GrammarElement::RuleReference { name: r#"binding_pattern"#.to_string() },
             ] },
-            line_number: 309,
+            line_number: 321,
         },
         GrammarRule {
             name: r#"literal_pattern"#.to_string(),
@@ -536,12 +545,12 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"symbol_literal"#.to_string() },
                 GrammarElement::TokenReference { name: r#"KEYWORD"#.to_string() },
             ] },
-            line_number: 310,
+            line_number: 322,
         },
         GrammarRule {
             name: r#"binding_pattern"#.to_string(),
             body: GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
-            line_number: 311,
+            line_number: 323,
         },
         GrammarRule {
             name: r#"array_pattern"#.to_string(),
@@ -556,7 +565,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 312,
+            line_number: 324,
         },
         GrammarRule {
             name: r#"hash_pattern"#.to_string(),
@@ -571,7 +580,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 313,
+            line_number: 325,
         },
         GrammarRule {
             name: r#"hash_pattern_pair"#.to_string(),
@@ -580,7 +589,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"pattern"#.to_string() }) },
             ] },
-            line_number: 314,
+            line_number: 326,
         },
         GrammarRule {
             name: r#"begin_statement"#.to_string(),
@@ -596,7 +605,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"ensure_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 335,
+            line_number: 347,
         },
         GrammarRule {
             name: r#"rescue_clause"#.to_string(),
@@ -614,7 +623,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 344,
+            line_number: 356,
         },
         GrammarRule {
             name: r#"exception_list"#.to_string(),
@@ -625,7 +634,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
                     ] }) },
             ] },
-            line_number: 345,
+            line_number: 357,
         },
         GrammarRule {
             name: r#"ensure_clause"#.to_string(),
@@ -636,7 +645,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 346,
+            line_number: 358,
         },
         GrammarRule {
             name: r#"assignment"#.to_string(),
@@ -660,7 +669,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 366,
+            line_number: 378,
         },
         GrammarRule {
             name: r#"rightward_assignment"#.to_string(),
@@ -669,7 +678,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"=>"#.to_string() },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
             ] },
-            line_number: 385,
+            line_number: 397,
         },
         GrammarRule {
             name: r#"method_call"#.to_string(),
@@ -689,7 +698,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"dot_call"#.to_string() }) },
             ] },
-            line_number: 396,
+            line_number: 408,
         },
         GrammarRule {
             name: r#"dot_call"#.to_string(),
@@ -711,7 +720,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                     ] }) },
             ] },
-            line_number: 397,
+            line_number: 409,
         },
         GrammarRule {
             name: r#"scope_resolution"#.to_string(),
@@ -722,7 +731,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"KEYWORD"#.to_string() },
                     ] }) },
             ] },
-            line_number: 405,
+            line_number: 417,
         },
         GrammarRule {
             name: r#"call_arg"#.to_string(),
@@ -734,7 +743,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 435,
+            line_number: 447,
         },
         GrammarRule {
             name: r#"method_call_no_paren"#.to_string(),
@@ -749,17 +758,17 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 449,
+            line_number: 461,
         },
         GrammarRule {
             name: r#"expression_stmt"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"expression"#.to_string() },
-            line_number: 450,
+            line_number: 462,
         },
         GrammarRule {
             name: r#"expression"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"ternary"#.to_string() },
-            line_number: 557,
+            line_number: 569,
         },
         GrammarRule {
             name: r#"ternary"#.to_string(),
@@ -772,7 +781,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 558,
+            line_number: 570,
         },
         GrammarRule {
             name: r#"range"#.to_string(),
@@ -795,7 +804,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) },
                 ] },
             ] },
-            line_number: 559,
+            line_number: 571,
         },
         GrammarRule {
             name: r#"logical_or"#.to_string(),
@@ -809,7 +818,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_and"#.to_string() },
                     ] }) },
             ] },
-            line_number: 560,
+            line_number: 572,
         },
         GrammarRule {
             name: r#"logical_and"#.to_string(),
@@ -823,7 +832,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_not"#.to_string() },
                     ] }) },
             ] },
-            line_number: 561,
+            line_number: 573,
         },
         GrammarRule {
             name: r#"logical_not"#.to_string(),
@@ -834,7 +843,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) }) },
                 GrammarElement::RuleReference { name: r#"comparison"#.to_string() },
             ] },
-            line_number: 568,
+            line_number: 580,
         },
         GrammarRule {
             name: r#"comparison"#.to_string(),
@@ -852,7 +861,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"sum"#.to_string() },
                     ] }) },
             ] },
-            line_number: 569,
+            line_number: 581,
         },
         GrammarRule {
             name: r#"sum"#.to_string(),
@@ -866,7 +875,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term"#.to_string() },
                     ] }) },
             ] },
-            line_number: 570,
+            line_number: 582,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -880,7 +889,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"factor"#.to_string() },
                     ] }) },
             ] },
-            line_number: 571,
+            line_number: 583,
         },
         GrammarRule {
             name: r#"factor"#.to_string(),
@@ -908,7 +917,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"scope_resolution"#.to_string() },
                     ] }) },
             ] },
-            line_number: 581,
+            line_number: 593,
         },
         GrammarRule {
             name: r#"lambda_literal"#.to_string(),
@@ -921,7 +930,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"block"#.to_string() },
             ] },
-            line_number: 600,
+            line_number: 612,
         },
         GrammarRule {
             name: r#"unary_minus"#.to_string(),
@@ -929,7 +938,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"factor"#.to_string() },
             ] },
-            line_number: 601,
+            line_number: 613,
         },
         GrammarRule {
             name: r#"defined_expression"#.to_string(),
@@ -937,7 +946,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"defined?"#.to_string() },
                 GrammarElement::RuleReference { name: r#"factor"#.to_string() },
             ] },
-            line_number: 612,
+            line_number: 624,
         },
         GrammarRule {
             name: r#"symbol_literal"#.to_string(),
@@ -949,7 +958,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 619,
+            line_number: 631,
         },
         GrammarRule {
             name: r#"array_literal"#.to_string(),
@@ -964,7 +973,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 620,
+            line_number: 632,
         },
         GrammarRule {
             name: r#"hash_literal"#.to_string(),
@@ -979,7 +988,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 621,
+            line_number: 633,
         },
         GrammarRule {
             name: r#"hash_entry"#.to_string(),
@@ -999,7 +1008,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                 ] },
             ] },
-            line_number: 622,
+            line_number: 634,
         },
     ],
         version: 1,

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -3856,6 +3856,50 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_undef_basic() {
+        // `undef foo` — the canonical single-name form.
+        let ast = parse_ruby("undef foo\n");
+        assert!(
+            find_descendant(&ast, "undef_statement").is_some(),
+            "expected undef_statement node"
+        );
+        assert!(
+            tree_has_token_value(&ast, "undef"),
+            "expected the `undef` keyword token in the tree"
+        );
+    }
+
+    #[test]
+    fn test_parse_undef_carries_name() {
+        // The single operand must appear under the undef_statement node.
+        let ast = parse_ruby("undef obsolete\n");
+        let u = find_descendant(&ast, "undef_statement")
+            .expect("expected undef_statement node");
+        assert!(
+            tree_has_token_value(u, "obsolete"),
+            "expected name operand `obsolete` under undef_statement"
+        );
+    }
+
+    #[test]
+    fn test_parse_undef_not_shadowed_by_method_call() {
+        // The leading `undef` keyword must win over the bare-KEYWORD
+        // `factor` alternative — i.e. `undef` is parsed as an
+        // undef_statement (consuming the name operand), not as a
+        // method_call / expression_stmt that swallows only `undef` and
+        // leaves the name dangling.
+        let ast = parse_ruby("undef quux\n");
+        assert!(
+            find_descendant(&ast, "undef_statement").is_some(),
+            "expected undef_statement node (undef must not be shadowed)"
+        );
+        assert!(
+            tree_has_token_value(&ast, "quux"),
+            "expected name operand `quux` to be consumed by undef_statement"
+        );
+    }
+
+    #[test]
     fn test_parse_endless_def_no_params() {
         // `def hello = 1` — endless method with no parameters.
         let ast = parse_ruby("def hello = 1");

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.79.0] - 2026-06-01
+
+### Added (Phase 24b (FC) — `undef name` lowering)
+
+An `undef_statement` node (`undef name`) lowers to a statement-position
+`BuiltinCall("undef", [StrLit(name)])` with `EffectSet::PURE`, mirroring
+the Phase 24a `alias` lowering exactly.  The method name is surfaced as
+a `StrLit` — it is a method name, **not** a local variable, so emitting
+a `VarRef` would be wrong and the SIR validator would reject the
+never-bound name.  `Feature::Strings` is declared for the `StrLit`
+operand (already permitted by the manifest builder allowlist).  Effects
+are `PURE`, like the other declaration-ish keyword statements
+(`redo`/`retry`/`defined?`/`alias`).
+
+This first slice covers the canonical single-bare-name form (`undef
+foo`); the symbol form (`undef :name`) and the multi-name form (`undef
+a, b`) are deliberate follow-ups.  New lowering tests:
+`undef_lowers_to_builtin_call`, `undef_operand_is_string_literal`,
+`undef_is_pure_and_validates_e2e` (lower → validate round-trip).
+
 ## [0.78.0] - 2026-06-01
 
 ### Added (Phase 24a (FC) — `alias new old` lowering)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -6341,6 +6341,69 @@ b = "y"
     }
 
     #[test]
+    fn undef_lowers_to_builtin_call() {
+        // `undef foo` → ExprStmt(BuiltinCall("undef", [StrLit])).
+        let m = lower("undef foo\n");
+        let b = main_body(&m);
+        match &b.stmts[0] {
+            Stmt::ExprStmt { expr, .. } => match expr {
+                Expr::BuiltinCall { name, args, .. } => {
+                    assert_eq!(name, "undef");
+                    assert_eq!(args.len(), 1);
+                }
+                other => panic!("expected BuiltinCall(undef, …), got {:?}", other),
+            },
+            other => panic!("expected ExprStmt for undef, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn undef_operand_is_string_literal() {
+        // The single operand surfaces as a StrLit carrying the verbatim
+        // method name — never a VarRef.
+        let m = lower("undef obsolete\n");
+        let b = main_body(&m);
+        let args = match &b.stmts[0] {
+            Stmt::ExprStmt {
+                expr: Expr::BuiltinCall { name, args, .. },
+                ..
+            } if name == "undef" => args,
+            other => panic!("expected undef BuiltinCall, got {:?}", other),
+        };
+        assert!(
+            matches!(&args[0], Expr::StrLit { value, .. } if value == "obsolete"),
+            "expected StrLit(\"obsolete\"), got {:?}",
+            args[0]
+        );
+    }
+
+    #[test]
+    fn undef_is_pure_and_validates_e2e() {
+        // Phase 24b (FC) — end-to-end: a bare `undef` statement lowers to a
+        // PURE BuiltinCall over a string-literal operand that round-trips
+        // the SIR validator (no unbound names, no effect surprises).
+        let m = lower("undef foo\n");
+        let b = main_body(&m);
+        match &b.stmts[0] {
+            Stmt::ExprStmt {
+                expr: Expr::BuiltinCall { effects, .. },
+                ..
+            } => assert!(
+                !effects.contains(Effect::Divergent),
+                "undef should be PURE (non-divergent), got {:?}",
+                effects
+            ),
+            other => panic!("expected undef BuiltinCall, got {:?}", other),
+        }
+        let result = semantic_ir::validate(&m);
+        assert!(
+            result.is_ok(),
+            "validator rejected undef-using module: {:?}",
+            result
+        );
+    }
+
+    #[test]
     fn case_in_array_pattern_validates_e2e() {
         // Phase 13a (FC) — end-to-end: a binding array pattern lowers to
         // real SIR (`SeqLen`/`SeqIndex` + `LetBinding`) that round-trips

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -1125,6 +1125,59 @@ impl Lowerer {
                     span: self.span_of(node),
                 })
             }
+            "undef_statement" => {
+                // Phase 24b (FC) — `undef name` removes the method `name`
+                // from the current class/module.  The single operand is a
+                // bare method-name NAME token (the symbol form `undef :name`
+                // and the multi-name form `undef a, b` are deliberate
+                // follow-up slices).  We lower to a zero-side-effect
+                // `BuiltinCall("undef", [StrLit(name)])`, mirroring the
+                // Phase 24a `alias` lowering exactly: the method name is
+                // surfaced as a string literal — it is NOT a local variable,
+                // so emitting a `VarRef` would be wrong and the SIR validator
+                // would reject the never-bound name.  Effects are `PURE`: in
+                // this model the undef declaration carries no runtime data
+                // effect, like the other declaration-ish keyword statements.
+                let names: Vec<&Token> = node
+                    .children
+                    .iter()
+                    .filter_map(|c| match c {
+                        ASTNodeOrToken::Token(t) if t.type_ == TokenType::Name => Some(t),
+                        _ => None,
+                    })
+                    .collect();
+                if names.len() != 1 {
+                    return Err(RubyLowerError {
+                        message: format!(
+                            "undef_statement expects 1 name operand, found {}",
+                            names.len()
+                        ),
+                        line: node.start_line.unwrap_or(0),
+                        column: node.start_column.unwrap_or(0),
+                    });
+                }
+                let args = names
+                    .iter()
+                    .map(|t| Expr::StrLit {
+                        value: t.value.clone(),
+                        span: self.span_of_token(t),
+                    })
+                    .collect();
+                // The method name surfaces as a `StrLit`, so the module uses
+                // the `strings` feature — declare it (the manifest builder
+                // allowlist already permits `Feature::Strings`).
+                self.features_used.insert(Feature::Strings);
+                let expr = Expr::BuiltinCall {
+                    name: "undef".to_string(),
+                    args,
+                    effects: EffectSet::PURE,
+                    span: self.span_of(node),
+                };
+                Ok(Stmt::ExprStmt {
+                    expr,
+                    span: self.span_of(node),
+                })
+            }
             other => Err(RubyLowerError {
                 message: format!("unsupported statement form `{other}`"),
                 line: node.start_line.unwrap_or(0),


### PR DESCRIPTION
## Phase 24b (FC) — `undef name` method removal

Adds Ruby's `undef name` statement to the Ruby 3.4 frontend (grammar + lowering), continuing the full-coverage convergence after Phase 24a (`alias`).

### Grammar
- New rule `undef_statement = "undef" NAME`, inserted into the `statement` alternation right after `alias_statement` (i.e. **before** `method_call`/`expression_stmt`).
- The lexer already classifies `undef` as a Ruby `KEYWORD` (matched here by value), so **no lexer change** was needed.
- Placement matters for the same reason the Phase 23b `defined?` and Phase 24a `alias` rules document: a bare leading `undef` would otherwise be matched by the `KEYWORD` alternative of `factor` (via `expression_stmt`), consuming only `undef` and leaving the name operand dangling.
- `_grammar.rs` regenerated.

### Lowering
- `undef name` lowers to a statement-position `BuiltinCall("undef", [StrLit(name)])` with `EffectSet::PURE`, mirroring the Phase 24a `alias` lowering exactly.
- The method name is surfaced as a `StrLit` — it is a method name, **not** a local variable, so emitting a `VarRef` would be wrong and the SIR validator would reject the never-bound name.
- `Feature::Strings` is declared for the `StrLit` operand (already permitted by the manifest builder allowlist).
- Effects are `PURE`, mirroring the other declaration-ish keyword statements (`redo`/`retry`/`defined?`/`alias`).

### Scope
This first slice covers the canonical single-bare-name form (`undef foo`). The symbol form (`undef :name`) and the multi-name form (`undef a, b`) are deliberate follow-up slices.

### Tests
- 3 parser pins: `test_parse_undef_basic`, `test_parse_undef_carries_name`, `test_parse_undef_not_shadowed_by_method_call`.
- 3 lowering tests: `undef_lowers_to_builtin_call`, `undef_operand_is_string_literal`, `undef_is_pure_and_validates_e2e` (lower → validate round-trip).
- Full lexer + parser + lowerer suites green (247 parser, 317 lowerer tests pass).

### Versions
- `coding-adventures-ruby-parser` CHANGELOG 0.70.0 → 0.71.0
- `ruby-to-semantic-ir` CHANGELOG 0.78.0 → 0.79.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
