### PR TITLE
feat(ruby): lower `__LINE__` pseudo-variable to an IntLit (Phase 23c FC)

### DIFF
--- a/code/.commit-msg-23c.txt
+++ b/code/.commit-msg-23c.txt
@@ -1,0 +1,24 @@
+feat(ruby): lower `__LINE__` pseudo-variable to an IntLit (Phase 23c FC)
+
+Ruby's `__LINE__` pseudo-variable now lowers to a compile-time IntLit
+carrying the (1-based) source line of the `__LINE__` token itself.
+
+Sibling of Phase 23a `__FILE__`: because `__LINE__` begins with `_` it
+is NOT a lexer keyword — it arrives as an ordinary Name token and the
+parser already matches it via `factor`'s bare-NAME alternative, so NO
+grammar or lexer change was needed. The meaning is supplied entirely in
+`lower_factor_atom`, intercepting the bare Name exactly like the
+`__FILE__` / bare-`raise` cases: when the token value is `__LINE__` and
+it is not shadowed by a local binding, we emit `IntLit { value:
+tok.line }`. Unlike `__FILE__`'s StrLit, no Feature declaration is
+required — integers are a baseline SIR capability. A `__LINE__` shadowed
+by a prior local (`__LINE__ = 7`) keeps the local read (a VarRef),
+mirroring the existing shadow guards.
+
+Tests: 3 parser parse-shape pins + 4 lowering tests (incl. line-tracking,
+lower -> validate E2E, and the shadow-guard case).
+
+Parser CHANGELOG 0.72.0 -> 0.73.0 (test-only pins; grammar unchanged);
+IR CHANGELOG 0.80.0 -> 0.81.0.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

--- a/code/.pr-body-fc-23c.md
+++ b/code/.pr-body-fc-23c.md
@@ -1,0 +1,24 @@
+## Phase 23c (FC) — `__LINE__` pseudo-variable
+
+Adds Ruby's `__LINE__` pseudo-variable to the Ruby 3.4 frontend, the sibling of Phase 23a (`__FILE__`).
+
+### Approach — lowering-only, no grammar/lexer change
+- `__LINE__` begins with `_`, so it is **not** a lexer keyword — it lexes as an ordinary `Name` token.
+- The parser already matches it via `factor`'s existing bare-`NAME` alternative in every expression position (standalone statement, call argument, assignment RHS).
+- Therefore **no grammar rule, no `_grammar.rs` regen, and no lexer change** were needed.
+
+### Lowering
+- In `lower_factor_atom`, the bare `Name` is intercepted exactly like the `__FILE__` / bare-`raise` cases: when the token value is `__LINE__` and it is not shadowed by a local binding, it lowers to `IntLit { value: tok.line }` — the token's own 1-based source line.
+- **No `Feature` declaration required** — integers are a baseline SIR capability (contrast `__FILE__`'s `StrLit`, which needs `Feature::Strings`).
+- **Shadow guard**: a `__LINE__` shadowed by a prior local (`__LINE__ = 7`) keeps the local read (a `VarRef`).
+
+### Tests
+- 3 parser parse-shape pins: `test_parse_line_keyword_as_factor`, `test_parse_line_keyword_in_call_arg`, `test_parse_line_keyword_in_assignment_rhs`.
+- 4 lowering tests: `line_keyword_lowers_to_intlit`, `line_keyword_tracks_source_line` (asserts the value is the actual line, not a constant), `line_keyword_validates_e2e` (lower → validate round-trip), `line_keyword_shadowed_by_local_is_varref`.
+- Full lexer + parser + lowerer suites green (173 lexer, 253 parser, 325 lowerer tests pass).
+
+### Versions
+- `coding-adventures-ruby-parser` CHANGELOG 0.72.0 → 0.73.0 (test-only pins; grammar unchanged)
+- `ruby-to-semantic-ir` CHANGELOG 0.80.0 → 0.81.0
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.73.0] - 2026-06-01
+
+### Added (Phase 23c (FC) — `__LINE__` parse pins)
+
+Regression pins confirming Ruby's `__LINE__` pseudo-variable parses with
+**no grammar change** (sibling of Phase 23a `__FILE__`): because
+`__LINE__` begins with `_` it is not a lexer keyword — it arrives as an
+ordinary `NAME` token matched by `factor`'s existing bare-`NAME`
+alternative in every expression position (standalone statement, call
+argument, assignment RHS).  The feature's semantics are supplied entirely
+at lowering time (see the `ruby-to-semantic-ir` 0.81.0 entry); this
+crate's grammar is unchanged, so these are pure parse-shape pins.  New
+tests: `test_parse_line_keyword_as_factor`,
+`test_parse_line_keyword_in_call_arg`,
+`test_parse_line_keyword_in_assignment_rhs`.
+
 ## [0.72.0] - 2026-06-01
 
 ### Added (Phase 23a (FC) — `__FILE__` parse pins)

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -3943,6 +3943,46 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_line_keyword_as_factor() {
+        // Phase 23c (FC) — `__LINE__`, like `__FILE__`, is NOT a lexer
+        // keyword (it starts with `_`, so it lexes as an ordinary NAME) and
+        // needs no grammar rule: it parses through `factor`'s bare-NAME
+        // alternative.  This pin confirms the token survives into the tree.
+        let ast = parse_ruby("__LINE__\n");
+        assert!(
+            tree_has_token_value(&ast, "__LINE__"),
+            "expected `__LINE__` token to be present in the parse tree"
+        );
+    }
+
+    #[test]
+    fn test_parse_line_keyword_in_call_arg() {
+        // `puts(__LINE__)` — `__LINE__` parses as a call argument
+        // expression (factor → NAME).
+        let ast = parse_ruby("puts(__LINE__)\n");
+        assert!(
+            tree_has_token_value(&ast, "__LINE__"),
+            "expected `__LINE__` token in the `puts(__LINE__)` call args"
+        );
+    }
+
+    #[test]
+    fn test_parse_line_keyword_in_assignment_rhs() {
+        // `n = __LINE__` — `__LINE__` parses as the assignment RHS
+        // expression, the same NAME-factor path a normal variable read
+        // would take.
+        let ast = parse_ruby("n = __LINE__\n");
+        assert!(
+            tree_has_token_value(&ast, "n"),
+            "expected LHS name `n` in the assignment"
+        );
+        assert!(
+            tree_has_token_value(&ast, "__LINE__"),
+            "expected `__LINE__` token as the assignment RHS"
+        );
+    }
+
+    #[test]
     fn test_parse_endless_def_no_params() {
         // `def hello = 1` — endless method with no parameters.
         let ast = parse_ruby("def hello = 1");

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.81.0] - 2026-06-01
+
+### Added (Phase 23c (FC) — `__LINE__` pseudo-variable lowering)
+
+Ruby's `__LINE__` pseudo-variable now lowers to a compile-time `IntLit`
+carrying the (1-based) source line of the `__LINE__` token itself.
+
+Sibling of Phase 23a `__FILE__`: because `__LINE__` begins with `_` it is
+**not** a lexer keyword — it arrives as an ordinary `Name` token and the
+parser already matches it via `factor`'s bare-`NAME` alternative, so **no
+grammar or lexer change** was needed.  The meaning is supplied entirely in
+`lower_factor_atom`, intercepting the bare `Name` exactly like the
+`__FILE__` / bare-`raise` cases: when the token value is `__LINE__` and it
+is **not** shadowed by a local binding, we emit `IntLit { value:
+tok.line }`.  Unlike `__FILE__`'s `StrLit`, **no `Feature` declaration is
+required** — integers are a baseline SIR capability.  A `__LINE__`
+shadowed by a prior local (`__LINE__ = 7`) keeps the local read (a
+`VarRef`), mirroring the existing shadow guards.
+
+New lowering tests: `line_keyword_lowers_to_intlit`,
+`line_keyword_tracks_source_line`, `line_keyword_validates_e2e`
+(lower → validate round-trip), `line_keyword_shadowed_by_local_is_varref`.
+
 ## [0.80.0] - 2026-06-01
 
 ### Added (Phase 23a (FC) — `__FILE__` pseudo-variable lowering)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -6469,6 +6469,75 @@ b = "y"
     }
 
     #[test]
+    fn line_keyword_lowers_to_intlit() {
+        // Phase 23c (FC) — `__LINE__` lowers to a compile-time IntLit
+        // carrying the token's 1-based source line, surfaced as the
+        // argument of the enclosing `puts`.  A lone `puts(...)` is the
+        // block's trailing VALUE, not a stmt.
+        let m = lower("puts(__LINE__)\n");
+        let b = main_body(&m);
+        let args = match &b.value {
+            Expr::BuiltinCall { name, args, .. } if name == "puts" => args,
+            other => panic!("expected BuiltinCall(puts, ...), got {:?}", other),
+        };
+        assert!(
+            matches!(&args[0], Expr::IntLit { value, .. } if *value == 1),
+            "expected `__LINE__` on line 1 to lower to IntLit(1), got {:?}",
+            args[0]
+        );
+    }
+
+    #[test]
+    fn line_keyword_tracks_source_line() {
+        // The IntLit value is the actual (1-based) line of the `__LINE__`
+        // token — here line 2, after a leading statement — proving it is
+        // not a hard-coded constant.
+        let m = lower("x = 1\nputs(__LINE__)\n");
+        let b = main_body(&m);
+        let args = match &b.value {
+            Expr::BuiltinCall { name, args, .. } if name == "puts" => args,
+            other => panic!("expected BuiltinCall(puts, ...), got {:?}", other),
+        };
+        assert!(
+            matches!(&args[0], Expr::IntLit { value, .. } if *value == 2),
+            "expected `__LINE__` on line 2 to lower to IntLit(2), got {:?}",
+            args[0]
+        );
+    }
+
+    #[test]
+    fn line_keyword_validates_e2e() {
+        // End-to-end: a `__LINE__`-using module round-trips the SIR
+        // validator (the IntLit is a self-contained literal — no unbound
+        // names, no feature requirement since integers are baseline).
+        let m = lower("puts(__LINE__)\n");
+        let result = semantic_ir::validate(&m);
+        assert!(
+            result.is_ok(),
+            "validator rejected `__LINE__`-using module: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn line_keyword_shadowed_by_local_is_varref() {
+        // A `__LINE__` shadowed by a prior local binding keeps the local
+        // (mirrors the `__FILE__` / bare-`raise` shadow guards): the read
+        // lowers to a VarRef, NOT the line-number IntLit.
+        let m = lower("__LINE__ = 7\nputs(__LINE__)\n");
+        let b = main_body(&m);
+        let args = match &b.value {
+            Expr::BuiltinCall { name, args, .. } if name == "puts" => args,
+            other => panic!("expected BuiltinCall(puts, ...), got {:?}", other),
+        };
+        assert!(
+            matches!(&args[0], Expr::VarRef { name, .. } if name == "__LINE__"),
+            "expected shadowed `__LINE__` to stay a VarRef, got {:?}",
+            args[0]
+        );
+    }
+
+    #[test]
     fn case_in_array_pattern_validates_e2e() {
         // Phase 13a (FC) — end-to-end: a binding array pattern lowers to
         // real SIR (`SeqLen`/`SeqIndex` + `LetBinding`) that round-trips

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -6066,6 +6066,34 @@ impl Lowerer {
                                     span,
                                 });
                             }
+                            // Phase 23c (FC) — `__LINE__` is Ruby's pseudo-
+                            // variable for the (1-based) line number of the
+                            // source line on which it appears.  Like
+                            // `__FILE__` it is NOT a lexer keyword (it
+                            // arrives as an ordinary `Name` token) and the
+                            // grammar already matches it via `factor`'s
+                            // bare-NAME alternative — so NO grammar/lexer
+                            // change is needed; we intercept it here at
+                            // lowering time, exactly like `__FILE__` /
+                            // bare-`raise`.
+                            //
+                            // It lowers to a compile-time `IntLit` carrying
+                            // the token's own line number (`tok.line`).
+                            // Integers are a baseline SIR capability, so —
+                            // unlike `__FILE__`'s StrLit — no `Feature`
+                            // declaration is required.
+                            //
+                            // A `__LINE__` shadowed by a local binding
+                            // (`__LINE__ = 1`) keeps the local, mirroring
+                            // the `__FILE__` / `raise` shadow guards.
+                            if tok.value == "__LINE__"
+                                && !self.declared_locals.contains("__LINE__")
+                            {
+                                return Ok(Expr::IntLit {
+                                    value: tok.line as i64,
+                                    span,
+                                });
+                            }
                             // Inside a function body, parameter
                             // names lex as `VarRef` with
                             // `Scope::Param` so the SIR validator


### PR DESCRIPTION
## Phase 23c (FC) — `__LINE__` pseudo-variable

Adds Ruby's `__LINE__` pseudo-variable to the Ruby 3.4 frontend, the sibling of Phase 23a (`__FILE__`).

### Approach — lowering-only, no grammar/lexer change
- `__LINE__` begins with `_`, so it is **not** a lexer keyword — it lexes as an ordinary `Name` token.
- The parser already matches it via `factor`'s existing bare-`NAME` alternative in every expression position (standalone statement, call argument, assignment RHS).
- Therefore **no grammar rule, no `_grammar.rs` regen, and no lexer change** were needed.

### Lowering
- In `lower_factor_atom`, the bare `Name` is intercepted exactly like the `__FILE__` / bare-`raise` cases: when the token value is `__LINE__` and it is not shadowed by a local binding, it lowers to `IntLit { value: tok.line }` — the token's own 1-based source line.
- **No `Feature` declaration required** — integers are a baseline SIR capability (contrast `__FILE__`'s `StrLit`, which needs `Feature::Strings`).
- **Shadow guard**: a `__LINE__` shadowed by a prior local (`__LINE__ = 7`) keeps the local read (a `VarRef`).

### Tests
- 3 parser parse-shape pins: `test_parse_line_keyword_as_factor`, `test_parse_line_keyword_in_call_arg`, `test_parse_line_keyword_in_assignment_rhs`.
- 4 lowering tests: `line_keyword_lowers_to_intlit`, `line_keyword_tracks_source_line` (asserts the value is the actual line, not a constant), `line_keyword_validates_e2e` (lower → validate round-trip), `line_keyword_shadowed_by_local_is_varref`.
- Full lexer + parser + lowerer suites green (173 lexer, 253 parser, 325 lowerer tests pass).

### Versions
- `coding-adventures-ruby-parser` CHANGELOG 0.72.0 → 0.73.0 (test-only pins; grammar unchanged)
- `ruby-to-semantic-ir` CHANGELOG 0.80.0 → 0.81.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
