### PR TITLE
feat(iir-to-wasm): whitelist call_builtin print_i64 (G2)

### DIFF
--- a/code/packages/rust/dartmouth-basic-iir-compiler/tests/backend_encode.rs
+++ b/code/packages/rust/dartmouth-basic-iir-compiler/tests/backend_encode.rs
@@ -6,20 +6,15 @@
 //! *encoder* (`lower_iir_to_*`) and asserts the output is real
 //! bytecode (correct magic prefix etc.).
 //!
-//! ## Known gap (intentional, documented)
+//! ## PRINT status
 //!
-//! These tests deliberately use BASIC programs WITHOUT `PRINT`.
-//! BASIC's `PRINT` lowers to `call_builtin "print_i64"`, and the
-//! `iir-to-wasm` / `iir-to-jvm-class-file` / `iir-to-cil-bytecode`
-//! backends currently only whitelist `putchar` / `getchar` as host
-//! imports.  Until those backends grow a `print_i64` host import
-//! (a small change: one entry in `CALL_BUILTIN_SUPPORTED_NAMES`
-//! and a lowering rule), BASIC programs that print don't make it
-//! all the way through the cross-platform encoders.
+//! As of G2 (iir-to-wasm 0.8.0), BASIC's `PRINT` reaches real
+//! `.wasm` bytecode — `call_builtin "print_i64"` is whitelisted
+//! and routed to the same `env.__print_i64` host import the
+//! `io_out` opcode uses.  See `print_lowers_to_wasm_bytes` below.
 //!
-//! BASIC programs without PRINT — pure arithmetic, control flow,
-//! GOTO/FOR/NEXT — DO make it through, which is what these tests
-//! prove.
+//! G3 and G4 (iir-to-jvm / iir-to-cil) are still pending — when
+//! those land, BASIC PRINT will lower through all three encoders.
 //!
 //! ## What's not here
 //!
@@ -176,22 +171,28 @@ fn basic_for_loop_lowers_to_clr_assembly() {
 // ===========================================================================
 
 #[test]
-fn print_is_blocked_until_backends_whitelist_print_i64() {
-    // This test is a regression marker: if it starts failing
-    // (the validator stops rejecting), the backends have grown a
-    // `print_i64` host import — at which point the file-level docs
-    // and the gating logic here should be reversed (PRINT becomes
-    // an officially-supported builtin across all 4 encoders).
+fn print_lowers_to_wasm_bytes() {
+    // G2 (PR #4738+) flipped this from "blocked" to "works" — BASIC's
+    // PRINT now reaches real wasm bytecode through the
+    // `env.__print_i64` host import that `iir-to-wasm` injects.
+    //
+    // We test the full path: BASIC source → IIR → validator (must
+    // accept) → lower (must succeed) → encode (must produce a
+    // .wasm-magic byte stream).
     let src = "10 PRINT 42\n20 END\n";
     let m = compile_source(src, "print_smoke")
-        .expect("BASIC compiles to IIR (frontend has no quarrel with PRINT)");
+        .expect("BASIC compiles to IIR");
     let errs = iir_to_wasm::validate::validate_for_wasm(&m);
-    assert!(
-        !errs.is_empty()
-            && errs.iter().any(|e| e.contains("print_i64")),
-        "expected wasm validator to reject `print_i64` until the host \
-         import is whitelisted; got {errs:?}.  If this assertion has \
-         started failing, congrats — extend the test to actually lower \
-         and run the wasm output."
-    );
+    assert!(errs.is_empty(),
+        "G2: wasm validator must now accept PRINT; got {errs:?}");
+    let wm = iir_to_wasm::lower::lower_iir_to_wasm(
+        &m, &iir_to_wasm::lower::IIRWasmConfig::default())
+        .expect("G2: lower must succeed for BASIC with PRINT");
+    let bytes = wasm_module_encoder::encode_module(&wm).expect("encode");
+    assert_eq!(&bytes[..4], &[0x00, 0x61, 0x73, 0x6D],
+        "expected wasm magic prefix; got {:?}", &bytes[..bytes.len().min(8)]);
+    // The host import must exist.
+    let has_print = wm.imports.iter().any(|i|
+        i.module_name == "env" && i.name == "__print_i64");
+    assert!(has_print, "expected env.__print_i64 host import");
 }

--- a/code/packages/rust/iir-to-wasm/CHANGELOG.md
+++ b/code/packages/rust/iir-to-wasm/CHANGELOG.md
@@ -3,6 +3,47 @@
 All notable changes to this crate are documented here.  The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.8.0] — 2026-06-01 (G2 — whitelist `call_builtin "print_i64"`)
+
+### Changed — `call_builtin "print_i64"` now reaches real wasm bytecode
+
+Pre-0.8.0, BASIC's `PRINT` lowered to `call_builtin "print_i64"`,
+and the validator rejected it with
+`UnsupportedOp ... print_i64 ... not in the WASM backend's
+host-import whitelist (supported: ["putchar", "getchar"])`.
+
+The host import already existed under a different name: the
+`io_out` opcode (a Twig/Lispy mechanism) wires
+`env.__print_i64 : (i64) -> ()`.  G2 makes `call_builtin
+"print_i64"` reuse that same import — no new host function needed,
+no breaking change for existing `io_out` users.
+
+The end-to-end effect is that BASIC programs containing `PRINT`
+statements now reach real `.wasm` bytecode through the same single
+encoder pipeline as Twig.
+
+### Implementation
+
+- `validate.rs::CALL_BUILTIN_SUPPORTED_NAMES`: `"print_i64"` added.
+- `lower.rs::collect_module_features`: a `call_builtin "print_i64"`
+  flips `uses_io_out` so the `env.__print_i64` import is wired in
+  even when the module never uses the `io_out` opcode.
+- `lower.rs::emit_instr`: new `"print_i64"` arm in the
+  `call_builtin` branch loads the i64 argument and emits
+  `call <print_fn_idx>` — identical lowering to the `io_out`
+  opcode.
+
+### Tests
+
+- 4 new tests in `tests/test_backend.rs`:
+  - `g2_call_builtin_print_i64_validator_accepts`
+  - `g2_call_builtin_print_i64_lowers_to_wasm_bytes`
+  - `g2_call_builtin_print_i64_injects_host_import`
+  - `g2_unknown_builtin_still_rejected` (regression marker —
+    confirms G2 didn't widen the whitelist beyond `print_i64`)
+- All 95 existing tests still pass.
+
+
 ## [0.7.0] — 2026-06-01 (G1 — accept `cmp_*`-prefixed comparison opcodes)
 
 ### Changed — `cmp_eq` / `cmp_ne` / `cmp_lt` / `cmp_le` / `cmp_gt` / `cmp_ge` now lower

--- a/code/packages/rust/iir-to-wasm/Cargo.toml
+++ b/code/packages/rust/iir-to-wasm/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iir-to-wasm"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
-description = "IIR → WASM backend — lowers IIRModule to WasmModule.  v0.7.0 (G1): accept `cmp_eq`/`cmp_ne`/`cmp_lt`/`cmp_le`/`cmp_gt`/`cmp_ge` alongside the bare `eq`/`ne`/`lt`/… form, so BASIC/Nib/Oct frontends (which prefix `cmp_`) lower to real wasm comparison opcodes."
+description = "IIR → WASM backend — lowers IIRModule to WasmModule.  v0.7.0 (G1): accept cmp_*-prefixed comparison opcodes.  v0.8.0 (G2): whitelist call_builtin print_i64 and route it to the env.__print_i64 host import that io_out uses, so BASIC's PRINT reaches real wasm bytecode."
 
 [lib]
 name = "iir_to_wasm"

--- a/code/packages/rust/iir-to-wasm/src/lower.rs
+++ b/code/packages/rust/iir-to-wasm/src/lower.rs
@@ -1683,6 +1683,31 @@ fn emit_instr(
                     code.extend(encode_call(fn_idx));
                     code.extend(encode_local_set(rd));
                 }
+                // G2: `print_i64` reuses the same `env.__print_i64`
+                // host import the `io_out` opcode injects.  Lowering
+                // is identical to `io_out`: load the i64 argument from
+                // its local and emit `call <print_fn_idx>`.
+                //
+                // Shape: `call_builtin "print_i64", val [void]`
+                // - srcs[0] = Var("print_i64")
+                // - srcs[1] = Var(val)
+                // - dest    = None (void)
+                "print_i64" => {
+                    let val_var = match instr.srcs.get(1) {
+                        Some(Operand::Var(v)) => v.as_str(),
+                        _ => return Err(IIRWasmError::InvalidOperand {
+                            function: fn_name.to_string(),
+                            detail: "call_builtin \"print_i64\" requires srcs[1] = Operand::Var(val)".to_string(),
+                        }),
+                    };
+                    let val_slot = get_reg(val_var)?;
+                    let fn_idx = print_fn_idx.ok_or_else(|| IIRWasmError::UnsupportedOp {
+                        function: fn_name.to_string(),
+                        op: "call_builtin \"print_i64\": no env.__print_i64 import registered (internal error — collect_module_features should have set uses_io_out)".to_string(),
+                    })?;
+                    code.extend(encode_local_get(val_slot));
+                    code.extend(encode_call(fn_idx));
+                }
                 _ => {
                     // Validator should have rejected this; defense in depth.
                     return Err(IIRWasmError::UnsupportedOp {
@@ -2030,6 +2055,13 @@ fn collect_module_features(module: &IIRModule) -> ModuleFeatures {
                         match name.as_str() {
                             "putchar" => uses_putchar = true,
                             "getchar" => uses_getchar = true,
+                            // G2: `print_i64` reuses the same
+                            // `env.__print_i64` import the `io_out`
+                            // opcode injects.  Flipping `uses_io_out`
+                            // ensures the import is wired in even when
+                            // the module uses `print_i64` exclusively
+                            // (no `io_out` opcodes).
+                            "print_i64" => uses_io_out = true,
                             // Other builtin names are rejected by the
                             // validator before we get here — be defensive
                             // and don't crash on unknown ones at compile time.

--- a/code/packages/rust/iir-to-wasm/src/validate.rs
+++ b/code/packages/rust/iir-to-wasm/src/validate.rs
@@ -126,10 +126,17 @@ const UNSUPPORTED_OPS: &[&str] = &[
 /// environment is expected to supply.  Today's list covers the
 /// Brainfuck I/O builtins:
 ///
-/// | Builtin     | Host import       | Signature |
-/// |-------------|-------------------|-----------|
-/// | `"putchar"` | `env.putchar`     | `(i32) -> ()`     |
-/// | `"getchar"` | `env.getchar`     | `() -> i32`       |
+/// | Builtin       | Host import         | Signature |
+/// |---------------|---------------------|-----------|
+/// | `"putchar"`   | `env.putchar`       | `(i32) -> ()`     |
+/// | `"getchar"`   | `env.getchar`       | `() -> i32`       |
+/// | `"print_i64"` | `env.__print_i64`   | `(i64) -> ()`     |
+///
+/// `print_i64` (G2) reuses the same `env.__print_i64` import the
+/// `io_out` opcode already injects.  This lets BASIC's `PRINT`
+/// statement (which lowers to `call_builtin "print_i64"`) and
+/// Twig's `io_out` opcode share a single host-provided printer
+/// function.
 ///
 /// Adding a new builtin requires:
 ///   1. Listing it here so the validator accepts it.
@@ -137,7 +144,8 @@ const UNSUPPORTED_OPS: &[&str] = &[
 ///      `call_builtin` branch that emits the right WASM call.
 ///   3. Injecting the import entry in `lower_iir_to_wasm` (see the
 ///      analogous wiring for `io_out` → `env.__print_i64`).
-pub(crate) const CALL_BUILTIN_SUPPORTED_NAMES: &[&str] = &["putchar", "getchar"];
+pub(crate) const CALL_BUILTIN_SUPPORTED_NAMES: &[&str] =
+    &["putchar", "getchar", "print_i64"];
 
 // ---------------------------------------------------------------------------
 // validate_for_wasm

--- a/code/packages/rust/iir-to-wasm/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-wasm/tests/test_backend.rs
@@ -1498,3 +1498,73 @@ fn g1_bare_eq_still_lowers_to_wasm() {
     let _ = lower_iir_to_wasm(&m, &IIRWasmConfig::default())
         .expect("G1: bare `eq` (Twig form) must still lower");
 }
+
+// ===========================================================================
+// G2 — `call_builtin "print_i64"` reuses the `env.__print_i64` host import.
+//
+// BASIC's `PRINT` lowers to `call_builtin "print_i64"`.  Pre-G2 this was
+// rejected by the validator because `print_i64` wasn't in
+// `CALL_BUILTIN_SUPPORTED_NAMES`.  G2 adds it; the import is the SAME
+// one the `io_out` opcode injects (`env.__print_i64`), so a module that
+// already uses `io_out` and one that uses `print_i64` exclusively both
+// produce the same single import.
+// ===========================================================================
+
+#[test]
+fn g2_call_builtin_print_i64_validator_accepts() {
+    let m = module_one("main", vec![("x", "i64")], "void", vec![
+        IIRInstr::new("call_builtin", None,
+            vec![Operand::Var("print_i64".into()), Operand::Var("x".into())],
+            "void"),
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ]);
+    let errs = validate_for_wasm(&m);
+    assert!(errs.is_empty(),
+        "G2: validator must accept call_builtin print_i64; got {errs:?}");
+}
+
+#[test]
+fn g2_call_builtin_print_i64_lowers_to_wasm_bytes() {
+    let m = module_one("main", vec![("x", "i64")], "void", vec![
+        IIRInstr::new("call_builtin", None,
+            vec![Operand::Var("print_i64".into()), Operand::Var("x".into())],
+            "void"),
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ]);
+    let wm = lower_iir_to_wasm(&m, &IIRWasmConfig::default())
+        .expect("G2: lower must succeed for call_builtin print_i64");
+    let bytes = encode_module(&wm).expect("encode");
+    assert!(bytes.len() >= 8);
+    assert_eq!(&bytes[..4], &[0x00, 0x61, 0x73, 0x6D], "wasm magic prefix");
+}
+
+#[test]
+fn g2_call_builtin_print_i64_injects_host_import() {
+    let m = module_one("main", vec![("x", "i64")], "void", vec![
+        IIRInstr::new("call_builtin", None,
+            vec![Operand::Var("print_i64".into()), Operand::Var("x".into())],
+            "void"),
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ]);
+    let wm = lower_iir_to_wasm(&m, &IIRWasmConfig::default())
+        .expect("lower");
+    let has_print = wm.imports.iter().any(|i|
+        i.module_name == "env" && i.name == "__print_i64");
+    assert!(has_print,
+        "G2: print_i64 builtin must inject the env.__print_i64 host import; got imports {:?}",
+        wm.imports.iter().map(|i| (&i.module_name, &i.name)).collect::<Vec<_>>());
+}
+
+#[test]
+fn g2_unknown_builtin_still_rejected() {
+    // Defense-in-depth: a builtin name not in the whitelist must still
+    // be rejected (so G2 didn't accidentally widen the gate).
+    let m = module_one("main", vec![], "void", vec![
+        IIRInstr::new("call_builtin", None,
+            vec![Operand::Var("does_not_exist".into())],
+            "void"),
+    ]);
+    let errs = validate_for_wasm(&m);
+    assert!(!errs.is_empty(),
+        "G2: unknown builtin must still be rejected; got no errors");
+}


### PR DESCRIPTION
## Summary

Item **G2** of the multi-language backend plan (PR #4737).

BASIC's \`PRINT\` lowers to \`call_builtin \"print_i64\"\`.  Pre-G2 the validator rejected it: \`print_i64\` wasn't in \`CALL_BUILTIN_SUPPORTED_NAMES\`.  But the host import already existed under a different mechanism — the \`io_out\` opcode (Twig/Lispy) wires \`env.__print_i64 : (i64) -> ()\`.

G2 makes \`call_builtin \"print_i64\"\` reuse that same import.  No new host function, no breaking change for existing \`io_out\` users.

## End-to-end effect

BASIC programs containing PRINT statements now reach real \`.wasm\` bytecode through the same encoder pipeline as every other language.

## BASIC regression marker flipped

\`dartmouth-basic-iir-compiler/tests/backend_encode.rs\`:
- \`print_is_blocked_until_backends_whitelist_print_i64\` → \`print_lowers_to_wasm_bytes\` (was "blocked", now asserts success)
- File-level docs updated: G2 lifts the BASIC PRINT block on wasm
- jvm/clr still pending (G3/G4)

## Versions

- \`iir-to-wasm\` 0.7.0 → 0.8.0

## Test plan

- [x] 4 new iir-to-wasm tests (validator accepts + lower succeeds + import injected + unknown builtin still rejected)
- [x] BASIC's flipped regression marker passes positively
- [x] All 99 iir-to-wasm + all BASIC encoder tests pass
- [x] \`/security-review\` passed (host import is the same existing one io_out uses; sandbox boundary unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)