### PR TITLE
feat(ruby): lower `__FILE__` pseudo-variable to a StrLit (Phase 23a FC)

### DIFF
--- a/code/.commit-msg-23a.txt
+++ b/code/.commit-msg-23a.txt
@@ -1,0 +1,25 @@
+feat(ruby): lower `__FILE__` pseudo-variable to a StrLit (Phase 23a FC)
+
+Ruby's `__FILE__` pseudo-variable now lowers to a compile-time StrLit
+carrying the lowerer's `file_name` (the SIR module identifier the source
+was compiled under) — the closest fixed value for "the current source
+file" absent a runtime filesystem.
+
+Because `__FILE__` begins with `_` it is NOT a lexer keyword: it arrives
+as an ordinary Name token and the parser already matches it via
+`factor`'s bare-NAME alternative, so NO grammar or lexer change was
+needed. The meaning is supplied entirely in `lower_factor_atom`,
+intercepting the bare Name exactly like the existing bare-`raise` case:
+when the token value is `__FILE__` and it is not shadowed by a local
+binding, we emit the StrLit and declare Feature::Strings (already in the
+manifest builder allowlist). A `__FILE__` shadowed by a prior local
+(`__FILE__ = 1`) keeps the local read (a VarRef), mirroring the raise
+shadow guard.
+
+Tests: 3 parser parse-shape pins + 4 lowering tests (incl. lower ->
+validate E2E and the shadow-guard case).
+
+Parser CHANGELOG 0.71.0 -> 0.72.0 (test-only pins; grammar unchanged);
+IR CHANGELOG 0.79.0 -> 0.80.0.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

--- a/code/.pr-body-fc-23a.md
+++ b/code/.pr-body-fc-23a.md
@@ -1,0 +1,27 @@
+## Phase 23a (FC) — `__FILE__` pseudo-variable
+
+Adds Ruby's `__FILE__` pseudo-variable to the Ruby 3.4 frontend, continuing the full-coverage convergence after Phase 24b (`undef`).
+
+### Approach — lowering-only, no grammar/lexer change
+- `__FILE__` begins with `_`, so it is **not** a lexer keyword — it lexes as an ordinary `Name` token.
+- The parser already matches it via `factor`'s existing bare-`NAME` alternative in every expression position (standalone statement, call argument, assignment RHS).
+- Therefore **no grammar rule, no `_grammar.rs` regen, and no lexer change** were needed. The pseudo-variable's meaning is supplied entirely at lowering time.
+
+### Lowering
+- In `lower_factor_atom`, the bare `Name` is intercepted **exactly like the existing bare-`raise` case**: when the token value is `__FILE__` and it is not shadowed by a local binding, it lowers to a `StrLit` carrying the lowerer's `file_name` (the SIR module identifier the source was compiled under).
+- `Feature::Strings` is declared for the emitted `StrLit` (already permitted by the manifest builder allowlist).
+- **Shadow guard**: a `__FILE__` shadowed by a prior local (`__FILE__ = 1`) keeps the local read (a `VarRef`), mirroring the `raise` guard.
+
+### Scope
+The `StrLit` is the compile-time module name — the closest fixed value for "the current file" without a runtime filesystem. A runtime-accurate absolute path would require host I/O and is out of scope for the pure frontend.
+
+### Tests
+- 3 parser parse-shape pins: `test_parse_file_keyword_as_factor`, `test_parse_file_keyword_in_call_arg`, `test_parse_file_keyword_in_assignment_rhs`.
+- 4 lowering tests: `file_keyword_lowers_to_strlit`, `file_keyword_declares_strings_feature`, `file_keyword_validates_e2e` (lower → validate round-trip), `file_keyword_shadowed_by_local_is_varref`.
+- Full lexer + parser + lowerer suites green (173 lexer, 250 parser, 321 lowerer tests pass).
+
+### Versions
+- `coding-adventures-ruby-parser` CHANGELOG 0.71.0 → 0.72.0 (test-only pins; grammar unchanged)
+- `ruby-to-semantic-ir` CHANGELOG 0.79.0 → 0.80.0
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.72.0] - 2026-06-01
+
+### Added (Phase 23a (FC) — `__FILE__` parse pins)
+
+Regression pins confirming Ruby's `__FILE__` pseudo-variable parses with
+**no grammar change**: because `__FILE__` begins with `_` it is not a
+lexer keyword — it arrives as an ordinary `NAME` token and is matched by
+`factor`'s existing bare-`NAME` alternative in every expression position
+(standalone statement, call argument, assignment RHS).  The feature's
+semantics are supplied entirely at lowering time (see the
+`ruby-to-semantic-ir` 0.80.0 entry); this crate's grammar is unchanged,
+so these are pure parse-shape pins.  New tests:
+`test_parse_file_keyword_as_factor`, `test_parse_file_keyword_in_call_arg`,
+`test_parse_file_keyword_in_assignment_rhs`.
+
 ## [0.71.0] - 2026-06-01
 
 ### Added (Phase 24b (FC) — `undef name` method removal)

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -3900,6 +3900,49 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_file_keyword_as_factor() {
+        // Phase 23a (FC) — `__FILE__` is NOT a lexer keyword (it starts
+        // with `_`, so it lexes as an ordinary NAME) and needs no grammar
+        // rule: it parses through `factor`'s bare-NAME alternative.  This
+        // pin confirms the `__FILE__` token survives into the tree when it
+        // appears as a standalone expression statement.
+        let ast = parse_ruby("__FILE__\n");
+        assert!(
+            tree_has_token_value(&ast, "__FILE__"),
+            "expected `__FILE__` token to be present in the parse tree"
+        );
+    }
+
+    #[test]
+    fn test_parse_file_keyword_in_call_arg() {
+        // `puts(__FILE__)` — `__FILE__` parses as a call argument
+        // expression (factor → NAME), confirming it composes in argument
+        // position exactly like any other bare name.
+        let ast = parse_ruby("puts(__FILE__)\n");
+        assert!(
+            tree_has_token_value(&ast, "__FILE__"),
+            "expected `__FILE__` token in the `puts(__FILE__)` call args"
+        );
+    }
+
+    #[test]
+    fn test_parse_file_keyword_in_assignment_rhs() {
+        // `path = __FILE__` — `__FILE__` parses as the assignment RHS
+        // expression, the same NAME-factor path a normal variable read
+        // would take.  We assert both the LHS name and the `__FILE__`
+        // token are present.
+        let ast = parse_ruby("path = __FILE__\n");
+        assert!(
+            tree_has_token_value(&ast, "path"),
+            "expected LHS name `path` in the assignment"
+        );
+        assert!(
+            tree_has_token_value(&ast, "__FILE__"),
+            "expected `__FILE__` token as the assignment RHS"
+        );
+    }
+
+    #[test]
     fn test_parse_endless_def_no_params() {
         // `def hello = 1` — endless method with no parameters.
         let ast = parse_ruby("def hello = 1");

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.80.0] - 2026-06-01
+
+### Added (Phase 23a (FC) — `__FILE__` pseudo-variable lowering)
+
+Ruby's `__FILE__` pseudo-variable now lowers to a compile-time `StrLit`
+carrying the lowerer's `file_name` (the SIR module identifier the source
+was compiled under) — the closest fixed value we have for "the current
+source file" absent a runtime filesystem.
+
+Because `__FILE__` begins with `_` it is **not** a lexer keyword: it
+arrives as an ordinary `Name` token and the parser already matches it via
+`factor`'s bare-`NAME` alternative, so **no grammar or lexer change** was
+needed.  The pseudo-variable's meaning is supplied entirely here, in
+`lower_factor_atom`, intercepting the bare `Name` exactly like the
+existing bare-`raise` case: when the token's value is `__FILE__` and it is
+**not** shadowed by a local binding, we emit the `StrLit` and declare
+`Feature::Strings` (already permitted by the manifest builder allowlist).
+A `__FILE__` shadowed by a prior local (`__FILE__ = 1`) keeps the local
+read (a `VarRef`), mirroring the `raise` shadow guard.
+
+New lowering tests: `file_keyword_lowers_to_strlit`,
+`file_keyword_declares_strings_feature`, `file_keyword_validates_e2e`
+(lower → validate round-trip), `file_keyword_shadowed_by_local_is_varref`.
+
 ## [0.79.0] - 2026-06-01
 
 ### Added (Phase 24b (FC) — `undef name` lowering)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -6404,6 +6404,71 @@ b = "y"
     }
 
     #[test]
+    fn file_keyword_lowers_to_strlit() {
+        // Phase 23a (FC) — `__FILE__` lowers to a compile-time StrLit
+        // carrying the lowerer's `file_name` (here the test module name
+        // "test"), surfaced as the argument of the enclosing `puts`.
+        let m = lower("puts(__FILE__)\n");
+        let b = main_body(&m);
+        // A lone `puts(...)` is the block's trailing VALUE, not a stmt.
+        let args = match &b.value {
+            Expr::BuiltinCall { name, args, .. } if name == "puts" => args,
+            other => panic!("expected BuiltinCall(puts, ...), got {:?}", other),
+        };
+        assert!(
+            matches!(&args[0], Expr::StrLit { value, .. } if value == "test"),
+            "expected `__FILE__` to lower to StrLit(\"test\"), got {:?}",
+            args[0]
+        );
+    }
+
+    #[test]
+    fn file_keyword_declares_strings_feature() {
+        // Emitting the StrLit means the module must declare the `strings`
+        // feature — verify the manifest carries it.
+        let m = lower("puts(__FILE__)\n");
+        assert!(
+            m.manifest.contains(semantic_ir::Feature::Strings),
+            "expected Strings feature for `__FILE__`; got {:?}",
+            m.manifest
+        );
+    }
+
+    #[test]
+    fn file_keyword_validates_e2e() {
+        // End-to-end: a `__FILE__`-using module round-trips the SIR
+        // validator (the StrLit is a self-contained literal — no unbound
+        // names, no undeclared features).
+        let m = lower("puts(__FILE__)\n");
+        let result = semantic_ir::validate(&m);
+        assert!(
+            result.is_ok(),
+            "validator rejected `__FILE__`-using module: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn file_keyword_shadowed_by_local_is_varref() {
+        // A `__FILE__` shadowed by a prior local binding keeps the local
+        // (mirrors the bare-`raise` shadow guard): the read lowers to a
+        // VarRef, NOT the file-name StrLit.
+        let m = lower("__FILE__ = 1\nputs(__FILE__)\n");
+        let b = main_body(&m);
+        // The `__FILE__ = 1` binding is a stmt; the trailing `puts(...)`
+        // is the block VALUE, where the shadowed read appears.
+        let args = match &b.value {
+            Expr::BuiltinCall { name, args, .. } if name == "puts" => args,
+            other => panic!("expected BuiltinCall(puts, ...), got {:?}", other),
+        };
+        assert!(
+            matches!(&args[0], Expr::VarRef { name, .. } if name == "__FILE__"),
+            "expected shadowed `__FILE__` to stay a VarRef, got {:?}",
+            args[0]
+        );
+    }
+
+    #[test]
     fn case_in_array_pattern_validates_e2e() {
         // Phase 13a (FC) — end-to-end: a binding array pattern lowers to
         // real SIR (`SeqLen`/`SeqIndex` + `LetBinding`) that round-trips

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -6035,6 +6035,37 @@ impl Lowerer {
                                     span,
                                 });
                             }
+                            // Phase 23a (FC) — `__FILE__` is Ruby's pseudo-
+                            // variable for the path of the current source
+                            // file.  The lexer does NOT classify it as a
+                            // keyword (it starts with `_`, so it arrives as
+                            // an ordinary `Name` token) and the grammar
+                            // already matches it via `factor`'s bare-NAME
+                            // alternative — so NO grammar/lexer change is
+                            // needed; we intercept it here at lowering time,
+                            // exactly like the bare-`raise` case above.
+                            //
+                            // It lowers to a compile-time `StrLit` carrying
+                            // the lowerer's `file_name` (the SIR module
+                            // identifier the source was compiled under) —
+                            // the closest fixed value we have for "the
+                            // current file" without a runtime filesystem.
+                            // Emitting a `StrLit` means the module uses the
+                            // `strings` feature, so we declare it (already
+                            // permitted by the manifest builder allowlist).
+                            //
+                            // A `__FILE__` shadowed by a local binding
+                            // (`__FILE__ = 1`) keeps the local, mirroring
+                            // the `raise` shadow guard.
+                            if tok.value == "__FILE__"
+                                && !self.declared_locals.contains("__FILE__")
+                            {
+                                self.features_used.insert(Feature::Strings);
+                                return Ok(Expr::StrLit {
+                                    value: self.file_name.clone(),
+                                    span,
+                                });
+                            }
                             // Inside a function body, parameter
                             // names lex as `VarRef` with
                             // `Scope::Param` so the SIR validator


### PR DESCRIPTION
## Phase 23a (FC) — `__FILE__` pseudo-variable

Adds Ruby's `__FILE__` pseudo-variable to the Ruby 3.4 frontend, continuing the full-coverage convergence after Phase 24b (`undef`).

### Approach — lowering-only, no grammar/lexer change
- `__FILE__` begins with `_`, so it is **not** a lexer keyword — it lexes as an ordinary `Name` token.
- The parser already matches it via `factor`'s existing bare-`NAME` alternative in every expression position (standalone statement, call argument, assignment RHS).
- Therefore **no grammar rule, no `_grammar.rs` regen, and no lexer change** were needed. The pseudo-variable's meaning is supplied entirely at lowering time.

### Lowering
- In `lower_factor_atom`, the bare `Name` is intercepted **exactly like the existing bare-`raise` case**: when the token value is `__FILE__` and it is not shadowed by a local binding, it lowers to a `StrLit` carrying the lowerer's `file_name` (the SIR module identifier the source was compiled under).
- `Feature::Strings` is declared for the emitted `StrLit` (already permitted by the manifest builder allowlist).
- **Shadow guard**: a `__FILE__` shadowed by a prior local (`__FILE__ = 1`) keeps the local read (a `VarRef`), mirroring the `raise` guard.

### Scope
The `StrLit` is the compile-time module name — the closest fixed value for "the current file" without a runtime filesystem. A runtime-accurate absolute path would require host I/O and is out of scope for the pure frontend.

### Tests
- 3 parser parse-shape pins: `test_parse_file_keyword_as_factor`, `test_parse_file_keyword_in_call_arg`, `test_parse_file_keyword_in_assignment_rhs`.
- 4 lowering tests: `file_keyword_lowers_to_strlit`, `file_keyword_declares_strings_feature`, `file_keyword_validates_e2e` (lower → validate round-trip), `file_keyword_shadowed_by_local_is_varref`.
- Full lexer + parser + lowerer suites green (173 lexer, 250 parser, 321 lowerer tests pass).

### Versions
- `coding-adventures-ruby-parser` CHANGELOG 0.71.0 → 0.72.0 (test-only pins; grammar unchanged)
- `ruby-to-semantic-ir` CHANGELOG 0.79.0 → 0.80.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
