### PR TITLE
docs(spec): ADJ12 v2 — 5-trial replication, corrected qwen2.5:1.5b row, methodology note

### DIFF
--- a/code/specs/ADJ12-small-model-benchmarks.md
+++ b/code/specs/ADJ12-small-model-benchmarks.md
@@ -36,17 +36,49 @@ All runs used the same canonical fixture:
 configured) was always `llama3.1:8b` to keep the (vendor,
 model_family) independence check passing.
 
-## Results (2026-05-12, local Ollama on macOS)
+## Results (v2 — 5-trial replication, 2026-06-01, M2 Max 96 GB, Ollama 0.23.2)
 
-| Model            | Params | Cold latency | ADJ02 | ADJ03 | ADJ04         | ADJ05         | ADJ06 fired? | Engine ran? |
-|------------------|--------|--------------|-------|-------|---------------|---------------|--------------|-------------|
-| `gemma4:latest`  | 8 B    | ~60 s        | Pass  | Pass  | Failed (drift)| Passed        | No           | Yes         |
-| `qwen2.5:3b`     | 3 B    | ~30 s        | Pass  | Pass  | Failed (drift)| Passed        | No           | Yes         |
-| `qwen2.5:1.5b`   | 1.5 B  | ~10 s        | Pass* | **Failed** | Skipped   | Skipped       | **Yes (1 round, resolved ADJ02)** | No (blocked at ADJ03) |
-| `qwen2.5:0.5b`   | 0.5 B  | ~10 s        | Pass  | Pass  | Failed (drift)| Failed (json) | No           | Yes         |
+The original v1 results were single-run point estimates. v2 re-runs
+each model 5 times against the canonical fixture, with no cache and
+default `max_clarify_attempts = 2`. The table reports per-cell pass
+rate (`n/5`) and mean latency.
 
-*qwen2.5:1.5b passed ADJ02 only after ADJ06 fired with the coverage
-violation and the model corrected its IR.
+| Model            | Params | Mean cold latency | ADJ02 | ADJ03 | ADJ04        | ADJ05      | ADJ06 fired               | Engine ran |
+|------------------|--------|-------------------|-------|-------|--------------|------------|---------------------------|------------|
+| `gemma4:latest`  | 8 B    | 75.8 s            | 5/5   | 5/5   | 0/5 (5/5 drift) | 5/5     | 0/5                       | 5/5        |
+| `qwen2.5:3b`     | 3 B    | 19.6 s            | 5/5   | 5/5   | 0/5 (5/5 drift) | 5/5     | 0/5                       | 5/5        |
+| `qwen2.5:1.5b`   | 1.5 B  | 19.2 s            | **0/5** | 5/5 | n/a (skipped) | n/a (skipped) | **5/5 (exhausted after 2 rounds)** | 0/5    |
+| `qwen2.5:0.5b`   | 0.5 B  | 13.8 s            | 5/5   | 5/5   | 0/5 (5/5 drift) | 0/5 (substantive disagreement, judge confirmed) | 0/5 | 5/5     |
+
+**Variance**: zero on every pass-fail cell. Every model produced the
+same outcome on all 5 trials. Latency varied ±2s on small models and
+±5s on gemma4; otherwise the framework is bit-stable on this
+fixture at `temperature: 0.0`.
+
+### What changed from v1
+
+1. **`qwen2.5:1.5b` does not recover via ADJ06 at the default
+   `max_clarify_attempts = 2`**. The v1 row reported a single-round
+   recovery with a trailing-asterisk note; v2 shows 0/5 recovery
+   over 5 trials with ADJ06 exhausting both retries every time. The
+   coverage gap is consistently at byte range `(12, 24)` — the
+   `", matches."` substring. The v1 result was likely either a
+   higher-`max_clarify_attempts` configuration or a different
+   `decompose_text` prompt revision; we have not reconstructed
+   which. **If the framework is to claim "1.5B recovers via ADJ06,"
+   the demonstration needs to specify the configuration that makes
+   it true.**
+2. **`qwen2.5:0.5b`'s ADJ05 failure is more interesting than v1
+   reported.** v1 logged a JSON parse error; v2 shows a substantive
+   adversarial finding ("the IR says 'Carry-on bag.', but a
+   plausible alternative reading is 'One carry-on bag is allowed.'")
+   that the llama3.1:8b judge upheld. This is the framework working
+   as intended — independent adversary surfaced a real ambiguity in
+   the extractor's IR — not a brittleness bug.
+3. **Latency on M2 Max**: small models faster than v1 reported
+   (~14–20 s vs ~10 s, but v1 didn't quantify cold-load overhead);
+   gemma4 slower (~76 s vs ~60 s, likely an Ollama version
+   difference or thinking-mode token budget change).
 
 ## Interpretation
 
@@ -73,13 +105,18 @@ violation and the model corrected its IR.
    model feedback; the model didn't get smarter.**
 
 4. **Different small models surface different failure modes**:
-   - qwen1.5b: ADJ02 needs one retry; then ADJ03 catches a real
-     polarity/modality issue (likely the model getting the
-     polarity of "matches" wrong).
-   - qwen0.5b: ADJ02 passes cleanly; ADJ05 errors on malformed
-     JSON (the truncation-retry helper handles transient cases
-     but a fundamentally malformed response surfaces as `Failed`
-     with the parse error in `telemetry.check_error`).
+   - qwen1.5b: ADJ02 fails consistently; ADJ06 cannot recover at
+     `max_clarify_attempts = 2`. **The framework correctly blocks
+     the verdict.** This is the right behavior — better to refuse
+     than to ship a flawed extraction — but it is not the "small
+     model + retry recovers" demonstration v1 claimed. Raise the
+     attempt count, or use a stronger extractor for this scale.
+   - qwen0.5b: ADJ02/ADJ03 pass cleanly; ADJ04 catches a renderer
+     drift and ADJ05 catches a substantive adversarial disagreement.
+     The pipeline blocks correctly. **At 0.5B parameters the
+     framework still produces a defensible verdict** — just one
+     that says "the model's IR is plausibly contestable, do not
+     act on it without review" rather than a green light.
 
 5. **Latency drops linearly with parameter count.** A 500 M model
    running locally completes the full pipeline in ~10 s. With the
@@ -94,11 +131,35 @@ violation and the model corrected its IR.
   parameter model with the structured pipeline is more reliable
   than the same model on its own — full stop.
 - ADJ06 is the load-bearing capability for the smaller end of the
-  spectrum. Below ~3 B parameters, expect ADJ02 to fail
-  occasionally; ADJ06 closes the loop.
+  spectrum. **Below ~3 B parameters, expect ADJ02 to fail and
+  expect ADJ06 to need more than 2 retries to recover.** The
+  default `max_clarify_attempts = 2` is too low for 1.5B-class
+  extractors on this fixture; bump it or accept the framework's
+  refusal-to-ship.
 - The cache is a force multiplier. Cold latencies in the
   10-60 s range are usable; warm latencies under 1 s are
   competitive with frontier-model network round-trips.
+
+## Methodological note on variance
+
+The v2 5-trial benchmark showed **zero variance on pass-fail outcomes**.
+Every model produced an identical cell on every trial, modulo
+±2-5 s latency noise. This is good news (the framework's
+`temperature: 0.0` + prompt-hash machinery delivers genuine
+reproducibility) and a warning (multi-trial benchmarks on a small
+fixture surface no new information — investing in fixture diversity
+gets more bang per benchmark-second than re-running the same fixture).
+
+For a publishable benchmark we recommend:
+
+- **One trial per cell**, not many.
+- **Many fixtures per domain** (~50, drawn from realistic source
+  distributions) — surfaces generalization, not noise.
+- **Explicit configuration disclosure** (model version, Ollama
+  version, `max_clarify_attempts`, prompt revision). The v1 → v2
+  divergence on `qwen2.5:1.5b` was caused by something in the
+  configuration we cannot reconstruct after the fact; better
+  hygiene prevents this.
 
 ## Future benchmark work
 
@@ -106,6 +167,13 @@ violation and the model corrected its IR.
   contract) and collate the full 4×3 matrix.
 - Add tinyllama, phi-3:mini, gemma3:1b, llama3.2:1b for
   cross-vendor coverage at the smaller scales.
+- **Scale up: benchmark qwen2.5:14b, qwen2.5:32b, llama3.1:70b**
+  on the same fixtures to identify where the framework's
+  structural-checker leverage stops paying compound interest.
+  Hypothesis: above ~14B params the raw arm becomes reliable
+  enough that ADJ02/03 stop catching errors, and the framework's
+  marginal contribution shifts to ADJ04/05 (drift + adversarial)
+  + audit trail (defensibility for high-stakes domains).
 - Wire ADJ06 to ADJ03/ADJ04/ADJ05 failures and measure how often
   the second attempt clears each pass.
 - Measure the cost of an in-process cache miss vs a disk-persisted


### PR DESCRIPTION
## Summary

Spec-only update to [ADJ12-small-model-benchmarks.md](code/specs/ADJ12-small-model-benchmarks.md) replacing the v1 single-run table with a 5-trial replication, correcting one row that does not reproduce at the current default settings, and surfacing a methodological finding about variance on small fixtures.

## What changed

- **Table is now pass/fail rates (n/5) plus mean latency** instead of single-point estimates.
- **`qwen2.5:1.5b` row corrected**: v1 said "Pass* (recovered via ADJ06 in 1 round)". v2 shows **0/5 recovery** — ADJ06 exhausts both retries (default `max_clarify_attempts = 2`) on the same byte-range gap `(12, 24)` every trial. The v1 configuration that produced recovery has not been reconstructed. Framework correctly Blocks the verdict; this is acceptable behavior, but it is not the "small model recovers via retry" demonstration v1 claimed.
- **`qwen2.5:0.5b` ADJ05** row updated: v1 logged "Failed (json)"; v2 shows a substantive adversarial finding upheld by the llama3.1:8b judge. Framework working as intended, not a brittleness bug.
- **Latencies** corrected to measured M2 Max 96 GB numbers (~14–20s small models, ~76s gemma4).

## Methodological finding

5-trial benchmark showed **zero variance on pass-fail cells** across all 4 models. Every cell came back identical on every trial. The framework is bit-stable on this fixture at `temperature: 0.0`. Multi-trial benchmarking surfaces no new information at this fixture size — the publishable benchmark should invest in **fixture diversity** (~50 per domain) rather than trial counts.

## Added future-work item

Scale up the benchmark to `qwen2.5:14b`, `qwen2.5:32b`, `llama3.1:70b` to identify the parameter count at which the raw arm becomes reliable enough that the framework's marginal contribution shifts from extraction-checking (ADJ02/03) to drift + adversarial verification (ADJ04/05) + audit-trail defensibility. Pulls for these are running in parallel in a follow-up session.

## Test plan

- [x] Markdown renders correctly
- [x] Both pass-rate table and methodological note are explicit about the configuration (`max_clarify_attempts = 2`, default `decompose_text` prompt, no cache, llama3.1:8b adversary)
- [x] qwen2.5:1.5b row honestly documents the failure rather than papering over it

🤖 Generated with [Claude Code](https://claude.com/claude-code)