### PR TITLE
docs(spec): ADJ14 + LP19e — likelihood-ratio aggregation as the framework's primary probabilistic inference model

### DIFF
--- a/code/specs/ADJ14-probabilistic-ir-semantics.md
+++ b/code/specs/ADJ14-probabilistic-ir-semantics.md
@@ -1,0 +1,539 @@
+# ADJ14 — Probabilistic IR Semantics: Likelihood-Ratio Aggregation
+
+> The spec that decides what "probabilistic adjudication" actually
+> means in this framework. Commits the IR + engine to a Bayesian
+> likelihood-ratio aggregation inference model — the math working
+> clinicians, lawyers, and analysts already reason in — and lays out
+> the grammar, lowering rules, engine algorithm, and proof-DAG
+> changes that make it real.
+
+## Overview
+
+The adjudication framework's design principle has been "the IR forces
+the model to commit." Through ADJ01–ADJ13 this commitment was
+*structural*: every byte belongs to a typed node; every node carries
+polarity / modality. ADJ14 extends the commitment to be *probabilistic*:
+every contribution of evidence to a conclusion is recorded as a
+likelihood ratio, posterior probabilities are computed in log-odds
+space, and the proof DAG ships every LR contribution as a first-class
+derivation step.
+
+This is the right inference model because the dominant real-world
+adjudication tasks — clinical differential diagnosis, legal
+sufficiency-of-evidence review, fraud risk scoring, intelligence
+analysis, scientific peer review — all follow the same conceptual
+pattern: **a base-rate prior, updated by independent (or
+quasi-independent) pieces of evidence, each shifting the posterior
+odds by a multiplicative factor.** Evidence-based medicine teaches
+this explicitly (positive likelihood ratio LR+, negative likelihood
+ratio LR−, pre-test and post-test odds); Bayesian forensic statistics
+formalizes it the same way (the "likelihood-ratio framework"). The
+framework adopts the same vocabulary.
+
+## The decision, in one paragraph
+
+The framework treats every assertion about an underlying state — an
+extractor's claim that a symptom is present, a rulebook's claim that
+a symptom raises a diagnosis's probability, a witness's testimony
+about a contract clause — as a **likelihood ratio on the underlying
+state, composed multiplicatively in log-odds space**. Conjunctive
+ProbLog-style rules (where the rule fires iff every body literal is
+proved) remain available for the cases where they're the right model
+(deterministic constraints, definitional rules), but the
+**probabilistic default is LR aggregation, not joint conjunction**.
+A single field — likelihood ratio — replaces the prior distinction
+between *epistemic* uncertainty (the model isn't sure what the source
+said) and *aleatoric* uncertainty (the world is genuinely random):
+both compose by the same arithmetic.
+
+## Layer position
+
+```
+        ADJ01 (IR grammar v2)
+              │
+              ▼
+        ADJ14 (THIS SPEC — probabilistic semantics)
+              │
+              ├──▶ ADJ11 v2 (connector: lowers contributes/prior subtypes)
+              │
+              ▼
+        LP19d (engine: LR-aggregation inference mode)
+              │
+              ▼
+        ADJ15 (proof DAG in audit trail — typed, includes LRContribution)
+              │
+              ▼
+        ADJ16 (human-readable derivation rendering)
+```
+
+ADJ14 stacks on ADJ01 v2 and depends on a new engine sub-spec
+**LP19d** (the LR-aggregation inference algorithm in `logic-engine`),
+which is the engineering deliverable that makes this spec executable.
+ADJ11 grows a v2 that recognises the two new rule subtypes; the
+existing `definitional` / `constraint` / `default` subtypes are
+unchanged.
+
+## What this spec defines
+
+1. **Two new `Rule` subtypes** (`contributes` and `prior`), plus an
+   optional third (`contributes_jointly`) for interaction terms.
+2. **Reinterpretation of `IRNode::confidence`** as a calibrated
+   probability of observation-correctness, which lowers to an
+   extractor-level likelihood ratio.
+3. **Lowering rules** for `NodeKind::Uncertainty` and for `Fact`
+   nodes with non-unit confidence.
+4. **LR-aggregation inference algorithm** in log-odds space, with
+   conditional-independence assumptions made explicit.
+5. **A new `DerivationOrigin::FromContribution` variant** so the
+   proof DAG carries every LR step as first-class data.
+6. **Compatibility rules** between LR-aggregation queries and
+   existing ProbLog-style WMC queries inside the same KB.
+
+What this spec does **not** define: cloud-LLM-based extractor
+calibration (ADJ14b candidate), interaction-term discovery / learning
+(deferred), or the human-readable derivation renderer (ADJ16).
+
+## Vocabulary
+
+| Term | Symbol | Definition |
+|---|---|---|
+| Prior odds | `O₀(c)` | `P(c) / (1 − P(c))` before any evidence |
+| Posterior odds | `O(c \| E)` | Prior odds × ∏ LR for observed evidence |
+| Likelihood ratio | `LR(e, c)` | `P(e \| c) / P(e \| ¬c)` for one evidence atom |
+| Prior logit | `λ₀(c)` | `log O₀(c)` |
+| Posterior logit | `λ(c \| E)` | `λ₀(c) + Σ log LR(eᵢ, c)` |
+| Posterior probability | `P(c \| E)` | `σ(λ(c \| E))` = `1 / (1 + e^{−λ})` |
+
+All math happens in log-odds (logit) space. This is numerically
+stable, makes contributions additive, makes LRs interpretable
+("LR=10 means this evidence makes the diagnosis 10× more likely"),
+and matches how evidence-based medicine and Bayesian forensics
+teach the math.
+
+## Grammar — new Rule subtypes
+
+ADJ Rule nodes encode their subtype in `term` (per ADJ01 convention).
+ADJ14 adds two required subtypes and one optional:
+
+### `prior(P, conclusion)` — base rate
+
+```text
+prior(p, c)  where  0 ≤ p < 1
+```
+
+Establishes the base rate (prior probability) for conclusion `c`.
+Required exactly once per conclusion that participates in LR
+aggregation. Multiple `prior` declarations for the same conclusion
+are a lowering error (`ConflictingPriors`).
+
+**Lowering**: produces an internal `PriorClause { conclusion: c,
+prior_logit: log(p / (1 − p)) }` recorded in the KB.
+
+### `contributes(LR, evidence, conclusion)` — single-source contribution
+
+```text
+contributes(lr, e, c)  where  lr > 0,  lr ≠ 1.0  by convention
+```
+
+Observing `e` shifts the posterior odds of `c` by a multiplicative
+factor of `lr`. `lr > 1` is a positive contributor (LR+); `lr < 1` is
+a negative contributor (LR−). `lr = 1` is permitted but semantically
+a no-op and is warned about at lowering time.
+
+**Lowering**: produces an internal `ContributionClause { conclusion:
+c, evidence_term: e, logit_delta: log(lr) }`.
+
+**Independence assumption**: contributions to the same conclusion are
+treated as conditionally independent given the conclusion (the
+classic "naïve Bayes" assumption). The assumption is explicit, not
+implicit; ADJ14 surfaces it in the audit trail as
+`engine_artifacts.independence_assumption_used: true` whenever LR
+aggregation produced the verdict.
+
+### `contributes_jointly(LR_extra, [e₁, …, eₙ], conclusion)` — interaction term
+
+```text
+contributes_jointly(lr_extra, [e1, e2, …, en], c)   where lr_extra > 0
+```
+
+When *all* of `[e₁, …, eₙ]` are observed simultaneously, apply an
+**additional** multiplicative factor `lr_extra` on top of each
+individual `contributes` contribution. `lr_extra > 1` models synergy
+("these three findings together raise P(diagnosis) more than the
+product of their individual LRs would suggest"); `lr_extra < 1`
+models suppression / explaining-away.
+
+**Lowering**: produces `JointContributionClause { conclusion: c,
+evidence_set: {e₁,…,eₙ}, joint_logit_delta: log(lr_extra) }`.
+
+Optional in v0.1 of the spec — the LR-aggregation algorithm handles
+the absence of any `contributes_jointly` clause as the pure
+conditional-independence case.
+
+## Reinterpreting `IRNode::confidence`
+
+In ADJ01 v2 the field reads:
+> Extractor's self-reported confidence. Informational only; not used
+> by the type check.
+
+ADJ14 makes it semantic:
+
+> Extractor's self-reported probability that the observation it
+> emitted faithfully represents the source. Lowers to an
+> extractor-level likelihood ratio.
+
+**Lowering rule for a `Fact` node with `confidence = c`**:
+
+- If `c ≥ 1.0 − ε` (configurable, default `ε = 0.05`): treat as
+  `Probability::Certain`. The observation is asserted.
+- Otherwise: lower to an *observed* atom plus an implicit
+  `contributes(c / (1 − c), <fact_term>, <fact_observed_state>)`
+  clause. The extractor-LR enters the same aggregation as the
+  domain-level LRs.
+
+The `ε` cutoff is the calibration knob: deployments with
+well-calibrated extractors can lower it; deployments with overconfident
+extractors raise it. Default `ε = 0.05` mirrors common clinical
+"definite" / "probable" / "possible" buckets.
+
+**Backwards compatibility**: existing IR documents that set
+`confidence = 1.0` continue to lower to `Probability::Certain`
+unchanged. The grammar change is purely additive.
+
+## Reinterpreting `NodeKind::Uncertainty`
+
+Today `NodeKind::Uncertainty` is excluded from lowering (see
+`adjudication-connector::lower_to_kb`, where the variant is a no-op).
+ADJ14 makes it productive:
+
+> An `Uncertainty` node represents a partially-observed atom whose
+> presence the framework should weight by the extractor's stated
+> confidence.
+
+**Lowering rule for an `Uncertainty` node with `term: t, confidence:
+c`**:
+
+- Produce a single `ContributionClause { conclusion: t,
+  evidence_term: <extractor_evidence>(t), logit_delta: log(c / (1 −
+  c)) }` and add `<extractor_evidence>(t)` to the KB as an observed
+  fact.
+- Effectively: the extractor's observation that `t` *might be*
+  present provides one log-odds unit of `log(c / (1 − c))` evidence
+  for `t` actually being true.
+
+This is the formal unification: an `Uncertainty` node and a `Fact`
+node with `confidence < 1` lower to the *same* shape — an
+extractor-level LR contribution. The distinction in the IR remains
+useful for audit (which spans the model flagged as uncertain) and
+for ADJ06 escalation (which uncertainties to ask about), but the
+inference math is uniform.
+
+## The inference algorithm (LP19d)
+
+Pseudocode for evaluating `P(c | E)` under LR aggregation:
+
+```python
+def lr_aggregate(conclusion_term: Term, kb: KnowledgeBase) -> tuple[float, ProofDAG]:
+    # 1. Find the prior; require exactly one
+    priors = kb.priors_for(conclusion_term)
+    if len(priors) == 0:
+        return 0.5, empty_dag  # uniform fallback; warned in trail
+    if len(priors) > 1:
+        raise ConflictingPriors(conclusion_term)
+    prior_logit = priors[0].prior_logit
+
+    # 2. Collect every observed evidence atom that contributes to c
+    contribs = []
+    for clause in kb.contributions_for(conclusion_term):
+        if kb.is_observed(clause.evidence_term):
+            contribs.append(clause)
+
+    # 3. Apply each contribution to the running logit
+    logit = prior_logit
+    for clause in contribs:
+        logit += clause.logit_delta
+
+    # 4. Apply joint contributions whose evidence set is fully observed
+    joints = []
+    for j in kb.joint_contributions_for(conclusion_term):
+        if all(kb.is_observed(e) for e in j.evidence_set):
+            logit += j.joint_logit_delta
+            joints.append(j)
+
+    # 5. Convert logit → probability and build the proof DAG
+    posterior = sigmoid(logit)
+    dag = build_lr_proof_dag(conclusion_term, prior_logit, contribs, joints, posterior)
+    return posterior, dag
+```
+
+**Cost**: linear in the number of contributors. No 2ⁿ world
+enumeration. This is the asymptotic win over ProbLog WMC for the
+dominant probabilistic-adjudication shape; WMC remains available for
+the cases that genuinely need it.
+
+## The new proof step variant
+
+`logic_engine::DerivationOrigin` grows a new variant:
+
+```rust
+pub enum DerivationOrigin {
+    FromFact(FactId),
+    FromRule(RuleId),
+    /// LR contribution: this step applied `log(LR)` to the running
+    /// log-odds of the conclusion. `clause_id` cites the originating
+    /// `contributes(...)` rule; `evidence_fact_ids` cites the
+    /// observed evidence that made this contribution active.
+    FromContribution {
+        clause_id: RuleId,
+        evidence_fact_ids: Vec<FactId>,
+        logit_delta: f64,
+    },
+    /// Joint LR contribution from a `contributes_jointly` clause.
+    FromJointContribution {
+        clause_id: RuleId,
+        evidence_fact_ids: Vec<FactId>,
+        joint_logit_delta: f64,
+    },
+    /// Prior establishment — appears once per LR-aggregation proof.
+    FromPrior {
+        clause_id: RuleId,
+        prior_logit: f64,
+    },
+}
+```
+
+A complete LR-aggregation `Proof` looks like:
+
+```text
+Proof {
+  bindings: {},
+  steps: [
+    ProofStep { goal: stomach_bug, origin: FromPrior { clause_id: R1, prior_logit: -2.20 } },
+    ProofStep { goal: stomach_bug, origin: FromContribution { clause_id: R2, evidence_fact_ids: [F1], logit_delta: 1.386 } },
+    ProofStep { goal: stomach_bug, origin: FromContribution { clause_id: R3, evidence_fact_ids: [F2], logit_delta: 1.099 } },
+  ],
+  via_facts: [F1, F2],
+  via_rules: [R1, R2, R3],
+  posterior_logit: 0.285,         // new field on Proof in LP19d
+  posterior_probability: 0.571,   // new field
+}
+```
+
+Two new fields are appended to `Proof` (additive, non-breaking):
+`posterior_logit` and `posterior_probability`. They're `Option<f64>`
+in the wire format so deterministic / WMC-only proofs leave them as
+`None`.
+
+## Worked example — differential diagnosis
+
+Source (paraphrased medical chart):
+```
+Patient: diarrhea, vomiting, mild fever, no known drug allergy.
+```
+
+The framework extracts an IR with three `Fact` nodes for the observed
+symptoms (all `confidence = 0.95`, lowered to `Certain`), one denied
+`Fact` for the allergy, and one `Query` for `safe_to_discharge`.
+The rulebook (compiled per ADJ09) contributes the relevant priors
+and LRs:
+
+| Rule node | Subtype                                         | Meaning                                                                  |
+|-----------|-------------------------------------------------|--------------------------------------------------------------------------|
+| R1        | `prior(0.10, stomach_bug)`                      | 10% base rate of stomach bug in the population reviewed                  |
+| R2        | `contributes(4.0, diarrhea, stomach_bug)`       | Diarrhea has LR+ ≈ 4 for stomach bug                                     |
+| R3        | `contributes(3.0, vomiting, stomach_bug)`       | Vomiting has LR+ ≈ 3                                                     |
+| R4        | `contributes(1.5, mild_fever, stomach_bug)`     | Mild fever has weak LR+ ≈ 1.5                                            |
+| R5        | `contributes(0.7, drug_allergy, stomach_bug)`   | Drug allergy *lowers* the prior on stomach bug (LR− = 0.7)               |
+| R6        | `contributes_jointly(1.8, [diarrhea, vomiting], stomach_bug)` | When both are present, an extra synergy factor of 1.8                    |
+
+Inference:
+
+```text
+λ₀ = log(0.10 / 0.90)              = −2.197    (prior logit)
+   + log(4.0)                      = +1.386    (R2: diarrhea observed)
+   + log(3.0)                      = +1.099    (R3: vomiting observed)
+   + log(1.5)                      = +0.405    (R4: mild fever observed)
+   + 0                             =  0.000    (R5: drug_allergy denied, not contributed)
+   + log(1.8)                      = +0.588    (R6: joint synergy, both observed)
+   ──────────────────────────────────────
+   λ(stomach_bug | observed)       = +1.281
+   P(stomach_bug | observed)       =  0.783
+```
+
+The human-readable derivation (ADJ16) renders this as:
+
+> **P(stomach_bug | observed) = 78.3%.** Derived from a prior of 10%
+> (R1) and the following observed contributions:
+> - Diarrhea (F1, bytes 9..17): LR+ 4.0 → +1.39 log-odds (R2)
+> - Vomiting (F2, bytes 19..27): LR+ 3.0 → +1.10 log-odds (R3)
+> - Mild fever (F3, bytes 29..39): LR+ 1.5 → +0.41 log-odds (R4)
+> - Joint synergy of diarrhea + vomiting: ×1.8 → +0.59 log-odds (R6)
+>
+> The denied drug allergy (F4, bytes 41..63) would have contributed
+> LR− 0.7 (R5) if present; since it is denied, no contribution is
+> applied.
+
+Every clause id resolves to an IR node id; every IR node id resolves
+to source spans; every span resolves to source bytes. The audit
+trail makes this resolvable; the rendering surfaces it.
+
+## Compatibility with existing ProbLog primitives
+
+ADJ14 does **not** remove the existing `definitional` / `probabilistic`
+/ `constraint` / `default` Rule subtypes. They remain in the
+connector and in `logic-engine`. The two inference paths coexist:
+
+- **WMC path** (`SearchMode::EnumerateAll`): possible-worlds
+  enumeration over Bernoulli-distributed clauses. Used for
+  ProbLog-style joint conjunctive rules and for queries that mix
+  conjunctive deterministic rules with probabilistic indicators.
+- **LR-aggregation path** (`SearchMode::LRAggregate`, new in LP19d):
+  log-odds composition over `prior` + `contributes` clauses. Used
+  when the query's conclusion is the target of one or more
+  `contributes` clauses.
+
+`SearchMode::AutoDetect` is extended:
+1. If every clause touched by the query is `Certain` and no
+   `contributes` clause names the conclusion: use `FindFirst`.
+2. Else if at least one `contributes` clause names the conclusion:
+   use `LRAggregate`.
+3. Else: use `EnumerateAll` + WMC.
+
+A single KB may contain both shapes — e.g., a clinical KB where the
+diagnostic step is LR-aggregated but the discharge decision is a
+deterministic rule over the diagnosis. The connector raises
+`MixedShapeOnSameConclusion` if both a `contributes(*, *, c)` and a
+`probabilistic(p, c, …)` are present for the same `c`, because the
+math then becomes ambiguous and the deployment must choose.
+
+## Audit trail implications (preview of ADJ15)
+
+The `EngineArtifacts` struct (ADJ07) grows three additive fields:
+
+```rust
+pub struct EngineArtifacts {
+    // …existing fields…
+    pub independence_assumption_used: bool,            // new
+    pub lr_contributions: Vec<LrContributionRecord>,    // new
+    pub prior_record: Option<PriorRecord>,              // new
+}
+```
+
+Every `contributes` step that fired during inference is recorded
+once in `lr_contributions` with its clause id, the IR node id it
+lowered from, the observed evidence facts, the LR value, and the
+log-odds delta it added. A reviewer following the trail sees the
+prior, every contribution, and the running logit — the entire
+inference, by data, not commentary.
+
+## Calibration — what's in scope, what's not
+
+**In scope**: every `contributes` clause has an explicit numerical
+LR. Where that number comes from (literature meta-analyses,
+domain-expert elicitation, learned coefficients) is the rulebook
+author's problem; ADJ14 surfaces and applies the LR but does not
+claim to derive it.
+
+**Out of scope**: learning LRs from labelled outcome data, drift
+detection over time, posterior re-calibration when the population's
+base rate changes. These are real engineering tasks but they
+belong in ADJ09 (rule compilation) or a future "rule-calibration"
+sub-spec.
+
+**Important consequence**: the framework's verdicts are
+*conditional on the rulebook's calibration being correct*. A
+miscalibrated rulebook produces miscalibrated verdicts. The audit
+trail makes this auditable — every LR comes from a cited rule node,
+which cites a rulebook source span — but it does not make it
+*correct*. Calibration remains a human responsibility.
+
+## Conditional independence — the named assumption
+
+LR aggregation under `λ = λ₀ + Σ log LRᵢ` is exactly correct when
+the contributing evidence is **conditionally independent given the
+conclusion**. Real-world evidence rarely satisfies this exactly:
+diarrhea and vomiting are correlated even within stomach-bug cases.
+The framework's responses:
+
+1. **`contributes_jointly` is the explicit escape hatch.** A
+   modeler who knows two findings are correlated declares it; the
+   joint clause absorbs the correlation as an extra LR term.
+2. **The independence assumption is recorded in the audit trail**
+   (`engine_artifacts.independence_assumption_used: true`) whenever
+   any LR aggregation produced the answer.
+3. **The renderer surfaces the assumption** in the derivation prose:
+   "assuming conditional independence of the listed contributions"
+   appears verbatim in the rendered output (ADJ16).
+
+These three are not a cure for the independence assumption's
+limitations. They are an honest framing: the framework gives a
+defensible verdict under the stated assumption, the audit trail
+records the assumption, and the modeler is responsible for whether
+the assumption is appropriate for the case at hand. This is what
+Bayesian forensic statistics has always done; the framework
+inherits the tradition.
+
+## Open questions
+
+1. **Calibration sensitivity.** How sensitive is `P(c | E)` to small
+   errors in LR values? `contributes_jointly` partially absorbs
+   correlation; what fraction of clinical realism is recoverable
+   without it? Empirical follow-up; ADJ18 (sensitivity / VOI) is
+   the natural home.
+2. **Extractor confidence calibration in practice.** The default
+   `ε = 0.05` cutoff and the `c / (1 − c)` mapping are crude. A
+   future ADJ14b should benchmark actual LLM extractor confidence
+   distributions on labelled corpora and propose a calibrated
+   transform.
+3. **Negative joint interactions.** `contributes_jointly` covers
+   "evidence A and B together raise / lower more than the product
+   of individual LRs." Does the framework need an analogous
+   "evidence A and B together cancel each other out" primitive?
+   Probably representable as `contributes_jointly(small_lr, [a, b],
+   c)`; flagged here for follow-up.
+4. **Streaming inference.** When new evidence arrives mid-pipeline
+   (e.g., a clarification dialogue yields a new observed fact),
+   recomputing from scratch is trivial. But does the framework
+   want an incremental update API (`update_logit(conclusion,
+   new_evidence)`)? Probably yes, as a performance optimization in
+   LP19d v0.2.
+
+## Limitations
+
+1. **Per-conclusion `prior` requirement.** Conclusions without a
+   declared prior default to 0.5 (uniform), which is rarely the
+   right choice. The rulebook author has to put work into priors;
+   the framework will not invent them.
+2. **The independence assumption is the assumption.** Joint
+   interaction terms ameliorate but do not eliminate it. Verdicts
+   under LR aggregation are defensible *under the stated
+   assumption*; the audit trail records the assumption; the modeler
+   is on the hook for whether it's appropriate.
+3. **Mixed-shape KBs require disambiguation.** A KB cannot
+   simultaneously declare `contributes(*, *, c)` and
+   `probabilistic(p, c, …)` for the same `c`. The connector
+   rejects the combination; the deployment must pick a shape per
+   conclusion.
+
+## Status
+
+Draft. The grammar is sufficient to implement; the engine work
+lives in `LP19d` (to be drafted as a sibling sub-spec to LP19c).
+The connector v2 (ADJ11 v2) will recognise the two new rule
+subtypes and emit the new clause variants; this is purely additive
+to the existing ADJ11.
+
+## Where to read next
+
+- [ADJ01](ADJ01-adjudication-ir-grammar.md) — the IR grammar this
+  spec extends.
+- [ADJ11](ADJ11-problog-connector.md) — the existing connector
+  this spec grows a v2 of.
+- [LP19](LP19-probabilistic-logic-core.md) — the engine foundation
+  this spec depends on. LP19d will be the LR-aggregation sub-spec
+  that complements LP19c (conditional probability via WMC ratio).
+- [ADJ15](ADJ15-lowering-map-and-proof-dag.md) — the audit-trail
+  integration that surfaces this spec's outputs.
+- [ADJ16](ADJ16-derivation-rendering.md) — the human-readable
+  prose renderer that turns LR-aggregation proofs into derivations
+  a doctor / lawyer / analyst can defend.

--- a/code/specs/ADJ14-probabilistic-ir-semantics.md
+++ b/code/specs/ADJ14-probabilistic-ir-semantics.md
@@ -57,7 +57,7 @@ both compose by the same arithmetic.
               ├──▶ ADJ11 v2 (connector: lowers contributes/prior subtypes)
               │
               ▼
-        LP19d (engine: LR-aggregation inference mode)
+        LP19e (engine: LR-aggregation inference mode)
               │
               ▼
         ADJ15 (proof DAG in audit trail — typed, includes LRContribution)
@@ -67,7 +67,7 @@ both compose by the same arithmetic.
 ```
 
 ADJ14 stacks on ADJ01 v2 and depends on a new engine sub-spec
-**LP19d** (the LR-aggregation inference algorithm in `logic-engine`),
+**LP19e** (the LR-aggregation inference algorithm in `logic-engine`),
 which is the engineering deliverable that makes this spec executable.
 ADJ11 grows a v2 that recognises the two new rule subtypes; the
 existing `definitional` / `constraint` / `default` subtypes are
@@ -228,7 +228,7 @@ useful for audit (which spans the model flagged as uncertain) and
 for ADJ06 escalation (which uncertainties to ask about), but the
 inference math is uniform.
 
-## The inference algorithm (LP19d)
+## The inference algorithm (LP19e)
 
 Pseudocode for evaluating `P(c | E)` under LR aggregation:
 
@@ -314,7 +314,7 @@ Proof {
   ],
   via_facts: [F1, F2],
   via_rules: [R1, R2, R3],
-  posterior_logit: 0.285,         // new field on Proof in LP19d
+  posterior_logit: 0.285,         // new field on Proof in LP19e
   posterior_probability: 0.571,   // new field
 }
 ```
@@ -387,7 +387,7 @@ connector and in `logic-engine`. The two inference paths coexist:
   enumeration over Bernoulli-distributed clauses. Used for
   ProbLog-style joint conjunctive rules and for queries that mix
   conjunctive deterministic rules with probabilistic indicators.
-- **LR-aggregation path** (`SearchMode::LRAggregate`, new in LP19d):
+- **LR-aggregation path** (`SearchMode::LRAggregate`, new in LP19e):
   log-odds composition over `prior` + `contributes` clauses. Used
   when the query's conclusion is the target of one or more
   `contributes` clauses.
@@ -496,7 +496,7 @@ inherits the tradition.
    recomputing from scratch is trivial. But does the framework
    want an incremental update API (`update_logit(conclusion,
    new_evidence)`)? Probably yes, as a performance optimization in
-   LP19d v0.2.
+   LP19e v0.2.
 
 ## Limitations
 
@@ -518,7 +518,8 @@ inherits the tradition.
 ## Status
 
 Draft. The grammar is sufficient to implement; the engine work
-lives in `LP19d` (to be drafted as a sibling sub-spec to LP19c).
+lives in `LP19e` (to be drafted as a sibling sub-spec to LP19c and
+LP19d).
 The connector v2 (ADJ11 v2) will recognise the two new rule
 subtypes and emit the new clause variants; this is purely additive
 to the existing ADJ11.
@@ -530,8 +531,9 @@ to the existing ADJ11.
 - [ADJ11](ADJ11-problog-connector.md) — the existing connector
   this spec grows a v2 of.
 - [LP19](LP19-probabilistic-logic-core.md) — the engine foundation
-  this spec depends on. LP19d will be the LR-aggregation sub-spec
-  that complements LP19c (conditional probability via WMC ratio).
+  this spec depends on. LP19e will be the LR-aggregation sub-spec
+  that complements LP19c (conditional probability via WMC ratio)
+  and LP19d (approximate inference via Monte Carlo).
 - [ADJ15](ADJ15-lowering-map-and-proof-dag.md) — the audit-trail
   integration that surfaces this spec's outputs.
 - [ADJ16](ADJ16-derivation-rendering.md) — the human-readable

--- a/code/specs/LP19e-likelihood-ratio-aggregation.md
+++ b/code/specs/LP19e-likelihood-ratio-aggregation.md
@@ -1,0 +1,496 @@
+# LP19e — Likelihood-Ratio Aggregation: Bayesian Posterior Inference
+
+## Overview
+
+[`LP19`](LP19-probabilistic-logic-core.md) defines exact weighted
+model counting over possible worlds. That algorithm is the right
+answer for **joint conjunctive probabilistic programs** — where a
+clause body fires iff every literal in the body is independently
+true, and the answer is a sum over possible-worlds probability mass.
+
+[`ADJ14`](ADJ14-probabilistic-ir-semantics.md) commits the
+adjudication framework to a *different* dominant inference shape:
+**independent evidence atoms each contributing a likelihood ratio to
+a conclusion, composed multiplicatively in log-odds space**. This is
+how evidence-based medicine, Bayesian forensic statistics, and
+quantitative legal-sufficiency review actually reason. It is also
+the inference shape the framework's small-model + retry-with-correction
+thesis depends on, because it makes the proof DAG natively
+human-readable: a verdict is a *prior plus a list of named
+contributions*, not a sum over enumerated possible worlds.
+
+This sub-spec specifies the engine's algorithm for that shape.
+
+## Why a separate sub-spec
+
+The math is straightforward. Specifying it explicitly matters because
+the API surface, the proof-DAG shape, and the mode-selection
+interaction with `AutoDetect` all have to be nailed down before the
+connector (ADJ11 v2) can lower `contributes` / `prior` clauses, and
+before the audit trail (ADJ15) can serialize LR contributions as
+first-class proof steps.
+
+LP19e is the engine engineering deliverable that makes ADJ14
+executable.
+
+## Layer position
+
+```
+   LP19  probabilistic logic core         ← exact WMC over proof DAG
+        │
+        ├── LP19a  d-DNNF compilation     ← scales WMC formula side
+        ├── LP19b  rational arithmetic    ← scales WMC precision side
+        ├── LP19c  conditional probability ← P(query | evidence) via WMC ratio
+        ├── LP19d  approximate inference  ← Monte Carlo over WMC's worlds
+        └── LP19e  LR aggregation         ← THIS SPEC: log-odds composition
+                                            for Bayesian inference
+```
+
+LP19e is purely additive. Existing `SearchMode::FindFirst`,
+`EnumerateAll`, `AutoDetect` modes continue to work unchanged. A new
+`SearchMode::LRAggregate` variant joins them, and `AutoDetect` learns
+to route to it.
+
+## The new clause types
+
+ADJ14 specifies the **user-facing rule subtypes** (`prior`,
+`contributes`, `contributes_jointly`) that the connector recognises.
+This spec defines the **engine-internal clause types** that result
+from lowering them.
+
+```rust
+/// A prior probability for a conclusion. Required exactly once per
+/// conclusion that participates in LR aggregation. Multiple priors
+/// for the same conclusion is a KB-construction error
+/// (`KbError::ConflictingPriors`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct PriorClause {
+    pub id: PriorClauseId,
+    pub conclusion: Term,
+    pub prior_logit: f64,      // log(p / (1 - p))
+}
+
+/// A single-source likelihood-ratio contribution. Multiple
+/// contributions per (conclusion, evidence_term) pair are permitted
+/// — they sum in log-odds — and used for cross-rulebook composition.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ContributionClause {
+    pub id: ContributionClauseId,
+    pub conclusion: Term,
+    pub evidence_term: Term,
+    pub logit_delta: f64,      // log(LR)
+}
+
+/// A joint-evidence interaction term. Active iff every term in
+/// evidence_set is observed in the current KB. Synergy if
+/// joint_logit_delta > 0; suppression / explaining-away if < 0.
+#[derive(Debug, Clone, PartialEq)]
+pub struct JointContributionClause {
+    pub id: JointContributionClauseId,
+    pub conclusion: Term,
+    pub evidence_set: Vec<Term>,
+    pub joint_logit_delta: f64,
+}
+```
+
+Each new clause type carries a fresh-typed id so it can be cited in
+proof-DAG steps and in the lowering map (ADJ15).
+
+## The KB extension
+
+`KnowledgeBase` grows three additive parallel maps (none break
+existing Fact / Rule storage):
+
+```rust
+pub struct KnowledgeBase {
+    // …existing fact and rule indexes…
+
+    priors:        HashMap<Term, PriorClause>,                       // new
+    contributions: HashMap<Term, Vec<ContributionClause>>,           // new
+    joint_contributions: HashMap<Term, Vec<JointContributionClause>>,// new
+}
+```
+
+Three new accessors:
+
+```rust
+impl KnowledgeBase {
+    pub fn prior_for(&self, conclusion: &Term) -> Option<&PriorClause>;
+    pub fn contributions_for(&self, conclusion: &Term) -> &[ContributionClause];
+    pub fn joint_contributions_for(&self, conclusion: &Term) -> &[JointContributionClause];
+
+    pub fn add_prior(&mut self, clause: PriorClause) -> Result<(), KbError>;
+    pub fn add_contribution(&mut self, clause: ContributionClause);
+    pub fn add_joint_contribution(&mut self, clause: JointContributionClause);
+
+    /// True iff at least one contribution names `conclusion` as its target.
+    pub fn participates_in_lr_aggregation(&self, conclusion: &Term) -> bool;
+}
+```
+
+`add_prior` is the only one that can fail — `ConflictingPriors` if a
+prior for the same conclusion already exists.
+
+## The new SearchMode variant
+
+```rust
+pub enum SearchMode {
+    FindFirst,
+    EnumerateAll,
+    AutoDetect,
+    LRAggregate,    // new in LP19e
+}
+```
+
+And a new result variant:
+
+```rust
+pub enum SearchResult {
+    FindFirstResult(Option<Substitution>),
+    EnumerateAllResult { dag: ProofDAG, probability: f64 },
+    LRAggregateResult { dag: ProofDAG, posterior: f64, posterior_logit: f64 },
+        // new in LP19e
+}
+```
+
+`LRAggregateResult.dag` carries one `Proof` whose `steps` enumerate
+the prior, every active contribution, and every active joint
+contribution — in evaluation order.
+
+## The inference algorithm
+
+```rust
+fn lr_aggregate(query: &Term, kb: &KnowledgeBase) -> LRAggregateResult {
+    // 1. Require a prior. Without it, we cannot start.
+    let prior = match kb.prior_for(query) {
+        Some(p) => p,
+        None => {
+            // No prior → fall through with logit = 0 (P = 0.5), warned.
+            return LRAggregateResult::no_prior(query.clone());
+        }
+    };
+
+    let mut steps = vec![ProofStep {
+        goal: query.clone(),
+        origin: DerivationOrigin::FromPrior {
+            clause_id: prior.id,
+            prior_logit: prior.prior_logit,
+        },
+    }];
+    let mut logit = prior.prior_logit;
+    let mut via_facts: Vec<FactId> = Vec::new();
+    let mut via_rules: Vec<RuleId> = Vec::new();
+
+    // 2. Apply every active single-source contribution.
+    for contrib in kb.contributions_for(query) {
+        if let Some(observed_fact_ids) = kb.observed_evidence(&contrib.evidence_term) {
+            steps.push(ProofStep {
+                goal: query.clone(),
+                origin: DerivationOrigin::FromContribution {
+                    clause_id: contrib.id,
+                    evidence_fact_ids: observed_fact_ids.clone(),
+                    logit_delta: contrib.logit_delta,
+                },
+            });
+            logit += contrib.logit_delta;
+            via_facts.extend(observed_fact_ids);
+        }
+    }
+
+    // 3. Apply every active joint contribution.
+    for joint in kb.joint_contributions_for(query) {
+        let mut all_observed = true;
+        let mut every_evidence: Vec<FactId> = Vec::new();
+        for ev_term in &joint.evidence_set {
+            match kb.observed_evidence(ev_term) {
+                Some(ids) => every_evidence.extend(ids),
+                None => { all_observed = false; break; }
+            }
+        }
+        if all_observed {
+            steps.push(ProofStep {
+                goal: query.clone(),
+                origin: DerivationOrigin::FromJointContribution {
+                    clause_id: joint.id,
+                    evidence_fact_ids: every_evidence,
+                    joint_logit_delta: joint.joint_logit_delta,
+                },
+            });
+            logit += joint.joint_logit_delta;
+        }
+    }
+
+    // 4. Convert to posterior and emit.
+    let posterior = sigmoid(logit);
+    LRAggregateResult {
+        dag: ProofDAG {
+            root_query: query.clone(),
+            proofs: vec![Proof {
+                bindings: Substitution::empty(),
+                steps,
+                via_facts: dedup(via_facts),
+                via_rules,
+                posterior_logit: Some(logit),
+                posterior_probability: Some(posterior),
+            }],
+        },
+        posterior,
+        posterior_logit: logit,
+    }
+}
+
+fn sigmoid(x: f64) -> f64 {
+    if x >= 0.0 {
+        let z = (-x).exp();
+        1.0 / (1.0 + z)
+    } else {
+        // Numerically stable for very negative x: avoids exp(huge) overflow.
+        let z = x.exp();
+        z / (1.0 + z)
+    }
+}
+```
+
+**Complexity**: linear in the number of contributions and joint
+contributions naming the query. The 2ⁿ-world enumeration that WMC
+needs is *not* required for this inference shape — the
+conditional-independence assumption makes the math collapse to a sum.
+
+## AutoDetect: extended routing
+
+`AutoDetect` chooses between `FindFirst`, `EnumerateAll`, and
+`LRAggregate` per query. The decision tree:
+
+```text
+                  query: Q
+                     │
+                     ▼
+    ┌───────────────────────────────────┐
+    │ kb.participates_in_lr_aggregation(Q) ?
+    └───────────────────────────────────┘
+            │ yes                  │ no
+            ▼                      ▼
+    ┌─────────────┐    ┌───────────────────────┐
+    │ LRAggregate │    │ kb.is_all_certain() ? │
+    └─────────────┘    └───────────────────────┘
+                              │ yes        │ no
+                              ▼            ▼
+                       ┌──────────┐  ┌──────────────┐
+                       │ FindFirst│  │ EnumerateAll │
+                       └──────────┘  └──────────────┘
+```
+
+Per ADJ14, the connector raises `MixedShapeOnSameConclusion` when a
+query is the target of *both* `contributes(*, *, Q)` and
+`probabilistic(p, Q, …)` — i.e., the user has declared both
+inference shapes for the same conclusion. The engine never sees this
+case (the connector rejects it at lowering time), but the routing
+code asserts it as an invariant for defense in depth.
+
+## Observed evidence — what counts as "observed"
+
+The algorithm above calls `kb.observed_evidence(term) -> Option<Vec<FactId>>`.
+Its semantics:
+
+- A `Fact` clause with this term, polarity = Affirmed, and
+  `Probability::Certain`: returns the fact's id.
+- A `Fact` clause with this term and polarity = Affirmed but
+  `Probability::Value(p)`: the fact is *probabilistically observed*.
+  For LR aggregation, the spec's v0.1 treats this as observed with
+  full weight (the probability-of-observation enters separately via
+  the extractor-LR — see ADJ14 §"Reinterpreting IRNode::confidence");
+  v0.2 will route to a more careful treatment.
+- A `Fact` with polarity = Denied: **not observed**. The
+  contribution is not applied. A separate `contributes(LR, ¬e, c)`
+  clause is the right way to model "absence of evidence is evidence
+  of absence."
+- No matching fact in the KB: not observed. Skipped.
+
+This deliberately keeps the "observation gate" mechanical and
+inspectable. Adding latent variables is a future-work item.
+
+## Proof DAG integration
+
+`Proof` grows two additive fields:
+
+```rust
+pub struct Proof {
+    pub bindings: Substitution,
+    pub steps: Vec<ProofStep>,
+    pub via_facts: Vec<FactId>,
+    pub via_rules: Vec<RuleId>,
+    pub posterior_logit: Option<f64>,        // new
+    pub posterior_probability: Option<f64>,  // new
+}
+```
+
+Both are `Option<f64>`:
+- `Some(_)` after an `LRAggregate` search.
+- `None` after `FindFirst`, `EnumerateAll`, or `AutoDetect → WMC`.
+
+`DerivationOrigin` grows three additive variants (already specified
+in ADJ14):
+
+```rust
+pub enum DerivationOrigin {
+    FromFact(FactId),
+    FromRule(RuleId),
+    FromPrior { clause_id: PriorClauseId, prior_logit: f64 },
+    FromContribution {
+        clause_id: ContributionClauseId,
+        evidence_fact_ids: Vec<FactId>,
+        logit_delta: f64,
+    },
+    FromJointContribution {
+        clause_id: JointContributionClauseId,
+        evidence_fact_ids: Vec<FactId>,
+        joint_logit_delta: f64,
+    },
+}
+```
+
+A reviewer following the proof DAG reads the prior, then every
+contribution in evaluation order, with running logit reconstructible
+from the deltas. The DAG is the derivation.
+
+## Audit trail integration
+
+`adjudication-audit-trail::EngineArtifacts` grows three additive
+fields per ADJ14:
+
+```rust
+pub struct EngineArtifacts {
+    // …existing fields…
+    pub independence_assumption_used: bool,
+    pub lr_contributions: Vec<LrContributionRecord>,
+    pub prior_record: Option<PriorRecord>,
+}
+```
+
+Every `LrContributionRecord` carries:
+- the clause id and IR node id (via the lowering map of ADJ15),
+- the evidence facts' ids and IR node ids,
+- the LR value, the logit delta, and the running logit *after* this
+  contribution,
+- the source-span citations the proof is grounded in.
+
+The trail records the full computation, not the conclusion.
+
+## Edge cases
+
+### No prior declared
+The query falls through with `prior_logit = 0` (uniform). The result
+sets `prior_record = None` and adds a `Warning` to the audit trail.
+This is the only path the engine produces a "default" probability;
+explicit priors are encouraged.
+
+### No contributions active
+The result is the prior (i.e., `posterior == sigmoid(prior_logit)`).
+The proof DAG contains exactly one step (`FromPrior`). The
+derivation rendering surfaces this honestly: "no observed evidence
+contributes; verdict equals prior."
+
+### A contribution names an evidence atom that's not in the KB
+Silently skipped. Not an error — it's the common case when an
+LR table covers more symptoms than any one patient presents.
+
+### A `contributes(LR=1.0, …)` clause
+Permitted but a no-op. The engine emits a `Warning` once per such
+clause to surface likely modeler intent errors.
+
+### A negative or zero LR
+`LR ≤ 0` is rejected at clause construction. Negative log-odds are
+modeled with a positive LR less than 1 (e.g., LR=0.5 means the
+evidence halves the odds), per Bayesian convention.
+
+### Numerical stability
+Logit arithmetic is performed in `f64` with a final `sigmoid` step.
+For extreme logit values (`|logit| > 700`) the sigmoid saturates to
+0 or 1 by IEEE-754 rules — acceptable for the v0.1 implementation,
+with no quiet error. Deployments needing more precision can route
+through LP19b (rational arithmetic), which gets a future
+extension to support log-odds rationals.
+
+## Mode interaction with conditional probability (LP19c)
+
+`search_conditional(query, evidence, kb, mode)` is the LP19c API for
+conditional probability. With `mode = LRAggregate`:
+- Every observation in `evidence` is treated as an "observed" fact
+  for the purpose of `contributions_for(query)` matching.
+- The prior is unaffected by the evidence (priors are prior).
+- The contributions for the conclusion are filtered by which of
+  their `evidence_term`s are present in the conditioning set.
+
+This composition makes LP19c a perfect orthogonal layer on top of
+LP19e: declare evidence in the LP19c surface, get the LR-aggregated
+posterior automatically. Same proof DAG structure, same audit trail
+shape.
+
+## What's deliberately out of scope
+
+- **Learning LRs from labelled outcome data.** That belongs in
+  ADJ09 (rule compilation) or a future ADJ-calibration sub-spec.
+- **Drift detection / recalibration over time.** Same answer.
+- **Hierarchical priors** (a prior conditional on demographic
+  bucket, etc.). Representable today as one `prior(p, c)` per
+  bucket and a `contributes` from a demographic fact, but a
+  dedicated hierarchical primitive is a future addition.
+- **Soft observations** (an observation reported with its own
+  probability). v0.1 treats observation as Boolean; the
+  extractor-LR pathway in ADJ14 covers the LLM-confidence case.
+  Generalised soft observations are future work.
+
+## Open questions
+
+1. **How to fail loud on missing priors.** Default to uniform with
+   a warning, or refuse to run with `LRMissingPrior`? v0.1 says
+   warn-and-proceed; v0.2 may flip to refuse-by-default with a
+   configuration flag, as missing priors are a common rulebook
+   construction bug.
+2. **Multi-conclusion queries.** A clinical query may ask for the
+   posterior on *every* candidate diagnosis (the differential).
+   The current API runs one query at a time; a batched
+   `lr_aggregate_all(kb)` would compute every targeted conclusion
+   in one pass and could share evidence-presence checks. Performance
+   optimization; design in v0.2.
+3. **Cycles in joint contributions.** A `contributes_jointly([a, b],
+   c)` is straightforward. A `contributes_jointly([a, c], a)` is
+   not — the conclusion appears in its own evidence set. v0.1
+   rejects this at clause construction; v0.2 may consider
+   fixed-point semantics if a real use case appears.
+
+## Limitations
+
+1. **The independence assumption is not eliminated by joint terms.**
+   Joint contributions partially absorb correlation, but a fully
+   correlated set of evidence atoms still requires careful modeling.
+   The audit trail records the assumption as used; the modeler is
+   responsible for whether it's appropriate.
+2. **`contributes` clauses are flat.** Hierarchical contribution
+   (e.g., "abdominal symptoms" as an umbrella term that
+   `gastritis` and `appendicitis` contribute under) is not natively
+   modeled. A representation via `definitional` rules linking
+   abstract terms to ground evidence works today.
+3. **Engine numerical precision is f64.** Extreme priors or
+   long chains of contributions can saturate the sigmoid. LP19b
+   (rational) provides the path to higher precision when needed.
+
+## Status
+
+Draft. Implementation is straightforward and self-contained inside
+`logic-engine`: new clause types, new KB indexes, new SearchMode
+variant, new ProofDAG fields. No breaking changes to existing APIs.
+
+The connector's v2 (ADJ11 v2) is the integration deliverable that
+makes ADJ14's user-facing rule subtypes flow through this engine.
+
+## Where to read next
+
+- [ADJ14](ADJ14-probabilistic-ir-semantics.md) — the user-facing
+  semantics this sub-spec implements.
+- [LP19](LP19-probabilistic-logic-core.md) — the engine foundation
+  this sub-spec extends.
+- [LP19c](LP19c-conditional-probability-evidence.md) — the
+  conditional-probability layer that composes with this one.
+- [ADJ15](ADJ15-lowering-map-and-proof-dag.md) — the audit-trail
+  integration that surfaces this sub-spec's outputs.


### PR DESCRIPTION
## Summary

Spec-only PR. Two new specs that lock in the framework's central probabilistic inference model and the engine sub-spec that makes it executable.

**ADJ14 — Probabilistic IR Semantics** commits the framework to *Bayesian likelihood-ratio aggregation* as the dominant probabilistic inference shape — the math evidence-based medicine (LR+, LR−, pre-test/post-test odds), Bayesian forensic statistics, and quantitative legal-sufficiency review already use. Replaces the implicit "joint conjunctive ProbLog rule" reading with explicit `contributes(LR, evidence, conclusion)` clauses composed multiplicatively in log-odds space. The existing `definitional` / `probabilistic` / `constraint` / `default` rule subtypes remain available; the routing is `AutoDetect`-driven.

**LP19e — LR Aggregation Engine Sub-Spec** is the engine engineering deliverable. Sibling to LP19a (d-DNNF), LP19b (rational), LP19c (P|E), LP19d (Monte Carlo); fully additive to existing logic-engine APIs.

## Why this matters

The three consequences that fall out of locking in LR aggregation:

1. **Extractor confidence and clinical likelihood ratio unify.** `IRNode::confidence` (today "informational only") becomes a calibrated probability that lowers to an extractor-level LR. A model saying "I'm 80% sure I saw 'diarrhea'" and a rule saying "diarrhea has LR+ = 4 for stomach bug" become the *same kind of object*, composable via Bayes. Epistemic and aleatoric uncertainty share one channel.
2. **Fact-merge across documents falls out.** Two reports of the same observation from different sources are two independent contributions to the same latent — no max-confidence override, no ad-hoc weighted average. Sets up ADJ17 (knowledge store).
3. **The proof DAG becomes natively human-readable.** A verdict reads: *"P(stomach_bug) shifted from prior 10% → posterior 78% because diarrhea (F1, bytes 9..17) contributed LR=4.0, vomiting (F2, bytes 19..27) contributed LR=3.0, …"* — *that is* the defensibility deliverable. Sets up ADJ16 (derivation rendering).

## What ADJ14 defines

- Two required new Rule subtypes (`prior(P, c)`, `contributes(LR, e, c)`) plus an optional third (`contributes_jointly(LR_extra, [e1,...,en], c)`) for synergy / suppression interaction terms.
- Reinterpretation of `IRNode::confidence` with a `c / (1 − c)` LR mapping and a configurable `ε = 0.05` cutoff for treating high-confidence facts as Certain.
- Lowering rule for `NodeKind::Uncertainty` (today excluded from lowering) as a partially-observed atom.
- The explicit conditional-independence assumption + `contributes_jointly` as the escape hatch + audit-trail recording of when the assumption was used.
- Worked clinical example: differential diagnosis with prior + four single contributions + one joint synergy term yielding `P(stomach_bug | observed) = 78.3%` with every contribution citing an IR node id which cites source spans which cite source bytes.
- Compatibility rules with existing ProbLog primitives — `MixedShapeOnSameConclusion` rejected at lowering time.

## What LP19e defines

- Three new engine clause types (`PriorClause`, `ContributionClause`, `JointContributionClause`) — additive to existing `Fact` / `Rule` storage.
- `KnowledgeBase` gains three parallel indexes keyed on conclusion term; `ConflictingPriors` error on duplicate priors.
- New `SearchMode::LRAggregate` variant + new `SearchResult::LRAggregateResult { dag, posterior, posterior_logit }`.
- `AutoDetect` routing extended: queries whose conclusion participates in LR aggregation route to `LRAggregate`; all-certain → `FindFirst` short-circuit and probabilistic → `EnumerateAll + WMC` paths preserved unchanged.
- `Proof` grows additive `posterior_logit: Option<f64>` and `posterior_probability: Option<f64>` fields; `None` on non-LR paths.
- `DerivationOrigin` grows `FromPrior`, `FromContribution`, `FromJointContribution` variants — proof DAG carries every LR step as first-class data, not post-hoc reconstruction.
- O(n) inference cost in number of active contributions — the asymptotic win over WMC's 2ⁿ for this query shape.
- Composes orthogonally with LP19c — declare evidence at the LP19c surface, get LR-aggregated posterior automatically.

## Layer position

```
   ADJ01 (IR grammar v2)
        │
        ▼
   ADJ14 (THIS PR — probabilistic semantics)
        │
        ├──▶ ADJ11 v2 (connector — follow-up: lower contributes/prior subtypes)
        │
        ▼
   LP19e (THIS PR — engine inference mode)
        │
        ▼
   ADJ15 (follow-up: proof DAG in audit trail — typed, includes LRContribution)
        │
        ▼
   ADJ16 (follow-up: human-readable derivation rendering)
```

## What's deliberately deferred

- **Learning LRs from labelled data** — belongs in ADJ09 or a future calibration sub-spec.
- **Hierarchical priors** — representable today as one `prior(p, c)` per bucket + a `contributes` from a demographic fact; a dedicated primitive is future work.
- **Drift detection / re-calibration over time** — same answer.
- **Soft observations** (Boolean only in v0.1; the extractor-LR pathway covers the LLM-confidence case).

## Test plan

- [x] Both specs render correctly (markdown lint, cross-references valid)
- [x] LP19d → LP19e renumber audited (LP19d already taken by approximate-inference sub-spec; all 10 references updated)
- [ ] Follow-up PR: ADJ11 v2 connector recognises the new rule subtypes
- [ ] Follow-up PR: LP19e implementation in `logic-engine` (new clause types, SearchMode variant, AutoDetect routing)
- [ ] Follow-up PR: ADJ15 typed proof DAG in audit trail
- [ ] Follow-up PR: ADJ16 derivation renderer

🤖 Generated with [Claude Code](https://claude.com/claude-code)