### PR TITLE
G4: iir-to-clr print_i64 → call env.BasicRuntime::PrintI64(int64)

### DIFF
--- a/code/packages/rust/iir-to-cil-bytecode/CHANGELOG.md
+++ b/code/packages/rust/iir-to-cil-bytecode/CHANGELOG.md
@@ -2,6 +2,55 @@
 
 All notable changes to this crate are documented here.
 
+## [0.7.0] — 2026-06-01 (G4 — `print_i64` host call → `env.BasicRuntime::PrintI64(int64)`)
+
+### Added — `call_builtin "print_i64"` whitelisted and lowered
+
+Completes the cross-backend trio for BASIC's `PRINT`:
+
+| Backend                  | Builtin     | Target                                            |
+|--------------------------|-------------|---------------------------------------------------|
+| iir-to-wasm v0.8.0       | `print_i64` | `env.__print_i64` host import                     |
+| iir-to-jvm-class-file v0.7.0 | `print_i64` | `invokestatic env/BasicRuntime.println(J)V`   |
+| **iir-to-cil-bytecode v0.7.0 (this)** | `print_i64` | `call void env.BasicRuntime::PrintI64(int64)` |
+
+After this release, BASIC's PRINT lowers to real bytecode on all three
+non-BEAM backends — gap G4 (final gap in the `print_i64` group) of the
+[multi-language backend plan][plan].
+
+#### Validator changes (`src/validate.rs`)
+
+* `CALL_BUILTIN_SUPPORTED_NAMES` widened from `["putchar", "getchar"]`
+  to `["putchar", "getchar", "print_i64"]`.  Defence in depth unchanged:
+  every other name still fails with `UnsupportedOp`.
+
+#### Lowering changes (`src/lower.rs`)
+
+* New sentinel metadata token
+  `BASIC_PRINT_I64_TOKEN: u32 = 0x0A00_0005` (MemberRef row 5, next
+  after `BF_GETCHAR_TOKEN` @ row 4).  At link / sim time the token
+  resolves to `env.BasicRuntime::PrintI64(int64)`.
+* New `"print_i64"` arm in the `call_builtin` match:
+  ```
+  srcs = [Var("print_i64"), Var(val: i64)]   dest = None
+  →
+  ldloc val_slot          ; via emit_load (picks width from reg_info)
+  call <BASIC_PRINT_I64_TOKEN>
+  ```
+
+Why a dedicated host class (vs. reusing `env.BFRuntime`): BASIC's I/O
+is line/value oriented; Brainfuck's is byte-stream oriented.  Separate
+host classes let a CLR runtime / launcher stub or provide either one
+independently.
+
+#### Tests added (`tests/test_backend.rs`)
+
+* `g4_validator_accepts_print_i64`
+* `g4_validator_still_rejects_unknown_builtin`
+* `g4_lowers_print_i64_to_call_with_basic_token`
+
+[plan]: ../../../specs/MULTILANG-BACKEND-PLAN.md
+
 ## [0.6.0] — 2026-05-26 (Validator accepts `ref<any>` + `mov` for ref types)
 
 ### Changed — `ref<any>` widens the supported reference types; `mov` for refs

--- a/code/packages/rust/iir-to-cil-bytecode/Cargo.toml
+++ b/code/packages/rust/iir-to-cil-bytecode/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iir-to-cil-bytecode"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
-description = "IIR → CIL bytecode backend — lowers IIRModule to CILProgramArtifact (now with Brainfuck tape + I/O via env.BFRuntime).  Path A increment 6c: validator accepts `ref<any>` (lowers to System.Object) and `mov` for ref types."
+description = "IIR → CIL bytecode backend — lowers IIRModule to CILProgramArtifact.  v0.7.0 (G4): whitelist call_builtin print_i64 and lower it to call env.BasicRuntime::PrintI64(int64), mirroring iir-to-wasm v0.8.0 (env.__print_i64) and iir-to-jvm-class-file v0.7.0 (env/BasicRuntime.println(J)V).  Together they let BASIC's PRINT reach real wasm, JVM, and CLR bytecode."
 
 [lib]
 name = "iir_to_cil_bytecode"

--- a/code/packages/rust/iir-to-cil-bytecode/src/lower.rs
+++ b/code/packages/rust/iir-to-cil-bytecode/src/lower.rs
@@ -96,6 +96,23 @@ const BF_TAPE_TOKEN: u32     = 0x0400_0001; // FieldRef row 1
 const BF_PUTCHAR_TOKEN: u32  = 0x0A00_0003; // MemberRef row 3 (after WriteLine @ row 2)
 const BF_GETCHAR_TOKEN: u32  = 0x0A00_0004; // MemberRef row 4
 
+// ─── BASIC host-class metadata token (G4) ─────────────────────────────────────
+//
+// Sentinel for `env.BasicRuntime::PrintI64(int64)` — the CLR counterpart to
+// wasm's `env.__print_i64` import (iir-to-wasm v0.8.0) and JVM's
+// `env/BasicRuntime.println(J)V` invokestatic target (iir-to-jvm-class-file
+// v0.7.0).  Reserved at MemberRef row 5 (next after BF_GETCHAR_TOKEN @ row 4).
+//
+// Host contract: a CLR runtime / launcher must provide `env.BasicRuntime`
+// with:
+//
+//   * `public static void PrintI64(int64)`  ← print one i64 followed by a newline
+//
+// We pick a separate class from `env.BFRuntime` because BASIC's I/O model
+// (line/value, mostly numeric) differs from Brainfuck's (byte-stream); a CLR
+// runtime can stub or provide either one independently.
+const BASIC_PRINT_I64_TOKEN: u32 = 0x0A00_0005; // MemberRef row 5
+
 use crate::validate::validate_iir_for_clr;
 
 // ===========================================================================
@@ -1695,8 +1712,9 @@ pub fn lower_iir_to_cil(
                 //
                 // | Builtin   | Operand layout                        | CIL emitted                                                  |
                 // |-----------|----------------------------------------|---------------------------------------------------------------|
-                // | `putchar` | srcs = [Var("putchar"), Var(val)]; no dest | `ldloc val; call <BF_PUTCHAR_TOKEN>`                          |
-                // | `getchar` | srcs = [Var("getchar")]; dest = byte slot  | `call <BF_GETCHAR_TOKEN>; stloc dest`                         |
+                // | `putchar`   | srcs = [Var("putchar"), Var(val)]; no dest    | `ldloc val; call <BF_PUTCHAR_TOKEN>`                          |
+                // | `getchar`   | srcs = [Var("getchar")]; dest = byte slot     | `call <BF_GETCHAR_TOKEN>; stloc dest`                         |
+                // | `print_i64` | srcs = [Var("print_i64"), Var(val:i64)]; no dest | `ldloc val; call <BASIC_PRINT_I64_TOKEN>`                     |
                 "call_builtin" => {
                     let builtin_name = match instr.srcs.first() {
                         Some(Operand::Var(s)) => s.clone(),
@@ -1728,6 +1746,27 @@ pub fn lower_iir_to_cil(
                             let dest_info = reg_info!(dest_name).clone();
                             builder.emit_call(BF_GETCHAR_TOKEN);
                             emit_store(&mut builder, &dest_info, fn_name)?;
+                        }
+                        "print_i64" => {
+                            // G4: BASIC PRINT → env.BasicRuntime::PrintI64(int64).
+                            // Layout: srcs = [Var("print_i64"), Var(val: i64)],
+                            // dest = None.  Emits `ldloc val; call <token>` — the
+                            // load opcode chosen by emit_load already matches the
+                            // val's register width (long → ldloc / ldarg etc.).
+                            //
+                            // Mirrors iir-to-wasm v0.8.0 (env.__print_i64 import)
+                            // and iir-to-jvm-class-file v0.7.0
+                            // (invokestatic env/BasicRuntime.println(J)V).
+                            let val_name = match instr.srcs.get(1) {
+                                Some(Operand::Var(v)) => v.clone(),
+                                _ => return Err(IIRClrError::InvalidOperand {
+                                    function: fn_name.clone(),
+                                    detail: "call_builtin \"print_i64\" requires srcs[1] = Operand::Var(val:i64)".to_string(),
+                                }),
+                            };
+                            let val_info = reg_info!(val_name).clone();
+                            emit_load(&mut builder, &val_info, fn_name)?;
+                            builder.emit_call(BASIC_PRINT_I64_TOKEN);
                         }
                         _ => {
                             // Validator should have rejected this; defense in depth.

--- a/code/packages/rust/iir-to-cil-bytecode/src/validate.rs
+++ b/code/packages/rust/iir-to-cil-bytecode/src/validate.rs
@@ -112,17 +112,27 @@ const UNSUPPORTED_OPS: &[&str] = &[
 /// lowering time via reserved metadata tokens (MemberRef table rows on
 /// the simulated `env.BFRuntime` class):
 ///
-/// | Builtin     | CIL call                                            |
-/// |-------------|------------------------------------------------------|
-/// | `"putchar"` | `call void env.BFRuntime::putchar(int32)`            |
-/// | `"getchar"` | `call int32 env.BFRuntime::getchar()`                |
+/// | Builtin       | CIL call                                              |
+/// |---------------|-------------------------------------------------------|
+/// | `"putchar"`   | `call void env.BFRuntime::putchar(int32)`             |
+/// | `"getchar"`   | `call int32 env.BFRuntime::getchar()`                 |
+/// | `"print_i64"` | `call void env.BasicRuntime::PrintI64(int64)`         |
 ///
 /// Adding a new builtin requires:
 ///   1. Listing the name here so the validator accepts it.
 ///   2. Reserving a new metadata-token constant in `lower.rs`.
 ///   3. Adding a matching `case` to lower.rs's `call_builtin` arm
 ///      that emits the right `call <token>` sequence.
-pub(crate) const CALL_BUILTIN_SUPPORTED_NAMES: &[&str] = &["putchar", "getchar"];
+///
+/// G4 note: `print_i64` is the CLR counterpart to wasm's `env.__print_i64`
+/// (iir-to-wasm v0.8.0) and JVM's `env/BasicRuntime.println(J)V`
+/// (iir-to-jvm-class-file v0.7.0).  Together the three lower BASIC's
+/// `PRINT` statement to real backend bytecode without the backend itself
+/// owning a stdout.  We pick a dedicated `env.BasicRuntime` host class
+/// (distinct from `env.BFRuntime`) because BASIC's I/O model is
+/// line/value oriented while Brainfuck's is byte-stream oriented; a CLR
+/// runtime can stub or provide either independently.
+pub(crate) const CALL_BUILTIN_SUPPORTED_NAMES: &[&str] = &["putchar", "getchar", "print_i64"];
 
 // ---------------------------------------------------------------------------
 // Heap ops that need special validation (type-restricted)

--- a/code/packages/rust/iir-to-cil-bytecode/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-cil-bytecode/tests/test_backend.rs
@@ -1517,3 +1517,105 @@ fn lang37_dispatch_method_contains_ldelem_i4() {
 // sequences that require dup to prime the array reference).
 #[allow(dead_code)]
 const _DUP_USED: u8 = DUP;
+
+// ===========================================================================
+// G4 — call_builtin "print_i64" → call env.BasicRuntime::PrintI64(int64)
+// ===========================================================================
+//
+// CLR counterpart to iir-to-wasm v0.8.0 (env.__print_i64 import) and
+// iir-to-jvm-class-file v0.7.0 (invokestatic env/BasicRuntime.println(J)V).
+// All three let BASIC's PRINT lower to real backend bytecode without the
+// backend itself owning a stdout.
+//
+// Convention picked: a new sentinel metadata token
+//   BASIC_PRINT_I64_TOKEN = 0x0A00_0005
+// reserved at MemberRef row 5, which a CLR runtime / launcher resolves to
+//   env.BasicRuntime::PrintI64(int64)
+// at link time.
+//
+// Reference: code/specs/MULTILANG-BACKEND-PLAN.md (item G4).
+
+/// Build a function that calls `print_i64` once with an i64 local.
+///
+/// IIR:
+///   fn print_42() -> void {
+///     v = const 42 : i64
+///     call_builtin print_i64(v)
+///     ret_void
+///   }
+fn g4_print_i64_module() -> IIRModule {
+    single_fn(vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(42)], "i64"),
+        IIRInstr::new(
+            "call_builtin",
+            None,
+            vec![
+                Operand::Var("print_i64".into()),
+                Operand::Var("v".into()),
+            ],
+            "void",
+        ),
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ])
+}
+
+/// Validator must accept `call_builtin "print_i64"` after G4.
+#[test]
+fn g4_validator_accepts_print_i64() {
+    let module = g4_print_i64_module();
+    let errors = validate_iir_for_clr(&module);
+    assert!(
+        errors.is_empty(),
+        "validator should accept call_builtin \"print_i64\" after G4; got: {:?}",
+        errors
+    );
+}
+
+/// Validator still rejects unknown builtin names — guards against the
+/// whitelist accidentally widening.
+#[test]
+fn g4_validator_still_rejects_unknown_builtin() {
+    let module = single_fn(vec![
+        IIRInstr::new(
+            "call_builtin",
+            None,
+            vec![Operand::Var("definitely_not_a_real_builtin".into())],
+            "void",
+        ),
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ]);
+    let errors = validate_iir_for_clr(&module);
+    assert!(
+        errors.iter().any(|e| e.contains("UnsupportedOp")),
+        "unknown call_builtin name must still produce UnsupportedOp; got: {:?}",
+        errors
+    );
+}
+
+/// Lowering `print_i64` emits a CALL (0x28) byte AND the little-endian
+/// 4-byte encoding of `BASIC_PRINT_I64_TOKEN` (0x0A00_0005) immediately
+/// after it.
+///
+/// CIL `call` is `0x28 <tok:le u32>`, so scanning for the byte sequence
+/// `[0x28, 0x05, 0x00, 0x00, 0x0A]` confirms both:
+///   1. We routed through the host-class `call` path (not silently dropped).
+///   2. The token is the new BASIC sentinel — *not* an accidental reuse of
+///      `CONSOLE_WRITELINE_I64_TOKEN` (0x0A00_0002, used by `io_out`),
+///      `BF_PUTCHAR_TOKEN` (0x0A00_0003), or `BF_GETCHAR_TOKEN`
+///      (0x0A00_0004).
+#[test]
+fn g4_lowers_print_i64_to_call_with_basic_token() {
+    let module = g4_print_i64_module();
+    let artifact = lower_iir_to_cil(&module, &default_cfg()).unwrap();
+    let body = &artifact.methods[0].body;
+
+    // Expected byte sequence: call (0x28) + LE u32 0x0A00_0005.
+    let expected: [u8; 5] = [0x28, 0x05, 0x00, 0x00, 0x0A];
+    let found = body.windows(5).any(|w| w == expected);
+    assert!(
+        found,
+        "expected `call BASIC_PRINT_I64_TOKEN` byte sequence {:02X?} \
+         in print_42 body; got: {:02X?}",
+        expected, body
+    );
+}


### PR DESCRIPTION
## Summary

- **G4** of [`MULTILANG-BACKEND-PLAN.md`](code/specs/MULTILANG-BACKEND-PLAN.md): CLR counterpart to G2 (wasm) and G3 (JVM). Completes the print_i64 trio — BASIC's `PRINT` now lowers to real bytecode on all three non-BEAM backends.
- Whitelists `call_builtin "print_i64"` in `validate.rs` and lowers it in `lower.rs` to `call <BASIC_PRINT_I64_TOKEN>` (new sentinel `0x0A00_0005`, MemberRef row 5).
- Sentinel resolves to `env.BasicRuntime::PrintI64(int64)`. Separate host class from `env.BFRuntime` so a CLR runtime can stub or provide BASIC vs BF I/O independently.

## Convention parity across backends

| Backend | Builtin | Target |
|---------|---------|--------|
| iir-to-wasm v0.8.0 | `print_i64` | `env.__print_i64` host import |
| iir-to-jvm-class-file v0.7.0 | `print_i64` | `invokestatic env/BasicRuntime.println(J)V` |
| **iir-to-cil-bytecode v0.7.0 (this)** | `print_i64` | `call void env.BasicRuntime::PrintI64(int64)` |

## Changes

| File | Change |
|------|--------|
| `validate.rs` | `CALL_BUILTIN_SUPPORTED_NAMES` gains `"print_i64"` |
| `lower.rs` | new `BASIC_PRINT_I64_TOKEN = 0x0A00_0005` const + `"print_i64"` arm (`ldloc val; call <token>`) |
| `tests/test_backend.rs` | 3 new G4 tests |
| `Cargo.toml` | 0.6.0 → 0.7.0 |
| `CHANGELOG.md` | 0.7.0 entry |

## Test plan
- [x] `cargo test -p iir-to-cil-bytecode` — 33 + 86 + 4 doctests green
- [x] `g4_validator_accepts_print_i64`
- [x] `g4_validator_still_rejects_unknown_builtin`
- [x] `g4_lowers_print_i64_to_call_with_basic_token` (asserts on byte sequence `[0x28, 0x05, 0x00, 0x00, 0x0A]` — call + LE token)
- [x] /security-review passed (no findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)