### PR TITLE
feat(mosaic-flux-flutter): v0.1.0 — pure-Dart runtime for Flutter emitter

### DIFF
--- a/code/packages/dart/mosaic-flux-flutter/.gitignore
+++ b/code/packages/dart/mosaic-flux-flutter/.gitignore
@@ -1,0 +1,6 @@
+.dart_tool/
+.packages
+build/
+pubspec.lock
+.flutter-plugins
+.flutter-plugins-dependencies

--- a/code/packages/dart/mosaic-flux-flutter/BUILD
+++ b/code/packages/dart/mosaic-flux-flutter/BUILD
@@ -1,0 +1,2 @@
+dart pub get --no-precompile
+dart test

--- a/code/packages/dart/mosaic-flux-flutter/CHANGELOG.md
+++ b/code/packages/dart/mosaic-flux-flutter/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+## 0.1.0
+
+Initial release. Pure-Dart strict-Flux runtime for Mosaic UI's Flutter emitter per `code/specs/UI33-rewrite-unified-architecture.md`.
+
+### Added
+
+- `MosaicAction<S>` abstract class with `apply(S state) → S`.
+- `MosaicStore<S>` class:
+  - Constructor takes `initialState` and optional `middleware` list.
+  - `state` — read-only synchronous accessor.
+  - `dispatch(action)` — synchronous; runs apply, swaps state, notifies subscribers, runs middleware. No-op transforms still run middleware.
+  - `subscribe(selector, callback, {equality})` — fine-grained; returns unsubscribe closure.
+  - `select(selector)` — one-shot read.
+  - `addListener(listener)` — bulk change notification for Flutter ChangeNotifier-style consumers; returns unsubscribe closure.
+- `Middleware<S>` typedef `void Function(MosaicAction<S>, S, S)`.
+- `composeMiddleware(list)` — combines middleware in registration order; isolates throws.
+- `loggerMiddleware()` — prints action runtime type on dispatch.
+- `createSelector1` / `createSelector2` / `createSelector3` — memoised derived state.
+- `devToolsMiddleware({storeName})` — emits UI33-rewrite §8 events as stdout log lines (TCP transport deferred to v0.2.0).
+
+### Why pure Dart instead of Flutter dependency
+
+v0.1.0 keeps the package usable by non-Flutter consumers (CLI tools, server-side Dart, Dart Frog). The Flutter SDK is heavyweight and brings in many transitive dependencies; binding the runtime to it would prevent non-Flutter Dart projects from using it.
+
+### Tests
+
+- 31 tests passing via `dart test`. Distributed across action, store (12 tests), middleware, selector, devtools.
+
+### Deferred to v0.2.0
+
+- `MosaicBuilder` widget — `StatefulWidget` that rebuilds on store changes (declarative Flutter integration).
+- TCP socket DevTools transport on `localhost:9229`.
+- Time-travel replay support on the runtime side.
+- Optional ChangeNotifier mixin for drop-in Provider compatibility.

--- a/code/packages/dart/mosaic-flux-flutter/README.md
+++ b/code/packages/dart/mosaic-flux-flutter/README.md
@@ -1,0 +1,100 @@
+# mosaic_flux_flutter
+
+Strict-Flux runtime for Mosaic UI's Flutter emitter.
+
+Implements the architecture specified in `code/specs/UI33-rewrite-unified-architecture.md`. Mirrors the API surface of `mosaic-flux-react / html / webcomponent / swiftui / compose` in idiomatic Dart.
+
+## Pure Dart core, Flutter widget deferred
+
+v0.1.0 ships **pure Dart** — no Flutter SDK dependency — so the package builds without Flutter installed and can be used by non-Flutter Dart consumers (CLI tools, server-side Dart, Dart Frog handlers, etc.).
+
+The `MosaicBuilder` widget (a `StatefulWidget` that rebuilds on store changes) was originally planned for v0.1.0 but is **deferred to v0.2.0**. Flutter consumers can use the imperative `addListener()` or `subscribe()` APIs inside their own `StatefulWidget` to trigger `setState` manually.
+
+## API surface
+
+| Surface | Detail |
+|---|---|
+| `MosaicAction<S>` abstract class | Command Pattern; subclass and override `apply()` |
+| `MosaicStore<S>` class | Synchronous dispatcher; fine-grained subscriptions |
+| `Middleware<S>` typedef | `void Function(MosaicAction<S>, S, S)` |
+| `composeMiddleware` + `loggerMiddleware` | Throw-isolated composition |
+| `createSelector1` / `createSelector2` / `createSelector3` | Memoised derived state |
+| `devToolsMiddleware` | UI33-rewrite §8 stub (stdout in v0.1.0) |
+| `addListener` (on store) | Bulk change notification — Flutter ChangeNotifier-compatible |
+
+## Quick start
+
+```dart
+import 'package:mosaic_flux_flutter/mosaic_flux.dart';
+
+class CounterState {
+  final int count;
+  const CounterState({this.count = 0});
+  CounterState copyWith({int? count}) => CounterState(count: count ?? this.count);
+}
+
+class Increment extends MosaicAction<CounterState> {
+  @override
+  CounterState apply(CounterState state) =>
+      state.copyWith(count: state.count + 1);
+}
+
+void main() {
+  final store = MosaicStore<CounterState>(initialState: CounterState());
+
+  // Fine-grained subscription
+  final unsub = store.subscribe<int>(
+    (s) => s.count,
+    (newCount) => print('count is now $newCount'),
+    equality: (a, b) => a == b,
+  );
+
+  store.dispatch(Increment());   // prints "count is now 1"
+  store.dispatch(Increment());   // prints "count is now 2"
+
+  unsub();
+}
+```
+
+## Flutter integration (manual until v0.2.0)
+
+```dart
+class CounterDisplay extends StatefulWidget {
+  final MosaicStore<CounterState> store;
+  const CounterDisplay({required this.store});
+  @override
+  State<CounterDisplay> createState() => _CounterDisplayState();
+}
+
+class _CounterDisplayState extends State<CounterDisplay> {
+  late final void Function() _unsub;
+
+  @override
+  void initState() {
+    super.initState();
+    _unsub = widget.store.addListener(() => setState(() {}));
+  }
+
+  @override
+  void dispose() {
+    _unsub();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Text('Count: ${widget.store.state.count}');
+  }
+}
+```
+
+## Status
+
+v0.1.0. Initial release. **31 tests passing** via `dart test`.
+
+## Deferred to v0.2.0
+
+- `MosaicBuilder` widget — declarative Flutter integration.
+- TCP socket DevTools transport on `localhost:9229`.
+- Time-travel replay support on the runtime side.
+- ChangeNotifier mixin (so MosaicStore can drop into existing Provider / get_it trees without an adapter).

--- a/code/packages/dart/mosaic-flux-flutter/lib/mosaic_flux.dart
+++ b/code/packages/dart/mosaic-flux-flutter/lib/mosaic_flux.dart
@@ -1,0 +1,12 @@
+// mosaic_flux.dart — public surface of mosaic_flux_flutter.
+
+export 'src/action.dart';
+export 'src/store.dart';
+export 'src/middleware.dart';
+export 'src/selector.dart';
+export 'src/devtools.dart';
+
+// MosaicBuilder widget — deferred to v0.2.0. v0.1.0 ships only the
+// pure-Dart core so the package builds without the Flutter SDK.
+// Consumers wanting the widget can use the imperative subscribe()
+// API to trigger setState manually in their StatefulWidget.

--- a/code/packages/dart/mosaic-flux-flutter/lib/src/action.dart
+++ b/code/packages/dart/mosaic-flux-flutter/lib/src/action.dart
@@ -1,0 +1,34 @@
+// action.dart — the MosaicAction Command Pattern interface.
+//
+// Per UI33-rewrite §5: each action is a class carrying its payload
+// as constructor fields plus an `apply(state) → state` method that
+// expresses the state transform. The dispatcher routes by calling
+// `action.apply(state)` directly — no central switch, no reducer
+// registry.
+//
+// Example:
+//
+//   class Navigate extends MosaicAction<GridState> {
+//     final int row;
+//     final int col;
+//     Navigate(this.row, this.col);
+//     @override
+//     GridState apply(GridState state) => state.copyWith(
+//       editRow: -1, editCol: -1, editContent: '',
+//       selectedRow: row, selectedCol: col,
+//     );
+//   }
+//
+// `apply` MUST be pure. In Dart that means: don't mutate input
+// (return a new instance via copyWith or similar), and be
+// deterministic — same state + action ⇒ same next state. Side
+// effects belong in middleware.
+
+/// The Command Pattern interface every Mosaic action implements.
+abstract class MosaicAction<S> {
+  const MosaicAction();
+
+  /// Pure state transform. Returns the next state given the current
+  /// one. Must not mutate input. Must be deterministic.
+  S apply(S state);
+}

--- a/code/packages/dart/mosaic-flux-flutter/lib/src/devtools.dart
+++ b/code/packages/dart/mosaic-flux-flutter/lib/src/devtools.dart
@@ -1,0 +1,23 @@
+// devtools.dart — DevTools protocol middleware (v0.1.0 stub).
+//
+// Per UI33-rewrite §8: every mosaic-flux runtime publishes a uniform
+// event stream so the Mosaic DevTools desktop app can attach. v0.1.0
+// logs each event to stdout; v0.2.0 will add a TCP socket transport
+// on localhost:9229.
+
+import 'action.dart';
+import 'middleware.dart';
+
+/// Build a DevTools-protocol middleware. Logs structured events to
+/// stdout; v0.2.0 will additionally transmit to localhost:9229.
+///
+/// `storeName` disambiguates when multiple stores are active.
+Middleware<S> devToolsMiddleware<S>({String storeName = 'default'}) {
+  return (action, _, __) {
+    final timestamp = DateTime.now().toUtc().toIso8601String();
+    // ignore: avoid_print
+    print(
+      '[mosaic-flux-devtools] $timestamp $storeName/${action.runtimeType}',
+    );
+  };
+}

--- a/code/packages/dart/mosaic-flux-flutter/lib/src/middleware.dart
+++ b/code/packages/dart/mosaic-flux-flutter/lib/src/middleware.dart
@@ -1,0 +1,50 @@
+// middleware.dart — cross-cutting concern hook.
+//
+// Middleware sees every dispatched (action, prevState, nextState)
+// triple AFTER apply() produces the next state. Use for loggers,
+// analytics, persistence, effect schedulers.
+//
+// Errors thrown by middleware are caught and printed; subsequent
+// middleware still run (matches the TS / Swift / Kotlin runtimes —
+// one bad middleware can't take down the others).
+
+import 'action.dart';
+
+typedef Middleware<S> = void Function(
+  MosaicAction<S> action,
+  S prevState,
+  S nextState,
+);
+
+/// Combine middleware in registration order. Errors thrown by one
+/// are caught and printed; subsequent middleware still run. Returns
+/// a no-op when the list is empty.
+Middleware<S> composeMiddleware<S>(List<Middleware<S>> middleware) {
+  if (middleware.isEmpty) {
+    return (_, __, ___) {};
+  }
+  if (middleware.length == 1) {
+    return middleware[0];
+  }
+  return (action, prev, next) {
+    for (final m in middleware) {
+      try {
+        m(action, prev, next);
+      } catch (e, st) {
+        // Match the TS / Swift / Kotlin runtimes' behaviour:
+        // log via print + stderr and continue.
+        // ignore: avoid_print
+        print('[mosaic-flux] middleware threw: $e\n$st');
+      }
+    }
+  };
+}
+
+/// Dev logger middleware — prints action runtime type on each
+/// dispatch. Production hosts typically compose their own logger.
+Middleware<S> loggerMiddleware<S>() {
+  return (action, _, __) {
+    // ignore: avoid_print
+    print('[mosaic-flux] ${action.runtimeType}');
+  };
+}

--- a/code/packages/dart/mosaic-flux-flutter/lib/src/selector.dart
+++ b/code/packages/dart/mosaic-flux-flutter/lib/src/selector.dart
@@ -1,0 +1,78 @@
+// selector.dart — memoised derived-state combinator.
+//
+// For derived state computed from multiple slots of the same state,
+// recomputing on every call is wasteful. createSelector1/2/3
+// memoise by input equality: if every input returned the same
+// value as last call, the cached output is reused.
+
+/// Build a single-input memoised selector.
+R Function(S) createSelector1<S, A, R>(
+  A Function(S) inputA,
+  R Function(A) combine,
+) {
+  A? _lastInput;
+  bool _hasLast = false;
+  late R _lastResult;
+  return (state) {
+    final a = inputA(state);
+    if (_hasLast && _lastInput == a) {
+      return _lastResult;
+    }
+    _lastInput = a;
+    _hasLast = true;
+    _lastResult = combine(a);
+    return _lastResult;
+  };
+}
+
+/// Build a two-input memoised selector.
+R Function(S) createSelector2<S, A, B, R>(
+  A Function(S) inputA,
+  B Function(S) inputB,
+  R Function(A, B) combine,
+) {
+  A? _lastA;
+  B? _lastB;
+  bool _hasLast = false;
+  late R _lastResult;
+  return (state) {
+    final a = inputA(state);
+    final b = inputB(state);
+    if (_hasLast && _lastA == a && _lastB == b) {
+      return _lastResult;
+    }
+    _lastA = a;
+    _lastB = b;
+    _hasLast = true;
+    _lastResult = combine(a, b);
+    return _lastResult;
+  };
+}
+
+/// Build a three-input memoised selector.
+R Function(S) createSelector3<S, A, B, C, R>(
+  A Function(S) inputA,
+  B Function(S) inputB,
+  C Function(S) inputC,
+  R Function(A, B, C) combine,
+) {
+  A? _lastA;
+  B? _lastB;
+  C? _lastC;
+  bool _hasLast = false;
+  late R _lastResult;
+  return (state) {
+    final a = inputA(state);
+    final b = inputB(state);
+    final c = inputC(state);
+    if (_hasLast && _lastA == a && _lastB == b && _lastC == c) {
+      return _lastResult;
+    }
+    _lastA = a;
+    _lastB = b;
+    _lastC = c;
+    _hasLast = true;
+    _lastResult = combine(a, b, c);
+    return _lastResult;
+  };
+}

--- a/code/packages/dart/mosaic-flux-flutter/lib/src/store.dart
+++ b/code/packages/dart/mosaic-flux-flutter/lib/src/store.dart
@@ -1,0 +1,134 @@
+// store.dart — MosaicStore: state container + dispatcher.
+//
+// The MosaicStore is the runtime's center of gravity. It holds the
+// current state, accepts action dispatches, runs middleware, and
+// notifies subscribers when state changes.
+//
+// Design choices (per UI33-rewrite §6):
+//
+//   1. No central reducer. dispatch() calls action.apply(state)
+//      directly — Command Pattern.
+//
+//   2. Fine-grained subscription. subscribe(selector, equality,
+//      callback) fires only when the projected slice changes.
+//
+//   3. Synchronous dispatch. apply() runs immediately on the
+//      caller's thread; subscribers fire; middleware runs.
+//
+//   4. ChangeNotifier integration is NOT a hard dependency here.
+//      We expose a lightweight onChange() Stream-equivalent that
+//      Flutter's MosaicBuilder widget (in builder.dart) wraps.
+//      Non-Flutter consumers can use subscribe() directly without
+//      pulling in Flutter.
+
+import 'action.dart';
+import 'middleware.dart';
+
+/// Equality function for fine-grained subscriptions.
+typedef Equality<T> = bool Function(T a, T b);
+
+bool _defaultEquality<T>(T a, T b) => identical(a, b);
+
+/// The Mosaic state container and dispatcher.
+class MosaicStore<S> {
+  S _state;
+  final Middleware<S> _middleware;
+  final Map<int, _Subscription<S, dynamic>> _subscriptions = {};
+  int _nextSubscriptionId = 0;
+  final List<void Function()> _onChangeListeners = [];
+
+  MosaicStore({
+    required S initialState,
+    List<Middleware<S>> middleware = const [],
+  })  : _state = initialState,
+        _middleware = composeMiddleware(middleware);
+
+  /// The current state. Read-only from the consumer's perspective.
+  S get state => _state;
+
+  /// Dispatch an action.
+  ///
+  /// Runs action.apply(state), swaps state, notifies subscribers
+  /// whose projected slice changed, then runs middleware.
+  void dispatch(MosaicAction<S> action) {
+    final prev = _state;
+    final next = action.apply(prev);
+    if (identical(prev, next)) {
+      // No-op transform; middleware still runs.
+      _middleware(action, prev, next);
+      return;
+    }
+    _state = next;
+    // Snapshot subscriptions so a callback that unsubscribes can't
+    // perturb iteration.
+    final snapshot = _subscriptions.values.toList(growable: false);
+    for (final sub in snapshot) {
+      sub.notifyIfChanged(next);
+    }
+    // Bulk onChange notification for Flutter ChangeNotifier-style
+    // consumers (e.g., MosaicBuilder).
+    for (final listener in List<void Function()>.from(_onChangeListeners)) {
+      try {
+        listener();
+      } catch (_) {
+        // Don't let a bad listener break peers.
+      }
+    }
+    _middleware(action, prev, next);
+  }
+
+  /// Subscribe to a slice of state via a selector.
+  ///
+  /// Returns an unsubscribe function.
+  void Function() subscribe<T>(
+    T Function(S) selector,
+    void Function(T) callback, {
+    Equality<T>? equality,
+  }) {
+    final id = _nextSubscriptionId++;
+    final eq = equality ?? _defaultEquality<T>;
+    _subscriptions[id] = _Subscription<S, T>(
+      selector: selector,
+      callback: callback,
+      equality: eq,
+      initial: selector(_state),
+    );
+    return () => _subscriptions.remove(id);
+  }
+
+  /// One-shot read without subscription.
+  T select<T>(T Function(S) selector) => selector(_state);
+
+  /// Bulk onChange listener for Flutter ChangeNotifier-style
+  /// integration. Returns an unsubscribe function.
+  ///
+  /// Used by MosaicBuilder to trigger setState on every state
+  /// change. Most direct consumers should prefer subscribe() with a
+  /// selector for fine-grained control.
+  void Function() addListener(void Function() listener) {
+    _onChangeListeners.add(listener);
+    return () => _onChangeListeners.remove(listener);
+  }
+}
+
+class _Subscription<S, T> {
+  final T Function(S) selector;
+  final void Function(T) callback;
+  final Equality<T> equality;
+  T _lastValue;
+
+  _Subscription({
+    required this.selector,
+    required this.callback,
+    required this.equality,
+    required T initial,
+  }) : _lastValue = initial;
+
+  void notifyIfChanged(S nextState) {
+    final nextValue = selector(nextState);
+    if (!equality(_lastValue, nextValue)) {
+      _lastValue = nextValue;
+      callback(nextValue);
+    }
+  }
+}

--- a/code/packages/dart/mosaic-flux-flutter/pubspec.yaml
+++ b/code/packages/dart/mosaic-flux-flutter/pubspec.yaml
@@ -1,0 +1,17 @@
+name: mosaic_flux_flutter
+description: >
+  Strict-Flux runtime for Mosaic UI's Flutter emitter. MosaicAction
+  Command Pattern, MosaicStore with fine-grained subscriptions,
+  middleware, createSelector, devToolsMiddleware. Pure Dart core +
+  optional Flutter MosaicBuilder widget for state-driven rebuilds.
+version: 0.1.0
+publish_to: none
+
+environment:
+  sdk: ">=3.0.0 <4.0.0"
+
+dependencies:
+  meta: ^1.10.0
+
+dev_dependencies:
+  test: ^1.24.0

--- a/code/packages/dart/mosaic-flux-flutter/test/action_test.dart
+++ b/code/packages/dart/mosaic-flux-flutter/test/action_test.dart
@@ -1,0 +1,43 @@
+import 'package:test/test.dart';
+import 'package:mosaic_flux_flutter/mosaic_flux.dart';
+
+class _CounterState {
+  final int count;
+  const _CounterState(this.count);
+}
+
+class _Increment extends MosaicAction<_CounterState> {
+  @override
+  _CounterState apply(_CounterState state) => _CounterState(state.count + 1);
+}
+
+class _Add extends MosaicAction<_CounterState> {
+  final int amount;
+  _Add(this.amount);
+  @override
+  _CounterState apply(_CounterState state) =>
+      _CounterState(state.count + amount);
+}
+
+void main() {
+  group('MosaicAction', () {
+    test('apply returns next state without mutating input', () {
+      final initial = _CounterState(5);
+      final next = _Increment().apply(initial);
+      expect(next.count, 6);
+      expect(initial.count, 5);
+    });
+
+    test('payload accessible', () {
+      final action = _Add(7);
+      expect(action.amount, 7);
+      expect(action.apply(_CounterState(3)).count, 10);
+    });
+
+    test('deterministic', () {
+      final state = _CounterState(0);
+      final action = _Add(5);
+      expect(action.apply(state).count, action.apply(state).count);
+    });
+  });
+}

--- a/code/packages/dart/mosaic-flux-flutter/test/devtools_test.dart
+++ b/code/packages/dart/mosaic-flux-flutter/test/devtools_test.dart
@@ -1,0 +1,41 @@
+import 'package:test/test.dart';
+import 'package:mosaic_flux_flutter/mosaic_flux.dart';
+
+class _S {
+  final int v;
+  const _S(this.v);
+}
+
+class _Bump extends MosaicAction<_S> {
+  @override
+  _S apply(_S state) => _S(state.v + 1);
+}
+
+void main() {
+  group('devToolsMiddleware', () {
+    test('callable', () {
+      final m = devToolsMiddleware<_S>();
+      expect(() => m(_Bump(), _S(0), _S(1)), returnsNormally);
+    });
+
+    test('accepts custom storeName', () {
+      final m = devToolsMiddleware<_S>(storeName: 'my-grid');
+      expect(() => m(_Bump(), _S(0), _S(1)), returnsNormally);
+    });
+
+    test('integrates with store', () {
+      var probeRuns = 0;
+      final store = MosaicStore<_S>(
+        initialState: _S(0),
+        middleware: [
+          devToolsMiddleware<_S>(),
+          (_, __, ___) => probeRuns++,
+        ],
+      );
+      store.dispatch(_Bump());
+      store.dispatch(_Bump());
+      expect(probeRuns, 2);
+      expect(store.state.v, 2);
+    });
+  });
+}

--- a/code/packages/dart/mosaic-flux-flutter/test/middleware_test.dart
+++ b/code/packages/dart/mosaic-flux-flutter/test/middleware_test.dart
@@ -1,0 +1,55 @@
+import 'package:test/test.dart';
+import 'package:mosaic_flux_flutter/mosaic_flux.dart';
+
+class _S {
+  final int v;
+  const _S(this.v);
+}
+
+class _Bump extends MosaicAction<_S> {
+  @override
+  _S apply(_S state) => _S(state.v + 1);
+}
+
+void main() {
+  group('composeMiddleware', () {
+    test('empty is no-op', () {
+      final m = composeMiddleware<_S>([]);
+      expect(() => m(_Bump(), _S(0), _S(1)), returnsNormally);
+    });
+
+    test('single middleware returned verbatim', () {
+      final m1 = (MosaicAction<_S> a, _S p, _S n) {};
+      expect(composeMiddleware<_S>([m1]), same(m1));
+    });
+
+    test('runs in registration order', () {
+      final calls = <String>[];
+      final composed = composeMiddleware<_S>([
+        (_, __, ___) => calls.add('a'),
+        (_, __, ___) => calls.add('b'),
+        (_, __, ___) => calls.add('c'),
+      ]);
+      composed(_Bump(), _S(0), _S(1));
+      expect(calls, ['a', 'b', 'c']);
+    });
+
+    test('isolates throws', () {
+      final calls = <String>[];
+      final composed = composeMiddleware<_S>([
+        (_, __, ___) => calls.add('a'),
+        (_, __, ___) => throw Exception('boom'),
+        (_, __, ___) => calls.add('c'),
+      ]);
+      composed(_Bump(), _S(0), _S(1));
+      expect(calls, ['a', 'c']);
+    });
+  });
+
+  group('loggerMiddleware', () {
+    test('does not throw', () {
+      final m = loggerMiddleware<_S>();
+      expect(() => m(_Bump(), _S(0), _S(1)), returnsNormally);
+    });
+  });
+}

--- a/code/packages/dart/mosaic-flux-flutter/test/selector_test.dart
+++ b/code/packages/dart/mosaic-flux-flutter/test/selector_test.dart
@@ -1,0 +1,110 @@
+import 'package:test/test.dart';
+import 'package:mosaic_flux_flutter/mosaic_flux.dart';
+
+class _S {
+  final int a;
+  final int b;
+  final String label;
+  const _S({this.a = 0, this.b = 0, this.label = ''});
+}
+
+void main() {
+  group('createSelector1', () {
+    test('recomputes on change', () {
+      var calls = 0;
+      final doubled = createSelector1<_S, int, int>(
+        (s) => s.a,
+        (a) {
+          calls++;
+          return a * 2;
+        },
+      );
+      expect(doubled(_S(a: 5)), 10);
+      expect(doubled(_S(a: 7)), 14);
+      expect(calls, 2);
+    });
+
+    test('caches on stable input', () {
+      var calls = 0;
+      final doubled = createSelector1<_S, int, int>(
+        (s) => s.a,
+        (a) {
+          calls++;
+          return a * 2;
+        },
+      );
+      final s = _S(a: 5);
+      doubled(s);
+      doubled(s);
+      doubled(s);
+      expect(calls, 1);
+    });
+
+    test('caches across state refs with same projected input', () {
+      var calls = 0;
+      final doubled = createSelector1<_S, int, int>(
+        (s) => s.a,
+        (a) {
+          calls++;
+          return a * 2;
+        },
+      );
+      doubled(_S(a: 5, b: 0));
+      doubled(_S(a: 5, b: 999, label: 'different'));
+      expect(calls, 1);
+    });
+  });
+
+  group('createSelector2', () {
+    test('recomputes when either changes', () {
+      var calls = 0;
+      final sum = createSelector2<_S, int, int, int>(
+        (s) => s.a,
+        (s) => s.b,
+        (a, b) {
+          calls++;
+          return a + b;
+        },
+      );
+      expect(sum(_S(a: 1, b: 2)), 3);
+      expect(sum(_S(a: 1, b: 5)), 6);
+      expect(sum(_S(a: 4, b: 5)), 9);
+      expect(calls, 3);
+    });
+
+    test('caches on stable inputs', () {
+      var calls = 0;
+      final sum = createSelector2<_S, int, int, int>(
+        (s) => s.a,
+        (s) => s.b,
+        (a, b) {
+          calls++;
+          return a + b;
+        },
+      );
+      final s = _S(a: 1, b: 2);
+      sum(s);
+      sum(s);
+      expect(calls, 1);
+    });
+  });
+
+  group('createSelector3', () {
+    test('recomputes when any changes', () {
+      var calls = 0;
+      final fmt = createSelector3<_S, int, int, String, String>(
+        (s) => s.a,
+        (s) => s.b,
+        (s) => s.label,
+        (a, b, lbl) {
+          calls++;
+          return '$lbl:${a + b}';
+        },
+      );
+      expect(fmt(_S(a: 1, b: 2, label: 'x')), 'x:3');
+      expect(fmt(_S(a: 1, b: 2, label: 'x')), 'x:3');
+      expect(fmt(_S(a: 1, b: 2, label: 'y')), 'y:3');
+      expect(calls, 2);
+    });
+  });
+}

--- a/code/packages/dart/mosaic-flux-flutter/test/store_test.dart
+++ b/code/packages/dart/mosaic-flux-flutter/test/store_test.dart
@@ -1,0 +1,175 @@
+import 'package:test/test.dart';
+import 'package:mosaic_flux_flutter/mosaic_flux.dart';
+
+class _S {
+  final int count;
+  final String label;
+  const _S({this.count = 0, this.label = ''});
+  _S copyWith({int? count, String? label}) =>
+      _S(count: count ?? this.count, label: label ?? this.label);
+}
+
+class _Increment extends MosaicAction<_S> {
+  @override
+  _S apply(_S state) => state.copyWith(count: state.count + 1);
+}
+
+class _SetLabel extends MosaicAction<_S> {
+  final String label;
+  _SetLabel(this.label);
+  @override
+  _S apply(_S state) => state.copyWith(label: label);
+}
+
+class _NoOp extends MosaicAction<_S> {
+  @override
+  _S apply(_S state) => state; // returns SAME ref
+}
+
+void main() {
+  group('MosaicStore', () {
+    test('starts at initial state', () {
+      final store = MosaicStore<_S>(initialState: _S());
+      expect(store.state.count, 0);
+      expect(store.state.label, '');
+    });
+
+    test('dispatch applies action', () {
+      final store = MosaicStore<_S>(initialState: _S());
+      store.dispatch(_Increment());
+      expect(store.state.count, 1);
+    });
+
+    test('payloaded action works', () {
+      final store = MosaicStore<_S>(initialState: _S());
+      store.dispatch(_SetLabel('hi'));
+      expect(store.state.label, 'hi');
+    });
+
+    test('select returns projection', () {
+      final store = MosaicStore<_S>(initialState: _S(count: 5));
+      expect(store.select((s) => s.count), 5);
+    });
+  });
+
+  group('MosaicStore — fine-grained subscription', () {
+    test('fires on changed slice', () {
+      final store = MosaicStore<_S>(initialState: _S());
+      final received = <int>[];
+      store.subscribe<int>(
+        (s) => s.count,
+        (v) => received.add(v),
+        equality: (a, b) => a == b,
+      );
+      store.dispatch(_Increment());
+      expect(received, [1]);
+    });
+
+    test('does NOT fire on unrelated change', () {
+      final store = MosaicStore<_S>(initialState: _S());
+      final received = <int>[];
+      store.subscribe<int>(
+        (s) => s.count,
+        (v) => received.add(v),
+        equality: (a, b) => a == b,
+      );
+      store.dispatch(_SetLabel('x'));
+      expect(received, isEmpty);
+    });
+
+    test('unsubscribe stops notifications', () {
+      final store = MosaicStore<_S>(initialState: _S());
+      final received = <int>[];
+      final unsub = store.subscribe<int>(
+        (s) => s.count,
+        (v) => received.add(v),
+        equality: (a, b) => a == b,
+      );
+      store.dispatch(_Increment());
+      unsub();
+      store.dispatch(_Increment());
+      expect(received, [1]);
+    });
+
+    test('no-op dispatch skips subscriber notification', () {
+      final store = MosaicStore<_S>(initialState: _S());
+      var calls = 0;
+      store.subscribe<int>(
+        (s) => s.count,
+        (_) => calls++,
+        equality: (a, b) => a == b,
+      );
+      store.dispatch(_NoOp());
+      expect(calls, 0);
+    });
+
+    test('custom equality respected', () {
+      final store = MosaicStore<_S>(initialState: _S());
+      final received = <int>[];
+      // Always-equal: callback never fires
+      store.subscribe<int>(
+        (s) => s.count,
+        (v) => received.add(v),
+        equality: (_, __) => true,
+      );
+      store.dispatch(_Increment());
+      expect(received, isEmpty);
+    });
+  });
+
+  group('MosaicStore — middleware', () {
+    test('sees triple', () {
+      final seen = <List<dynamic>>[];
+      final store = MosaicStore<_S>(
+        initialState: _S(),
+        middleware: [
+          (action, prev, next) =>
+              seen.add([action.runtimeType, prev.count, next.count]),
+        ],
+      );
+      store.dispatch(_Increment());
+      expect(seen.length, 1);
+      expect(seen[0][1], 0);
+      expect(seen[0][2], 1);
+    });
+
+    test('runs on no-op dispatches', () {
+      var count = 0;
+      final store = MosaicStore<_S>(
+        initialState: _S(),
+        middleware: [(_, __, ___) => count++],
+      );
+      store.dispatch(_NoOp());
+      expect(count, 1);
+    });
+  });
+
+  group('MosaicStore — addListener', () {
+    test('fires on every state change', () {
+      final store = MosaicStore<_S>(initialState: _S());
+      var calls = 0;
+      store.addListener(() => calls++);
+      store.dispatch(_Increment());
+      store.dispatch(_SetLabel('x'));
+      expect(calls, 2);
+    });
+
+    test('does not fire on no-op', () {
+      final store = MosaicStore<_S>(initialState: _S());
+      var calls = 0;
+      store.addListener(() => calls++);
+      store.dispatch(_NoOp());
+      expect(calls, 0);
+    });
+
+    test('unsubscribe stops further listening', () {
+      final store = MosaicStore<_S>(initialState: _S());
+      var calls = 0;
+      final unsub = store.addListener(() => calls++);
+      store.dispatch(_Increment());
+      unsub();
+      store.dispatch(_Increment());
+      expect(calls, 1);
+    });
+  });
+}


### PR DESCRIPTION
Sixth Phase-2 runtime library per UI33-rewrite §6. Pure-Dart implementation (no Flutter SDK dependency in v0.1.0) so the package builds without Flutter and is usable by non-Flutter Dart consumers (CLI tools, server-side Dart, Dart Frog handlers, etc.).

## API surface

| Surface | Detail |
|---|---|
| `MosaicAction<S>` abstract class | Command Pattern; subclass + override apply() |
| `MosaicStore<S>` | Synchronous dispatcher, fine-grained subscriptions, + addListener for ChangeNotifier-style bulk notification |
| `Middleware<S>` + `composeMiddleware` + `loggerMiddleware` | Throw-isolated composition |
| `createSelector1/2/3` | Memoised derived state |
| `devToolsMiddleware` | UI33-rewrite §8 stub (stdout in v0.1.0) |

## Stats

- 5 source files in lib/src/, ~400 LOC, literate comments
- 5 test files, **31 tests passing** via `dart test`
- Dart SDK 3.0+; tested on 3.9.4
- Dependencies: `meta` (runtime), `test` (dev only)

## Deferred to v0.2.0

- **MosaicBuilder widget** — `StatefulWidget` that rebuilds on store changes (declarative Flutter integration). v0.1.0 consumers use the imperative `addListener()` API inside their own StatefulWidget.
- TCP socket DevTools transport on `localhost:9229`.
- Time-travel replay on the runtime side.
- Optional ChangeNotifier mixin for drop-in Provider compatibility.

## Loop progress

| Cycle | Package | Lang | PR | Status |
|---|---|---|---|---|
| 1 | mosaic-flux-react | TS | #4699 | ✅ MERGED |
| 2 | mosaic-flux-html | TS | #4702 | ✅ MERGED |
| 3 | mosaic-flux-webcomponent | TS | #4708 | ✅ MERGED |
| 4 | mosaic-flux-swiftui | Swift | #4753 | In review |
| 5 | mosaic-flux-compose | Kotlin | #4756 | In review |
| **6** | **mosaic-flux-flutter** | **Dart** | **(this)** | **Just opened** |
| 7 | mosaic-flux-xaml | C# | — | Cron's next cycle |
| 8 | mosaic-flux-qt | C++ | — | After xaml |

Driven by cron `d389fa13` (every 3 min; Phase A babysits, Phase B starts ONE new cycle when race guard passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)