### PR TITLE
CLOC12.17 — typeof-identity fold (gap-029 closed) [independent]

### DIFF
--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.6.0] - 2026-06-01
+
+### Added — CLOC12.17: typeof-identity fold (closes gap-029)
+
+Adds a new structural-equality arm in `try_fold_binary_op` that
+recognises `typeof <Identifier> === typeof <same Identifier>` and
+folds to `true`; the `!==` form folds to `false`.
+
+Truth table:
+
+| Input                       | Output      | Why                          |
+|-----------------------------|-------------|------------------------------|
+| `typeof a === typeof a`     | `true`      | identical sub-expressions    |
+| `typeof a !== typeof a`     | `false`     | identical sub-expressions    |
+| `typeof a === typeof b`     | unchanged   | different identifier names   |
+| `typeof a == typeof a`      | unchanged   | only strict ops are folded   |
+
+**Safety:** ECMAScript §UnaryTypeofExpression special-cases
+`typeof <undeclared-identifier>` to return the string `"undefined"`
+instead of throwing a ReferenceError, so even when the binding
+doesn't exist, evaluating `typeof x` twice produces the same string
+both times. This makes the fold sound regardless of whether the
+identifier resolves to a real binding.
+
+The fold deliberately fires only on `Identifier` arguments — not
+on member/call expressions — because those can have observable
+side effects (getter invocation, function call) that we can't
+prove are absent without a heavier purity analysis.
+
+Un-ignores `test_typeof_identifier_identity_fold` in the upstream
+test port (`tests/upstream/peephole_fold_constants_test.rs`).
+
 ## [0.5.2] - 2026-06-01
 
 ### Changed — CLOC12.14: handle new `ThrowStatement` variant

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -608,6 +608,55 @@ fn try_fold_binary_op(
         }
     }
 
+    // typeof-identity fold (closes CLOC12 gap-029).
+    //
+    // `typeof x === typeof x` → true
+    // `typeof x !== typeof x` → false
+    //
+    // Fires only when:
+    // 1. The operator is `===` or `!==`.
+    // 2. Both sides are `typeof <Identifier>` with the SAME
+    //    identifier name.
+    //
+    // Why Identifier-only is provably safe: ECMAScript §UnaryTypeofExpression
+    // special-cases `typeof <undeclared-identifier>` so it returns
+    // the string `"undefined"` *instead* of throwing a
+    // ReferenceError. So even if `x` is never declared in the
+    // program, evaluating `typeof x` twice produces the same
+    // string both times — guaranteeing the equality. No shadowing
+    // / no race / no side effect can flip the result between the
+    // two evaluations because reading a binding from a scope chain
+    // is observably deterministic within a single expression's
+    // evaluation.
+    //
+    // Why we don't bother with NumericLiteral / StringLiteral /
+    // BooleanLiteral / NullLiteral / BigIntLiteral on the inside:
+    // by the time we get here, the inner `typeof <literal>` has
+    // already been folded to a StringLiteral by the unary-fold
+    // path (CLOC12.09 + the bigint extension), and the resulting
+    // two StringLiterals were then collapsed by the string-string
+    // comparison branch above. So the only new behaviour this
+    // arm adds is the identifier case.
+    if matches!(op, StrictEq | StrictNotEq) {
+        if let (Expression::UnaryExpression(lu), Expression::UnaryExpression(ru)) = (left, right) {
+            if lu.operator == UnaryOperator::TypeOf
+                && ru.operator == UnaryOperator::TypeOf
+            {
+                if let (Expression::Identifier(la), Expression::Identifier(ra)) =
+                    (lu.argument.as_ref(), ru.argument.as_ref())
+                {
+                    if la.name == ra.name {
+                        return match op {
+                            StrictEq => Some(FoldedLiteral::Boolean(true)),
+                            StrictNotEq => Some(FoldedLiteral::Boolean(false)),
+                            _ => unreachable!(),
+                        };
+                    }
+                }
+            }
+        }
+    }
+
     None
 }
 

--- a/code/packages/rust/closure-pass-constant-fold/tests/upstream/peephole_fold_constants_test.rs
+++ b/code/packages/rust/closure-pass-constant-fold/tests/upstream/peephole_fold_constants_test.rs
@@ -369,16 +369,40 @@ fn test_typeof_identifier_is_left_alone() {
 ///   test("typeof a === typeof a", "true");
 ///   test("typeof a !== typeof a", "false");
 ///
-/// Folding these requires recognising that the two sub-expressions are
-/// *structurally identical* (same operator, same identifier name), not
-/// just folding each side independently. That's a different kind of
-/// fold rule — see gap-029. Stays `#[ignore]`-ed here.
+/// **gap-029 closed in CLOC12.17**: a new structural-equality arm in
+/// `try_fold_binary_op` recognises `typeof <Identifier> {===,!==} typeof
+/// <same Identifier>` and folds to `true`/`false` respectively.
+///
+/// Safety: ECMAScript §UnaryTypeofExpression special-cases
+/// `typeof <undeclared-identifier>` to return `"undefined"` instead of
+/// throwing a ReferenceError, so even if `a` is never declared the two
+/// evaluations produce the same string and the fold is sound.
 #[test]
-#[ignore = "blocked on gap-029: identity-of-typeof-same-identifier fold not implemented"]
 fn test_typeof_identifier_identity_fold() {
-    // Would assert:
+    use coding_adventures_javascript_ast::{Identifier, UnaryExpression, UnaryOperator};
+    let typeof_ = |name: &str| {
+        Expression::UnaryExpression(UnaryExpression {
+            cv: None,
+            operator: UnaryOperator::TypeOf,
+            prefix: true,
+            argument: Box::new(Expression::Identifier(Identifier {
+                cv: None,
+                name: name.to_string(),
+            })),
+        })
+    };
     //   typeof a === typeof a  →  true
+    assert_fold(
+        b(typeof_("a"), BinaryOperator::StrictEq, typeof_("a")),
+        bool_(true),
+    );
     //   typeof a !== typeof a  →  false
+    assert_fold(
+        b(typeof_("a"), BinaryOperator::StrictNotEq, typeof_("a")),
+        bool_(false),
+    );
+    //   typeof a === typeof b  →  NOT folded (different identifiers)
+    assert_same(b(typeof_("a"), BinaryOperator::StrictEq, typeof_("b")));
 }
 
 /// Upstream "and similar" lines that boil down to plain arithmetic on

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -241,8 +241,7 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-029 — identity-of-typeof-same-identifier fold not implemented
 
-- **Status:** OPEN
+- **Status:** RESOLVED in CLOC12.17 (PR pending).
 - **Upstream test:** `PeepholeFoldConstantsTest::testStringStringComparison` (`typeof a === typeof a` lines)
 - **Ported file:** `closure-pass-constant-fold/tests/upstream/peephole_fold_constants_test.rs`
-- **Why it fails:** Upstream folds `typeof a === typeof a` → `true` and `typeof a !== typeof a` → `false` because the two sub-expressions are *structurally identical*. Our constant-fold pass folds by *value substitution* — it doesn't compare two expressions for structural equality.
-- **What it needs:** A new fold rule on `BinaryExpression` with `StrictEq`/`StrictNotEq` that, when neither side is foldable to a literal, tests whether the two sides are syntactically equivalent. If both sides are the same `UnaryExpression { op: TypeOf, argument: <pure expression> }` shape with `argument` being the same identifier, fold to `true`/`false` respectively. Care needed: only fire when the argument is provably side-effect-free (an `Identifier` or another literal). Roughly 30-40 lines in `try_fold_binary_op`.
+- **Resolution note:** Added a new structural-equality arm in `try_fold_binary_op` for `StrictEq`/`StrictNotEq` operators where both sides are `UnaryExpression { op: TypeOf, argument: Identifier }` with the same identifier name. Folds to `true`/`false` respectively. Identifier-only because `typeof <undeclared>` is special-cased by ECMAScript §UnaryTypeofExpression to return `"undefined"` rather than throw, so the fold is safe even without declaration-tracking — `typeof x` evaluated twice deterministically produces the same string. Member/call expressions are deliberately NOT folded because they can have side effects that we can't prove are absent without a heavier purity analysis. `test_typeof_identifier_identity_fold` un-ignored.


### PR DESCRIPTION
## Summary

**INDEPENDENT** of #4752 (CLOC12.15 BigIntLiteral) — both can be reviewed in parallel. Touches only `closure-pass-constant-fold`, no AST changes.

- Adds structural-equality fold for `typeof <Identifier> {===,!==} typeof <same Identifier>`
- Folds to `true` / `false` respectively
- Identifier-only by design (member/call args could have side effects)
- Un-ignores `test_typeof_identifier_identity_fold` in the upstream port
- Closes gap-029

## Safety

Per ECMAScript §UnaryTypeofExpression, `typeof <undeclared-identifier>` returns `"undefined"` rather than throwing a ReferenceError. So `typeof a === typeof a` evaluates two `typeof a` sub-expressions in the same scope, both deterministically producing the same string — the fold is sound regardless of whether `a` resolves to a binding.

## Truth table

| Input | Output |
|-------|--------|
| `typeof a === typeof a` | `true` |
| `typeof a !== typeof a` | `false` |
| `typeof a === typeof b` | unchanged (different identifiers) |
| `typeof a == typeof a` | unchanged (only strict ops folded) |

## Version

| Crate | Old | New |
|-------|-----|-----|
| `closure-pass-constant-fold` | 0.5.2 | 0.6.0 |

## Test plan

- [x] `cargo test -p closure-pass-constant-fold` → 10 passed + 4 ignored (was 9+5; un-ignored 1)
- [x] Security review: APPROVED (sound fold, no unsafe, no panic paths, identifier-only restriction documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)