### PR TITLE
feat(iir-to-wasm): accept cmp_*-prefixed comparison opcodes (G1)

### DIFF
--- a/code/packages/rust/iir-to-wasm/CHANGELOG.md
+++ b/code/packages/rust/iir-to-wasm/CHANGELOG.md
@@ -3,6 +3,37 @@
 All notable changes to this crate are documented here.  The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.7.0] — 2026-06-01 (G1 — accept `cmp_*`-prefixed comparison opcodes)
+
+### Changed — `cmp_eq` / `cmp_ne` / `cmp_lt` / `cmp_le` / `cmp_gt` / `cmp_ge` now lower
+
+Pre-0.7.0, the `lower_iir_to_wasm` step only recognised the bare
+shape (`eq` / `ne` / `lt` / `le` / `gt` / `ge`) — the form
+`twig-ir-compiler` emits.  Languages that prefix the mnemonic with
+`cmp_` — BASIC, Nib, Oct — would fail at lowering even though the
+validator accepted them, surfacing as
+`IIR -> WasmModule: UnsupportedOp { op: "cmp_gt" }`.
+
+This release accepts both shapes.  The implementation strips a
+leading `cmp_` from the opcode name and routes the bare form
+through the existing per-type opcode dispatch (i32/i64 signed/
+unsigned + f32/f64).  No new opcodes are added; the wasm
+comparison opcode table is unchanged.  Twig's existing bare-form
+emissions continue to lower identically.
+
+This unblocks:
+- BASIC `IF A > 5 THEN 100` lowering to wasm
+- BASIC `FOR I = 1 TO 3 / NEXT I` (cmp_le) lowering to wasm
+- Nib `if a < b { ... }` lowering to wasm
+- Oct `while x < 10 { ... }` lowering to wasm
+
+### Tests
+
+- 7 new tests in `tests/test_backend.rs`: one per `cmp_*` variant
+  asserting `lower_iir_to_wasm` no longer rejects, plus a
+  back-compat test for the bare-`eq` form.
+- All 95 existing unit tests still pass.
+
 ## [0.6.0] — 2026-05-26 (Validator accepts `ref<any>` for `field_load`)
 
 ### Changed — `ref<any>` joins `SUPPORTED_REF_TYPES`

--- a/code/packages/rust/iir-to-wasm/Cargo.toml
+++ b/code/packages/rust/iir-to-wasm/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iir-to-wasm"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
-description = "IIR → WASM backend — lowers IIRModule to WasmModule (now with Brainfuck linear-memory + I/O imports).  Path A increment 6b: validator accepts `field_store [void]` (canonical Phase 2 form) in addition to `field_store [ref<*>]`.  Path A increment 6c: `ref<any>` added to SUPPORTED_REF_TYPES (lowers to anyref, matches cons-cell field type)."
+description = "IIR → WASM backend — lowers IIRModule to WasmModule.  v0.7.0 (G1): accept `cmp_eq`/`cmp_ne`/`cmp_lt`/`cmp_le`/`cmp_gt`/`cmp_ge` alongside the bare `eq`/`ne`/`lt`/… form, so BASIC/Nib/Oct frontends (which prefix `cmp_`) lower to real wasm comparison opcodes."
 
 [lib]
 name = "iir_to_wasm"

--- a/code/packages/rust/iir-to-wasm/src/lower.rs
+++ b/code/packages/rust/iir-to-wasm/src/lower.rs
@@ -857,7 +857,14 @@ fn emit_instr(
         // WASM comparisons always produce an i32 result (0 or 1).
         // The source operands have the type described by `ty`; the result
         // is always i32.
-        "eq" | "ne" | "lt" | "le" | "gt" | "ge" => {
+        //
+        // **Naming**.  Twig historically emitted bare `eq` / `ne` / `lt` etc.
+        // — the names we still match below.  BASIC, Nib, and Oct emit the
+        // `cmp_*`-prefixed form (`cmp_eq`, `cmp_ne`, …).  We accept both
+        // shapes by stripping the `cmp_` prefix on entry and routing the
+        // bare form through the same opcode table.
+        "eq" | "ne" | "lt" | "le" | "gt" | "ge"
+        | "cmp_eq" | "cmp_ne" | "cmp_lt" | "cmp_le" | "cmp_gt" | "cmp_ge" => {
             let dest = instr.dest.as_deref().ok_or_else(|| IIRWasmError::InvalidOperand {
                 function: fn_name.to_string(),
                 detail: format!("{} must have a dest", instr.op),
@@ -869,7 +876,11 @@ fn emit_instr(
             code.extend(encode_local_get(r1));
             code.extend(encode_local_get(r2));
 
-            let opcode: u8 = match (instr.op.as_str(), ty) {
+            // Strip the `cmp_` prefix so the existing per-type lookup table
+            // doesn't need 12 extra arms.
+            let bare = instr.op.strip_prefix("cmp_").unwrap_or(instr.op.as_str());
+
+            let opcode: u8 = match (bare, ty) {
                 // i64
                 ("eq", t) if is_i64_hint(t) => I64_EQ,
                 ("ne", t) if is_i64_hint(t) => I64_NE,

--- a/code/packages/rust/iir-to-wasm/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-wasm/tests/test_backend.rs
@@ -1420,3 +1420,81 @@ fn lang35_closure_opcode_error_not_untyped() {
         "error must not say UntypedInstruction for closure ops; got: {errs:?}"
     );
 }
+
+// ===========================================================================
+// G1 — cmp_* opcode lowerings (BASIC / Nib / Oct emit `cmp_lt` etc.).
+//
+// The lower step pre-G1 only matched the bare `eq | ne | lt | le | gt | ge`
+// shape (the form Twig historically emitted).  Languages that prefix with
+// `cmp_` would lower to `UnsupportedOp` even though the validator accepted
+// them.  G1 extends the match to strip the prefix.
+// ===========================================================================
+
+/// Helper: build a module where `main(a: i64, b: i64) -> i64` runs `cmp_<op>`
+/// over its parameters and returns the result.  The dest's type at the IIR
+/// level is `bool` because that's how the BASIC/Nib/Oct frontends emit it,
+/// but the underlying wasm opcode produces i32, which we widen to i64 with a
+/// final `i64.extend_i32_u` step modeled by a separate `mov`-style helper
+/// in real frontends.  For this unit test we keep the return type `i32` so
+/// no widening is needed.
+fn cmp_i64_module(op: &str) -> IIRModule {
+    module_one("main", vec![("a", "i64"), ("b", "i64")], "i32", vec![
+        IIRInstr::new(op, Some("r".into()),
+            vec![Operand::Var("a".into()), Operand::Var("b".into())],
+            "i64"),
+        IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "i32"),
+    ])
+}
+
+#[test]
+fn g1_cmp_eq_i64_lowers_to_wasm() {
+    let m = cmp_i64_module("cmp_eq");
+    let errs = validate_for_wasm(&m);
+    assert!(errs.is_empty(), "validator accepted cmp_eq before G1; got {errs:?}");
+    let _wm = lower_iir_to_wasm(&m, &IIRWasmConfig::default())
+        .expect("G1: cmp_eq must lower; pre-G1 this would have returned UnsupportedOp");
+}
+
+#[test]
+fn g1_cmp_ne_i64_lowers_to_wasm() {
+    let _ = lower_iir_to_wasm(&cmp_i64_module("cmp_ne"), &IIRWasmConfig::default())
+        .expect("G1: cmp_ne must lower");
+}
+
+#[test]
+fn g1_cmp_lt_i64_lowers_to_wasm() {
+    let _ = lower_iir_to_wasm(&cmp_i64_module("cmp_lt"), &IIRWasmConfig::default())
+        .expect("G1: cmp_lt must lower");
+}
+
+#[test]
+fn g1_cmp_le_i64_lowers_to_wasm() {
+    let _ = lower_iir_to_wasm(&cmp_i64_module("cmp_le"), &IIRWasmConfig::default())
+        .expect("G1: cmp_le must lower");
+}
+
+#[test]
+fn g1_cmp_gt_i64_lowers_to_wasm() {
+    let _ = lower_iir_to_wasm(&cmp_i64_module("cmp_gt"), &IIRWasmConfig::default())
+        .expect("G1: cmp_gt must lower");
+}
+
+#[test]
+fn g1_cmp_ge_i64_lowers_to_wasm() {
+    let _ = lower_iir_to_wasm(&cmp_i64_module("cmp_ge"), &IIRWasmConfig::default())
+        .expect("G1: cmp_ge must lower");
+}
+
+/// Backwards-compatibility: Twig's existing bare `eq` / `lt` / etc.  must
+/// still lower.  The prefix-stripper passes the bare form through unchanged.
+#[test]
+fn g1_bare_eq_still_lowers_to_wasm() {
+    let m = module_one("main", vec![("a", "i64"), ("b", "i64")], "i32", vec![
+        IIRInstr::new("eq", Some("r".into()),
+            vec![Operand::Var("a".into()), Operand::Var("b".into())],
+            "i64"),
+        IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "i32"),
+    ]);
+    let _ = lower_iir_to_wasm(&m, &IIRWasmConfig::default())
+        .expect("G1: bare `eq` (Twig form) must still lower");
+}


### PR DESCRIPTION
## Summary

Item **G1** of the multi-language backend plan (PR #4737).

Pre-G1, the \`lower_iir_to_wasm\` step only matched the bare \`eq | ne | lt | le | gt | ge\` shape (the form Twig emits).  BASIC, Nib, and Oct prefix with \`cmp_\`, so their IIR failed at lowering with \`UnsupportedOp { op: \"cmp_gt\" }\` even though the validator accepted it.

Now the match arm strips a leading \`cmp_\` and routes the bare form through the existing per-type opcode table.  Twig's bare-form emissions continue to lower identically.

## Impact

- BASIC \`IF A > 5 THEN 100\` lowers to real wasm bytecode ✅
- BASIC \`FOR I = 1 TO 3 / NEXT I\` (uses cmp_le) lowers ✅
- Nib \`if a < b { ... }\` lowers ✅
- Oct \`while x < 10 { ... }\` lowers ✅

## Versions

- \`iir-to-wasm\` 0.6.0 → 0.7.0

## Test plan

- [x] 7 new tests in \`tests/test_backend.rs\` (one per cmp_* variant + back-compat for bare \`eq\`)
- [x] All 95 existing iir-to-wasm tests still pass
- [x] Downstream BASIC/Nib/Oct/Twig tests all still pass
- [x] \`/security-review\` passed — no vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)