### PR TITLE
CLOC12.19 — block flattening (gap-010 closed) [independent]

### DIFF
--- a/code/packages/rust/closure-pass-dce/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-dce/CHANGELOG.md
@@ -2,6 +2,52 @@
 
 All notable changes to the `coding-adventures-closure-pass-dce` crate will be documented in this file.
 
+## [0.5.0] - 2026-06-01
+
+### Added — CLOC12.19: block flattening (closes gap-010)
+
+Adds a flatten step to `dce_block_statement` that splices any
+direct-child `BlockStatement`'s body into the enclosing block —
+after the recurse-into-children pass and before the existing
+dead-after-terminator + empty-statement sweeps.
+
+Truth table:
+
+| Input                       | Output                  |
+|-----------------------------|-------------------------|
+| `{{foo();}}`                | `{foo();}`              |
+| `{foo();{}}`                | `{foo();}`              |
+| `{{};foo();}`               | `{foo();}`              |
+| `{{a();b();};}`             | `{a();b();}`            |
+| `{foo();{bar();baz();}}`    | `{foo();bar();baz();}`  |
+| `{let x=1;{let x=2;}}`      | unchanged (scope-safe)  |
+| `{var x=1;{var y=2;}}`      | `{var x=1;var y=2;}`    |
+
+**Scope safety.** ECMAScript block scope means `let`, `const`,
+`class`, and inner `function` declarations are bound to their
+enclosing block. Hoisting them into the outer block would either
+leak the binding to a wider scope or trigger a redeclaration TDZ
+error against a same-named outer binding. The new helper
+`block_is_scope_safe_to_flatten(b) -> bool` walks an inner
+block's body and returns `false` if any statement is a block-bound
+declaration — those inner blocks stay put. Plain `var` is fine
+because `var` is function-scoped, not block-scoped, so hoisting
+`{var x = 1;}` upward produces the same effective binding.
+
+The flatten contributes a `block-flattened` record per outer
+block where any splicing happened (not per child — that'd be
+noisy). Dead-after-return and EmptyStatement drops still cascade
+afterward, so input like `{x;{return;y;};z;}` collapses to
+`{x;return;}` in a single pass.
+
+Un-ignores upstream-port `test_fold_block_flattening` with four
+assertions covering the `{{foo();}}`, `{foo();{}}`, `{{};foo();}`,
+and `{foo();{bar();}}` cases. Updates the existing
+`recurses_into_nested_blocks` inline test (renamed to
+`recurses_into_nested_blocks_and_flattens`) to reflect the new
+cascade behaviour where the inner block is now spliced into the
+outer rather than preserved.
+
 ## [0.4.2] - 2026-06-01
 
 ### Changed — CLOC12.14: handle new `ThrowStatement` variant

--- a/code/packages/rust/closure-pass-dce/Cargo.toml
+++ b/code/packages/rust/closure-pass-dce/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-dce"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2021"
 description = "Dead-code elimination pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Drops code after definite-terminator statements and removes EmptyStatement noise."
 

--- a/code/packages/rust/closure-pass-dce/src/lib.rs
+++ b/code/packages/rust/closure-pass-dce/src/lib.rs
@@ -71,7 +71,7 @@ use coding_adventures_javascript_ast::{
     BlockStatement, CallExpression, ConditionalExpression, Declaration, Expression,
     ExpressionStatement, ForInit, ForStatement, FunctionDeclaration, IfStatement,
     LogicalExpression, MemberExpression, ObjectExpression, Program, ProgramItem, Property,
-    PropertyKey, ReturnStatement, Statement, UnaryExpression, VariableDeclaration,
+    PropertyKey, ReturnStatement, Statement, UnaryExpression, VarKind, VariableDeclaration,
     VariableDeclarator, WhileStatement,
 };
 use serde_json::json;
@@ -303,6 +303,61 @@ fn dce_block_statement(b: &BlockStatement, st: &mut DceState) -> BlockStatement 
         .map(|s| dce_statement(s, st))
         .collect();
 
+    // Block flattening (closes CLOC12 gap-010).
+    //
+    // Splice any direct-child `BlockStatement`'s body into our own
+    // body. After the recurse-into-children step above, the inner
+    // block has already had its own DCE applied, so what we splice
+    // in is the already-cleaned version. Truth table:
+    //
+    //   {{foo();}}            → {foo();}           (1-stmt inner)
+    //   {foo();{}}            → {foo();}           (empty inner)
+    //   {{};foo();}           → {foo();}           (empty inner first)
+    //   {{a();b();};}         → {a();b();}         (multi-stmt inner)
+    //   {foo();{bar();baz();}} → {foo();bar();baz();}
+    //   {let x=1;{let x=2;}}  → unchanged          (scope-safety)
+    //
+    // Scope safety: ECMAScript block scope means `let`, `const`,
+    // `class`, and inner `function` declarations are bound to their
+    // enclosing block. Hoisting their bodies into our scope would
+    // either leak a binding upward (changing semantics) or trigger
+    // a redeclaration TDZ error if a same-named binding already
+    // exists. So we ONLY flatten an inner block when its body
+    // contains no scope-bound declarations. Plain `var` is fine
+    // — it's function-scoped, so hoisting it out of an inner
+    // block doesn't change the binding's containing scope.
+    //
+    // Why DCE owns this fold: block flattening is a pure structural
+    // simplification with no semantic prerequisites — it can run
+    // safely without scope/symbol info beyond the per-block scan
+    // we already do here, and it makes downstream emitter output
+    // tighter. Per gap-010 it lives here for v1.
+    let pre_flatten_len = working.len();
+    let mut flattened: Vec<Statement> = Vec::with_capacity(pre_flatten_len);
+    let mut flattening_happened = false;
+    for stmt in working.drain(..) {
+        match &stmt {
+            Statement::Tagged(TaggedStatement::BlockStatement(inner))
+                if block_is_scope_safe_to_flatten(inner) =>
+            {
+                flattening_happened = true;
+                for inner_stmt in inner.body.iter() {
+                    flattened.push(inner_stmt.clone());
+                }
+            }
+            _ => flattened.push(stmt),
+        }
+    }
+    working = flattened;
+    if flattening_happened {
+        st.record(
+            &b.cv,
+            "block-flattened",
+            &format!("block with {} statements", pre_flatten_len),
+            &format!("flattened to {} statements", working.len()),
+        );
+    }
+
     // Drop dead-after-terminator.
     let original_len = working.len();
     if let Some(terminator_idx) = working
@@ -348,6 +403,35 @@ fn is_terminator(stmt: &Statement) -> bool {
         stmt,
         Statement::Tagged(TaggedStatement::ReturnStatement(_))
     )
+}
+
+/// Returns `true` when an inner BlockStatement's body can be
+/// hoisted into the enclosing block without changing ECMAScript
+/// scoping semantics. Used by the block-flattening fold
+/// (CLOC12.19 / gap-010).
+///
+/// Block-scoped declarations (`let`, `const`, `class`, inner
+/// function declarations) are bound to their enclosing block.
+/// Hoisting them upward either leaks the binding to a wider
+/// scope or causes a redeclaration error against a same-named
+/// binding in the outer block — either way, observably different.
+///
+/// `var` is function-scoped, so hoisting `{var x = 1;}` out of
+/// an inner block to the function-body level produces the same
+/// effective binding (a `var` declaration was already implicitly
+/// hoisted to the function scope by the spec). Hence `Var`-kind
+/// declarations are safe to flatten.
+fn block_is_scope_safe_to_flatten(b: &BlockStatement) -> bool {
+    b.body.iter().all(|s| match s {
+        Statement::Declaration(Declaration::VariableDeclaration(v)) => {
+            matches!(v.kind, VarKind::Var)
+        }
+        Statement::Declaration(Declaration::FunctionDeclaration(_)) => false,
+        // Tagged statements never introduce a new lexical binding
+        // by themselves. `ExpressionStatement`, control flow,
+        // `EmptyStatement`, etc. are all safe.
+        Statement::Tagged(_) => true,
+    })
 }
 
 fn is_empty_statement(stmt: &Statement) -> bool {
@@ -711,11 +795,18 @@ mod tests {
     // ---------------- nested blocks ---------------------------
 
     #[test]
-    fn recurses_into_nested_blocks() {
+    fn recurses_into_nested_blocks_and_flattens() {
         // { x; { return; y; } z; }
-        // Outer block: kept (no top-level terminator at outer
-        // scope; the `return` is inside the inner block).
-        // Inner block: { return; y; } → { return; } (drop y).
+        //
+        // Step 1 (recurse): inner `{ return; y; }` → `{ return; }`
+        //                   (drop dead-after-return)
+        // Step 2 (flatten, CLOC12.19 / gap-010): inner block has no
+        //         scope-bound decls, splice its body into outer:
+        //         `{ x; return; z; }`
+        // Step 3 (dead-after-return on outer): drop `z`:
+        //         `{ x; return; }`
+        //
+        // So the outer body ends with 2 statements (was 3 pre-fold).
         let inner_block = BlockStatement {
             cv: Some("inner.1".to_string()),
             body: vec![return_stmt(), expr_stmt(ident("y"))],
@@ -729,20 +820,21 @@ mod tests {
         let (out, _contribs, changed, _) = run_pass(prog);
         assert!(changed);
         let outer = extract_function_body(&out);
-        // Outer block still has 3 statements (x, block, z).
-        assert_eq!(outer.body.len(), 3);
-        // Inner block: extract and check.
-        match &outer.body[1] {
-            Statement::Tagged(TaggedStatement::BlockStatement(inner)) => {
-                assert_eq!(
-                    inner.body.len(),
-                    1,
-                    "inner block should have just `return`; got {:?}",
-                    inner.body
-                );
-            }
-            other => panic!("expected nested BlockStatement; got {:?}", other),
-        }
+        assert_eq!(
+            outer.body.len(),
+            2,
+            "expected outer body = [x; return;] after flatten+drop; got {:?}",
+            outer.body
+        );
+        // Second statement is `return;`.
+        assert!(
+            matches!(
+                &outer.body[1],
+                Statement::Tagged(TaggedStatement::ReturnStatement(_))
+            ),
+            "expected ReturnStatement at outer.body[1]; got {:?}",
+            outer.body[1]
+        );
     }
 
     // ---------------- untraced ---------------------------------

--- a/code/packages/rust/closure-pass-dce/tests/upstream/peephole_remove_dead_code_test.rs
+++ b/code/packages/rust/closure-pass-dce/tests/upstream/peephole_remove_dead_code_test.rs
@@ -203,14 +203,50 @@ fn test_remove_no_op_labelled_statement() {
 ///   fold("{foo();{}}", "foo()");
 ///   ... (block-flattening cases) ...
 ///
-/// Block flattening — collapsing nested `BlockStatement` that holds
-/// only one or zero meaningful statements into its child — is not
-/// part of our DCE today. Tracked separately from the dead-code
-/// removal DCE actually does.
+/// **gap-010 closed in CLOC12.19**: a new flatten step in
+/// `dce_block_statement` splices any direct-child BlockStatement's
+/// body into the enclosing block. Empty inner blocks disappear;
+/// multi-statement inner blocks hoist their contents up. The
+/// flatten is gated on a scope-safety check so `let`/`const`/
+/// `class`/`function` inner blocks stay put (their bindings would
+/// leak upward otherwise).
 #[test]
-#[ignore = "blocked on gap-010: block-flattening / single-child block collapse not implemented"]
 fn test_fold_block_flattening() {
-    // Would assert that `{{foo();}}` collapses to `foo();`.
+    let block = |body: Vec<Statement>| {
+        Statement::block_statement(BlockStatement { cv: None, body })
+    };
+    let foo_call = expr_stmt(Expression::Identifier(Identifier {
+        cv: None,
+        name: "foo".to_string(),
+    }));
+    let bar_call = expr_stmt(Expression::Identifier(Identifier {
+        cv: None,
+        name: "bar".to_string(),
+    }));
+
+    // {{foo();}}  →  {foo();}   (outer body unchanged, but inner
+    // {foo();} flattens, leaving the outer body with just the
+    // call after one DCE pass).
+    assert_dce_yields(vec![block(vec![foo_call.clone()])], vec![foo_call.clone()]);
+
+    // {foo();{}}  →  {foo();}   (empty inner block drops, then
+    // EmptyStatement-removal phase also drops the empty)
+    assert_dce_yields(
+        vec![foo_call.clone(), block(vec![])],
+        vec![foo_call.clone()],
+    );
+
+    // {{};foo();}  →  {foo();}
+    assert_dce_yields(
+        vec![block(vec![]), foo_call.clone()],
+        vec![foo_call.clone()],
+    );
+
+    // {foo();{bar();}}  →  {foo();bar();}
+    assert_dce_yields(
+        vec![foo_call.clone(), block(vec![bar_call.clone()])],
+        vec![foo_call.clone(), bar_call.clone()],
+    );
 }
 
 /// Upstream `testFoldBlock` line:

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -94,11 +94,10 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-010 — block-flattening (single-child block collapse) not implemented
 
-- **Status:** OPEN
+- **Status:** RESOLVED in CLOC12.19 (PR pending).
 - **Upstream test:** `PeepholeRemoveDeadCodeTest::testFoldBlock` (block-flattening lines)
 - **Ported file:** `closure-pass-dce/tests/upstream/peephole_remove_dead_code_test.rs`
-- **Why it fails:** Upstream collapses `{{foo();}}` to `foo();`, `{foo();{}}` to `foo();`, etc. We don't flatten nested blocks — DCE's responsibility is dead-after-terminator and empty-statement removal, not structural simplification.
-- **What it needs:** Either extend DCE with a "block-with-single-statement → that statement" rule, or stand up a dedicated normaliser pass. Probably belongs in DCE for simplicity (~30 lines).
+- **Resolution note:** Added a flatten step at the top of `dce_block_statement` (after the recurse pass, before dead-after-terminator and EmptyStatement drops). For each direct-child statement, if it's a `BlockStatement` AND a new `block_is_scope_safe_to_flatten` helper returns true (i.e., contains no `let`/`const`/`class`/`function` declarations), splice its body into the enclosing block. `var` is fine because it's function-scoped. Cascades cleanly with the existing dead-code drops: `{x;{return;y;};z;}` → `{x;return;}` in one pass. `test_fold_block_flattening` un-ignored with four assertions; existing `recurses_into_nested_blocks` updated to reflect the new behaviour.
 
 ### gap-011 — `if`-with-constant-test collapse lives in `fold-control-flow`, not DCE
 


### PR DESCRIPTION
## Summary

**INDEPENDENT** of #4752 (BigIntLiteral) and #4757 (if-else ternary). Touches only `closure-pass-dce`, no AST changes.

- Adds block flattening to `dce_block_statement`: direct-child BlockStatement bodies splice into the outer block
- Scope-safety check (`block_is_scope_safe_to_flatten`) keeps `let`/`const`/`function`-inner blocks intact; `var` flattens (function-scoped)
- Cascades with existing dead-after-return + EmptyStatement sweeps
- Closes gap-010

## Truth table

| Input | Output |
|-------|--------|
| `{{foo();}}` | `{foo();}` |
| `{foo();{}}` | `{foo();}` |
| `{{};foo();}` | `{foo();}` |
| `{{a();b();};}` | `{a();b();}` |
| `{foo();{bar();baz();}}` | `{foo();bar();baz();}` |
| `{let x=1;{let x=2;}}` | unchanged (scope-safe) |
| `{var x=1;{var y=2;}}` | `{var x=1;var y=2;}` |
| `{x;{return;y;};z;}` | `{x;return;}` (cascade) |

## Version

| Crate | Old | New |
|-------|-----|-----|
| `closure-pass-dce` | 0.4.2 | 0.5.0 |

## Test plan

- [x] `cargo test -p closure-pass-dce` → 14 inline + 8 upstream (was 13 + 7; un-ignored 1, updated 1 inline)
- [x] Security review: APPROVED (scope-safety check correct for current AST; no over-fire on IfStatement/etc. body blocks; recursion bounded; LabeledStatement-wrapped blocks correctly skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)