### PR TITLE
feat(ruby): lower `using Mod` to a PURE BuiltinCall (Phase 26a FC)

### DIFF
--- a/code/.commit-msg-26a.txt
+++ b/code/.commit-msg-26a.txt
@@ -1,0 +1,22 @@
+feat(ruby): lower `using Mod` to a PURE BuiltinCall (Phase 26a FC)
+
+`using Mod` (refinement activation) now lowers to a first-class
+`BuiltinCall("using", [<module>])` with `EffectSet::PURE`, rather than
+falling through to a `DirectCall("using", …)` that the SIR validator
+rejected as an undeclared callee.
+
+`using` is an ordinary method (not a keyword), so it arrives as a
+`method_call_no_paren` with the refinement module as its sole argument
+— NO grammar or lexer change was needed. The fix adds `using` to the
+lowerer's `ruby_builtin_effects` table as a PURE builtin, alongside the
+other declaration-style forms; the module operand is lowered through the
+normal expression path (a Const reference for `using Foo`).
+
+Tests: 3 parser parse-shape pins + 3 lowering tests (incl. lower ->
+validate E2E with the constant operand declared by a preceding
+assignment).
+
+Parser CHANGELOG 0.74.0 -> 0.75.0 (test-only pins; grammar unchanged);
+IR CHANGELOG 0.82.0 -> 0.83.0.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

--- a/code/.pr-body-fc-26a.md
+++ b/code/.pr-body-fc-26a.md
@@ -1,0 +1,22 @@
+## Phase 26a (FC) — `using Mod` refinement activation
+
+Adds Ruby's `using Mod` (refinement activation) to the Ruby 3.4 frontend, the penultimate Tier-5 slice before `refine` (26b).
+
+### Problem
+`using Foo` is an ordinary paren-less method call, so it parsed fine but **lowered to a `DirectCall("using", …)`** — and the SIR validator rejects `DirectCall`s to undeclared callees, so any `using`-using module failed end-to-end validation.
+
+### Fix — lowering-only, no grammar/lexer change
+- `using` is a method (not a keyword), so `using Foo` / `using Foo::Bar` already parse as `method_call_no_paren` with the module as the sole argument.
+- Added `"using"` to the lowerer's `ruby_builtin_effects` table as a **PURE** builtin (alongside the other declaration-style forms), so it now lowers to `BuiltinCall("using", [<module>])` and validates as a first-class call.
+- The module operand is lowered through the normal expression path (e.g. a `Const` reference for `using Foo`). In this model the activation carries no runtime data effect.
+
+### Tests
+- 3 parser parse-shape pins: `test_parse_using_is_method_call_no_paren`, `test_parse_using_carries_callee_and_module`, `test_parse_using_scoped_module`.
+- 3 lowering tests: `using_lowers_to_builtin_call`, `using_operand_is_the_module_ref`, `using_is_pure_and_validates_e2e` (lower → validate round-trip; the constant operand is declared by a preceding assignment).
+- Full lexer + parser + lowerer suites green (173 lexer, 259 parser, 332 lowerer tests pass).
+
+### Versions
+- `coding-adventures-ruby-parser` CHANGELOG 0.74.0 → 0.75.0 (test-only pins; grammar unchanged)
+- `ruby-to-semantic-ir` CHANGELOG 0.82.0 → 0.83.0
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.75.0] - 2026-06-01
+
+### Added (Phase 26a (FC) — `using Mod` parse pins)
+
+Regression pins confirming Ruby's `using Mod` refinement-activation
+statement parses with **no grammar change**: `using` is an ordinary
+method (not a keyword), so `using Foo` / `using Foo::Bar` parse as a
+`method_call_no_paren` with the refinement module as the sole argument.
+The feature's semantics (lowering to a PURE `BuiltinCall` instead of an
+undeclared `DirectCall`) are supplied entirely in the lowerer (see the
+`ruby-to-semantic-ir` 0.83.0 entry); this crate's grammar is unchanged,
+so these are pure parse-shape pins.  New tests:
+`test_parse_using_is_method_call_no_paren`,
+`test_parse_using_carries_callee_and_module`,
+`test_parse_using_scoped_module`.
+
 ## [0.74.0] - 2026-06-01
 
 ### Added (Phase 23d (FC) — `__dir__` parse pins)

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -4022,6 +4022,48 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_using_is_method_call_no_paren() {
+        // Phase 26a (FC) — `using Mod` is an ordinary paren-less method
+        // call (`using` is a method, not a keyword): it parses as a
+        // `method_call_no_paren` with the module as its sole argument.
+        let ast = parse_ruby("using Foo\n");
+        assert!(
+            find_descendant(&ast, "method_call_no_paren").is_some(),
+            "expected `using Foo` to parse as method_call_no_paren"
+        );
+    }
+
+    #[test]
+    fn test_parse_using_carries_callee_and_module() {
+        // Both the `using` callee and the `Foo` module operand must
+        // appear in the parse tree.
+        let ast = parse_ruby("using Foo\n");
+        assert!(
+            tree_has_token_value(&ast, "using"),
+            "expected the `using` callee token in the tree"
+        );
+        assert!(
+            tree_has_token_value(&ast, "Foo"),
+            "expected the `Foo` module operand token in the tree"
+        );
+    }
+
+    #[test]
+    fn test_parse_using_scoped_module() {
+        // `using Foo::Bar` — the operand may be a scoped constant; the
+        // scope-resolution tokens survive into the tree.
+        let ast = parse_ruby("using Foo::Bar\n");
+        assert!(
+            find_descendant(&ast, "method_call_no_paren").is_some(),
+            "expected `using Foo::Bar` to parse as method_call_no_paren"
+        );
+        assert!(
+            tree_has_token_value(&ast, "Bar"),
+            "expected the scoped `Bar` operand token in the tree"
+        );
+    }
+
+    #[test]
     fn test_parse_endless_def_no_params() {
         // `def hello = 1` — endless method with no parameters.
         let ast = parse_ruby("def hello = 1");

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.83.0] - 2026-06-01
+
+### Added (Phase 26a (FC) — `using Mod` refinement activation)
+
+`using Mod` (refinement activation) now lowers to a first-class
+`BuiltinCall("using", [<module>])` with `EffectSet::PURE`, rather than
+falling through to a `DirectCall("using", …)` that the SIR validator
+rejected as an undeclared callee.
+
+`using` is an ordinary method (not a keyword), so it arrives as a
+`method_call_no_paren` with the refinement module as its sole argument —
+**no grammar or lexer change** was needed.  The fix adds `"using"` to the
+lowerer's `ruby_builtin_effects` table as a PURE builtin, alongside the
+other declaration-style forms; the module operand is lowered through the
+normal expression path (e.g. a `Const` reference for `using Foo`).  In
+this model the activation carries no runtime data effect.
+
+New lowering tests: `using_lowers_to_builtin_call`,
+`using_operand_is_the_module_ref`, `using_is_pure_and_validates_e2e`
+(lower → validate round-trip).
+
 ## [0.82.0] - 2026-06-01
 
 ### Added (Phase 23d (FC) — `__dir__` pseudo-variable lowering)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -6600,6 +6600,61 @@ b = "y"
     }
 
     #[test]
+    fn using_lowers_to_builtin_call() {
+        // Phase 26a (FC) — `using Mod` lowers to a statement-position
+        // BuiltinCall("using", [<module>]) rather than an unknown
+        // DirectCall.  A lone trailing call is the block's VALUE.
+        let m = lower("Foo = 1\nusing Foo\n");
+        let b = main_body(&m);
+        match &b.value {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "using");
+                assert_eq!(args.len(), 1, "expected exactly the module arg");
+            }
+            other => panic!("expected BuiltinCall(using, …), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn using_operand_is_the_module_ref() {
+        // The sole argument is the refinement module, lowered through the
+        // normal expression path — here a constant reference `Foo`.
+        let m = lower("Foo = 1\nusing Foo\n");
+        let b = main_body(&m);
+        let args = match &b.value {
+            Expr::BuiltinCall { name, args, .. } if name == "using" => args,
+            other => panic!("expected using BuiltinCall, got {:?}", other),
+        };
+        assert!(
+            matches!(&args[0], Expr::VarRef { name, .. } if name == "Foo"),
+            "expected module operand VarRef(\"Foo\"), got {:?}",
+            args[0]
+        );
+    }
+
+    #[test]
+    fn using_is_pure_and_validates_e2e() {
+        // End-to-end: a `using`-activated module round-trips the SIR
+        // validator — the call is no longer an undeclared DirectCall, and
+        // the constant operand is declared by the preceding assignment.
+        let m = lower("Foo = 1\nusing Foo\n");
+        match &main_body(&m).value {
+            Expr::BuiltinCall { effects, .. } => assert!(
+                !effects.contains(Effect::Divergent),
+                "using should be PURE (non-divergent), got {:?}",
+                effects
+            ),
+            other => panic!("expected using BuiltinCall, got {:?}", other),
+        }
+        let result = semantic_ir::validate(&m);
+        assert!(
+            result.is_ok(),
+            "validator rejected `using`-using module: {:?}",
+            result
+        );
+    }
+
+    #[test]
     fn case_in_array_pattern_validates_e2e() {
         // Phase 13a (FC) — end-to-end: a binding array pattern lowers to
         // real SIR (`SeqLen`/`SeqIndex` + `LetBinding`) that round-trips

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -6496,6 +6496,19 @@ fn ruby_builtin_effects(name: &str) -> Option<EffectSet> {
         | "partition" | "each_slice" | "each_cons" => {
             Some(EffectSet::PURE)
         }
+        // Phase 26a (FC) — `using Mod` activates a refinement module in
+        // the current lexical scope.  It is an ordinary method call
+        // (`using` is a `Kernel`/`Module` method, not a keyword), so it
+        // arrives here as a `method_call_no_paren` with callee `using`
+        // and the refinement module as its sole argument.  Without this
+        // entry it would fall through to a `DirectCall("using", …)`,
+        // which the SIR validator rejects as an undeclared callee.
+        // Tagging it a PURE builtin — like the other declaration-style
+        // forms (`alias` / `undef`) — lets it lower and validate as a
+        // first-class call whose argument (the module, e.g. a `Const`
+        // ref) is lowered through the normal expression path.  In this
+        // model the activation carries no runtime data effect.
+        "using" => Some(EffectSet::PURE),
         _ => None,
     }
 }


### PR DESCRIPTION
## Phase 26a (FC) — `using Mod` refinement activation

Adds Ruby's `using Mod` (refinement activation) to the Ruby 3.4 frontend, the penultimate Tier-5 slice before `refine` (26b).

### Problem
`using Foo` is an ordinary paren-less method call, so it parsed fine but **lowered to a `DirectCall("using", …)`** — and the SIR validator rejects `DirectCall`s to undeclared callees, so any `using`-using module failed end-to-end validation.

### Fix — lowering-only, no grammar/lexer change
- `using` is a method (not a keyword), so `using Foo` / `using Foo::Bar` already parse as `method_call_no_paren` with the module as the sole argument.
- Added `"using"` to the lowerer's `ruby_builtin_effects` table as a **PURE** builtin (alongside the other declaration-style forms), so it now lowers to `BuiltinCall("using", [<module>])` and validates as a first-class call.
- The module operand is lowered through the normal expression path (e.g. a `Const` reference for `using Foo`). In this model the activation carries no runtime data effect.

### Tests
- 3 parser parse-shape pins: `test_parse_using_is_method_call_no_paren`, `test_parse_using_carries_callee_and_module`, `test_parse_using_scoped_module`.
- 3 lowering tests: `using_lowers_to_builtin_call`, `using_operand_is_the_module_ref`, `using_is_pure_and_validates_e2e` (lower → validate round-trip; the constant operand is declared by a preceding assignment).
- Full lexer + parser + lowerer suites green (173 lexer, 259 parser, 332 lowerer tests pass).

### Versions
- `coding-adventures-ruby-parser` CHANGELOG 0.74.0 → 0.75.0 (test-only pins; grammar unchanged)
- `ruby-to-semantic-ir` CHANGELOG 0.82.0 → 0.83.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
