### PR TITLE
feat(ruby): lower `__dir__` pseudo-variable to a StrLit (Phase 23d FC)

### DIFF
--- a/code/.commit-msg-23d.txt
+++ b/code/.commit-msg-23d.txt
@@ -1,0 +1,27 @@
+feat(ruby): lower `__dir__` pseudo-variable to a StrLit (Phase 23d FC)
+
+Ruby's `__dir__` pseudo-variable now lowers to a compile-time StrLit
+carrying the directory portion of the lowerer's `file_name`: the
+substring before the final path separator (`/` or `\`), or "." when the
+name has no directory component — the closest fixed value for "the
+current directory" absent a runtime filesystem, consistent with how
+`__FILE__` surfaces the bare module name.
+
+Sibling of Phase 23a `__FILE__` / 23c `__LINE__`: because `__dir__` is
+NOT a lexer keyword it arrives as an ordinary Name token and the parser
+already matches it via `factor`'s bare-NAME alternative, so NO grammar
+or lexer change was needed. The meaning is supplied entirely in
+`lower_factor_atom`, intercepting the bare Name exactly like the sibling
+pseudo-variables: when the token value is `__dir__` and it is not
+shadowed by a local binding, we emit the StrLit and declare
+Feature::Strings. A `__dir__` shadowed by a prior local (`__dir__ = 1`)
+keeps the local read (a VarRef). Scope: the bare form; `__dir__()` is a
+deliberate follow-up slice.
+
+Tests: 3 parser parse-shape pins + 4 lowering tests (incl. lower ->
+validate E2E and the shadow-guard case).
+
+Parser CHANGELOG 0.73.0 -> 0.74.0 (test-only pins; grammar unchanged);
+IR CHANGELOG 0.81.0 -> 0.82.0.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

--- a/code/.pr-body-fc-23d.md
+++ b/code/.pr-body-fc-23d.md
@@ -1,0 +1,27 @@
+## Phase 23d (FC) — `__dir__` pseudo-variable
+
+Adds Ruby's `__dir__` pseudo-variable to the Ruby 3.4 frontend, completing the `__FILE__` / `__LINE__` / `__dir__` source-location trio.
+
+### Approach — lowering-only, no grammar/lexer change
+- `__dir__` is **not** a lexer keyword — it lexes as an ordinary `Name` token.
+- The parser already matches it via `factor`'s existing bare-`NAME` alternative in every expression position (standalone statement, call argument, assignment RHS).
+- Therefore **no grammar rule, no `_grammar.rs` regen, and no lexer change** were needed.
+
+### Lowering
+- In `lower_factor_atom`, the bare `Name` is intercepted exactly like the `__FILE__` / `__LINE__` / bare-`raise` cases: when the token value is `__dir__` and it is not shadowed by a local binding, it lowers to a `StrLit` carrying the directory portion of `file_name` — the substring before the final path separator (`/` or `\`), or `"."` when there is no directory component.
+- `Feature::Strings` is declared for the emitted `StrLit`.
+- **Shadow guard**: a `__dir__` shadowed by a prior local (`__dir__ = 1`) keeps the local read (a `VarRef`).
+
+### Scope
+The `StrLit` is the directory of the compile-time module name — the closest fixed value for "the current directory" without a runtime filesystem. The explicit-call form `__dir__()` (with parens) is a deliberate follow-up slice.
+
+### Tests
+- 3 parser parse-shape pins: `test_parse_dir_keyword_as_factor`, `test_parse_dir_keyword_in_call_arg`, `test_parse_dir_keyword_in_assignment_rhs`.
+- 4 lowering tests: `dir_keyword_lowers_to_strlit`, `dir_keyword_declares_strings_feature`, `dir_keyword_validates_e2e` (lower → validate round-trip), `dir_keyword_shadowed_by_local_is_varref`.
+- Full lexer + parser + lowerer suites green (173 lexer, 256 parser, 329 lowerer tests pass).
+
+### Versions
+- `coding-adventures-ruby-parser` CHANGELOG 0.73.0 → 0.74.0 (test-only pins; grammar unchanged)
+- `ruby-to-semantic-ir` CHANGELOG 0.81.0 → 0.82.0
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.74.0] - 2026-06-01
+
+### Added (Phase 23d (FC) — `__dir__` parse pins)
+
+Regression pins confirming Ruby's `__dir__` pseudo-variable parses with
+**no grammar change** (sibling of Phase 23a `__FILE__` / 23c `__LINE__`):
+`__dir__` is not a lexer keyword — it arrives as an ordinary `NAME` token
+matched by `factor`'s existing bare-`NAME` alternative in every
+expression position (standalone statement, call argument, assignment
+RHS).  The feature's semantics are supplied entirely at lowering time
+(see the `ruby-to-semantic-ir` 0.82.0 entry); this crate's grammar is
+unchanged, so these are pure parse-shape pins.  New tests:
+`test_parse_dir_keyword_as_factor`, `test_parse_dir_keyword_in_call_arg`,
+`test_parse_dir_keyword_in_assignment_rhs`.
+
 ## [0.73.0] - 2026-06-01
 
 ### Added (Phase 23c (FC) — `__LINE__` parse pins)

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -3983,6 +3983,45 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_dir_keyword_as_factor() {
+        // Phase 23d (FC) — `__dir__`, like `__FILE__` / `__LINE__`, is NOT
+        // a lexer keyword (it lexes as an ordinary NAME) and needs no
+        // grammar rule: it parses through `factor`'s bare-NAME alternative.
+        let ast = parse_ruby("__dir__\n");
+        assert!(
+            tree_has_token_value(&ast, "__dir__"),
+            "expected `__dir__` token to be present in the parse tree"
+        );
+    }
+
+    #[test]
+    fn test_parse_dir_keyword_in_call_arg() {
+        // `puts(__dir__)` — `__dir__` parses as a call argument expression
+        // (factor → NAME).
+        let ast = parse_ruby("puts(__dir__)\n");
+        assert!(
+            tree_has_token_value(&ast, "__dir__"),
+            "expected `__dir__` token in the `puts(__dir__)` call args"
+        );
+    }
+
+    #[test]
+    fn test_parse_dir_keyword_in_assignment_rhs() {
+        // `d = __dir__` — `__dir__` parses as the assignment RHS
+        // expression, the same NAME-factor path a normal variable read
+        // would take.
+        let ast = parse_ruby("d = __dir__\n");
+        assert!(
+            tree_has_token_value(&ast, "d"),
+            "expected LHS name `d` in the assignment"
+        );
+        assert!(
+            tree_has_token_value(&ast, "__dir__"),
+            "expected `__dir__` token as the assignment RHS"
+        );
+    }
+
+    #[test]
     fn test_parse_endless_def_no_params() {
         // `def hello = 1` — endless method with no parameters.
         let ast = parse_ruby("def hello = 1");

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.82.0] - 2026-06-01
+
+### Added (Phase 23d (FC) — `__dir__` pseudo-variable lowering)
+
+Ruby's `__dir__` pseudo-variable now lowers to a compile-time `StrLit`
+carrying the directory portion of the lowerer's `file_name`: the
+substring before the final path separator (`/` or `\`), or `"."` when the
+name has no directory component — the closest fixed value for "the
+current directory" absent a runtime filesystem, consistent with how
+`__FILE__` surfaces the bare module name.
+
+Sibling of Phase 23a `__FILE__` / 23c `__LINE__`: because `__dir__` is
+**not** a lexer keyword it arrives as an ordinary `Name` token and the
+parser already matches it via `factor`'s bare-`NAME` alternative, so **no
+grammar or lexer change** was needed.  The meaning is supplied entirely in
+`lower_factor_atom`, intercepting the bare `Name` exactly like the sibling
+pseudo-variables: when the token value is `__dir__` and it is **not**
+shadowed by a local binding, we emit the `StrLit` and declare
+`Feature::Strings`.  A `__dir__` shadowed by a prior local (`__dir__ = 1`)
+keeps the local read (a `VarRef`), mirroring the existing shadow guards.
+Scope: the bare form; the explicit-call form `__dir__()` is a deliberate
+follow-up slice.
+
+New lowering tests: `dir_keyword_lowers_to_strlit`,
+`dir_keyword_declares_strings_feature`, `dir_keyword_validates_e2e`
+(lower → validate round-trip), `dir_keyword_shadowed_by_local_is_varref`.
+
 ## [0.81.0] - 2026-06-01
 
 ### Added (Phase 23c (FC) — `__LINE__` pseudo-variable lowering)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -6538,6 +6538,68 @@ b = "y"
     }
 
     #[test]
+    fn dir_keyword_lowers_to_strlit() {
+        // Phase 23d (FC) — `__dir__` lowers to a compile-time StrLit
+        // carrying the directory portion of the lowerer's `file_name`.
+        // The test module name is "test" (no path separator), so the
+        // directory is the conventional ".".
+        let m = lower("puts(__dir__)\n");
+        let b = main_body(&m);
+        let args = match &b.value {
+            Expr::BuiltinCall { name, args, .. } if name == "puts" => args,
+            other => panic!("expected BuiltinCall(puts, ...), got {:?}", other),
+        };
+        assert!(
+            matches!(&args[0], Expr::StrLit { value, .. } if value == "."),
+            "expected `__dir__` to lower to StrLit(\".\"), got {:?}",
+            args[0]
+        );
+    }
+
+    #[test]
+    fn dir_keyword_declares_strings_feature() {
+        // Emitting the StrLit means the module must declare the `strings`
+        // feature — verify the manifest carries it.
+        let m = lower("puts(__dir__)\n");
+        assert!(
+            m.manifest.contains(semantic_ir::Feature::Strings),
+            "expected Strings feature for `__dir__`; got {:?}",
+            m.manifest
+        );
+    }
+
+    #[test]
+    fn dir_keyword_validates_e2e() {
+        // End-to-end: a `__dir__`-using module round-trips the SIR
+        // validator (the StrLit is a self-contained literal).
+        let m = lower("puts(__dir__)\n");
+        let result = semantic_ir::validate(&m);
+        assert!(
+            result.is_ok(),
+            "validator rejected `__dir__`-using module: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn dir_keyword_shadowed_by_local_is_varref() {
+        // A `__dir__` shadowed by a prior local binding keeps the local
+        // (mirrors the sibling shadow guards): the read lowers to a
+        // VarRef, NOT the directory StrLit.
+        let m = lower("__dir__ = 1\nputs(__dir__)\n");
+        let b = main_body(&m);
+        let args = match &b.value {
+            Expr::BuiltinCall { name, args, .. } if name == "puts" => args,
+            other => panic!("expected BuiltinCall(puts, ...), got {:?}", other),
+        };
+        assert!(
+            matches!(&args[0], Expr::VarRef { name, .. } if name == "__dir__"),
+            "expected shadowed `__dir__` to stay a VarRef, got {:?}",
+            args[0]
+        );
+    }
+
+    #[test]
     fn case_in_array_pattern_validates_e2e() {
         // Phase 13a (FC) — end-to-end: a binding array pattern lowers to
         // real SIR (`SeqLen`/`SeqIndex` + `LetBinding`) that round-trips

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -6094,6 +6094,46 @@ impl Lowerer {
                                     span,
                                 });
                             }
+                            // Phase 23d (FC) — `__dir__` is Ruby's
+                            // pseudo-variable for the directory name of the
+                            // current source file (`File.dirname(__FILE__)`,
+                            // expanded).  Like `__FILE__` / `__LINE__` it is
+                            // NOT a lexer keyword (it arrives as an ordinary
+                            // `Name` token) and the grammar already matches
+                            // it via `factor`'s bare-NAME alternative — so NO
+                            // grammar/lexer change is needed; we intercept it
+                            // here at lowering time, exactly like the sibling
+                            // pseudo-variables.
+                            //
+                            // It lowers to a compile-time `StrLit` carrying
+                            // the directory portion of the lowerer's
+                            // `file_name`: the substring before the final
+                            // path separator (`/` or `\`), or `"."` when the
+                            // name has no directory component (the closest
+                            // fixed value for "the current directory" without
+                            // a runtime filesystem — consistent with how
+                            // `__FILE__` surfaces the bare module name).
+                            // Emitting a `StrLit` means the module uses the
+                            // `strings` feature, so we declare it.
+                            //
+                            // A `__dir__` shadowed by a local binding
+                            // (`__dir__ = 1`) keeps the local, mirroring the
+                            // sibling shadow guards.  Scope: the bare form;
+                            // the explicit-call form `__dir__()` is a
+                            // deliberate follow-up slice.
+                            if tok.value == "__dir__"
+                                && !self.declared_locals.contains("__dir__")
+                            {
+                                let dir = match self
+                                    .file_name
+                                    .rfind(|c| c == '/' || c == '\\')
+                                {
+                                    Some(i) => self.file_name[..i].to_string(),
+                                    None => ".".to_string(),
+                                };
+                                self.features_used.insert(Feature::Strings);
+                                return Ok(Expr::StrLit { value: dir, span });
+                            }
                             // Inside a function body, parameter
                             // names lex as `VarRef` with
                             // `Scope::Param` so the SIR validator


### PR DESCRIPTION
## Phase 23d (FC) — `__dir__` pseudo-variable

Adds Ruby's `__dir__` pseudo-variable to the Ruby 3.4 frontend, completing the `__FILE__` / `__LINE__` / `__dir__` source-location trio.

### Approach — lowering-only, no grammar/lexer change
- `__dir__` is **not** a lexer keyword — it lexes as an ordinary `Name` token.
- The parser already matches it via `factor`'s existing bare-`NAME` alternative in every expression position (standalone statement, call argument, assignment RHS).
- Therefore **no grammar rule, no `_grammar.rs` regen, and no lexer change** were needed.

### Lowering
- In `lower_factor_atom`, the bare `Name` is intercepted exactly like the `__FILE__` / `__LINE__` / bare-`raise` cases: when the token value is `__dir__` and it is not shadowed by a local binding, it lowers to a `StrLit` carrying the directory portion of `file_name` — the substring before the final path separator (`/` or `\`), or `"."` when there is no directory component.
- `Feature::Strings` is declared for the emitted `StrLit`.
- **Shadow guard**: a `__dir__` shadowed by a prior local (`__dir__ = 1`) keeps the local read (a `VarRef`).

### Scope
The `StrLit` is the directory of the compile-time module name — the closest fixed value for "the current directory" without a runtime filesystem. The explicit-call form `__dir__()` (with parens) is a deliberate follow-up slice.

### Tests
- 3 parser parse-shape pins: `test_parse_dir_keyword_as_factor`, `test_parse_dir_keyword_in_call_arg`, `test_parse_dir_keyword_in_assignment_rhs`.
- 4 lowering tests: `dir_keyword_lowers_to_strlit`, `dir_keyword_declares_strings_feature`, `dir_keyword_validates_e2e` (lower → validate round-trip), `dir_keyword_shadowed_by_local_is_varref`.
- Full lexer + parser + lowerer suites green (173 lexer, 256 parser, 329 lowerer tests pass).

### Versions
- `coding-adventures-ruby-parser` CHANGELOG 0.73.0 → 0.74.0 (test-only pins; grammar unchanged)
- `ruby-to-semantic-ir` CHANGELOG 0.81.0 → 0.82.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
