### PR TITLE
feat(mosaic-flux-xaml): v0.1.0 — Mosaic-owned strict-Flux runtime for WinUI/XAML

### DIFF
--- a/code/packages/csharp/Mosaic.Flux/.gitignore
+++ b/code/packages/csharp/Mosaic.Flux/.gitignore
@@ -1,0 +1,4 @@
+bin/
+obj/
+*.user
+.vs/

--- a/code/packages/csharp/Mosaic.Flux/BUILD
+++ b/code/packages/csharp/Mosaic.Flux/BUILD
@@ -1,0 +1,1 @@
+dotnet test --nologo --verbosity quiet

--- a/code/packages/csharp/Mosaic.Flux/CHANGELOG.md
+++ b/code/packages/csharp/Mosaic.Flux/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to `Mosaic.Flux` are documented here.
+This project follows [Semantic Versioning](https://semver.org/).
+
+## [0.1.0] — 2026-06-01
+
+### Added
+
+- `IMosaicAction<TState>` interface: command-pattern action with an
+  `Apply(state) → state` method.
+- `MosaicStore<TState>` dispatcher that holds state, runs reducers via
+  `action.Apply`, fires `INotifyPropertyChanged` for the XAML binding
+  pipeline, and supports custom middleware.
+- `MosaicStore.Subscribe<TSlice>` with selector + equality comparator
+  (default: `Object.ReferenceEquals` falling through to `Equals`),
+  returning an `IDisposable` unsubscribe handle.
+- `MosaicStore.Select<TSlice>` one-shot projection.
+- `Middleware<TState>` delegate plus `MiddlewareHelpers.Compose` and
+  `MiddlewareHelpers.Logger<TState>()`.
+- `Selector.Create` memoised helpers for 1-, 2-, and 3-input slice
+  projections, mirroring the shape used by Reselect and the other
+  Mosaic runtimes.
+- `DevTools.Create<TState>(string storeName = "default")` middleware
+  factory — no-op locally, ready to be wired to a WinUI debug channel.
+- 29 xUnit tests covering action `Apply` semantics, dispatch +
+  subscribe + unsubscribe, no-op short-circuit, `PropertyChanged`
+  emission, middleware composition + error isolation, selector
+  memoisation, and dev-tools integration.
+
+### Notes
+
+- Targets `net9.0` to match the rest of the repo's CI toolchain.
+- `TreatWarningsAsErrors=true` and `Nullable=enable` are on for the
+  library project so any reference-nullability or analyzer warning
+  fails the build.

--- a/code/packages/csharp/Mosaic.Flux/Mosaic.Flux.csproj
+++ b/code/packages/csharp/Mosaic.Flux/Mosaic.Flux.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <LangVersion>12.0</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <PackageId>Mosaic.Flux</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Strict-Flux runtime for Mosaic UI's WinUI / XAML emitter.</Description>
+    <RootNamespace>Mosaic.Flux</RootNamespace>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="src/**/*.cs" />
+  </ItemGroup>
+
+</Project>

--- a/code/packages/csharp/Mosaic.Flux/README.md
+++ b/code/packages/csharp/Mosaic.Flux/README.md
@@ -1,0 +1,65 @@
+# Mosaic.Flux
+
+Strict-Flux runtime for the Mosaic UI WinUI / XAML emitter.
+
+This is the C# counterpart to `@coding-adventures/mosaic-flux-react`,
+`mosaic-flux-swiftui`, `mosaic-flux-compose`, and `mosaic-flux-flutter`.
+Every Mosaic backend ships its own runtime so application code never
+depends on a third-party Flux library — TCA, Bloc, Fluxor, etc. are
+deliberately avoided. The shape of the API is identical across
+backends so cross-platform Mosaic projects only learn it once.
+
+## What's in the box
+
+| Type | Role |
+| --- | --- |
+| `IMosaicAction<TState>` | command-pattern action with an `Apply(state) → state` method |
+| `MosaicStore<TState>` | dispatcher + state holder + `INotifyPropertyChanged` for XAML binding |
+| `Middleware<TState>` | logger / dev-tools hook between every dispatch |
+| `Selector` | memoised projection helpers (1–3 input slices) |
+| `DevTools` | local channel for inspecting actions and state diffs |
+
+## Why strict Flux
+
+Mosaic UI takes the Redux contract literally:
+
+1. The view layer is **read-only**. Nothing in a `.msl` file mutates
+   state directly.
+2. Every change goes through `Store.Dispatch`. Even a single keystroke
+   in a VisiCalc cell rounds back through the store before the view
+   re-renders.
+3. Actions are **classes** (records) with an explicit `Apply(state)`
+   method. If a backend needs special handling for an action — for
+   example, debouncing a network call from XAML — you edit the action
+   class, not a hidden reducer table.
+
+That last bullet is why this exists rather than reusing Fluxor or
+ReactiveUI: Mosaic wants the generated action surface to be exactly
+the thing the user edits.
+
+## Usage
+
+```csharp
+using Mosaic.Flux;
+
+public record AppState(int Count = 0);
+
+public sealed record Increment : IMosaicAction<AppState>
+{
+    public AppState Apply(AppState state) => state with { Count = state.Count + 1 };
+}
+
+var store = new MosaicStore<AppState>(new AppState());
+store.Subscribe(s => s.Count, count => Console.WriteLine($"count = {count}"));
+store.Dispatch(new Increment());  // → "count = 1"
+```
+
+In a WinUI page, bind to `store.State` and `PropertyChanged` will fire
+the XAML data-binding pipeline whenever an action changes the slice
+your control reads.
+
+## Status
+
+`v0.1.0` — core dispatcher, subscription, selector, middleware, and
+dev-tools surface. The WinUI-specific glue (XAML markup extension,
+`MosaicBinding`, page lifecycle hooks) lands in `v0.2.0`.

--- a/code/packages/csharp/Mosaic.Flux/src/Action.cs
+++ b/code/packages/csharp/Mosaic.Flux/src/Action.cs
@@ -1,0 +1,41 @@
+// Action.cs — the IMosaicAction Command Pattern interface.
+//
+// Per UI33-rewrite §5: each action is a type (typically a `sealed
+// record` carrying its payload as positional or init-only
+// properties) implementing IMosaicAction<TState> with an Apply
+// method that expresses the state transform.  The dispatcher routes
+// by calling action.Apply(state) directly — no central switch, no
+// reducer registry.
+//
+// Example:
+//
+//     public sealed record Navigate(int Row, int Col) : IMosaicAction<GridState>
+//     {
+//         public GridState Apply(GridState state) => state with
+//         {
+//             EditRow = -1, EditCol = -1, EditContent = "",
+//             SelectedRow = Row, SelectedCol = Col,
+//         };
+//     }
+//
+// `Apply` MUST be pure: it must not mutate the input (use C# `with`
+// expressions on records to return new instances), and it must be
+// deterministic — same state + same action ⇒ same next state.
+// Side effects belong in middleware, not in Apply.
+
+namespace Mosaic.Flux;
+
+/// <summary>
+/// The Command Pattern interface every Mosaic action implements.
+/// Implementations are typically <c>sealed record</c> types whose
+/// constructor parameters carry the action's payload.
+/// </summary>
+/// <typeparam name="TState">The state type the action transforms.</typeparam>
+public interface IMosaicAction<TState>
+{
+    /// <summary>
+    /// Pure state transform.  Returns the next state given the
+    /// current one.  Must not mutate input.  Must be deterministic.
+    /// </summary>
+    TState Apply(TState state);
+}

--- a/code/packages/csharp/Mosaic.Flux/src/DevTools.cs
+++ b/code/packages/csharp/Mosaic.Flux/src/DevTools.cs
@@ -1,0 +1,36 @@
+// DevTools.cs — DevTools protocol middleware (v0.1.0 stub).
+//
+// Per UI33-rewrite §8: every mosaic-flux runtime publishes a uniform
+// event stream so the Mosaic DevTools desktop app can attach.  On
+// .NET hosts the transport is a named pipe \\.\pipe\mosaic-devtools.
+//
+// v0.1.0 ships the middleware shape and logs each event to
+// Console.Out in a format the future DevTools client will
+// recognise.  The named-pipe implementation requires async setup
+// and is deferred to v0.2.0.
+
+namespace Mosaic.Flux;
+
+/// <summary>
+/// DevTools protocol middleware factory.
+/// </summary>
+public static class DevTools
+{
+    /// <summary>
+    /// Build a DevTools middleware.  Logs structured events to
+    /// Console.Out; v0.2.0 will additionally transmit via the
+    /// named pipe \\.\pipe\mosaic-devtools.
+    /// </summary>
+    /// <param name="storeName">Disambiguator when multiple stores
+    /// are active.  Defaults to "default".</param>
+    public static Middleware<TState> Create<TState>(
+        string storeName = "default")
+    {
+        return (action, _, _) =>
+        {
+            var ts = DateTime.UtcNow.ToString("O");
+            Console.WriteLine(
+                $"[mosaic-flux-devtools] {ts} {storeName}/{action.GetType().Name}");
+        };
+    }
+}

--- a/code/packages/csharp/Mosaic.Flux/src/Middleware.cs
+++ b/code/packages/csharp/Mosaic.Flux/src/Middleware.cs
@@ -1,0 +1,74 @@
+// Middleware.cs — cross-cutting concern hook.
+//
+// Middleware sees every dispatched (action, prevState, nextState)
+// triple AFTER Apply produces the next state.  Use for loggers,
+// analytics, persistence, and effect schedulers.
+//
+// Errors thrown by middleware are caught and reported via
+// Console.Error; subsequent middleware still run (matches the
+// TS / Swift / Kotlin / Dart runtimes — one bad middleware can't
+// take down the others).
+
+namespace Mosaic.Flux;
+
+/// <summary>
+/// Middleware delegate: invoked after each dispatch with the
+/// applied action, the state before, and the state after.
+/// </summary>
+public delegate void Middleware<TState>(
+    IMosaicAction<TState> action,
+    TState prevState,
+    TState nextState);
+
+/// <summary>
+/// Static helpers for middleware composition.
+/// </summary>
+public static class MiddlewareHelpers
+{
+    /// <summary>
+    /// Compose middleware in registration order.  Returns a no-op
+    /// when the list is empty.  Errors thrown by one middleware
+    /// are caught and reported; subsequent middleware still run.
+    /// </summary>
+    public static Middleware<TState> Compose<TState>(
+        IEnumerable<Middleware<TState>> middleware)
+    {
+        var list = middleware.ToList();
+        if (list.Count == 0)
+        {
+            return (_, _, _) => { /* no-op */ };
+        }
+        if (list.Count == 1)
+        {
+            return list[0];
+        }
+        return (action, prev, next) =>
+        {
+            foreach (var m in list)
+            {
+                try
+                {
+                    m(action, prev, next);
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine(
+                        $"[mosaic-flux] middleware threw: {ex.Message}");
+                }
+            }
+        };
+    }
+
+    /// <summary>
+    /// Dev logger middleware — writes action type name to
+    /// Console.Out on each dispatch.  Production hosts typically
+    /// compose their own logger that ships to telemetry.
+    /// </summary>
+    public static Middleware<TState> Logger<TState>()
+    {
+        return (action, _, _) =>
+        {
+            Console.WriteLine($"[mosaic-flux] {action.GetType().Name}");
+        };
+    }
+}

--- a/code/packages/csharp/Mosaic.Flux/src/Selector.cs
+++ b/code/packages/csharp/Mosaic.Flux/src/Selector.cs
@@ -1,0 +1,110 @@
+// Selector.cs — memoised derived-state combinator.
+//
+// For derived state computed from multiple slots of the same state,
+// recomputing on every call is wasteful.  CreateSelector* methods
+// memoise by input equality: if every input returned the same value
+// as last call, the cached output is reused.
+
+namespace Mosaic.Flux;
+
+/// <summary>
+/// Memoised derived-state selector combinators (1-, 2-, and 3-input
+/// variants).
+/// </summary>
+public static class Selector
+{
+    /// <summary>
+    /// Build a single-input memoised selector.
+    /// </summary>
+    public static Func<TState, TResult> Create<TState, TA, TResult>(
+        Func<TState, TA> inputA,
+        Func<TA, TResult> combine)
+        where TA : notnull
+    {
+        TA? lastInput = default;
+        bool hasLast = false;
+        TResult lastResult = default!;
+        return state =>
+        {
+            var a = inputA(state);
+            if (hasLast && EqualityComparer<TA>.Default.Equals(lastInput!, a))
+            {
+                return lastResult;
+            }
+            lastInput = a;
+            hasLast = true;
+            lastResult = combine(a);
+            return lastResult;
+        };
+    }
+
+    /// <summary>
+    /// Build a two-input memoised selector.
+    /// </summary>
+    public static Func<TState, TResult> Create<TState, TA, TB, TResult>(
+        Func<TState, TA> inputA,
+        Func<TState, TB> inputB,
+        Func<TA, TB, TResult> combine)
+        where TA : notnull
+        where TB : notnull
+    {
+        TA? lastA = default;
+        TB? lastB = default;
+        bool hasLast = false;
+        TResult lastResult = default!;
+        return state =>
+        {
+            var a = inputA(state);
+            var b = inputB(state);
+            if (hasLast
+                && EqualityComparer<TA>.Default.Equals(lastA!, a)
+                && EqualityComparer<TB>.Default.Equals(lastB!, b))
+            {
+                return lastResult;
+            }
+            lastA = a;
+            lastB = b;
+            hasLast = true;
+            lastResult = combine(a, b);
+            return lastResult;
+        };
+    }
+
+    /// <summary>
+    /// Build a three-input memoised selector.
+    /// </summary>
+    public static Func<TState, TResult> Create<TState, TA, TB, TC, TResult>(
+        Func<TState, TA> inputA,
+        Func<TState, TB> inputB,
+        Func<TState, TC> inputC,
+        Func<TA, TB, TC, TResult> combine)
+        where TA : notnull
+        where TB : notnull
+        where TC : notnull
+    {
+        TA? lastA = default;
+        TB? lastB = default;
+        TC? lastC = default;
+        bool hasLast = false;
+        TResult lastResult = default!;
+        return state =>
+        {
+            var a = inputA(state);
+            var b = inputB(state);
+            var c = inputC(state);
+            if (hasLast
+                && EqualityComparer<TA>.Default.Equals(lastA!, a)
+                && EqualityComparer<TB>.Default.Equals(lastB!, b)
+                && EqualityComparer<TC>.Default.Equals(lastC!, c))
+            {
+                return lastResult;
+            }
+            lastA = a;
+            lastB = b;
+            lastC = c;
+            hasLast = true;
+            lastResult = combine(a, b, c);
+            return lastResult;
+        };
+    }
+}

--- a/code/packages/csharp/Mosaic.Flux/src/Store.cs
+++ b/code/packages/csharp/Mosaic.Flux/src/Store.cs
@@ -1,0 +1,188 @@
+// Store.cs — MosaicStore: state container + dispatcher.
+//
+// The MosaicStore is the runtime's center of gravity.  It holds the
+// current state, accepts action dispatches, runs middleware, and
+// notifies subscribers when state changes.
+//
+// Design choices (per UI33-rewrite §6):
+//
+//   1. No central reducer.  Dispatch calls action.Apply(state)
+//      directly — Command Pattern.
+//
+//   2. Fine-grained subscription via Subscribe(selector,
+//      equality, callback).  Callback fires only when the
+//      projected slice changes.
+//
+//   3. INotifyPropertyChanged integration so XAML hosts can bind
+//      directly to <c>store.State</c> via {x:Bind State.Foo,
+//      Mode=OneWay} bindings.  PropertyChanged fires with
+//      property name "State" on every change.
+//
+//   4. Synchronous dispatch.  Apply runs immediately; subscribers
+//      fire; middleware runs.
+
+using System.Collections.Concurrent;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace Mosaic.Flux;
+
+/// <summary>
+/// The Mosaic state container and dispatcher.  Generic over the
+/// state type.  Implements INotifyPropertyChanged so XAML hosts can
+/// bind to <c>store.State</c> directly.
+/// </summary>
+public sealed class MosaicStore<TState> : INotifyPropertyChanged
+{
+    private TState _state;
+    private readonly Middleware<TState> _middleware;
+    // ConcurrentDictionary guards against the case where Subscribe /
+    // Unsubscribe / Dispatch are called from different threads (e.g.
+    // a background data load dispatching while the UI thread is
+    // subscribing).  Dictionary<,> is not thread-safe and corruption
+    // is observable as InvalidOperationException or an infinite loop.
+    private readonly ConcurrentDictionary<int, ISubscription> _subscriptions = new();
+    private int _nextSubscriptionId;
+
+    public MosaicStore(
+        TState initialState,
+        IEnumerable<Middleware<TState>>? middleware = null)
+    {
+        _state = initialState;
+        _middleware = MiddlewareHelpers.Compose(
+            middleware ?? Array.Empty<Middleware<TState>>());
+    }
+
+    /// <summary>
+    /// The current state.  Read-only from the consumer's
+    /// perspective.  XAML bindings to State.{property} will fire
+    /// the PropertyChanged event when the state is swapped.
+    /// </summary>
+    public TState State
+    {
+        get => _state;
+        private set
+        {
+            _state = value;
+            OnPropertyChanged();
+        }
+    }
+
+    /// <inheritdoc/>
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private void OnPropertyChanged(
+        [CallerMemberName] string? propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+
+    /// <summary>
+    /// Dispatch an action.  Runs action.Apply(State), swaps state,
+    /// notifies subscribers whose projected slice changed, raises
+    /// PropertyChanged for "State", then runs middleware.
+    /// </summary>
+    public void Dispatch<TAction>(TAction action)
+        where TAction : IMosaicAction<TState>
+    {
+        var prev = _state;
+        var next = action.Apply(prev);
+        if (ReferenceEqualsOrValueEquals(prev, next))
+        {
+            // No-op transform; middleware still runs.
+            _middleware(action, prev, next);
+            return;
+        }
+        State = next;  // sets _state AND raises PropertyChanged
+
+        // Snapshot subscriptions so a callback that unsubscribes
+        // can't perturb iteration.
+        var snapshot = _subscriptions.Values.ToList();
+        foreach (var sub in snapshot)
+        {
+            sub.NotifyIfChanged(next);
+        }
+        _middleware(action, prev, next);
+    }
+
+    /// <summary>
+    /// Subscribe to a slice of state via a selector.  The callback
+    /// fires when the projected slice changes by the supplied
+    /// equality function (default: object equality).
+    /// </summary>
+    /// <returns>A disposable that unsubscribes when disposed.</returns>
+    public IDisposable Subscribe<T>(
+        Func<TState, T> selector,
+        Action<T> callback,
+        Func<T, T, bool>? equality = null)
+    {
+        var id = Interlocked.Increment(ref _nextSubscriptionId);
+        var eq = equality ?? ((a, b) => Equals(a, b));
+        _subscriptions[id] = new Subscription<T>(
+            selector, callback, eq, selector(_state));
+        return new Unsubscribe(() => _subscriptions.TryRemove(id, out _));
+    }
+
+    /// <summary>
+    /// One-shot read of a slice without subscription.
+    /// </summary>
+    public T Select<T>(Func<TState, T> selector) => selector(_state);
+
+    // Choose value-equality for value-type states (so they compare
+    // structurally) and reference-equality for class-typed states.
+    // Records' value equality is captured automatically because
+    // their Equals override forwards to value comparison.
+    private static bool ReferenceEqualsOrValueEquals(TState a, TState b)
+    {
+        if (typeof(TState).IsValueType)
+        {
+            return Equals(a, b);
+        }
+        return ReferenceEquals(a, b);
+    }
+
+    private interface ISubscription
+    {
+        void NotifyIfChanged(TState nextState);
+    }
+
+    private sealed class Subscription<T> : ISubscription
+    {
+        private readonly Func<TState, T> _selector;
+        private readonly Action<T> _callback;
+        private readonly Func<T, T, bool> _equality;
+        private T _lastValue;
+
+        public Subscription(
+            Func<TState, T> selector,
+            Action<T> callback,
+            Func<T, T, bool> equality,
+            T initial)
+        {
+            _selector = selector;
+            _callback = callback;
+            _equality = equality;
+            _lastValue = initial;
+        }
+
+        public void NotifyIfChanged(TState nextState)
+        {
+            var nextValue = _selector(nextState);
+            if (!_equality(_lastValue, nextValue))
+            {
+                _lastValue = nextValue;
+                _callback(nextValue);
+            }
+        }
+    }
+
+    private sealed class Unsubscribe : IDisposable
+    {
+        private Action? _action;
+        public Unsubscribe(Action action) => _action = action;
+        // Interlocked.Exchange makes Dispose idempotent and safe
+        // under concurrent double-dispose: only the thread that wins
+        // the swap sees a non-null action and runs it.
+        public void Dispose() => Interlocked.Exchange(ref _action, null)?.Invoke();
+    }
+}

--- a/code/packages/csharp/Mosaic.Flux/tests/ActionTests.cs
+++ b/code/packages/csharp/Mosaic.Flux/tests/ActionTests.cs
@@ -1,0 +1,44 @@
+using Xunit;
+using Mosaic.Flux;
+
+namespace Mosaic.Flux.Tests;
+
+public record ActionTestState(int Count);
+
+public sealed record Increment : IMosaicAction<ActionTestState>
+{
+    public ActionTestState Apply(ActionTestState state) => state with { Count = state.Count + 1 };
+}
+
+public sealed record Add(int Amount) : IMosaicAction<ActionTestState>
+{
+    public ActionTestState Apply(ActionTestState state) => state with { Count = state.Count + Amount };
+}
+
+public class ActionTests
+{
+    [Fact]
+    public void ApplyReturnsNextStateWithoutMutatingInput()
+    {
+        var initial = new ActionTestState(5);
+        var next = new Increment().Apply(initial);
+        Assert.Equal(6, next.Count);
+        Assert.Equal(5, initial.Count);
+    }
+
+    [Fact]
+    public void PayloadAccessible()
+    {
+        var action = new Add(7);
+        Assert.Equal(7, action.Amount);
+        Assert.Equal(10, action.Apply(new ActionTestState(3)).Count);
+    }
+
+    [Fact]
+    public void Deterministic()
+    {
+        var state = new ActionTestState(0);
+        var action = new Add(5);
+        Assert.Equal(action.Apply(state).Count, action.Apply(state).Count);
+    }
+}

--- a/code/packages/csharp/Mosaic.Flux/tests/DevToolsTests.cs
+++ b/code/packages/csharp/Mosaic.Flux/tests/DevToolsTests.cs
@@ -1,0 +1,45 @@
+using Xunit;
+using Mosaic.Flux;
+
+namespace Mosaic.Flux.Tests;
+
+public record DtState(int V = 0);
+
+public sealed record DtBump : IMosaicAction<DtState>
+{
+    public DtState Apply(DtState state) => state with { V = state.V + 1 };
+}
+
+public class DevToolsTests
+{
+    [Fact]
+    public void Callable()
+    {
+        var m = DevTools.Create<DtState>();
+        m(new DtBump(), new DtState(0), new DtState(1));
+    }
+
+    [Fact]
+    public void CustomStoreName()
+    {
+        var m = DevTools.Create<DtState>("my-grid");
+        m(new DtBump(), new DtState(0), new DtState(1));
+    }
+
+    [Fact]
+    public void IntegratesWithStore()
+    {
+        var probeRuns = 0;
+        var store = new MosaicStore<DtState>(
+            new DtState(),
+            new Middleware<DtState>[]
+            {
+                DevTools.Create<DtState>(),
+                (_, _, _) => probeRuns++,
+            });
+        store.Dispatch(new DtBump());
+        store.Dispatch(new DtBump());
+        Assert.Equal(2, probeRuns);
+        Assert.Equal(2, store.State.V);
+    }
+}

--- a/code/packages/csharp/Mosaic.Flux/tests/MiddlewareTests.cs
+++ b/code/packages/csharp/Mosaic.Flux/tests/MiddlewareTests.cs
@@ -1,0 +1,64 @@
+using Xunit;
+using Mosaic.Flux;
+
+namespace Mosaic.Flux.Tests;
+
+public record MwState(int V = 0);
+
+public sealed record MwBump : IMosaicAction<MwState>
+{
+    public MwState Apply(MwState state) => state with { V = state.V + 1 };
+}
+
+public class MiddlewareTests
+{
+    [Fact]
+    public void EmptyComposeIsNoOp()
+    {
+        var m = MiddlewareHelpers.Compose<MwState>(Array.Empty<Middleware<MwState>>());
+        m(new MwBump(), new MwState(0), new MwState(1));  // should not throw
+    }
+
+    [Fact]
+    public void SingleMiddlewareReturnedVerbatim()
+    {
+        Middleware<MwState> single = (_, _, _) => { };
+        var composed = MiddlewareHelpers.Compose(new[] { single });
+        Assert.Same(single, composed);
+    }
+
+    [Fact]
+    public void RunsInOrder()
+    {
+        var calls = new List<string>();
+        var composed = MiddlewareHelpers.Compose(new Middleware<MwState>[]
+        {
+            (_, _, _) => calls.Add("a"),
+            (_, _, _) => calls.Add("b"),
+            (_, _, _) => calls.Add("c"),
+        });
+        composed(new MwBump(), new MwState(0), new MwState(1));
+        Assert.Equal(new[] { "a", "b", "c" }, calls);
+    }
+
+    [Fact]
+    public void IsolatesThrows()
+    {
+        var calls = new List<string>();
+        var composed = MiddlewareHelpers.Compose(new Middleware<MwState>[]
+        {
+            (_, _, _) => calls.Add("a"),
+            (_, _, _) => throw new Exception("boom"),
+            (_, _, _) => calls.Add("c"),
+        });
+        composed(new MwBump(), new MwState(0), new MwState(1));
+        Assert.Equal(new[] { "a", "c" }, calls);
+    }
+
+    [Fact]
+    public void LoggerMiddlewareDoesNotThrow()
+    {
+        var m = MiddlewareHelpers.Logger<MwState>();
+        m(new MwBump(), new MwState(0), new MwState(1));
+    }
+}

--- a/code/packages/csharp/Mosaic.Flux/tests/Mosaic.Flux.Tests.csproj
+++ b/code/packages/csharp/Mosaic.Flux/tests/Mosaic.Flux.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <LangVersion>12.0</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Mosaic.Flux.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/code/packages/csharp/Mosaic.Flux/tests/SelectorTests.cs
+++ b/code/packages/csharp/Mosaic.Flux/tests/SelectorTests.cs
@@ -1,0 +1,87 @@
+using Xunit;
+using Mosaic.Flux;
+
+namespace Mosaic.Flux.Tests;
+
+public record SelState(int A = 0, int B = 0, string Label = "");
+
+public class SelectorTests
+{
+    [Fact]
+    public void SingleInputRecomputesOnChange()
+    {
+        var calls = 0;
+        var doubled = Selector.Create<SelState, int, int>(
+            s => s.A,
+            a => { calls++; return a * 2; });
+        Assert.Equal(10, doubled(new SelState(A: 5)));
+        Assert.Equal(14, doubled(new SelState(A: 7)));
+        Assert.Equal(2, calls);
+    }
+
+    [Fact]
+    public void SingleInputCachesOnStable()
+    {
+        var calls = 0;
+        var doubled = Selector.Create<SelState, int, int>(
+            s => s.A,
+            a => { calls++; return a * 2; });
+        var s = new SelState(A: 5);
+        doubled(s); doubled(s); doubled(s);
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public void SingleInputCachesAcrossStateRefs()
+    {
+        var calls = 0;
+        var doubled = Selector.Create<SelState, int, int>(
+            s => s.A,
+            a => { calls++; return a * 2; });
+        doubled(new SelState(A: 5, B: 0));
+        doubled(new SelState(A: 5, B: 999, Label: "different"));
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public void TwoInputRecomputesWhenEitherChanges()
+    {
+        var calls = 0;
+        var sum = Selector.Create<SelState, int, int, int>(
+            s => s.A,
+            s => s.B,
+            (a, b) => { calls++; return a + b; });
+        Assert.Equal(3, sum(new SelState(A: 1, B: 2)));
+        Assert.Equal(6, sum(new SelState(A: 1, B: 5)));
+        Assert.Equal(9, sum(new SelState(A: 4, B: 5)));
+        Assert.Equal(3, calls);
+    }
+
+    [Fact]
+    public void TwoInputCachesOnStableInputs()
+    {
+        var calls = 0;
+        var sum = Selector.Create<SelState, int, int, int>(
+            s => s.A,
+            s => s.B,
+            (a, b) => { calls++; return a + b; });
+        var s = new SelState(A: 1, B: 2);
+        sum(s); sum(s);
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public void ThreeInputRecomputesWhenAnyChanges()
+    {
+        var calls = 0;
+        var fmt = Selector.Create<SelState, int, int, string, string>(
+            s => s.A,
+            s => s.B,
+            s => s.Label,
+            (a, b, lbl) => { calls++; return $"{lbl}:{a + b}"; });
+        Assert.Equal("x:3", fmt(new SelState(A: 1, B: 2, Label: "x")));
+        Assert.Equal("x:3", fmt(new SelState(A: 1, B: 2, Label: "x")));
+        Assert.Equal("y:3", fmt(new SelState(A: 1, B: 2, Label: "y")));
+        Assert.Equal(2, calls);
+    }
+}

--- a/code/packages/csharp/Mosaic.Flux/tests/StoreTests.cs
+++ b/code/packages/csharp/Mosaic.Flux/tests/StoreTests.cs
@@ -1,0 +1,149 @@
+using Xunit;
+using System.ComponentModel;
+using Mosaic.Flux;
+
+namespace Mosaic.Flux.Tests;
+
+public record StoreState(int Count = 0, string Label = "");
+
+public sealed record StIncrement : IMosaicAction<StoreState>
+{
+    public StoreState Apply(StoreState state) => state with { Count = state.Count + 1 };
+}
+
+public sealed record StSetLabel(string Label) : IMosaicAction<StoreState>
+{
+    public StoreState Apply(StoreState state) => state with { Label = Label };
+}
+
+public sealed record StNoOp : IMosaicAction<StoreState>
+{
+    // Returns the SAME instance to test the no-op short-circuit.
+    public StoreState Apply(StoreState state) => state;
+}
+
+public class StoreTests
+{
+    [Fact]
+    public void StartsAtInitialState()
+    {
+        var store = new MosaicStore<StoreState>(new StoreState());
+        Assert.Equal(0, store.State.Count);
+        Assert.Equal("", store.State.Label);
+    }
+
+    [Fact]
+    public void DispatchAppliesAction()
+    {
+        var store = new MosaicStore<StoreState>(new StoreState());
+        store.Dispatch(new StIncrement());
+        Assert.Equal(1, store.State.Count);
+    }
+
+    [Fact]
+    public void PayloadedActionWorks()
+    {
+        var store = new MosaicStore<StoreState>(new StoreState());
+        store.Dispatch(new StSetLabel("hi"));
+        Assert.Equal("hi", store.State.Label);
+    }
+
+    [Fact]
+    public void SelectReturnsProjection()
+    {
+        var store = new MosaicStore<StoreState>(new StoreState(Count: 5));
+        Assert.Equal(5, store.Select(s => s.Count));
+    }
+
+    [Fact]
+    public void SubscribeFiresOnChangedSlice()
+    {
+        var store = new MosaicStore<StoreState>(new StoreState());
+        var received = new List<int>();
+        store.Subscribe(s => s.Count, received.Add);
+        store.Dispatch(new StIncrement());
+        Assert.Equal(new[] { 1 }, received);
+    }
+
+    [Fact]
+    public void SubscribeDoesNotFireOnUnrelatedChange()
+    {
+        var store = new MosaicStore<StoreState>(new StoreState());
+        var received = new List<int>();
+        store.Subscribe(s => s.Count, received.Add);
+        store.Dispatch(new StSetLabel("x"));
+        Assert.Empty(received);
+    }
+
+    [Fact]
+    public void UnsubscribeStopsNotifications()
+    {
+        var store = new MosaicStore<StoreState>(new StoreState());
+        var received = new List<int>();
+        var sub = store.Subscribe(s => s.Count, received.Add);
+        store.Dispatch(new StIncrement());
+        sub.Dispose();
+        store.Dispatch(new StIncrement());
+        Assert.Equal(new[] { 1 }, received);
+    }
+
+    [Fact]
+    public void NoOpDispatchSkipsSubscriberButRunsMiddleware()
+    {
+        var subscriberCalls = 0;
+        var middlewareCalls = 0;
+        var store = new MosaicStore<StoreState>(
+            new StoreState(),
+            new Middleware<StoreState>[] { (_, _, _) => middlewareCalls++ });
+        store.Subscribe(s => s.Count, _ => subscriberCalls++);
+        store.Dispatch(new StNoOp());
+        Assert.Equal(0, subscriberCalls);
+        Assert.Equal(1, middlewareCalls);
+    }
+
+    [Fact]
+    public void PropertyChangedFiresOnDispatch()
+    {
+        var store = new MosaicStore<StoreState>(new StoreState());
+        var notifications = new List<string?>();
+        store.PropertyChanged += (_, e) => notifications.Add(e.PropertyName);
+        store.Dispatch(new StIncrement());
+        Assert.Contains("State", notifications);
+    }
+
+    [Fact]
+    public void PropertyChangedDoesNotFireOnNoOp()
+    {
+        var store = new MosaicStore<StoreState>(new StoreState());
+        var notifications = new List<string?>();
+        store.PropertyChanged += (_, e) => notifications.Add(e.PropertyName);
+        store.Dispatch(new StNoOp());
+        Assert.Empty(notifications);
+    }
+
+    [Fact]
+    public void MiddlewareSeesTriple()
+    {
+        var seen = new List<(string Type, int Prev, int Next)>();
+        var store = new MosaicStore<StoreState>(
+            new StoreState(),
+            new Middleware<StoreState>[]
+            {
+                (action, prev, next) => seen.Add((action.GetType().Name, prev.Count, next.Count))
+            });
+        store.Dispatch(new StIncrement());
+        Assert.Single(seen);
+        Assert.Equal(0, seen[0].Prev);
+        Assert.Equal(1, seen[0].Next);
+    }
+
+    [Fact]
+    public void CustomEqualityRespected()
+    {
+        var store = new MosaicStore<StoreState>(new StoreState());
+        var received = new List<int>();
+        store.Subscribe(s => s.Count, received.Add, (_, _) => true);
+        store.Dispatch(new StIncrement());
+        Assert.Empty(received);
+    }
+}


### PR DESCRIPTION
## Summary

Seventh per-backend Mosaic runtime (UI33-rewrite §6). C# / net9.0 sibling to the React, HTML, WebComponent, SwiftUI, Compose, and Flutter packages — same strict-Flux contract, same surface shape, Mosaic-owned (no TCA / Fluxor / ReactiveUI dependency).

- `IMosaicAction<TState>` — command-pattern action with `Apply(state) → state`
- `MosaicStore<TState>` — `INotifyPropertyChanged`-aware dispatcher; `ConcurrentDictionary` subscription registry; snapshot iteration so a callback that unsubscribes doesn't perturb the loop
- `Middleware<TState>` + `Compose` / `Logger`; `Selector.Create` (1–3 input memoised projections); `DevTools.Create` no-op factory (real channel in v0.2.0)

29 xUnit tests cover Apply semantics, dispatch / subscribe / unsubscribe, no-op short-circuit, `PropertyChanged` emission, custom equality, middleware composition + error isolation, selector memoisation, and DevTools integration.

Security review (general-purpose subagent) flagged the plain `Dictionary<int, ISubscription>` as not thread-safe under concurrent Subscribe/Dispatch. Replaced with `ConcurrentDictionary`; made `Unsubscribe.Dispose` idempotent via `Interlocked.Exchange`. Re-review clean.

## Test plan

- [x] `dotnet test` — 29 passed, 0 failed, ~14 ms
- [x] `TreatWarningsAsErrors=true` + `Nullable=enable` build clean
- [x] Security review clean after concurrency fix
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)