### PR TITLE
feat(mosaic-flux-compose): v0.1.0 — Kotlin runtime for Jetpack Compose emitter

### DIFF
--- a/code/packages/kotlin/mosaic-flux-compose/.gitignore
+++ b/code/packages/kotlin/mosaic-flux-compose/.gitignore
@@ -1,0 +1,6 @@
+.gradle/
+.gradle-out/
+build/
+.idea/
+*.iml
+local.properties

--- a/code/packages/kotlin/mosaic-flux-compose/BUILD
+++ b/code/packages/kotlin/mosaic-flux-compose/BUILD
@@ -1,0 +1,1 @@
+gradle test --no-daemon

--- a/code/packages/kotlin/mosaic-flux-compose/CHANGELOG.md
+++ b/code/packages/kotlin/mosaic-flux-compose/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+## 0.1.0
+
+Initial release. JVM/Kotlin strict-Flux runtime for Mosaic UI's Jetpack Compose emitter per `code/specs/UI33-rewrite-unified-architecture.md`.
+
+### Added
+
+- `MosaicAction<S>` interface with `apply(state: S): S`.
+- `MosaicStore<S>` class:
+  - Constructor takes `initialState` and optional `middleware` list.
+  - `state: S` — read-only synchronous accessor.
+  - `stateFlow: StateFlow<S>` — Compose-aware reactive surface for `collectAsState()`.
+  - `dispatch(action)` — synchronous; runs apply, swaps state, notifies subscribers, runs middleware. No-op transforms still run middleware.
+  - `subscribe(selector, equality, callback)` — returns unsubscribe closure.
+  - `select(selector)` — one-shot read.
+- `Middleware<S>` typealias `(MosaicAction<S>, S, S) -> Unit`.
+- `composeMiddleware(list)` — combines middleware in registration order; isolates throws.
+- `loggerMiddleware()` — prints action class name on dispatch.
+- `createSelector` — memoised derived state with 1-, 2-, 3-input variants.
+- `devToolsMiddleware(storeName)` — emits UI33-rewrite §8 events as stdout log lines (TCP transport deferred to v0.2.0).
+
+### Build
+
+- Gradle 8.14+ with Kotlin JVM plugin (Kotlin 2.0).
+- JVM 17 minimum.
+- Gradle output redirected to `.gradle-out/` to avoid name collision with the repo's `BUILD` script on case-insensitive macOS HFS+.
+
+### Tests
+
+- 27 JUnit5 tests, all passing on JDK 21.
+- Distributed across 5 test classes (Action, Store, Middleware, Selector, DevTools).
+
+### Deferred to v0.2.0
+
+- TCP socket DevTools transport on `localhost:9229`.
+- Compose-specific helpers (state-driven Modifier composition, etc.).
+- Time-travel replay support on the runtime side.

--- a/code/packages/kotlin/mosaic-flux-compose/README.md
+++ b/code/packages/kotlin/mosaic-flux-compose/README.md
@@ -1,0 +1,73 @@
+# mosaic-flux-compose
+
+Strict-Flux runtime for Mosaic UI's Jetpack Compose emitter.
+
+Implements the architecture specified in `code/specs/UI33-rewrite-unified-architecture.md`:
+
+- **`MosaicAction<S>` interface** — the Command Pattern. Each action is a class (typically a `data class`) carrying its payload as constructor parameters + an `apply(state) → state` method.
+- **`MosaicStore<S>` class** — state container + dispatcher. Exposes state via `kotlinx.coroutines.flow.StateFlow<S>` for fine-grained `collectAsState()` integration with Compose.
+- **`Middleware<S>`** typealias + `composeMiddleware` (with throw isolation) + `loggerMiddleware`.
+- **`createSelector`** — memoised derived-state combinator (1-, 2-, 3-input variants).
+- **`devToolsMiddleware`** — UI33-rewrite §8 protocol stub (logs to stdout in v0.1.0; TCP socket transport to localhost:9229 deferred to v0.2.0).
+
+## Quick start
+
+```kotlin
+import org.mosaic.flux.*
+
+// 1. State + actions (in real Mosaic projects auto-generated from .mil)
+data class CounterState(val count: Int = 0)
+
+data class Increment(val by: Int = 1) : MosaicAction<CounterState> {
+    override fun apply(state: CounterState): CounterState =
+        state.copy(count = state.count + by)
+}
+
+// 2. Store
+val store = MosaicStore<CounterState>(CounterState())
+
+// 3a. Compose integration — collectAsState on the StateFlow
+@Composable
+fun Counter() {
+    val state by store.stateFlow.collectAsState()
+    Column {
+        Text("Count: ${state.count}")
+        Button(onClick = { store.dispatch(Increment()) }) {
+            Text("Increment")
+        }
+    }
+}
+
+// 3b. Imperative subscription (non-Compose hosts)
+val unsubscribe = store.subscribe({ it.count }, { a, b -> a == b }) { newCount ->
+    println("count is now $newCount")
+}
+store.dispatch(Increment())     // prints "count is now 1"
+unsubscribe()
+```
+
+## Build
+
+Uses Gradle 8.14+ with the Kotlin JVM plugin. JVM 17 minimum.
+
+```bash
+gradle test
+```
+
+### macOS HFS+ note
+
+The repo's required `BUILD` file (lowercase command, uppercase filename) collides with Gradle's default `build/` output directory on case-insensitive filesystems. This package redirects Gradle's output to `.gradle-out/` via `layout.buildDirectory.set(file(".gradle-out"))` in `build.gradle.kts` to avoid the conflict.
+
+## Status
+
+v0.1.0. Initial release.
+
+- 27 JUnit5 tests, all passing
+- Tested on JDK 21 with Kotlin 2.0
+- Zero external dependencies beyond kotlinx-coroutines-core (for `StateFlow`)
+
+## Deferred to v0.2.0
+
+- TCP socket DevTools transport on `localhost:9229`
+- Compose-specific helpers (state-driven Modifier composition, etc.)
+- Time-travel replay support on the runtime side

--- a/code/packages/kotlin/mosaic-flux-compose/build.gradle.kts
+++ b/code/packages/kotlin/mosaic-flux-compose/build.gradle.kts
@@ -1,0 +1,50 @@
+// build.gradle.kts — mosaic-flux-compose v0.1.0.
+//
+// Kotlin runtime for Mosaic UI's Jetpack Compose emitter.  Mirrors
+// the API surface of mosaic-flux-react / html / webcomponent /
+// swiftui in idiomatic Kotlin: interface MosaicAction with apply(),
+// generic MosaicStore<S> exposing kotlinx.coroutines.flow.StateFlow<S>
+// for fine-grained Compose `collectAsState` integration.
+
+plugins {
+    kotlin("jvm") version "2.0.0"
+}
+
+group = "org.mosaic.flux"
+version = "0.1.0"
+
+// Redirect Gradle's output directory away from "build/" because the
+// repo's case-insensitive filesystem treats it as the same name as
+// our required "BUILD" file (the build-tool script).  Using a
+// dot-prefixed name also keeps gradle output out of git ls-files
+// listings.
+layout.buildDirectory.set(file(".gradle-out"))
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
+    testImplementation(kotlin("test"))
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.10.0")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}
+
+kotlin {
+    // JVM 17 is the minimum but the CI environment may have only JDK
+    // 21; we use jvmTarget=17 with whatever JDK is available rather
+    // than requiring a toolchain download.
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+    }
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}

--- a/code/packages/kotlin/mosaic-flux-compose/settings.gradle.kts
+++ b/code/packages/kotlin/mosaic-flux-compose/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "mosaic-flux-compose"

--- a/code/packages/kotlin/mosaic-flux-compose/src/main/kotlin/org/mosaic/flux/Action.kt
+++ b/code/packages/kotlin/mosaic-flux-compose/src/main/kotlin/org/mosaic/flux/Action.kt
@@ -1,0 +1,36 @@
+// Action.kt — the MosaicAction Command Pattern interface.
+//
+// Per UI33-rewrite §5: each action is a class (typically a data class
+// carrying its payload as constructor parameters) with an apply()
+// method that expresses the state transform.  The dispatcher routes
+// by calling action.apply(state) directly — there is no central
+// switch statement or reducer registry.
+//
+// Example:
+//
+//   data class Navigate(val row: Int, val col: Int) : MosaicAction<GridState> {
+//       override fun apply(state: GridState): GridState = state.copy(
+//           editRow = -1, editCol = -1, editContent = "",
+//           selectedRow = row, selectedCol = col
+//       )
+//   }
+//
+// apply() MUST be pure: it must not mutate the input (Kotlin data
+// classes' copy() method makes this easy), and it must be
+// deterministic — same state + same action = same next state.
+// Side effects belong in middleware, not in apply().
+
+package org.mosaic.flux
+
+/**
+ * The Command Pattern interface every Mosaic action implements.
+ * Conforming types are typically `data class` declarations whose
+ * constructor parameters carry the action's payload.
+ */
+interface MosaicAction<S> {
+    /**
+     * Pure state transform.  Returns the next state given the
+     * current one.  Must not mutate input.  Must be deterministic.
+     */
+    fun apply(state: S): S
+}

--- a/code/packages/kotlin/mosaic-flux-compose/src/main/kotlin/org/mosaic/flux/DevTools.kt
+++ b/code/packages/kotlin/mosaic-flux-compose/src/main/kotlin/org/mosaic/flux/DevTools.kt
@@ -1,0 +1,29 @@
+// DevTools.kt — DevTools protocol middleware (v0.1.0 stub).
+//
+// Per UI33-rewrite §8, every mosaic-flux runtime publishes a uniform
+// event stream so the Mosaic DevTools desktop app can attach.  On
+// JVM platforms the transport is a local TCP socket on port 9229.
+//
+// v0.1.0 ships the middleware shape and logs each event to stdout
+// in a format the future DevTools client will recognise.  The TCP
+// socket implementation requires kotlinx-io or java.net.Socket plus
+// async setup — deferred to v0.2.0.
+
+package org.mosaic.flux
+
+import java.time.Instant
+
+/**
+ * Build a DevTools-protocol middleware.  Logs structured events to
+ * stdout; v0.2.0 will additionally transmit to localhost:9229 so the
+ * Mosaic DevTools desktop app can attach.
+ *
+ * @param storeName Disambiguator when multiple stores are active.
+ */
+fun <S> devToolsMiddleware(storeName: String = "default"): Middleware<S> {
+    return { action, _, _ ->
+        val timestamp = Instant.now().toString()
+        val actionType = action::class.simpleName ?: "Action"
+        println("[mosaic-flux-devtools] $timestamp $storeName/$actionType")
+    }
+}

--- a/code/packages/kotlin/mosaic-flux-compose/src/main/kotlin/org/mosaic/flux/Middleware.kt
+++ b/code/packages/kotlin/mosaic-flux-compose/src/main/kotlin/org/mosaic/flux/Middleware.kt
@@ -1,0 +1,44 @@
+// Middleware.kt — cross-cutting concern hook.
+//
+// Middleware sees every dispatched (action, prevState, nextState)
+// triple AFTER apply() has produced the next state.  Use for
+// loggers, analytics, persistence, and effect schedulers.
+//
+// Errors thrown by middleware are caught and printed; subsequent
+// middleware still run (matches the TS / Swift runtimes — one bad
+// middleware can't take down the others).
+
+package org.mosaic.flux
+
+typealias Middleware<S> = (MosaicAction<S>, S, S) -> Unit
+
+/**
+ * Combine an array of middleware into a single middleware.  Each
+ * runs in registration order.  Errors thrown by one are caught and
+ * printed; subsequent middleware still run.  Returns a no-op when
+ * the list is empty.
+ */
+fun <S> composeMiddleware(middleware: List<Middleware<S>>): Middleware<S> {
+    if (middleware.isEmpty()) return { _, _, _ -> /* no-op */ }
+    if (middleware.size == 1) return middleware[0]
+    return { action, prev, next ->
+        for (m in middleware) {
+            try {
+                m(action, prev, next)
+            } catch (t: Throwable) {
+                // Match the TS / Swift runtimes' behaviour: log and
+                // continue, so one bad middleware can't break peers.
+                System.err.println("[mosaic-flux] middleware threw: ${t.message}")
+            }
+        }
+    }
+}
+
+/**
+ * Dev logger middleware — prints action class name on each dispatch.
+ * Production hosts typically compose their own logger that ships to
+ * telemetry rather than println.
+ */
+fun <S> loggerMiddleware(): Middleware<S> = { action, _, _ ->
+    println("[mosaic-flux] ${action::class.simpleName ?: "Action"}")
+}

--- a/code/packages/kotlin/mosaic-flux-compose/src/main/kotlin/org/mosaic/flux/Selector.kt
+++ b/code/packages/kotlin/mosaic-flux-compose/src/main/kotlin/org/mosaic/flux/Selector.kt
@@ -1,0 +1,98 @@
+// Selector.kt — memoised derived-state combinator.
+//
+// For derived state computed from multiple slots of the same state,
+// recomputing on every selector call is wasteful.  createSelector
+// memoises by input equality: if every input returned the same value
+// as last call, the cached output is reused.
+//
+// v0.1.0 provides 1-, 2-, and 3-input variants.
+
+package org.mosaic.flux
+
+/**
+ * Build a single-input memoised selector.  Combiner runs only when
+ * the input changes (by ==).
+ */
+fun <S, A, R> createSelector(
+    inputA: (S) -> A,
+    combine: (A) -> R,
+): (S) -> R {
+    var lastInput: A? = null
+    var hasLast = false
+    var lastResult: R? = null
+    return { state ->
+        val a = inputA(state)
+        @Suppress("UNCHECKED_CAST")
+        if (hasLast && lastInput == a) {
+            lastResult as R
+        } else {
+            lastInput = a
+            hasLast = true
+            val r = combine(a)
+            lastResult = r
+            r
+        }
+    }
+}
+
+/**
+ * Build a two-input memoised selector.
+ */
+fun <S, A, B, R> createSelector(
+    inputA: (S) -> A,
+    inputB: (S) -> B,
+    combine: (A, B) -> R,
+): (S) -> R {
+    var lastA: A? = null
+    var lastB: B? = null
+    var hasLast = false
+    var lastResult: R? = null
+    return { state ->
+        val a = inputA(state)
+        val b = inputB(state)
+        @Suppress("UNCHECKED_CAST")
+        if (hasLast && lastA == a && lastB == b) {
+            lastResult as R
+        } else {
+            lastA = a
+            lastB = b
+            hasLast = true
+            val r = combine(a, b)
+            lastResult = r
+            r
+        }
+    }
+}
+
+/**
+ * Build a three-input memoised selector.
+ */
+fun <S, A, B, C, R> createSelector(
+    inputA: (S) -> A,
+    inputB: (S) -> B,
+    inputC: (S) -> C,
+    combine: (A, B, C) -> R,
+): (S) -> R {
+    var lastA: A? = null
+    var lastB: B? = null
+    var lastC: C? = null
+    var hasLast = false
+    var lastResult: R? = null
+    return { state ->
+        val a = inputA(state)
+        val b = inputB(state)
+        val c = inputC(state)
+        @Suppress("UNCHECKED_CAST")
+        if (hasLast && lastA == a && lastB == b && lastC == c) {
+            lastResult as R
+        } else {
+            lastA = a
+            lastB = b
+            lastC = c
+            hasLast = true
+            val r = combine(a, b, c)
+            lastResult = r
+            r
+        }
+    }
+}

--- a/code/packages/kotlin/mosaic-flux-compose/src/main/kotlin/org/mosaic/flux/Store.kt
+++ b/code/packages/kotlin/mosaic-flux-compose/src/main/kotlin/org/mosaic/flux/Store.kt
@@ -1,0 +1,128 @@
+// Store.kt — MosaicStore: state container + dispatcher.
+//
+// The MosaicStore is the runtime's center of gravity.  It holds the
+// current state, accepts action dispatches, runs middleware, and
+// exposes the state as a kotlinx.coroutines.flow.StateFlow<S> for
+// fine-grained Compose `collectAsState` integration.
+//
+// Design choices (per UI33-rewrite §6):
+//
+//   1. No central reducer.  dispatch() calls action.apply(state)
+//      directly — Command Pattern.
+//
+//   2. Fine-grained subscription via StateFlow.  Compose hosts use
+//      `store.stateFlow.collectAsState()` to re-compose only when
+//      the observed slice changes; non-Compose hosts use the
+//      imperative subscribe(selector, equality, callback) variant.
+//
+//   3. Synchronous dispatch.  apply() runs immediately on the
+//      caller's thread; subscribers fire; middleware runs — all
+//      synchronous.  Async work belongs in middleware that
+//      schedules subsequent dispatches.
+
+package org.mosaic.flux
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Equality function for fine-grained subscription decisions.
+ */
+typealias Equality<T> = (T, T) -> Boolean
+
+private val defaultEquality: Equality<Any?> = { a, b -> a === b }
+
+/**
+ * The Mosaic state container and dispatcher.
+ *
+ * @param initialState The state at construction time.
+ * @param middleware Optional middleware that runs after each dispatch.
+ */
+class MosaicStore<S>(
+    initialState: S,
+    middleware: List<Middleware<S>> = emptyList(),
+) {
+    private val _state = MutableStateFlow(initialState)
+    private val middlewareFn: Middleware<S> = composeMiddleware(middleware)
+    private val subscriptions = mutableMapOf<Int, InternalSubscription<S, *>>()
+    private val nextSubscriptionId = AtomicInteger(0)
+
+    /**
+     * StateFlow surface for Compose-aware consumers.  Use with
+     * `collectAsState()` for automatic recomposition on state change.
+     */
+    val stateFlow: StateFlow<S> = _state.asStateFlow()
+
+    /**
+     * Current state, read synchronously.
+     */
+    val state: S get() = _state.value
+
+    /**
+     * Dispatch an action.  Runs action.apply(state), swaps state,
+     * notifies subscribers whose projected slice changed, runs
+     * middleware.
+     */
+    fun <A : MosaicAction<S>> dispatch(action: A) {
+        val prev = _state.value
+        val next = action.apply(prev)
+        if (prev === next) {
+            // No-op transform; middleware still runs so loggers see
+            // every dispatch.
+            middlewareFn(action, prev, next)
+            return
+        }
+        _state.value = next
+        // Snapshot subscriptions so a callback that unsubscribes
+        // doesn't perturb iteration.
+        val snapshot = subscriptions.values.toList()
+        for (sub in snapshot) {
+            sub.notifyIfChanged(next)
+        }
+        middlewareFn(action, prev, next)
+    }
+
+    /**
+     * Subscribe to a slice of state via a selector.  Callback fires
+     * when the projected slice changes by the supplied equality
+     * function (default: reference identity).
+     *
+     * Returns an unsubscribe function — invoke it to stop receiving
+     * callbacks.
+     */
+    fun <T> subscribe(
+        selector: (S) -> T,
+        @Suppress("UNCHECKED_CAST")
+        equality: Equality<T> = defaultEquality as Equality<T>,
+        callback: (T) -> Unit,
+    ): () -> Unit {
+        val id = nextSubscriptionId.getAndIncrement()
+        val sub = InternalSubscription(selector, callback, equality, selector(_state.value))
+        subscriptions[id] = sub
+        return { subscriptions.remove(id) }
+    }
+
+    /**
+     * One-shot read of a slice without subscription.
+     */
+    fun <T> select(selector: (S) -> T): T = selector(_state.value)
+}
+
+private class InternalSubscription<S, T>(
+    private val selector: (S) -> T,
+    private val callback: (T) -> Unit,
+    private val equality: Equality<T>,
+    initial: T,
+) {
+    private var lastValue: T = initial
+
+    fun notifyIfChanged(nextState: S) {
+        val nextValue = selector(nextState)
+        if (!equality(lastValue, nextValue)) {
+            lastValue = nextValue
+            callback(nextValue)
+        }
+    }
+}

--- a/code/packages/kotlin/mosaic-flux-compose/src/test/kotlin/org/mosaic/flux/ActionTest.kt
+++ b/code/packages/kotlin/mosaic-flux-compose/src/test/kotlin/org/mosaic/flux/ActionTest.kt
@@ -1,0 +1,38 @@
+package org.mosaic.flux
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private data class ActionTestS(val count: Int = 0)
+
+private class ActionTestInc : MosaicAction<ActionTestS> {
+    override fun apply(state: ActionTestS): ActionTestS = state.copy(count = state.count + 1)
+}
+
+private data class ActionTestAdd(val amount: Int) : MosaicAction<ActionTestS> {
+    override fun apply(state: ActionTestS): ActionTestS = state.copy(count = state.count + amount)
+}
+
+class ActionTest {
+    @Test
+    fun applyReturnsNextStateWithoutMutatingInput() {
+        val initial = ActionTestS(count = 5)
+        val next = ActionTestInc().apply(initial)
+        assertEquals(6, next.count)
+        assertEquals(5, initial.count)  // Kotlin data class copy semantics
+    }
+
+    @Test
+    fun payloadAccessible() {
+        val action = ActionTestAdd(amount = 7)
+        assertEquals(7, action.amount)
+        assertEquals(10, action.apply(ActionTestS(count = 3)).count)
+    }
+
+    @Test
+    fun deterministic() {
+        val state = ActionTestS(count = 0)
+        val action = ActionTestAdd(amount = 5)
+        assertEquals(action.apply(state), action.apply(state))
+    }
+}

--- a/code/packages/kotlin/mosaic-flux-compose/src/test/kotlin/org/mosaic/flux/DevToolsTest.kt
+++ b/code/packages/kotlin/mosaic-flux-compose/src/test/kotlin/org/mosaic/flux/DevToolsTest.kt
@@ -1,0 +1,37 @@
+package org.mosaic.flux
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private data class DtS(val v: Int = 0)
+
+private class DtBump : MosaicAction<DtS> {
+    override fun apply(state: DtS): DtS = state.copy(v = state.v + 1)
+}
+
+class DevToolsTest {
+    @Test
+    fun callable() {
+        val m = devToolsMiddleware<DtS>()
+        m(DtBump(), DtS(), DtS(v = 1))
+    }
+
+    @Test
+    fun customStoreName() {
+        val m = devToolsMiddleware<DtS>("my-grid")
+        m(DtBump(), DtS(), DtS(v = 1))
+    }
+
+    @Test
+    fun integratesWithStore() {
+        var probeRuns = 0
+        val store = MosaicStore<DtS>(
+            DtS(),
+            listOf(devToolsMiddleware(), { _, _, _ -> probeRuns++ }),
+        )
+        store.dispatch(DtBump())
+        store.dispatch(DtBump())
+        assertEquals(2, probeRuns)
+        assertEquals(2, store.state.v)
+    }
+}

--- a/code/packages/kotlin/mosaic-flux-compose/src/test/kotlin/org/mosaic/flux/MiddlewareTest.kt
+++ b/code/packages/kotlin/mosaic-flux-compose/src/test/kotlin/org/mosaic/flux/MiddlewareTest.kt
@@ -1,0 +1,54 @@
+package org.mosaic.flux
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private data class MwS(val v: Int = 0)
+
+private class MwBump : MosaicAction<MwS> {
+    override fun apply(state: MwS): MwS = state.copy(v = state.v + 1)
+}
+
+class MiddlewareTest {
+    @Test
+    fun emptyComposeIsNoOp() {
+        val m = composeMiddleware<MwS>(emptyList())
+        m(MwBump(), MwS(), MwS(v = 1))
+    }
+
+    @Test
+    fun singleMiddlewareReturnedVerbatim() {
+        val m: Middleware<MwS> = { _, _, _ -> }
+        assertEquals(m, composeMiddleware(listOf(m)))
+    }
+
+    @Test
+    fun runsInOrder() {
+        val calls = mutableListOf<String>()
+        val composed = composeMiddleware<MwS>(listOf(
+            { _, _, _ -> calls.add("a") },
+            { _, _, _ -> calls.add("b") },
+            { _, _, _ -> calls.add("c") },
+        ))
+        composed(MwBump(), MwS(), MwS(v = 1))
+        assertEquals(listOf("a", "b", "c"), calls)
+    }
+
+    @Test
+    fun isolatesThrows() {
+        val calls = mutableListOf<String>()
+        val composed = composeMiddleware<MwS>(listOf(
+            { _, _, _ -> calls.add("a") },
+            { _, _, _ -> throw RuntimeException("boom") },
+            { _, _, _ -> calls.add("c") },
+        ))
+        composed(MwBump(), MwS(), MwS(v = 1))
+        assertEquals(listOf("a", "c"), calls)
+    }
+
+    @Test
+    fun loggerMiddlewareDoesNotThrow() {
+        val m = loggerMiddleware<MwS>()
+        m(MwBump(), MwS(), MwS(v = 1))
+    }
+}

--- a/code/packages/kotlin/mosaic-flux-compose/src/test/kotlin/org/mosaic/flux/SelectorTest.kt
+++ b/code/packages/kotlin/mosaic-flux-compose/src/test/kotlin/org/mosaic/flux/SelectorTest.kt
@@ -1,0 +1,73 @@
+package org.mosaic.flux
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private data class SelS(val a: Int = 0, val b: Int = 0, val label: String = "")
+
+class SelectorTest {
+    @Test
+    fun singleInputRecomputesOnChange() {
+        var calls = 0
+        val doubled = createSelector<SelS, Int, Int>(
+            { it.a },
+            { a -> calls++; a * 2 },
+        )
+        assertEquals(10, doubled(SelS(a = 5)))
+        assertEquals(14, doubled(SelS(a = 7)))
+        assertEquals(2, calls)
+    }
+
+    @Test
+    fun singleInputCachesOnStable() {
+        var calls = 0
+        val doubled = createSelector<SelS, Int, Int>(
+            { it.a },
+            { a -> calls++; a * 2 },
+        )
+        val s = SelS(a = 5)
+        doubled(s); doubled(s); doubled(s)
+        assertEquals(1, calls)
+    }
+
+    @Test
+    fun singleInputCachesAcrossStateRefs() {
+        var calls = 0
+        val doubled = createSelector<SelS, Int, Int>(
+            { it.a },
+            { a -> calls++; a * 2 },
+        )
+        doubled(SelS(a = 5, b = 0))
+        doubled(SelS(a = 5, b = 999, label = "different"))
+        assertEquals(1, calls)
+    }
+
+    @Test
+    fun twoInputRecomputesWhenEitherChanges() {
+        var calls = 0
+        val sum = createSelector<SelS, Int, Int, Int>(
+            { it.a },
+            { it.b },
+            { a, b -> calls++; a + b },
+        )
+        assertEquals(3, sum(SelS(a = 1, b = 2)))
+        assertEquals(6, sum(SelS(a = 1, b = 5)))
+        assertEquals(9, sum(SelS(a = 4, b = 5)))
+        assertEquals(3, calls)
+    }
+
+    @Test
+    fun threeInputRecomputesWhenAnyChanges() {
+        var calls = 0
+        val fmt = createSelector<SelS, Int, Int, String, String>(
+            { it.a },
+            { it.b },
+            { it.label },
+            { a, b, lbl -> calls++; "$lbl:${a + b}" },
+        )
+        assertEquals("x:3", fmt(SelS(a = 1, b = 2, label = "x")))
+        assertEquals("x:3", fmt(SelS(a = 1, b = 2, label = "x")))
+        assertEquals("y:3", fmt(SelS(a = 1, b = 2, label = "y")))
+        assertEquals(2, calls)
+    }
+}

--- a/code/packages/kotlin/mosaic-flux-compose/src/test/kotlin/org/mosaic/flux/StoreTest.kt
+++ b/code/packages/kotlin/mosaic-flux-compose/src/test/kotlin/org/mosaic/flux/StoreTest.kt
@@ -1,0 +1,120 @@
+package org.mosaic.flux
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private data class StS(val count: Int = 0, val label: String = "")
+
+private class StIncrement : MosaicAction<StS> {
+    override fun apply(state: StS): StS = state.copy(count = state.count + 1)
+}
+
+private data class StSetLabel(val label: String) : MosaicAction<StS> {
+    override fun apply(state: StS): StS = state.copy(label = label)
+}
+
+private class StNoOp : MosaicAction<StS> {
+    override fun apply(state: StS): StS = state
+}
+
+class StoreTest {
+    @Test
+    fun startsAtInitialState() {
+        val store = MosaicStore(StS())
+        assertEquals(StS(), store.state)
+    }
+
+    @Test
+    fun dispatchAppliesAction() {
+        val store = MosaicStore(StS())
+        store.dispatch(StIncrement())
+        assertEquals(1, store.state.count)
+    }
+
+    @Test
+    fun payloadedActionWorks() {
+        val store = MosaicStore(StS())
+        store.dispatch(StSetLabel("hi"))
+        assertEquals("hi", store.state.label)
+    }
+
+    @Test
+    fun selectReturnsProjection() {
+        val store = MosaicStore(StS(count = 5))
+        assertEquals(5, store.select { it.count })
+    }
+
+    @Test
+    fun subscribeFiresOnChangedSlice() {
+        val store = MosaicStore(StS())
+        val received = mutableListOf<Int>()
+        store.subscribe({ it.count }, { a, b -> a == b }) { received.add(it) }
+        store.dispatch(StIncrement())
+        assertEquals(listOf(1), received)
+    }
+
+    @Test
+    fun subscribeDoesNotFireOnUnrelatedChange() {
+        val store = MosaicStore(StS())
+        val received = mutableListOf<Int>()
+        store.subscribe({ it.count }, { a, b -> a == b }) { received.add(it) }
+        store.dispatch(StSetLabel("ignore"))
+        assertTrue(received.isEmpty())
+    }
+
+    @Test
+    fun unsubscribeStopsNotifications() {
+        val store = MosaicStore(StS())
+        val received = mutableListOf<Int>()
+        val unsub = store.subscribe({ it.count }, { a, b -> a == b }) { received.add(it) }
+        store.dispatch(StIncrement())
+        unsub()
+        store.dispatch(StIncrement())
+        assertEquals(listOf(1), received)
+    }
+
+    @Test
+    fun middlewareSeesTriple() {
+        val seen = mutableListOf<Triple<String, Int, Int>>()
+        val m: Middleware<StS> = { action, prev, next ->
+            seen.add(Triple(action::class.simpleName ?: "?", prev.count, next.count))
+        }
+        val store = MosaicStore(StS(), listOf(m))
+        store.dispatch(StIncrement())
+        assertEquals(1, seen.size)
+        assertEquals(0, seen[0].second)
+        assertEquals(1, seen[0].third)
+    }
+
+    @Test
+    fun noOpDispatchSkipsSubscriberButRunsMiddleware() {
+        var subscriberCalls = 0
+        var middlewareCalls = 0
+        val store = MosaicStore(
+            StS(),
+            listOf({ _, _, _ -> middlewareCalls++ }),
+        )
+        store.subscribe({ it.count }, { a, b -> a == b }) { subscriberCalls++ }
+        store.dispatch(StNoOp())
+        assertEquals(0, subscriberCalls)
+        assertEquals(1, middlewareCalls)
+    }
+
+    @Test
+    fun stateFlowExposesCurrentState() {
+        val store = MosaicStore(StS(count = 42))
+        assertEquals(42, store.stateFlow.value.count)
+        store.dispatch(StIncrement())
+        assertEquals(43, store.stateFlow.value.count)
+    }
+
+    @Test
+    fun customEqualityRespected() {
+        val store = MosaicStore(StS())
+        val received = mutableListOf<Int>()
+        store.subscribe({ it.count }, { _, _ -> true }) { received.add(it) }
+        store.dispatch(StIncrement())
+        assertTrue(received.isEmpty())
+    }
+}


### PR DESCRIPTION
Fifth Phase-2 runtime library per UI33-rewrite §6. Kotlin implementation mirroring the React/HTML/WebComponent/SwiftUI API surface.

## API surface

| Surface | Detail |
|---|---|
| `MosaicAction<S>` interface | Command Pattern; data classes naturally carry payload |
| `MosaicStore<S>` class | Exposes state via `StateFlow<S>` for Compose `collectAsState()` |
| `Middleware<S>` + `composeMiddleware` + `loggerMiddleware` | Throw-isolated composition |
| `createSelector` | 1-, 2-, 3-input memoised by `==` |
| `devToolsMiddleware` | UI33-rewrite §8 stub (stdout in v0.1.0, TCP socket deferred) |

## Stats

- 5 source files, ~500 LOC, literate comments
- 5 test classes, **27 JUnit5 tests passing** (verified on JDK 21)
- Gradle 8.14+ with Kotlin JVM 2.0
- JVM 17 minimum

## Build quirk worth noting

The repo's required `BUILD` file (lowercase command) collides with Gradle's default `build/` output directory on case-insensitive macOS HFS+. Output redirected to `.gradle-out/` via `layout.buildDirectory.set(file(".gradle-out"))` in build.gradle.kts. This will be documented in lessons.md.

## Loop progress

| Cycle | Package | Lang | PR | Status |
|---|---|---|---|---|
| 1 | mosaic-flux-react | TS | #4699 | ✅ MERGED |
| 2 | mosaic-flux-html | TS | #4702 | ✅ MERGED |
| 3 | mosaic-flux-webcomponent | TS | #4708 | ✅ MERGED |
| 4 | mosaic-flux-swiftui | Swift | #4753 | In review |
| **5** | **mosaic-flux-compose** | **Kotlin** | **(this)** | **Just opened** |
| 6 | mosaic-flux-flutter | Dart | — | Next cycle |
| 7 | mosaic-flux-xaml | C# | — | Later |
| 8 | mosaic-flux-qt | C++ | — | Later |

Loop driven by **cron 159be70b** — every 3 min, race-safe (Phase A babysits unconditionally; Phase B starts a new cycle only when working tree is clean to avoid stepping on in-progress conversation work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)