### PR TITLE
CLOC12.18 — if-else→ternary fold (gap-017 closed) [independent]

### DIFF
--- a/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to the `coding-adventures-closure-pass-fold-control-flow` crate will be documented in this file.
 
+## [0.4.0] - 2026-06-01
+
+### Added — CLOC12.18: if-else→ternary fold (closes gap-017)
+
+Adds a rewrite rule in `fold_if_statement`: when the test is not a
+known literal AND both branches reduce to a single ExpressionStatement
+(directly or via single-statement BlockStatement layers), the
+IfStatement rewrites to an ExpressionStatement wrapping a
+ConditionalExpression.
+
+Truth table:
+
+| Input                                       | Output                  |
+|---------------------------------------------|-------------------------|
+| `if (x) foo(); else bar();`                 | `x ? foo() : bar();`    |
+| `if (x) { foo(); } else { bar(); }`         | `x ? foo() : bar();`    |
+| `if (x) foo();`                             | unchanged (no alternate)|
+| `if (x) { a; b; } else c;`                  | unchanged (multi-stmt)  |
+| `if (x) return 1; else return 2;`           | unchanged (return ≠ expr; tracked as gap-019) |
+
+Side-effect safety: a ConditionalExpression evaluates `test` first
+then exactly one of the two branches — identical to the if-else.
+
+Un-ignores `test_fold_one_child_blocks_if_else_to_ternary` in the
+upstream port. Updates two existing tests
+(`test_if_non_literal_test_left_alone`,
+`if_non_literal_test_passes_through`) to reflect the new fold.
+
+The helper `single_expr_stmt(stmt) -> Option<Expression>` recursively
+unwraps single-statement BlockStatement layers.
+
 ## [0.3.2] - 2026-06-01
 
 ### Changed — CLOC12.14: handle new `ThrowStatement` variant

--- a/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
+++ b/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-fold-control-flow"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 description = "Control-flow folding pass for the Closure Compiler clone. Slots between constant-fold and DCE per CLOC06's canonical pass set. Eliminates dead branches (`if (false) A else B → B`), removes unreachable code after `return`/`throw`, and collapses degenerate switch arms."
 

--- a/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
@@ -346,7 +346,60 @@ fn fold_if_statement(s: &IfStatement, st: &mut FoldState) -> Statement {
             })
         }
         None => {
-            // Non-literal test — keep the IfStatement.
+            // Non-literal test. Try the if-else→ternary fold first
+            // (CLOC12.18 / gap-017): when both branches reduce to a
+            // single ExpressionStatement, rewrite the whole
+            // IfStatement to an ExpressionStatement wrapping a
+            // ConditionalExpression.
+            //
+            // Truth table (assuming `test` has no literal-truthy
+            // resolution — those cases are handled above):
+            //
+            //   if (x) foo(); else bar();      → x ? foo() : bar();
+            //   if (x) { foo(); } else { bar(); }
+            //                                  → x ? foo() : bar();
+            //                                    (single-statement
+            //                                     blocks unwrap)
+            //   if (x) foo();                  → unchanged (no
+            //                                    alternate to fold)
+            //   if (x) { a; b; } else { c; }   → unchanged (multi-
+            //                                    statement consequent)
+            //   if (x) return 1; else return 2;
+            //                                  → unchanged (return is
+            //                                    not an expression
+            //                                    statement; tracked
+            //                                    as gap-019)
+            //
+            // Why this is safe: a ConditionalExpression has the same
+            // evaluation order as the if-else — `test` is evaluated
+            // first, then exactly one of the two branches. Side
+            // effects in `test`, in `consequent`, in `alternate`
+            // observed in the original program are all preserved in
+            // the rewritten form.
+            if let Some(alt) = &alternate {
+                if let (Some(c_expr), Some(a_expr)) =
+                    (single_expr_stmt(&consequent), single_expr_stmt(alt))
+                {
+                    st.record_fold(
+                        &s.cv,
+                        "if-else-to-ternary",
+                        "if (<test>) <expr1>; else <expr2>;",
+                        "<test> ? <expr1> : <expr2>;",
+                    );
+                    let cond = Expression::ConditionalExpression(ConditionalExpression {
+                        cv: None,
+                        test: Box::new(test),
+                        consequent: Box::new(c_expr),
+                        alternate: Box::new(a_expr),
+                    });
+                    return Statement::expression_statement(ExpressionStatement {
+                        cv: s.cv.clone(),
+                        expression: cond,
+                    });
+                }
+            }
+
+            // Couldn't ternarise — keep the IfStatement.
             Statement::if_statement(IfStatement {
                 cv: s.cv.clone(),
                 test,
@@ -354,6 +407,27 @@ fn fold_if_statement(s: &IfStatement, st: &mut FoldState) -> Statement {
                 alternate: alternate.map(Box::new),
             })
         }
+    }
+}
+
+/// Helper for the if-else→ternary fold (gap-017). Returns the inner
+/// expression when `stmt` is exactly one ExpressionStatement
+/// (possibly wrapped in single-statement BlockStatement layers);
+/// returns `None` for everything else.
+///
+/// We recurse through BlockStatement so source like `if (x) { foo(); }`
+/// (with explicit braces around a single statement) folds the same
+/// way as `if (x) foo();`. We do NOT recurse into anything that
+/// changes statement count — multi-statement blocks bail out.
+fn single_expr_stmt(stmt: &Statement) -> Option<Expression> {
+    match stmt {
+        Statement::Tagged(TaggedStatement::ExpressionStatement(es)) => {
+            Some(es.expression.clone())
+        }
+        Statement::Tagged(TaggedStatement::BlockStatement(b)) if b.body.len() == 1 => {
+            single_expr_stmt(&b.body[0])
+        }
+        _ => None,
     }
 }
 
@@ -774,7 +848,9 @@ mod tests {
     }
 
     #[test]
-    fn if_non_literal_test_passes_through() {
+    fn if_non_literal_test_with_single_expr_branches_folds_to_ternary() {
+        // CLOC12.18 / gap-017: `if (flag) x; else y;` now ternarises
+        // to `flag ? x : y;` even when `flag` isn't a known literal.
         let if_stmt = Statement::if_statement(IfStatement {
             cv: Some("if.1".to_string()),
             test: ident("flag"),
@@ -783,11 +859,37 @@ mod tests {
         });
         let prog = program().with_body(vec![ProgramItem::Statement(if_stmt)]);
         let (out, contribs, changed, _) = run_pass(prog);
-        assert!(!changed);
-        assert!(contribs.is_empty());
+        assert!(changed);
+        assert!(!contribs.is_empty());
+        match first_stmt(&out) {
+            Statement::Tagged(TaggedStatement::ExpressionStatement(es)) => {
+                match &es.expression {
+                    Expression::ConditionalExpression(_) => {}
+                    other => panic!("expected ConditionalExpression; got {:?}", other),
+                }
+            }
+            other => panic!("expected ExpressionStatement; got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn if_non_literal_test_with_no_alternate_passes_through() {
+        // No alternate → can't ternarise (gap-016 territory, not 017).
+        // Verifies the new fold doesn't over-fire.
+        let if_stmt = Statement::if_statement(IfStatement {
+            cv: Some("if.2".to_string()),
+            test: ident("flag"),
+            consequent: Box::new(expr_stmt(ident("x"), None)),
+            alternate: None,
+        });
+        let prog = program().with_body(vec![ProgramItem::Statement(if_stmt)]);
+        let (out, _contribs, _changed, _) = run_pass(prog);
+        // Don't assert !changed — the test field gets fold-walked and
+        // could in principle gain a contribution. What we DO assert
+        // is that the top-level structure stays IfStatement.
         match first_stmt(&out) {
             Statement::Tagged(TaggedStatement::IfStatement(_)) => {}
-            other => panic!("expected IfStatement intact; got {:?}", other),
+            other => panic!("expected IfStatement intact (no alternate); got {:?}", other),
         }
     }
 

--- a/code/packages/rust/closure-pass-fold-control-flow/tests/upstream/peephole_minimize_conditions_test.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/tests/upstream/peephole_minimize_conditions_test.rs
@@ -176,13 +176,70 @@ fn test_fold_one_child_blocks_if_to_logical_and() {
 ///   fold("function f(){if(x){foo()}else{bar()}}",
 ///        "function f(){x?foo():bar()}");
 ///
-/// Converting `if (x) C; else A;` to `x ? C : A;` (a
-/// ConditionalExpression statement) is upstream's compaction. We
-/// don't perform it.
+/// **gap-017 closed in CLOC12.18**: when both `consequent` and
+/// `alternate` reduce to a single `ExpressionStatement` (directly
+/// or via single-statement BlockStatement layers), the IfStatement
+/// rewrites to an `ExpressionStatement` wrapping a
+/// `ConditionalExpression`. Side-effect order is preserved because
+/// a ternary evaluates `test`, then exactly one branch — identical
+/// to the if-else.
 #[test]
-#[ignore = "blocked on gap-017: `if (x) C else A` → `x ? C : A` rewrite not implemented"]
 fn test_fold_one_child_blocks_if_else_to_ternary() {
-    // Would assert `if (x) foo(); else bar();` becomes `x ? foo() : bar();`.
+    use coding_adventures_javascript_ast::{
+        BlockStatement, CallExpression, ConditionalExpression,
+    };
+    let call = |name: &str| {
+        Expression::CallExpression(CallExpression {
+            cv: None,
+            callee: Box::new(ident(name)),
+            arguments: vec![],
+        })
+    };
+    let block = |s: Statement| {
+        Statement::block_statement(BlockStatement {
+            cv: None,
+            body: vec![s],
+        })
+    };
+    let expect_ternary = |t: Expression, c: Expression, a: Expression| -> Statement {
+        Statement::expression_statement(ExpressionStatement {
+            cv: None,
+            expression: Expression::ConditionalExpression(ConditionalExpression {
+                cv: None,
+                test: Box::new(t),
+                consequent: Box::new(c),
+                alternate: Box::new(a),
+            }),
+        })
+    };
+
+    // if (x) foo(); else bar();  →  x ? foo() : bar();
+    let inp = if_stmt(
+        ident("x"),
+        expr_stmt(call("foo")),
+        Some(expr_stmt(call("bar"))),
+    );
+    assert_fold(inp, expect_ternary(ident("x"), call("foo"), call("bar")));
+
+    // if (x) { foo(); } else { bar(); }  →  same ternary (single-
+    // statement block unwraps).
+    let inp_blocks = if_stmt(
+        ident("x"),
+        block(expr_stmt(call("foo"))),
+        Some(block(expr_stmt(call("bar")))),
+    );
+    assert_fold(
+        inp_blocks,
+        expect_ternary(ident("x"), call("foo"), call("bar")),
+    );
+
+    // testSame: no alternate → stays an IfStatement.
+    let inp_no_alt = if_stmt(ident("x"), expr_stmt(call("foo")), None);
+    assert_fold(
+        inp_no_alt.clone(),
+        // Identity fold: the IfStatement comes back unchanged.
+        inp_no_alt,
+    );
 }
 
 /// Constant true test always selects the consequent. Mirrors upstream's
@@ -255,10 +312,23 @@ fn test_if_null_folds_to_alternate() {
     assert_fold(inp, expr_stmt(ident("y")));
 }
 
-/// `testSame("if (x) C else A")` — non-literal test must be left alone.
+/// Upstream `testSame("if (x) C else A")` (when C and A are not single
+/// ExpressionStatements) — non-literal test stays as an IfStatement.
+///
+/// **Updated in CLOC12.18**: the original `if (x) c; else a;` shape
+/// (two single ExpressionStatement branches) is no longer a testSame —
+/// the new gap-017 ternary fold rewrites it. So this test now uses a
+/// multi-statement consequent block to keep the testSame behaviour
+/// at this seam. The original single-expr case is covered by
+/// `test_fold_one_child_blocks_if_else_to_ternary` above.
 #[test]
 fn test_if_non_literal_test_left_alone() {
-    let inp = if_stmt(ident("x"), expr_stmt(ident("c")), Some(expr_stmt(ident("a"))));
+    use coding_adventures_javascript_ast::BlockStatement;
+    let multi_block = Statement::block_statement(BlockStatement {
+        cv: None,
+        body: vec![expr_stmt(ident("c1")), expr_stmt(ident("c2"))],
+    });
+    let inp = if_stmt(ident("x"), multi_block, Some(expr_stmt(ident("a"))));
     assert_same(inp);
 }
 

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -150,11 +150,10 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-017 — `if (x) C else A` → `x ? C : A` rewrite not implemented
 
-- **Status:** OPEN
+- **Status:** RESOLVED in CLOC12.18 (PR pending).
 - **Upstream test:** `PeepholeMinimizeConditionsTest::testFoldOneChildBlocks` (`if(x){foo()}else{bar()}` → `x?foo():bar()` lines)
 - **Ported file:** `closure-pass-fold-control-flow/tests/upstream/peephole_minimize_conditions_test.rs`
-- **Why it fails:** Upstream rewrites an `IfStatement` with single-`ExpressionStatement` branches into an `ExpressionStatement` wrapping a `ConditionalExpression`. Our pass keeps the `IfStatement`.
-- **What it needs:** A rewrite rule that recognises the `if (test) C else A` shape where both branches are single `ExpressionStatement`s and produces `ConditionalExpression { test, consequent, alternate }`.
+- **Resolution note:** Added a rewrite arm in `fold_if_statement` that fires when the test isn't a literal AND both branches reduce to a single `ExpressionStatement` (recursively unwrapping single-statement `BlockStatement` layers via a `single_expr_stmt` helper). Emits an `ExpressionStatement` wrapping a `ConditionalExpression`. Side-effect-safe because ternary preserves the same evaluation order as if-else (test first, then exactly one branch). `test_fold_one_child_blocks_if_else_to_ternary` un-ignored.
 
 ### gap-018 — De Morgan / negation-swap rewrites not implemented
 


### PR DESCRIPTION
## Summary

**INDEPENDENT** of #4752 (BigIntLiteral) and #4755 (typeof-identity fold). All 3 can review in parallel — different pass crates, no AST changes.

- Adds `if (x) foo(); else bar();` → `x ? foo() : bar();` rewrite in `fold_if_statement`
- Single-statement BlockStatement layers unwrap automatically
- Closes gap-017
- Sets up gap-019 (return-statement variant) as a follow-up

## Truth table

| Input | Output |
|-------|--------|
| `if (x) foo(); else bar();` | `x ? foo() : bar();` |
| `if (x) { foo(); } else { bar(); }` | `x ? foo() : bar();` |
| `if (x) foo();` | unchanged (no alternate; gap-016) |
| `if (x) { a; b; } else c;` | unchanged (multi-stmt) |
| `if (x) return 1; else return 2;` | unchanged (gap-019) |

## Safety

A ConditionalExpression evaluates `test` first then exactly one of the two branches — identical to if-else, including throw-propagation. ExpressionStatement discards the result either way. Side-effect order is preserved.

## Version

| Crate | Old | New |
|-------|-----|-----|
| `closure-pass-fold-control-flow` | 0.3.2 | 0.4.0 |

## Test plan

- [x] `cargo test -p closure-pass-fold-control-flow` → 20 inline + 10 upstream (was 18 + 9; un-ignored 1, added 2 inline, updated 2 existing)
- [x] Security review: APPROVED (sound fold, recursion bounded by AST depth, all over-fire guards correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)