### PR TITLE
LLVM02: iir-to-llvm function signatures + ret/ret_void/const/mov

### DIFF
--- a/code/packages/rust/iir-to-llvm/CHANGELOG.md
+++ b/code/packages/rust/iir-to-llvm/CHANGELOG.md
@@ -3,6 +3,80 @@
 All notable changes to this crate are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.2.0] — 2026-06-01 (LLVM02 — function signatures + ret/ret_void/const/mov)
+
+### Added — function lowering and four instructions
+
+Implements item LLVM02 of the [multi-language backend plan][plan].  This
+release extends the v0.1.0 skeleton with the smallest set of instructions
+that produces a runnable LLVM module:
+
+| IIR op     | Lowering strategy                                      |
+|------------|--------------------------------------------------------|
+| `const`    | tracked in a name→operand map, no LLVM line emitted    |
+| `mov`      | aliases dest to source's operand, no LLVM line emitted |
+| `ret_void` | `  ret void`                                           |
+| `ret`      | `  ret <ty> <operand>`                                 |
+
+Sample output (`fn answer() -> i64 { const v = 42; ret v }`):
+
+```llvm
+; ModuleID = 'iir_module'
+target triple = "x86_64-unknown-linux-gnu"
+
+define i64 @answer() {
+  ret i64 42
+}
+```
+
+#### Design choices
+
+* **`const`/`mov` are side-map operations, not LLVM lines.**  An obvious
+  alternative is to emit `%dest = add <ty> 0, <src>` for both, but that
+  produces no-op SSA assignments that `opt -mem2reg` would have to
+  immediately clean up.  The side-map approach gives output that already
+  looks like what hand-written `.ll` looks like.
+* **Signless integer types.**  IIR's `u32` and `i32` both lower to LLVM
+  `i32` — LLVM has no signedness in types.  The sign manifests in the
+  opcode (`sdiv` vs `udiv`, `slt` vs `ult`) and will be picked up in
+  LLVM03 when arithmetic lowering arrives.
+* **Float literal format.**  We emit `{:e}` scientific notation (e.g.
+  `1.5e0`), which round-trips through `f64::to_string` for finite values
+  and is unambiguously parsed by LLVM.
+
+#### Public surface added
+
+* `IIRLlvmError::UndefinedVariable { function, name }` — surfaced when
+  `ret` references a name that was never `const`/`mov`/param-bound.
+
+#### Validator rules (`validate_for_llvm`)
+
+* `SUPPORTED_OPS` whitelist: `["const", "mov", "ret", "ret_void"]`.
+  Anything else → `UnsupportedOp`.
+* Type rules: `void`, `i{8,16,32,64}`, `u{8,16,32,64}`, `f32`, `f64`.
+  Anything else (incl. `ref<…>`, `str`, `bool`, `any`, `polymorphic`)
+  → `UnsupportedType`.
+* Checks run on: return type, every param type, every instruction's
+  `type_hint`.  Errors aggregate; the lowerer fails fast with
+  `ValidationFailed(Vec<String>)` if any are present.
+
+#### Tests added (22 total, was 7)
+
+* Function signature lowering (4): void/no-params, i32 with 2 params,
+  float types, u32+i32 → i32 mapping.
+* ret_void / ret (4): emission, const-inlined, param-register,
+  undefined-var error.
+* const / mov (3): no LLVM line for `const`, mov chains, mov of a param.
+* Validator (4): accept-supported, reject-op, reject-ret-type, reject-param-type.
+
+#### Not yet in v0.2.0
+
+* Arithmetic, comparisons, branches — LLVM03.
+* `call` and `call_builtin print_i64` extern decl — LLVM04.
+* `lang-aot --backend=llvm` wiring — LLVM04.
+
+[plan]: ../../../specs/MULTILANG-BACKEND-PLAN.md
+
 ## [0.1.0] — 2026-06-01 (LLVM01 — crate skeleton)
 
 ### Added — empty-module emission

--- a/code/packages/rust/iir-to-llvm/Cargo.toml
+++ b/code/packages/rust/iir-to-llvm/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iir-to-llvm"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
-description = "IIR → textual LLVM IR backend — emits .ll source for an LLVM target triple.  v0.1.0 (LLVM01): crate skeleton emitting `; ModuleID` + `target triple` header; instruction lowering deferred to v0.2.0+ (LLVM02 et al.)."
+description = "IIR → textual LLVM IR backend — emits .ll source for an LLVM target triple.  v0.2.0 (LLVM02): adds function signature lowering + ret/ret_void/const/mov instructions.  const and mov are tracked in a side map rather than emitting no-op SSA assignments."
 
 [lib]
 name = "iir_to_llvm"

--- a/code/packages/rust/iir-to-llvm/src/lib.rs
+++ b/code/packages/rust/iir-to-llvm/src/lib.rs
@@ -1,4 +1,4 @@
-//! # iir-to-llvm — IIR → textual LLVM IR backend (v0.1.0 skeleton).
+//! # iir-to-llvm — IIR → textual LLVM IR backend.
 //!
 //! Lowers an [`interpreter_ir::IIRModule`] to a `String` containing valid
 //! LLVM textual IR (a `.ll` source file).
@@ -7,21 +7,10 @@
 //!
 //! The existing IIR backends (wasm / JVM / CLR / BEAM) all target *managed*
 //! runtimes that own register allocation, memory layout, GC, and exception
-//! handling.  LLVM is a different beast: it is an AOT-native target whose
-//! output runs on the bare metal of whatever CPU LLVM ships a backend for,
-//! with the user's choice of LLVM optimization quality (`opt -O0` …
-//! `opt -O3`) in front of it.
-//!
-//! Adding LLVM as a backend gives us:
-//!
-//! 1. A **second AOT path** alongside our hand-rolled aarch64 / x86_64
-//!    emitters.  The hand-rolled emitters give us full encoding control (for
-//!    the debugger story); LLVM gives us world-class O2 optimization for
-//!    free.
-//! 2. A **direct comparison axis** — same IIR, two AOT-native code
-//!    generators, what does each do well?
-//! 3. A **bridge to every CPU LLVM ships a backend for** (Apple Silicon,
-//!    x86_64, RISC-V, MIPS, PowerPC, …) without writing per-CPU encoders.
+//! handling.  LLVM is a different beast: an AOT-native target whose output
+//! runs on the bare metal of whatever CPU LLVM ships a backend for, with the
+//! user's choice of LLVM optimization quality (`opt -O0` … `opt -O3`) in
+//! front of it.
 //!
 //! ## Why textual LLVM IR (not `llvm-sys`)?
 //!
@@ -43,60 +32,73 @@
 //!   → object file → linker → native executable
 //! ```
 //!
-//! ## Scope of v0.1.0 (LLVM01)
+//! ## Scope of v0.2.0 (LLVM02)
 //!
-//! This release is a **skeleton**: it emits a valid empty LLVM module —
-//! a `; ModuleID` comment and a `target triple` directive — but does **not**
-//! lower any IIR instructions.  Instruction lowering arrives in v0.2.0+
-//! (LLVM02–04, see [`code/specs/MULTILANG-BACKEND-PLAN.md`][plan]).
+//! Function signatures + four instructions:
 //!
-//! [plan]: ../../specs/MULTILANG-BACKEND-PLAN.md
+//! | IIR op     | Lowering strategy                                      |
+//! |------------|--------------------------------------------------------|
+//! | `const`    | tracked in a name→operand map, no LLVM line emitted    |
+//! | `mov`      | aliases dest to source's operand, no LLVM line emitted |
+//! | `ret_void` | `  ret void`                                           |
+//! | `ret`      | `  ret <ty> <operand>`                                 |
+//!
+//! Tracking constants and moves in a side map (rather than emitting
+//! `%dest = add 0, src` no-ops) keeps the output looking like what
+//! `opt -mem2reg` would produce — short, idiomatic, easy to eyeball-verify.
+//!
+//! Everything else is `UnsupportedOp` / `UnsupportedType`.  v0.3.0 (LLVM03)
+//! adds typed arithmetic + comparisons + branches.
 //!
 //! ## Quick start
 //!
 //! ```
-//! use interpreter_ir::IIRModule;
-//! use iir_to_llvm::{validate_for_llvm, lower_iir_to_llvm, IIRLlvmConfig};
+//! use interpreter_ir::{IIRModule, IIRFunction, IIRInstr, Operand};
+//! use iir_to_llvm::{lower_iir_to_llvm, IIRLlvmConfig};
 //!
+//! let fn_ = IIRFunction::new(
+//!     "answer",
+//!     vec![],
+//!     "i64",
+//!     vec![
+//!         IIRInstr::new("const", Some("v".into()), vec![Operand::Int(42)], "i64"),
+//!         IIRInstr::new("ret",   None,             vec![Operand::Var("v".into())], "i64"),
+//!     ],
+//! );
 //! let module = IIRModule {
 //!     name: "demo".into(),
-//!     functions: vec![],
-//!     entry_point: None,
-//!     language: "demo".into(),
+//!     functions: vec![fn_],
+//!     entry_point: Some("answer".into()),
+//!     language: "test".into(),
 //!     exports: vec![],
 //!     imports: vec![],
 //! };
 //!
-//! // v0.1.0: validator always returns empty (no rules yet).
-//! assert!(validate_for_llvm(&module).is_empty());
-//!
 //! let ll = lower_iir_to_llvm(&module, &IIRLlvmConfig::default())
 //!     .expect("lowering should succeed");
-//! assert!(ll.contains("target triple ="));
+//! assert!(ll.contains("define i64 @answer()"));
+//! assert!(ll.contains("ret i64 42"));
 //! ```
 
-use interpreter_ir::IIRModule;
+use interpreter_ir::{IIRFunction, IIRInstr, IIRModule, Operand};
+use std::collections::HashMap;
 use std::fmt;
 
-// ---------------------------------------------------------------------------
+// ===========================================================================
 // IIRLlvmConfig
-// ---------------------------------------------------------------------------
+// ===========================================================================
 
 /// Configuration for the IIR → LLVM textual IR lowering pass.
 ///
-/// `target_triple` is what LLVM calls the CPU+OS+ABI triple that downstream
-/// `llc` will assume.  We default to `"x86_64-unknown-linux-gnu"` — a fixed
-/// string — so test output is deterministic across machines.  Override via
-/// [`IIRLlvmConfig::with_target`] when you want to actually run the `.ll`.
+/// `target_triple` defaults to a fixed string (`"x86_64-unknown-linux-gnu"`)
+/// for deterministic test output.  Override via [`IIRLlvmConfig::with_target`]
+/// when you actually intend to run `llc` for a non-default architecture.
 ///
-/// We deliberately do NOT call out to `rustc -vV` or any host-detection
-/// helper at build time: that would make doctests host-dependent and create
-/// a cross-compilation footgun.  Better to make the override explicit.
+/// We deliberately do NOT detect the host triple at build time: that would
+/// make doctests host-dependent and create a cross-compilation footgun.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IIRLlvmConfig {
-    /// Module name — emitted in the `; ModuleID = '<name>'` comment.
     pub module_name: String,
-    /// LLVM target triple — emitted in `target triple = "<triple>"`.
     pub target_triple: String,
 }
 
@@ -109,8 +111,7 @@ impl IIRLlvmConfig {
         }
     }
 
-    /// Override the LLVM target triple.  Use when you actually intend to run
-    /// `llc` on the output for a non-default architecture.
+    /// Override the LLVM target triple.
     pub fn with_target(mut self, triple: impl Into<String>) -> Self {
         self.target_triple = triple.into();
         self
@@ -118,10 +119,6 @@ impl IIRLlvmConfig {
 }
 
 impl Default for IIRLlvmConfig {
-    /// Fixed-host default — picks `x86_64-unknown-linux-gnu` for determinism.
-    ///
-    /// This is NOT the running host's triple — it's a deliberate fixed value
-    /// so that test output is byte-identical no matter where the tests run.
     fn default() -> Self {
         Self {
             module_name: "iir_module".into(),
@@ -130,26 +127,23 @@ impl Default for IIRLlvmConfig {
     }
 }
 
-// ---------------------------------------------------------------------------
+// ===========================================================================
 // IIRLlvmError
-// ---------------------------------------------------------------------------
+// ===========================================================================
 
 /// Errors that can occur during IIR → LLVM IR lowering.
-///
-/// Every variant carries at minimum the function name where the error
-/// occurred, except for `ValidationFailed` which aggregates pre-flight errors
-/// before any function-specific work has started.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum IIRLlvmError {
-    /// The module failed pre-flight validation (see [`validate_for_llvm`]).
+    /// The module failed pre-flight validation.
     ValidationFailed(Vec<String>),
-    /// An IIR opcode not yet supported by this backend.  v0.1.0 does not
-    /// lower any instructions, so any non-empty function body returns this.
+    /// An IIR opcode not yet supported by this backend.
     UnsupportedOp { function: String, op: String },
-    /// A type hint that this backend does not know how to lower.
+    /// A type hint that does not map to any LLVM type this backend handles.
     UnsupportedType { function: String, type_hint: String },
-    /// An operand has an unexpected shape.
+    /// An operand has an unexpected shape (e.g. `Int` where `Var` expected).
     InvalidOperand { function: String, detail: String },
+    /// A `Var` operand references a name never defined in this function.
+    UndefinedVariable { function: String, name: String },
 }
 
 impl fmt::Display for IIRLlvmError {
@@ -162,13 +156,13 @@ impl fmt::Display for IIRLlvmError {
                 write!(f, "unsupported op in function {function:?}: {op}")
             }
             Self::UnsupportedType { function, type_hint } => {
-                write!(
-                    f,
-                    "unsupported type hint in function {function:?}: {type_hint}"
-                )
+                write!(f, "unsupported type in function {function:?}: {type_hint}")
             }
             Self::InvalidOperand { function, detail } => {
                 write!(f, "invalid operand in function {function:?}: {detail}")
+            }
+            Self::UndefinedVariable { function, name } => {
+                write!(f, "undefined variable {name:?} in function {function:?}")
             }
         }
     }
@@ -176,73 +170,304 @@ impl fmt::Display for IIRLlvmError {
 
 impl std::error::Error for IIRLlvmError {}
 
-// ---------------------------------------------------------------------------
+// ===========================================================================
+// Type mapping — IIR type-hint → LLVM type name
+// ===========================================================================
+//
+// LLVM types have no signedness — `i32` covers both `i32` and `u32`.  The
+// signed-ness shows up in the *opcode* (`sdiv` vs `udiv`, `slt` vs `ult`)
+// rather than the type, which is why arithmetic lowering in v0.3.0+ has to
+// remember both pieces of information.
+//
+// Float and double map to LLVM's `float` and `double` respectively.
+//
+// Anything else (refs, str, bool, polymorphic) is rejected; v0.2.0 deals
+// only in numeric scalars.
+fn llvm_type_for(type_hint: &str, function: &str) -> Result<&'static str, IIRLlvmError> {
+    match type_hint {
+        "void" => Ok("void"),
+        "i8"  | "u8"  => Ok("i8"),
+        "i16" | "u16" => Ok("i16"),
+        "i32" | "u32" => Ok("i32"),
+        "i64" | "u64" => Ok("i64"),
+        "f32" => Ok("float"),
+        "f64" => Ok("double"),
+        other => Err(IIRLlvmError::UnsupportedType {
+            function: function.to_string(),
+            type_hint: other.to_string(),
+        }),
+    }
+}
+
+// ===========================================================================
 // validate_for_llvm
-// ---------------------------------------------------------------------------
+// ===========================================================================
+
+/// Supported instruction opcodes in v0.2.0 (LLVM02).
+///
+/// Adding an opcode here requires also handling it in
+/// [`lower_instr`] — the validator and the lowerer must stay in lockstep.
+const SUPPORTED_OPS: &[&str] = &["const", "mov", "ret", "ret_void"];
 
 /// Pre-flight validation for IIR → LLVM lowering.
 ///
-/// **v0.1.0 stub**: always returns an empty `Vec` — there are no validation
-/// rules yet because no instructions are lowered.  Future versions will add
-/// rules as instructions come online (see `MULTILANG-BACKEND-PLAN.md` §LLVM).
+/// Returns a `Vec<String>` of human-readable error messages.  An empty vector
+/// means the module is safe to pass to [`lower_iir_to_llvm`].
 ///
-/// This mirrors the shape of the other IIR backends'
-/// `validate_for_{wasm,jvm,clr,beam}` so callers can switch backends without
-/// changing their pre-flight logic.
-pub fn validate_for_llvm(_module: &IIRModule) -> Vec<String> {
-    Vec::new()
+/// # Checks
+///
+/// 1. Every instruction's `op` is in [`SUPPORTED_OPS`].
+/// 2. Every instruction's `type_hint` maps to an LLVM type (see
+///    [`llvm_type_for`]).
+/// 3. Every function's return type maps to an LLVM type.
+///
+/// These mirror the post-hoc checks the lowerer would do anyway, but
+/// surfaced up-front so callers can fail-fast and aggregate all errors.
+pub fn validate_for_llvm(module: &IIRModule) -> Vec<String> {
+    let mut errors = Vec::new();
+
+    for func in &module.functions {
+        // Return type check.
+        if let Err(e) = llvm_type_for(&func.return_type, &func.name) {
+            errors.push(format!(
+                "UnsupportedType: function {:?}, return type {:?} not supported by LLVM backend",
+                func.name, func.return_type
+            ));
+            // Don't bail — keep collecting so the caller sees everything.
+            drop(e);
+        }
+        // Per-param type check.
+        for (pname, pty) in &func.params {
+            if llvm_type_for(pty, &func.name).is_err() {
+                errors.push(format!(
+                    "UnsupportedType: function {:?}, param {:?} type {:?} not supported",
+                    func.name, pname, pty
+                ));
+            }
+        }
+        // Per-instruction checks.
+        for instr in &func.instructions {
+            if !SUPPORTED_OPS.contains(&instr.op.as_str()) {
+                errors.push(format!(
+                    "UnsupportedOp: function {:?}, op {:?} not in LLVM backend's v0.2.0 whitelist (supported: {:?})",
+                    func.name, instr.op, SUPPORTED_OPS
+                ));
+            }
+            // `ret_void` carries type_hint "void"; everything else carries a
+            // real type.  Both go through `llvm_type_for`.
+            if llvm_type_for(&instr.type_hint, &func.name).is_err() {
+                errors.push(format!(
+                    "UnsupportedType: function {:?}, instr {:?} type_hint {:?} not supported",
+                    func.name, instr.op, instr.type_hint
+                ));
+            }
+        }
+    }
+
+    errors
 }
 
-// ---------------------------------------------------------------------------
-// lower_iir_to_llvm
-// ---------------------------------------------------------------------------
+// ===========================================================================
+// Lowering
+// ===========================================================================
 
 /// Lower an [`IIRModule`] to a `String` containing LLVM textual IR.
-///
-/// **v0.1.0 scope**: emits a minimal but valid empty module — a `; ModuleID`
-/// comment and a `target triple` directive.  Does not lower any instructions
-/// yet; functions in the input module are simply not reflected in the output.
-/// Instruction lowering arrives in v0.2.0+ (LLVM02 et al.).
 ///
 /// # Output shape
 ///
 /// ```text
 /// ; ModuleID = '<module_name>'
 /// target triple = "<target_triple>"
+///
+/// define <ret_ty> @<fn_name>(<param_ty> %<param>, ...) {
+///   ret <ty> <value>
+/// }
 /// ```
-///
-/// # Why this shape?
-///
-/// `; ModuleID` is the conventional first line of every LLVM `.ll` file as
-/// emitted by `clang -S -emit-llvm`.  `target triple` is required by `llc`
-/// (without it, llc falls back to the build-machine default, which is
-/// nondeterministic across CI runners).  Together they form the smallest
-/// LLVM module that round-trips through `opt` and `llc` without warnings.
 pub fn lower_iir_to_llvm(
     module: &IIRModule,
     cfg: &IIRLlvmConfig,
 ) -> Result<String, IIRLlvmError> {
-    // ── Pre-flight validation ────────────────────────────────────────────
-    //
-    // Even though the v0.1.0 validator is a stub, we run it unconditionally
-    // so the contract is established: callers can rely on
-    // `lower_iir_to_llvm` returning `ValidationFailed` for any rule the
-    // validator catches.  Wiring it now means later versions can add rules
-    // without changing the API.
+    // ── Pre-flight ────────────────────────────────────────────────────────
     let errors = validate_for_llvm(module);
     if !errors.is_empty() {
         return Err(IIRLlvmError::ValidationFailed(errors));
     }
 
-    // ── Emit header ──────────────────────────────────────────────────────
-    //
-    // Note: `; ModuleID` uses the module's *configured* name, NOT
-    // `module.name`.  This lets callers pin the emitted module identity
-    // (useful when bundling several IIR modules into one .ll).  If we ever
-    // need to surface the IIR-side name, we can add a second comment line.
-    let mut out = String::with_capacity(128);
+    // ── Header ────────────────────────────────────────────────────────────
+    let mut out = String::with_capacity(256);
     out.push_str(&format!("; ModuleID = '{}'\n", cfg.module_name));
     out.push_str(&format!("target triple = \"{}\"\n", cfg.target_triple));
 
+    // ── Function bodies ───────────────────────────────────────────────────
+    for func in &module.functions {
+        out.push('\n');
+        lower_function(func, &mut out)?;
+    }
+
     Ok(out)
+}
+
+/// Emit one LLVM `define` block for one IIR function.
+fn lower_function(func: &IIRFunction, out: &mut String) -> Result<(), IIRLlvmError> {
+    // ── Header line: `define <ret> @<name>(<params>) {`
+    let ret_ty = llvm_type_for(&func.return_type, &func.name)?;
+    out.push_str(&format!("define {ret_ty} @{}(", func.name));
+    for (i, (pname, pty)) in func.params.iter().enumerate() {
+        if i > 0 {
+            out.push_str(", ");
+        }
+        let llvm_pty = llvm_type_for(pty, &func.name)?;
+        out.push_str(&format!("{llvm_pty} %{pname}"));
+    }
+    out.push_str(") {\n");
+
+    // ── Local-name → emitted-LLVM-operand map ─────────────────────────────
+    //
+    // We seed this with the parameters (each param `a` is referenced in the
+    // body as `%a` in our scheme).  As we walk the body:
+    //
+    //   * `const` adds a literal mapping (`dest → "42"`).
+    //   * `mov`   adds an alias mapping  (`dest → operand_of(src)`).
+    //   * `ret`   looks up the source's operand and emits a single line.
+    //
+    // This sidesteps the "no-op SSA assignment" pattern that LLVM verifiers
+    // and `opt` would otherwise have to clean up — the result is tighter
+    // and closer to what hand-written `.ll` looks like.
+    let mut env: HashMap<String, String> = HashMap::new();
+    for (pname, _) in &func.params {
+        env.insert(pname.clone(), format!("%{pname}"));
+    }
+
+    // ── Body ──────────────────────────────────────────────────────────────
+    for instr in &func.instructions {
+        lower_instr(instr, &func.name, &mut env, out)?;
+    }
+
+    out.push_str("}\n");
+    Ok(())
+}
+
+/// Emit (or record state for) one IIR instruction.
+fn lower_instr(
+    instr: &IIRInstr,
+    fn_name: &str,
+    env: &mut HashMap<String, String>,
+    out: &mut String,
+) -> Result<(), IIRLlvmError> {
+    match instr.op.as_str() {
+        // ── const: tracked, not emitted ──────────────────────────────────
+        //
+        // `srcs[0]` carries the literal payload (Int / Float / Bool); `dest`
+        // names the IIR var that should be bound to it.  We render the
+        // literal in LLVM textual form and remember it for later use sites.
+        "const" => {
+            let dest = instr.dest.as_deref().ok_or_else(|| IIRLlvmError::InvalidOperand {
+                function: fn_name.into(),
+                detail: "const requires a dest".into(),
+            })?;
+            let lit = render_literal(instr.srcs.first(), &instr.type_hint, fn_name)?;
+            env.insert(dest.to_string(), lit);
+            Ok(())
+        }
+
+        // ── mov: alias, not emitted ──────────────────────────────────────
+        //
+        // `mov dest, src` aliases dest to whatever operand src already
+        // resolves to.  For const-source it becomes a literal pass-through;
+        // for var-source it becomes a register alias.  Either way no LLVM
+        // line is needed — the alias lives in `env`.
+        "mov" => {
+            let dest = instr.dest.as_deref().ok_or_else(|| IIRLlvmError::InvalidOperand {
+                function: fn_name.into(),
+                detail: "mov requires a dest".into(),
+            })?;
+            let src_operand = resolve_operand(instr.srcs.first(), env, &instr.type_hint, fn_name)?;
+            env.insert(dest.to_string(), src_operand);
+            Ok(())
+        }
+
+        // ── ret_void ────────────────────────────────────────────────────
+        "ret_void" => {
+            out.push_str("  ret void\n");
+            Ok(())
+        }
+
+        // ── ret <var> ───────────────────────────────────────────────────
+        "ret" => {
+            let ty = llvm_type_for(&instr.type_hint, fn_name)?;
+            let operand = resolve_operand(instr.srcs.first(), env, &instr.type_hint, fn_name)?;
+            out.push_str(&format!("  ret {ty} {operand}\n"));
+            Ok(())
+        }
+
+        other => Err(IIRLlvmError::UnsupportedOp {
+            function: fn_name.into(),
+            op: other.into(),
+        }),
+    }
+}
+
+/// Resolve an `Operand` to its LLVM textual form using `env` for variables
+/// or rendering literals directly.
+fn resolve_operand(
+    op: Option<&Operand>,
+    env: &HashMap<String, String>,
+    type_hint: &str,
+    fn_name: &str,
+) -> Result<String, IIRLlvmError> {
+    match op {
+        Some(Operand::Var(name)) => env.get(name).cloned().ok_or_else(|| {
+            IIRLlvmError::UndefinedVariable {
+                function: fn_name.into(),
+                name: name.clone(),
+            }
+        }),
+        Some(other) => render_literal(Some(other), type_hint, fn_name),
+        None => Err(IIRLlvmError::InvalidOperand {
+            function: fn_name.into(),
+            detail: "operand missing".into(),
+        }),
+    }
+}
+
+/// Render an `Operand` literal as LLVM textual form.
+///
+/// For floats we use `{:e}`-style formatting so the output is unambiguous
+/// (LLVM parses `1.500000e+00` as a `double`/`float` literal directly).
+/// Integers are decimal; bools are `0`/`1` in their declared int type.
+fn render_literal(
+    op: Option<&Operand>,
+    type_hint: &str,
+    fn_name: &str,
+) -> Result<String, IIRLlvmError> {
+    match op {
+        Some(Operand::Int(n)) => Ok(n.to_string()),
+        Some(Operand::Float(v)) => {
+            // LLVM accepts both 1.500000e+00 and 0x3FF8000000000000 for
+            // doubles; we use scientific notation because it round-trips
+            // through f64::to_string for finite values.
+            Ok(format!("{v:e}"))
+        }
+        Some(Operand::Bool(b)) => Ok(if *b { "1".into() } else { "0".into() }),
+        Some(Operand::Var(name)) => {
+            // A literal slot containing a `Var` is invalid — that means the
+            // caller asked us to render `%foo` as a constant, which is a
+            // type error in IIR.
+            Err(IIRLlvmError::InvalidOperand {
+                function: fn_name.into(),
+                detail: format!("expected literal, got Var({name:?})"),
+            })
+        }
+        // Any other Operand variant (e.g. Str) is not yet supported by the
+        // LLVM backend.  Strings would need a global constant + GEP dance
+        // that's out of scope for v0.2.0.
+        Some(other) => Err(IIRLlvmError::InvalidOperand {
+            function: fn_name.into(),
+            detail: format!("unsupported operand variant: {other:?}"),
+        }),
+        None => Err(IIRLlvmError::InvalidOperand {
+            function: fn_name.into(),
+            detail: format!("missing literal for type {type_hint}"),
+        }),
+    }
 }

--- a/code/packages/rust/iir-to-llvm/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-llvm/tests/test_backend.rs
@@ -1,27 +1,22 @@
-//! Integration tests for `iir-to-llvm` v0.1.0 (LLVM01 skeleton).
+//! Integration tests for `iir-to-llvm`.
 //!
-//! These tests exercise the public surface — `validate_for_llvm` +
-//! `lower_iir_to_llvm` + `IIRLlvmConfig` — and assert on the smallest
-//! correctness signals available at this scope:
+//! Test groups (grow with each release):
 //!
-//! 1. The output starts with either `;` (an LLVM comment, conventionally
-//!    `; ModuleID = …`) or `target` (the LLVM `target triple = …`
-//!    directive).  Anything else is malformed at first glance.
-//! 2. Both header lines are present.
-//! 3. Config defaults are sane.
-//!
-//! As instructions come online in v0.2.0+ this file grows accordingly.
+//! 1. Validator behaviour (LLVM01 + LLVM02 rules)
+//! 2. Header output shape (LLVM01)
+//! 3. Function signatures (LLVM02)
+//! 4. ret_void / ret lowering (LLVM02)
+//! 5. const / mov lowering (LLVM02)
+//! 6. Config defaults
+//! 7. Error display
 
-use interpreter_ir::IIRModule;
+use interpreter_ir::{IIRFunction, IIRInstr, IIRModule, Operand};
 use iir_to_llvm::{lower_iir_to_llvm, validate_for_llvm, IIRLlvmConfig, IIRLlvmError};
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-/// An empty IIR module — no functions, no exports, no imports.  v0.1.0
-/// doesn't lower instructions, so this is the canonical input fixture for
-/// every test in this file.
 fn empty_module() -> IIRModule {
     IIRModule {
         name: "demo".into(),
@@ -33,84 +28,282 @@ fn empty_module() -> IIRModule {
     }
 }
 
+fn module_with(func: IIRFunction) -> IIRModule {
+    let entry = func.name.clone();
+    IIRModule {
+        name: "test".into(),
+        functions: vec![func],
+        entry_point: Some(entry),
+        language: "test".into(),
+        exports: vec![],
+        imports: vec![],
+    }
+}
+
+fn lower(module: &IIRModule) -> String {
+    lower_iir_to_llvm(module, &IIRLlvmConfig::default()).expect("lowering should succeed")
+}
+
 // ===========================================================================
-// 1. Validator (stub) behaviour
+// 1. Validator behaviour
 // ===========================================================================
 
-/// v0.1.0 validator returns an empty `Vec` — no rules yet.
 #[test]
 fn validate_returns_empty_for_empty_module() {
     assert!(validate_for_llvm(&empty_module()).is_empty());
 }
 
+/// A function with only supported ops/types validates clean.
+#[test]
+fn validate_accepts_supported_ret_void_function() {
+    let f = IIRFunction::new("main", vec![], "void",
+        vec![IIRInstr::new("ret_void", None, vec![], "void")]);
+    assert!(validate_for_llvm(&module_with(f)).is_empty());
+}
+
+/// Unsupported op (e.g. `add`, not in v0.2.0 whitelist) is flagged.
+#[test]
+fn validate_rejects_unsupported_op() {
+    let f = IIRFunction::new("main", vec![], "i32",
+        vec![
+            IIRInstr::new("add", Some("v".into()),
+                vec![Operand::Int(1), Operand::Int(2)], "i32"),
+            IIRInstr::new("ret", None, vec![Operand::Var("v".into())], "i32"),
+        ]);
+    let errors = validate_for_llvm(&module_with(f));
+    assert!(errors.iter().any(|e| e.contains("UnsupportedOp")),
+        "expected UnsupportedOp for `add`; got: {errors:?}");
+}
+
+/// Unsupported type (e.g. `ref<X>`) is flagged.
+#[test]
+fn validate_rejects_unsupported_type() {
+    let f = IIRFunction::new("main", vec![], "ref<Foo>",
+        vec![IIRInstr::new("ret_void", None, vec![], "void")]);
+    let errors = validate_for_llvm(&module_with(f));
+    assert!(errors.iter().any(|e| e.contains("UnsupportedType")),
+        "expected UnsupportedType for ret-type ref<Foo>; got: {errors:?}");
+}
+
+/// Unsupported param type is flagged.
+#[test]
+fn validate_rejects_unsupported_param_type() {
+    let f = IIRFunction::new(
+        "f",
+        vec![("p".into(), "str".into())],
+        "void",
+        vec![IIRInstr::new("ret_void", None, vec![], "void")],
+    );
+    let errors = validate_for_llvm(&module_with(f));
+    assert!(errors.iter().any(|e| e.contains("UnsupportedType") && e.contains("\"str\"")),
+        "expected UnsupportedType for param `str`; got: {errors:?}");
+}
+
 // ===========================================================================
-// 2. Output shape
+// 2. Header output shape (LLVM01 — kept green)
 // ===========================================================================
 
-/// The emitted `.ll` contains a `; ModuleID = '<name>'` comment with the
-/// configured module name.
 #[test]
 fn output_contains_module_id_comment() {
     let cfg = IIRLlvmConfig::new("hello_module");
-    let ll = lower_iir_to_llvm(&empty_module(), &cfg).expect("lowering");
-    assert!(
-        ll.contains("; ModuleID = 'hello_module'"),
-        "expected ModuleID comment with name 'hello_module'; got:\n{ll}"
-    );
+    let ll = lower_iir_to_llvm(&empty_module(), &cfg).expect("lower");
+    assert!(ll.contains("; ModuleID = 'hello_module'"));
 }
 
-/// The emitted `.ll` contains a `target triple = "<triple>"` directive with
-/// the configured triple.
 #[test]
 fn output_contains_target_triple() {
     let cfg = IIRLlvmConfig::default().with_target("riscv32-unknown-elf");
-    let ll = lower_iir_to_llvm(&empty_module(), &cfg).expect("lowering");
-    assert!(
-        ll.contains("target triple = \"riscv32-unknown-elf\""),
-        "expected target triple directive for riscv32; got:\n{ll}"
-    );
+    let ll = lower_iir_to_llvm(&empty_module(), &cfg).expect("lower");
+    assert!(ll.contains("target triple = \"riscv32-unknown-elf\""));
 }
 
-/// **LLVM01 acceptance criterion**: the first non-blank line of the output
-/// must begin with either `;` (a comment) or `target` (an LLVM directive).
-/// Anything else is malformed at first glance and tells us the emitter is
-/// off-by-one or producing garbage.
+/// LLVM01 acceptance criterion: first non-blank line starts with `;` or `target`.
 #[test]
 fn output_starts_with_comment_or_target() {
-    let ll = lower_iir_to_llvm(&empty_module(), &IIRLlvmConfig::default())
-        .expect("lowering");
-    let first = ll
-        .lines()
-        .map(str::trim)
-        .find(|l| !l.is_empty())
-        .expect("output must have at least one non-blank line");
-    assert!(
-        first.starts_with(';') || first.starts_with("target"),
-        "first non-blank line must start with ';' or 'target'; got: {first:?}"
-    );
+    let ll = lower(&empty_module());
+    let first = ll.lines().map(str::trim).find(|l| !l.is_empty()).unwrap();
+    assert!(first.starts_with(';') || first.starts_with("target"),
+        "first non-blank line: {first:?}");
 }
 
 // ===========================================================================
-// 3. Config defaults
+// 3. Function signatures (LLVM02)
 // ===========================================================================
 
-/// The default target triple is a non-empty string so downstream `llc`
-/// doesn't fall back to the build host (which would be nondeterministic).
+/// Void function with no params: `define void @main() {`.
+#[test]
+fn signature_void_no_params() {
+    let f = IIRFunction::new("main", vec![], "void",
+        vec![IIRInstr::new("ret_void", None, vec![], "void")]);
+    let ll = lower(&module_with(f));
+    assert!(ll.contains("define void @main()"),
+        "expected `define void @main()` in:\n{ll}");
+}
+
+/// Signed-int return + two i32 params: param types use LLVM's signless `i32`.
+#[test]
+fn signature_i32_with_two_params() {
+    let f = IIRFunction::new(
+        "add",
+        vec![("a".into(), "i32".into()), ("b".into(), "i32".into())],
+        "i32",
+        vec![IIRInstr::new("ret", None, vec![Operand::Var("a".into())], "i32")],
+    );
+    let ll = lower(&module_with(f));
+    assert!(ll.contains("define i32 @add(i32 %a, i32 %b)"),
+        "expected `define i32 @add(i32 %a, i32 %b)` in:\n{ll}");
+}
+
+/// f64 maps to LLVM `double`, f32 to `float`.
+#[test]
+fn signature_float_types_map_correctly() {
+    let f = IIRFunction::new(
+        "f",
+        vec![("x".into(), "f32".into()), ("y".into(), "f64".into())],
+        "f64",
+        vec![IIRInstr::new("ret", None, vec![Operand::Var("y".into())], "f64")],
+    );
+    let ll = lower(&module_with(f));
+    assert!(ll.contains("define double @f(float %x, double %y)"),
+        "expected float→`float`, f64→`double` in:\n{ll}");
+}
+
+/// u32 and i32 both map to LLVM `i32` (signless).
+#[test]
+fn signature_u32_and_i32_both_map_to_llvm_i32() {
+    let f = IIRFunction::new(
+        "f",
+        vec![("a".into(), "u32".into()), ("b".into(), "i32".into())],
+        "u32",
+        vec![IIRInstr::new("ret", None, vec![Operand::Var("a".into())], "u32")],
+    );
+    let ll = lower(&module_with(f));
+    assert!(ll.contains("define i32 @f(i32 %a, i32 %b)"),
+        "expected both u32 and i32 → LLVM i32 in:\n{ll}");
+}
+
+// ===========================================================================
+// 4. ret_void / ret lowering
+// ===========================================================================
+
+#[test]
+fn ret_void_emits_ret_void_line() {
+    let f = IIRFunction::new("main", vec![], "void",
+        vec![IIRInstr::new("ret_void", None, vec![], "void")]);
+    let ll = lower(&module_with(f));
+    assert!(ll.contains("  ret void"),
+        "expected `  ret void` in:\n{ll}");
+}
+
+#[test]
+fn ret_with_const_inlines_literal() {
+    let f = IIRFunction::new("answer", vec![], "i64",
+        vec![
+            IIRInstr::new("const", Some("v".into()), vec![Operand::Int(42)], "i64"),
+            IIRInstr::new("ret",   None,             vec![Operand::Var("v".into())], "i64"),
+        ]);
+    let ll = lower(&module_with(f));
+    assert!(ll.contains("ret i64 42"),
+        "expected `ret i64 42` (const inlined); got:\n{ll}");
+    // And we must NOT have emitted a useless SSA assignment for the const.
+    assert!(!ll.contains("= add i64 0, 42"),
+        "const should not have produced an `add 0, x` no-op; got:\n{ll}");
+}
+
+#[test]
+fn ret_with_param_uses_param_register() {
+    let f = IIRFunction::new(
+        "identity",
+        vec![("x".into(), "i32".into())],
+        "i32",
+        vec![IIRInstr::new("ret", None, vec![Operand::Var("x".into())], "i32")],
+    );
+    let ll = lower(&module_with(f));
+    assert!(ll.contains("ret i32 %x"),
+        "expected `ret i32 %x`; got:\n{ll}");
+}
+
+#[test]
+fn ret_with_undefined_var_is_error() {
+    let f = IIRFunction::new("oops", vec![], "i32",
+        vec![IIRInstr::new("ret", None,
+            vec![Operand::Var("nonexistent".into())], "i32")]);
+    let err = lower_iir_to_llvm(&module_with(f), &IIRLlvmConfig::default())
+        .expect_err("undefined var should fail lowering");
+    match err {
+        IIRLlvmError::UndefinedVariable { name, .. } => assert_eq!(name, "nonexistent"),
+        other => panic!("expected UndefinedVariable, got: {other:?}"),
+    }
+}
+
+// ===========================================================================
+// 5. const / mov lowering
+// ===========================================================================
+
+#[test]
+fn const_does_not_emit_an_llvm_line() {
+    let f = IIRFunction::new("only_const", vec![], "i64",
+        vec![
+            IIRInstr::new("const", Some("v".into()), vec![Operand::Int(1)], "i64"),
+            IIRInstr::new("ret",   None,             vec![Operand::Var("v".into())], "i64"),
+        ]);
+    let ll = lower(&module_with(f));
+    // The whole function body should be exactly one `ret` line.
+    let body: Vec<&str> = ll.lines()
+        .skip_while(|l| !l.starts_with("define"))
+        .skip(1)  // skip the `define` line
+        .take_while(|l| !l.starts_with('}'))
+        .filter(|l| !l.trim().is_empty())
+        .collect();
+    assert_eq!(body.len(), 1,
+        "expected exactly 1 body line (the ret); got {body:?} in:\n{ll}");
+    assert!(body[0].trim().starts_with("ret "),
+        "expected the single body line to be `ret …`; got {:?}", body[0]);
+}
+
+#[test]
+fn mov_chains_through_constants() {
+    // const v = 7 ; mov w v ; mov x w ; ret x
+    let f = IIRFunction::new("chain", vec![], "i32",
+        vec![
+            IIRInstr::new("const", Some("v".into()), vec![Operand::Int(7)], "i32"),
+            IIRInstr::new("mov",   Some("w".into()), vec![Operand::Var("v".into())], "i32"),
+            IIRInstr::new("mov",   Some("x".into()), vec![Operand::Var("w".into())], "i32"),
+            IIRInstr::new("ret",   None,             vec![Operand::Var("x".into())], "i32"),
+        ]);
+    let ll = lower(&module_with(f));
+    assert!(ll.contains("ret i32 7"),
+        "mov chain should resolve `x` back to literal 7; got:\n{ll}");
+}
+
+#[test]
+fn mov_aliases_a_param() {
+    // fn f(p: i32) -> i32 { mov q p ; ret q }
+    let f = IIRFunction::new(
+        "f",
+        vec![("p".into(), "i32".into())],
+        "i32",
+        vec![
+            IIRInstr::new("mov", Some("q".into()), vec![Operand::Var("p".into())], "i32"),
+            IIRInstr::new("ret", None,             vec![Operand::Var("q".into())], "i32"),
+        ],
+    );
+    let ll = lower(&module_with(f));
+    assert!(ll.contains("ret i32 %p"),
+        "mov of a param should resolve to `%p`; got:\n{ll}");
+}
+
+// ===========================================================================
+// 6. Config defaults
+// ===========================================================================
+
 #[test]
 fn default_config_has_nonempty_triple() {
     let cfg = IIRLlvmConfig::default();
-    assert!(
-        !cfg.target_triple.is_empty(),
-        "default target triple must be non-empty"
-    );
-    assert!(
-        !cfg.module_name.is_empty(),
-        "default module_name must be non-empty"
-    );
+    assert!(!cfg.target_triple.is_empty());
+    assert!(!cfg.module_name.is_empty());
 }
 
-/// `IIRLlvmConfig::new` sets the module name but leaves the triple at
-/// default.  This is the smallest behavioural contract on the builder.
 #[test]
 fn new_sets_module_name_keeps_default_triple() {
     let cfg = IIRLlvmConfig::new("custom");
@@ -119,33 +312,14 @@ fn new_sets_module_name_keeps_default_triple() {
 }
 
 // ===========================================================================
-// 4. Error display
+// 7. Error display
 // ===========================================================================
 
-/// Smoke-check that error variants `Display` without panicking.  Each variant
-/// is its own assertion so a regression in one doesn't mask another.
 #[test]
 fn errors_display_without_panic() {
     let _ = format!("{}", IIRLlvmError::ValidationFailed(vec!["x".into()]));
-    let _ = format!(
-        "{}",
-        IIRLlvmError::UnsupportedOp {
-            function: "f".into(),
-            op: "weird_op".into(),
-        }
-    );
-    let _ = format!(
-        "{}",
-        IIRLlvmError::UnsupportedType {
-            function: "f".into(),
-            type_hint: "weird".into(),
-        }
-    );
-    let _ = format!(
-        "{}",
-        IIRLlvmError::InvalidOperand {
-            function: "f".into(),
-            detail: "bad shape".into(),
-        }
-    );
+    let _ = format!("{}", IIRLlvmError::UnsupportedOp { function: "f".into(), op: "weird".into() });
+    let _ = format!("{}", IIRLlvmError::UnsupportedType { function: "f".into(), type_hint: "weird".into() });
+    let _ = format!("{}", IIRLlvmError::InvalidOperand { function: "f".into(), detail: "bad".into() });
+    let _ = format!("{}", IIRLlvmError::UndefinedVariable { function: "f".into(), name: "nope".into() });
 }

--- a/code/specs/iir-to-llvm.md
+++ b/code/specs/iir-to-llvm.md
@@ -56,8 +56,8 @@ IIRModule
 
 | Version | Scope | Status |
 |---------|-------|--------|
-| **v0.1.0 (LLVM01 — this PR)** | crate skeleton: empty module header with `target triple` + `; ModuleID = …` comment. No instruction lowering yet. | this PR |
-| v0.2.0 (LLVM02) | function signatures + `ret`, `ret_void`, `const`, `mov` | next |
+| v0.1.0 (LLVM01) | crate skeleton: empty module header with `target triple` + `; ModuleID = …` comment. No instruction lowering yet. | **merged** |
+| **v0.2.0 (LLVM02 — this PR)** | function signatures + `ret`, `ret_void`, `const`, `mov` | this PR |
 | v0.3.0 (LLVM03) | typed arithmetic (`add`/`sub`/`mul`/`sdiv`/`udiv`) + cmp + branches | future |
 | v0.4.0 (LLVM04) | `call` + `call_builtin` print_i64 → `call void @__print_i64(i64)` extern decl | future |
 | (later) | memory ops, GC, debug info via `!dbg` metadata | future |


### PR DESCRIPTION
## Summary

- **LLVM02** of [`MULTILANG-BACKEND-PLAN.md`](code/specs/MULTILANG-BACKEND-PLAN.md): smallest jump from the v0.1.0 skeleton to something that produces a runnable LLVM module.
- Adds function signature lowering + four instructions: `const`, `mov`, `ret_void`, `ret`.
- `const` and `mov` are tracked in a side map (no LLVM line emitted) rather than emitting `%dest = add 0, x` no-ops. Result looks like hand-written `.ll`.
- 22 unit + 1 doctest, all green (was 7 + 1).

## Sample output

For `fn answer() -> i64 { const v = 42; ret v }`:

```llvm
; ModuleID = 'iir_module'
target triple = "x86_64-unknown-linux-gnu"

define i64 @answer() {
  ret i64 42
}
```

## Validator rules

| Rule | Effect |
|------|--------|
| `SUPPORTED_OPS = ["const", "mov", "ret", "ret_void"]` | Other ops → `UnsupportedOp` |
| Types: `void`, `i{8,16,32,64}`, `u{8,16,32,64}`, `f32`, `f64` | `ref<…>`/`str`/`bool`/`any` → `UnsupportedType` |
| Checks aggregate across ret-type, every param, every instr `type_hint` | Caller sees all errors at once |

## Test plan
- [x] `cargo test -p iir-to-llvm` — 22 unit + 1 doctest green
- [x] Signature lowering: void/no-params, i32+2 params, f32→`float` / f64→`double`, u32+i32→`i32`
- [x] `ret_void` emits `  ret void`
- [x] `ret <var>` inlines const literal back into the ret line
- [x] `ret` with undefined var → `UndefinedVariable` error
- [x] `const` adds zero body lines (side-map only)
- [x] `mov` chains resolve back to the originating literal
- [x] `mov` of a param resolves to `%param` register
- [x] Validator rejects unsupported op / unsupported types (return + param)
- [x] /security-review passed

## Spec status row updated

| Version | Scope | Status |
|---------|-------|--------|
| v0.1.0 (LLVM01) | skeleton | **merged** |
| **v0.2.0 (LLVM02 — this PR)** | sigs + ret/ret_void/const/mov | this PR |
| v0.3.0 (LLVM03) | typed arith + cmp + branches | future |
| v0.4.0 (LLVM04) | call + print_i64 + lang-aot wiring | future |

🤖 Generated with [Claude Code](https://claude.com/claude-code)