### PR TITLE
feat(forme-doc-demo): wire browser search client into the demo

### DIFF
--- a/code/programs/typescript/forme-doc-demo/BUILD
+++ b/code/programs/typescript/forme-doc-demo/BUILD
@@ -18,6 +18,7 @@ cd ../../../packages/typescript/forme-doc-sidebar-builder && npm ci --quiet
 cd ../../../packages/typescript/forme-doc-page-shell && npm ci --quiet
 cd ../../../packages/typescript/forme-doc-search-tokenizer && npm ci --quiet
 cd ../../../packages/typescript/forme-doc-search-index-builder && npm ci --quiet
+cd ../../../packages/typescript/forme-doc-search-client-js && npm ci --quiet
 cd ../../../packages/typescript/forme-aot-page-bundle-emitter && npm ci --quiet
 cd ../../../packages/typescript/forme-aot-html-doc-emitter && npm ci --quiet
 cd ../../../packages/typescript/forme-doc-site-emitter && npm ci --quiet

--- a/code/programs/typescript/forme-doc-demo/CHANGELOG.md
+++ b/code/programs/typescript/forme-doc-demo/CHANGELOG.md
@@ -1,5 +1,110 @@
 # Changelog — forme-doc-demo
 
+## 0.2.0 — 2026-06-01
+
+Wire the browser-side search client into the demo so the
+header search box actually searches.  Closes the search loop
+end-to-end:
+
+```
+  user types in <input class="search">
+    → debounced 120ms
+    → SearchClient.search(q) in the browser
+    → fetches /search/manifest.json + needed shards
+    → renders dropdown of pageId + matched-token results
+    → click navigates to /pageId
+```
+
+### Added
+
+- `src/search-bundle.ts` — bundles
+  `forme-doc-search-client-js` + UI bootstrap into a single
+  self-executing IIFE script.  Uses esbuild (added as devDep).
+  Output is ~9KB minified, targets ES2020, no globals leaked.
+- `build.ts.buildIdFor(bundleSrc)` — content-addressed
+  12-hex-char hash used as a cache-bust query string on the
+  script tag + manifest + shard fetches.  Defeats Safari's
+  aggressive caching when we rebuild.
+- `BROWSER_ENTRY_SOURCE` template in `search-bundle.ts`:
+  - Finds `<input class="search">` (the page-shell's existing
+    rendered element — no markup changes needed).
+  - Builds a debounced `input` handler (120 ms debounce; stale-
+    query guard via monotonic queryId).
+  - Renders results as a `<ul role="listbox">` floated at
+    `position: fixed` and anchored to the input via
+    `getBoundingClientRect()`.  Repositioned on scroll/resize.
+  - Click-outside + ESC dismissal.
+  - XSS-safe — every text insertion is `textContent`, never
+    `innerHTML`.
+- Map adapter inside the bootstrap's `fetchShard` callback —
+  converts the server's JSON-object `postings` (Maps don't
+  survive `JSON.stringify`) back into a `Map<string, Posting[]>`
+  so SearchClient's `isLikelyShard` shape check passes.
+- 13 new tests in `tests/search-bundle.test.ts`:
+  - **Unit** (7): bundle is non-empty, IIFE-wrapped, contains
+    SearchClient + tokenize + Map-adapter + correct DOM
+    selector + buildId reader; size ≤ 20KB minified.
+  - **End-to-end in JSDOM** (6): builds the site fresh,
+    stubs fetch, types queries into the rendered input, and
+    asserts the dropdown populates with real results.
+    Regression suite for the two bugs we caught in dev:
+    (a) "No matches" for every query — caused by `plainText`
+        reading `node.text` instead of `node.value`; the
+        search index ended up with only title tokens.
+    (b) "No matches" after Safari cache pinning — caused by
+        a stable client.js URL; fixed via the content-
+        addressed cache-bust above.
+
+### Fixed
+
+- **`plainText` was returning empty string for every page** —
+  it read `node.text`, but `commonmark-parser`'s `TextNode`
+  uses `node.value`.  Fixed to accept BOTH field names
+  defensively.  Index goes from 10 → 345 unique tokens on the
+  6-page corpus.  Regression test in `tests/build.test.ts`.
+- **CSS selector typo** — the theme styled `header .search
+  input` (descendant input of `.search`) but the rendered
+  element is `input.search` (input WITH class).  Search input
+  was using browser defaults instead of the themed style.
+- **Dropdown messed up the header layout** — original
+  placement put the dropdown as a sibling of the input inside
+  the `display: flex` header, making it a flex item.  Now
+  appended to `<body>` at `position: fixed` with coords
+  computed from `input.getBoundingClientRect()` — independent
+  of any ancestor styling, no layout disruption.
+- **Safari cache pinning** — every build now produces a unique
+  `?v=<sha256-12chars>` cache-bust on script + JSON URLs.
+
+### Added — UI styling
+
+- `header input.search` properly styled (border, padding,
+  focus ring), `min-width: 280px`.
+
+### Tests
+
+74 total (was 56):
+
+- 61 in `tests/build.test.ts` (added 3 for `buildIdFor` + 2
+  for `plainText`'s new `value`-field support)
+- 13 in `tests/search-bundle.test.ts` (new file)
+
+Coverage: **85.4% line / 92.3% branch / 90.5% function**.
+Per-file: `build.ts` 100% / 97.8% / 100%; `plain-text.ts`
+100% / 100% / 100%; `search-bundle.ts` 93.1% / 66.7% / 100%
+(uncovered lines are the defensive throw paths in
+`bundleSearchClient` for esbuild's unexpected-output case);
+`main.ts` 65% (CLI bootstrap, integration-tested via
+`npm start`).
+
+### Dependencies
+
+- Added `@coding-adventures/forme-doc-search-client-js` (was
+  only consumed transitively via emitter types; now imported
+  directly for the browser bundle).
+- Added `esbuild` as devDep (for the browser bundle step).
+- Added `jsdom@22` as devDep (for the end-to-end test).
+- BUILD chains the new `forme-doc-search-client-js` install.
+
 ## 0.1.0 — 2026-05-22
 
 Initial release.  End-to-end demo of the DOC00 v0 cluster —

--- a/code/programs/typescript/forme-doc-demo/README.md
+++ b/code/programs/typescript/forme-doc-demo/README.md
@@ -34,8 +34,11 @@ Open the printed URL.  The demo includes:
   css).
 - A working sidebar with one group (Guide) and three top-level
   pages.
-- A pre-built search index (one manifest + ten alphabetised
-  shards under `/search/`).
+- A pre-built search index (one manifest + ~130 alphabetised
+  shards under `/search/`) PLUS a working browser search box
+  in the header — try typing `install`, `widget`, `theme`,
+  `deno`, `render`.  Results dropdown is debounced (120 ms);
+  ESC clears; click outside dismisses.
 
 ## What it actually does
 
@@ -197,6 +200,56 @@ Putting the demo here means:
 - Killing or replacing the demo doesn't churn any of the 11
   shipped library packages.
 
+## Search wire-up
+
+The demo bundles `forme-doc-search-client-js` (plus its only
+dep, `forme-doc-search-tokenizer`) via esbuild into a single
+~9KB self-executing IIFE, written to `/search/client.js` and
+loaded by every page with a `<script defer>` tag.  The
+bootstrap inside the bundle:
+
+- Finds the page-shell's existing `<input class="search">`.
+- Lazily fetches `/search/manifest.json` on the first
+  keystroke (one round-trip per session; cached via
+  `SearchClient`'s built-in LRU).
+- Renders results as a floating dropdown anchored under the
+  input via `getBoundingClientRect()` + `position: fixed` —
+  doesn't disturb the header flex layout, doesn't depend on
+  any ancestor's positioning context.
+- Every keystroke is debounced 120 ms; stale-query guard
+  via a monotonic `queryId`.
+- ESC clears, click-outside dismisses, focus re-opens if
+  there's text.
+
+### Cache busting
+
+Every build computes a 12-hex-char SHA-256 of the bundle and
+uses it as a `?v=<id>` query string on the script tag AND on
+the manifest / shard fetches.  Same content → same hash →
+browser cache reused; different content → new URL → browser
+re-fetches.  Defeats Safari's aggressive same-URL caching,
+which would otherwise pin a stale client.js across rebuilds.
+
+### Shape adapter
+
+`forme-doc-site-emitter` serialises shard `postings` as plain
+JSON objects (Maps don't survive `JSON.stringify`).  The
+browser-side `fetchShard` callback converts each object back
+into a `Map<token, Posting[]>` so `SearchClient.isLikelyShard`
+accepts the shape:
+
+```ts
+async function fetchShard(key) {
+  const raw = await (await fetch(`/search/${key}.json?v=${buildId}`)).json();
+  return { shardKey: raw.shardKey, postings: new Map(Object.entries(raw.postings)) };
+}
+```
+
+This adapter lives at the consumer boundary, not in either
+library — neither `forme-doc-search-client-js` (capability
+`[]`) nor `forme-doc-site-emitter` (capability `[]`) had to
+change to make search work in the browser.
+
 ## v0 simplifications
 
 - No watch mode / live reload (run `npm start` again after
@@ -204,9 +257,7 @@ Putting the demo here means:
 - No multi-locale support.
 - No custom theme system — one inlined stylesheet.
 - No image / asset copying — corpus is text-only.
-- No search-client JS yet (the demo emits manifest + shards but
-  no `client.js` — building the bundle is the consumer-side
-  concern documented in `forme-doc-search-client-js`).
+- Search bundle uses esbuild; v1 could swap for rollup / tsc.
 
-These belong in v1+; the point of this demo is to prove the
-cluster composes correctly end-to-end.
+The cluster composes correctly end-to-end and the search
+loop closes in the browser.

--- a/code/programs/typescript/forme-doc-demo/package-lock.json
+++ b/code/programs/typescript/forme-doc-demo/package-lock.json
@@ -18,6 +18,7 @@
         "@coding-adventures/forme-doc-frontmatter": "file:../../../packages/typescript/forme-doc-frontmatter",
         "@coding-adventures/forme-doc-heading-anchors": "file:../../../packages/typescript/forme-doc-heading-anchors",
         "@coding-adventures/forme-doc-page-shell": "file:../../../packages/typescript/forme-doc-page-shell",
+        "@coding-adventures/forme-doc-search-client-js": "file:../../../packages/typescript/forme-doc-search-client-js",
         "@coding-adventures/forme-doc-search-index-builder": "file:../../../packages/typescript/forme-doc-search-index-builder",
         "@coding-adventures/forme-doc-search-tokenizer": "file:../../../packages/typescript/forme-doc-search-tokenizer",
         "@coding-adventures/forme-doc-sidebar-builder": "file:../../../packages/typescript/forme-doc-sidebar-builder",
@@ -27,12 +28,14 @@
       },
       "devDependencies": {
         "@vitest/coverage-v8": "^3.0.0",
+        "esbuild": "^0.24.0",
         "tsx": "^4.0.0",
         "typescript": "^5.0.0",
         "vitest": "^3.0.0"
       }
     },
     "../../../packages/typescript/commonmark-parser": {
+      "name": "@coding-adventures/commonmark-parser",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -48,6 +51,7 @@
       }
     },
     "../../../packages/typescript/document-ast": {
+      "name": "@coding-adventures/document-ast",
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
@@ -57,6 +61,7 @@
       }
     },
     "../../../packages/typescript/document-ast-to-html": {
+      "name": "@coding-adventures/document-ast-to-html",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -69,6 +74,7 @@
       }
     },
     "../../../packages/typescript/forme-aot-html-doc-emitter": {
+      "name": "@coding-adventures/forme-aot-html-doc-emitter",
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
@@ -78,6 +84,7 @@
       }
     },
     "../../../packages/typescript/forme-aot-page-bundle-emitter": {
+      "name": "@coding-adventures/forme-aot-page-bundle-emitter",
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
@@ -87,6 +94,7 @@
       }
     },
     "../../../packages/typescript/forme-doc-code-block-decorator": {
+      "name": "@coding-adventures/forme-doc-code-block-decorator",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -99,6 +107,7 @@
       }
     },
     "../../../packages/typescript/forme-doc-frontmatter": {
+      "name": "@coding-adventures/forme-doc-frontmatter",
       "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
@@ -118,6 +127,7 @@
       }
     },
     "../../../packages/typescript/forme-doc-heading-anchors": {
+      "name": "@coding-adventures/forme-doc-heading-anchors",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -130,6 +140,7 @@
       }
     },
     "../../../packages/typescript/forme-doc-page-shell": {
+      "name": "@coding-adventures/forme-doc-page-shell",
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
@@ -138,7 +149,21 @@
         "vitest": "^3.0.0"
       }
     },
+    "../../../packages/typescript/forme-doc-search-client-js": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/forme-doc-search-index-builder": "file:../forme-doc-search-index-builder",
+        "@coding-adventures/forme-doc-search-tokenizer": "file:../forme-doc-search-tokenizer"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
     "../../../packages/typescript/forme-doc-search-index-builder": {
+      "name": "@coding-adventures/forme-doc-search-index-builder",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -151,6 +176,7 @@
       }
     },
     "../../../packages/typescript/forme-doc-search-tokenizer": {
+      "name": "@coding-adventures/forme-doc-search-tokenizer",
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
@@ -160,6 +186,7 @@
       }
     },
     "../../../packages/typescript/forme-doc-sidebar-builder": {
+      "name": "@coding-adventures/forme-doc-sidebar-builder",
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
@@ -169,6 +196,7 @@
       }
     },
     "../../../packages/typescript/forme-doc-site-emitter": {
+      "name": "@coding-adventures/forme-doc-site-emitter",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -183,6 +211,7 @@
       }
     },
     "../../../packages/typescript/forme-doc-syntax-highlighter": {
+      "name": "@coding-adventures/forme-doc-syntax-highlighter",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -195,6 +224,7 @@
       }
     },
     "../../../packages/typescript/forme-doc-toc-extractor": {
+      "name": "@coding-adventures/forme-doc-toc-extractor",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -311,6 +341,10 @@
       "resolved": "../../../packages/typescript/forme-doc-page-shell",
       "link": true
     },
+    "node_modules/@coding-adventures/forme-doc-search-client-js": {
+      "resolved": "../../../packages/typescript/forme-doc-search-client-js",
+      "link": true
+    },
     "node_modules/@coding-adventures/forme-doc-search-index-builder": {
       "resolved": "../../../packages/typescript/forme-doc-search-index-builder",
       "link": true
@@ -336,9 +370,9 @@
       "link": true
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
+      "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
       "cpu": [
         "ppc64"
       ],
@@ -352,9 +386,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
+      "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
       "cpu": [
         "arm"
       ],
@@ -368,9 +402,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
+      "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
       "cpu": [
         "arm64"
       ],
@@ -384,9 +418,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
+      "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
       "cpu": [
         "x64"
       ],
@@ -400,9 +434,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
+      "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
       "cpu": [
         "arm64"
       ],
@@ -416,9 +450,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
+      "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
       "cpu": [
         "x64"
       ],
@@ -432,9 +466,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
       "cpu": [
         "arm64"
       ],
@@ -448,9 +482,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
+      "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
       "cpu": [
         "x64"
       ],
@@ -464,9 +498,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
+      "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
       "cpu": [
         "arm"
       ],
@@ -480,9 +514,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
+      "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
       "cpu": [
         "arm64"
       ],
@@ -496,9 +530,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
+      "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
       "cpu": [
         "ia32"
       ],
@@ -512,9 +546,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
+      "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
       "cpu": [
         "loong64"
       ],
@@ -528,9 +562,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
+      "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
       "cpu": [
         "mips64el"
       ],
@@ -544,9 +578,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
+      "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
       "cpu": [
         "ppc64"
       ],
@@ -560,9 +594,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
+      "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
       "cpu": [
         "riscv64"
       ],
@@ -576,9 +610,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
+      "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
       "cpu": [
         "s390x"
       ],
@@ -592,9 +626,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
+      "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
       "cpu": [
         "x64"
       ],
@@ -608,9 +642,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
       "cpu": [
         "arm64"
       ],
@@ -624,9 +658,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
       "cpu": [
         "x64"
       ],
@@ -640,9 +674,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
       "cpu": [
         "arm64"
       ],
@@ -656,9 +690,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
       "cpu": [
         "x64"
       ],
@@ -688,9 +722,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
+      "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
       "cpu": [
         "x64"
       ],
@@ -704,9 +738,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
+      "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
       "cpu": [
         "arm64"
       ],
@@ -720,9 +754,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
+      "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
       "cpu": [
         "ia32"
       ],
@@ -736,9 +770,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
+      "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
       "cpu": [
         "x64"
       ],
@@ -1486,9 +1520,9 @@
       "dev": true
     },
     "node_modules/esbuild": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
+      "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -1498,32 +1532,31 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.0",
-        "@esbuild/android-arm": "0.28.0",
-        "@esbuild/android-arm64": "0.28.0",
-        "@esbuild/android-x64": "0.28.0",
-        "@esbuild/darwin-arm64": "0.28.0",
-        "@esbuild/darwin-x64": "0.28.0",
-        "@esbuild/freebsd-arm64": "0.28.0",
-        "@esbuild/freebsd-x64": "0.28.0",
-        "@esbuild/linux-arm": "0.28.0",
-        "@esbuild/linux-arm64": "0.28.0",
-        "@esbuild/linux-ia32": "0.28.0",
-        "@esbuild/linux-loong64": "0.28.0",
-        "@esbuild/linux-mips64el": "0.28.0",
-        "@esbuild/linux-ppc64": "0.28.0",
-        "@esbuild/linux-riscv64": "0.28.0",
-        "@esbuild/linux-s390x": "0.28.0",
-        "@esbuild/linux-x64": "0.28.0",
-        "@esbuild/netbsd-arm64": "0.28.0",
-        "@esbuild/netbsd-x64": "0.28.0",
-        "@esbuild/openbsd-arm64": "0.28.0",
-        "@esbuild/openbsd-x64": "0.28.0",
-        "@esbuild/openharmony-arm64": "0.28.0",
-        "@esbuild/sunos-x64": "0.28.0",
-        "@esbuild/win32-arm64": "0.28.0",
-        "@esbuild/win32-ia32": "0.28.0",
-        "@esbuild/win32-x64": "0.28.0"
+        "@esbuild/aix-ppc64": "0.24.2",
+        "@esbuild/android-arm": "0.24.2",
+        "@esbuild/android-arm64": "0.24.2",
+        "@esbuild/android-x64": "0.24.2",
+        "@esbuild/darwin-arm64": "0.24.2",
+        "@esbuild/darwin-x64": "0.24.2",
+        "@esbuild/freebsd-arm64": "0.24.2",
+        "@esbuild/freebsd-x64": "0.24.2",
+        "@esbuild/linux-arm": "0.24.2",
+        "@esbuild/linux-arm64": "0.24.2",
+        "@esbuild/linux-ia32": "0.24.2",
+        "@esbuild/linux-loong64": "0.24.2",
+        "@esbuild/linux-mips64el": "0.24.2",
+        "@esbuild/linux-ppc64": "0.24.2",
+        "@esbuild/linux-riscv64": "0.24.2",
+        "@esbuild/linux-s390x": "0.24.2",
+        "@esbuild/linux-x64": "0.24.2",
+        "@esbuild/netbsd-arm64": "0.24.2",
+        "@esbuild/netbsd-x64": "0.24.2",
+        "@esbuild/openbsd-arm64": "0.24.2",
+        "@esbuild/openbsd-x64": "0.24.2",
+        "@esbuild/sunos-x64": "0.24.2",
+        "@esbuild/win32-arm64": "0.24.2",
+        "@esbuild/win32-ia32": "0.24.2",
+        "@esbuild/win32-x64": "0.24.2"
       }
     },
     "node_modules/estree-walker": {
@@ -2263,6 +2296,447 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
       }
     },
     "node_modules/typescript": {

--- a/code/programs/typescript/forme-doc-demo/package.json
+++ b/code/programs/typescript/forme-doc-demo/package.json
@@ -26,6 +26,7 @@
     "@coding-adventures/forme-doc-page-shell": "file:../../../packages/typescript/forme-doc-page-shell",
     "@coding-adventures/forme-doc-search-tokenizer": "file:../../../packages/typescript/forme-doc-search-tokenizer",
     "@coding-adventures/forme-doc-search-index-builder": "file:../../../packages/typescript/forme-doc-search-index-builder",
+    "@coding-adventures/forme-doc-search-client-js": "file:../../../packages/typescript/forme-doc-search-client-js",
     "@coding-adventures/forme-doc-site-emitter": "file:../../../packages/typescript/forme-doc-site-emitter",
     "@coding-adventures/forme-aot-html-doc-emitter": "file:../../../packages/typescript/forme-aot-html-doc-emitter",
     "@coding-adventures/forme-aot-page-bundle-emitter": "file:../../../packages/typescript/forme-aot-page-bundle-emitter"
@@ -34,6 +35,8 @@
     "typescript": "^5.0.0",
     "tsx": "^4.0.0",
     "vitest": "^3.0.0",
-    "@vitest/coverage-v8": "^3.0.0"
+    "@vitest/coverage-v8": "^3.0.0",
+    "esbuild": "^0.24.0",
+    "jsdom": "^22.0.0"
   }
 }

--- a/code/programs/typescript/forme-doc-demo/src/build.ts
+++ b/code/programs/typescript/forme-doc-demo/src/build.ts
@@ -49,6 +49,8 @@
  * then composed by `forme-doc-site-emitter.emitSite`.
  */
 
+import { createHash } from "node:crypto";
+
 import { extractFrontmatter } from "@coding-adventures/forme-doc-frontmatter";
 import { parse as parseMarkdown } from "@coding-adventures/commonmark-parser";
 import { generateHeadingAnchors } from "@coding-adventures/forme-doc-heading-anchors";
@@ -111,8 +113,40 @@ export function build(files: readonly MarkdownFile[], options: BuildOptions): Pa
   const sidebar = normaliseSidebarPaths(rawSidebar);
 
   // -- Step 3: render every page's HTML -------------------------
+  //
+  // headExtra carries:
+  //   - the inlined theme stylesheet, and
+  //   - (if `options.searchClientJs` is set) a <script> tag
+  //     that loads /search/client.js with `defer` so DOM is
+  //     parsed before the bootstrap runs.
+  //
+  // Loading the search script from a separate URL (rather
+  // than inlining the entire bundle into every page) means it
+  // is cached once per visit; the manifest fetch fires
+  // exactly once across the whole session via SearchClient's
+  // built-in caching.
+  //
+  // CACHE-BUST: the script src includes a `?v=<buildId>` query
+  // string derived from a SHA-256 of the bundle bytes (or the
+  // process start timestamp if no bundle is supplied — irrelevant
+  // there since there's nothing to load).  Safari in particular
+  // is aggressive about caching same-URL JS / JSON; without a
+  // unique query each build, a returning visitor sees the
+  // PREVIOUS build's search client even after we redeploy.
+  // We pass the same `?v=` to the manifest + shard fetches via
+  // an inlined `window.__formeDocSearchBuildId` constant the
+  // bootstrap reads.
   const themeCss = options.themeCss ?? DEFAULT_THEME_CSS;
-  const headExtra = `<style>${themeCss}</style>`;
+  const hasSearch =
+    options.searchClientJs !== undefined && options.searchClientJs.length > 0;
+  const buildId = hasSearch
+    ? buildIdFor(options.searchClientJs!)
+    : "";
+  const searchScriptTag = hasSearch
+    ? `<script>window.__formeDocSearchBuildId=${JSON.stringify(buildId)};</script>` +
+      `<script src="/search/client.js?v=${encodeURIComponent(buildId)}" defer></script>`
+    : "";
+  const headExtra = `<style>${themeCss}</style>${searchScriptTag}`;
   const pages = parsed.map((p) => renderPage(p, sidebar, options, headExtra));
 
   // -- Step 4: build the search index ---------------------------
@@ -365,6 +399,26 @@ function normaliseOne<
 }
 
 /**
+ * Compute a short, content-addressed build ID from the bundled
+ * search-client source.  Used as a cache-bust query string on
+ * the script tag + fetch URLs so a returning visitor never
+ * sees a stale bundle after we rebuild.
+ *
+ * Content-addressed (first 12 hex chars of SHA-256) means:
+ *   - Same bundle content → same ID → browser reuses its cache
+ *     (good — we WANT cache hits when nothing changed).
+ *   - Different bundle content → different ID → forced re-fetch
+ *     (good — we want fresh content when we ship).
+ *
+ * 12 hex chars = 48 bits of entropy — collisions essentially
+ * impossible across realistic build counts.  Short enough to
+ * keep URLs readable.
+ */
+export function buildIdFor(bundleSource: string): string {
+  return createHash("sha256").update(bundleSource).digest("hex").slice(0, 12);
+}
+
+/**
  * A minimal stylesheet — just enough to make the demo look
  * presentable.  Two-column layout, lightly-styled sidebar,
  * monospace for code.  Inlined into every page's <head>.
@@ -385,8 +439,11 @@ header { display: flex; align-items: center; gap: 1rem; padding: .8rem 1.5rem;
          border-bottom: 1px solid var(--border); position: sticky; top: 0;
          background: var(--bg); z-index: 10; }
 header .site-title { font-weight: 600; font-size: 1.05rem; color: var(--fg); }
-header .search input { padding: .35rem .6rem; border: 1px solid var(--border);
-                       border-radius: 4px; min-width: 240px; }
+header input.search { padding: .35rem .6rem; border: 1px solid var(--border);
+                      border-radius: 4px; min-width: 280px; font: inherit;
+                      background: var(--bg); color: var(--fg);
+                      outline: none; transition: border-color .15s; }
+header input.search:focus { border-color: var(--accent); }
 header .github-link { margin-left: auto; }
 .layout { display: grid; grid-template-columns: 240px minmax(0,1fr) 200px;
           gap: 0; min-height: calc(100vh - 56px); }

--- a/code/programs/typescript/forme-doc-demo/src/main.ts
+++ b/code/programs/typescript/forme-doc-demo/src/main.ts
@@ -33,6 +33,7 @@ import * as url from "node:url";
 import { routeToOutputPath } from "@coding-adventures/forme-aot-page-bundle-emitter";
 
 import { build, type MarkdownFile } from "./build.js";
+import { bundleSearchClient } from "./search-bundle.js";
 
 // ─────────────────────────────────────────────────────────────────────
 // CLI entry
@@ -52,10 +53,19 @@ async function cli(): Promise<void> {
   const files = await readCorpus(corpusDir);
   console.log(`[forme-doc-demo] read   = ${files.length} markdown files`);
 
+  // Bundle the browser-side search client + UI glue.  esbuild
+  // pulls in SearchClient + tokenizer (both pure TS, browser-
+  // safe), wraps with the in-page bootstrap, minifies, hands
+  // back a string we plug into `emitSite` as `search.clientJs`.
+  console.log(`[forme-doc-demo] bundling search client …`);
+  const searchClientJs = await bundleSearchClient();
+  console.log(`[forme-doc-demo] bundle = ${(searchClientJs.length / 1024).toFixed(1)}KB minified`);
+
   const bundle = build(files, {
     siteTitle: "Acme Docs",
     githubUrl: "https://github.com/example/acme",
     copyright: `© ${new Date().getFullYear()} Acme`,
+    searchClientJs,
   });
 
   await writeBundle(bundle, outDir);

--- a/code/programs/typescript/forme-doc-demo/src/plain-text.ts
+++ b/code/programs/typescript/forme-doc-demo/src/plain-text.ts
@@ -51,9 +51,19 @@ function walk(node: unknown, buf: string[], depth: number): void {
   if (depth > MAX_DEPTH) return;
   if (node === null || node === undefined) return;
   if (typeof node !== "object") return;
-  const n = node as { type?: unknown; text?: unknown; children?: unknown };
+  const n = node as { type?: unknown; text?: unknown; value?: unknown; children?: unknown };
+  // The DocumentNode IR uses TWO different field names depending
+  // on node type:
+  //   - `TextNode`, `CodeBlockNode`, `RawInlineNode`, etc. use
+  //     `value: string` for their textual payload.
+  //   - Older / sibling ASTs sometimes use `text: string`.
+  // Accept both so we work across the spectrum of nodes that
+  // pass through this demo's content pipeline.
   if (typeof n.text === "string") {
     buf.push(n.text);
+  }
+  if (typeof n.value === "string") {
+    buf.push(n.value);
   }
   // Recurse into children if the node has any.  Most DocumentNode
   // variants use `children: Node[]`; some inline nodes (TextNode,

--- a/code/programs/typescript/forme-doc-demo/src/search-bundle.ts
+++ b/code/programs/typescript/forme-doc-demo/src/search-bundle.ts
@@ -1,0 +1,353 @@
+/**
+ * search-bundle.ts — bundle `forme-doc-search-client-js` (plus
+ * its only file: dep, `forme-doc-search-tokenizer`) into a
+ * single browser-loadable JavaScript file, wrapped with the
+ * tiny in-page UI glue (find the search input, render a
+ * dropdown of results, navigate on click).
+ *
+ * # Why bundle in the demo program rather than ship a
+ *   pre-built bundle alongside the library?
+ *
+ * The library deliberately stays as TypeScript source and
+ * declares `capabilities: []` — it never instantiates `fetch()`
+ * itself, the caller injects the shard-fetcher.  Bundling for
+ * the browser is therefore a CALLER concern.  This demo is the
+ * first caller; it picks esbuild (battle-tested, single binary,
+ * no config), wraps the class with a small IIFE that wires
+ * `window` + DOM, and hands the result back as a string to
+ * `emitSite`'s `search.clientJs` option.
+ *
+ * # The Map-vs-Object shape adapter
+ *
+ * `forme-doc-site-emitter` serialises each shard's `postings`
+ * Map as a plain JSON object (Maps don't survive JSON round-
+ * trips).  The browser-side `SearchClient.isLikelyShard` check
+ * requires `postings instanceof Map`.  The wrapper below
+ * converts the parsed Object back into a Map inside its
+ * injected `fetchShard` callback — so the shape contract is
+ * preserved end-to-end without changing either package.
+ *
+ * # The UI bootstrap
+ *
+ * Conservative DOM scripting: find the `<input class="search">`
+ * page-shell already renders, attach a debounced `input`
+ * listener, render results as an `<ul>` directly below the
+ * input.  No frameworks, no virtual DOM; just `createElement`
+ * + `textContent` (defends against XSS — pageId / matched
+ * tokens become text nodes, never HTML).
+ *
+ * # Capabilities
+ *
+ * `[]` — this file is a pure transform (markdown of strings
+ * into a bundled string).  The build script in `main.ts` calls
+ * it; the resulting string is handed to `emitSite`.  esbuild
+ * is invoked synchronously in this process, but that's not an
+ * I/O capability — it's a library call.
+ */
+
+import { build as esbuild } from "esbuild";
+import * as path from "node:path";
+import * as url from "node:url";
+
+const HERE = path.dirname(url.fileURLToPath(import.meta.url));
+
+/**
+ * Bundle `SearchClient` + UI glue into one self-executing
+ * browser script.  Returns the JS source as a string ready to
+ * pass into `emitSite({ search: { clientJs: ... } })`.
+ *
+ * The bundle:
+ *   - Is an IIFE (no globals leak; safe to load via
+ *     `<script src="/search/client.js" defer>`).
+ *   - Exposes `window.__formeDocSearch` ONLY for debugging
+ *     (the actual wiring happens inside the IIFE).
+ *   - Imports `SearchClient` from
+ *     `forme-doc-search-client-js` via esbuild's
+ *     standard resolution from the demo program's
+ *     `node_modules` (where the library was installed as a
+ *     `file:` dependency).
+ *   - Targets ES2020 — fine for any browser shipped in the
+ *     last ~5 years; matches the rest of the repo's TS target.
+ *
+ * Minification: ON by default for the demo (smaller artifact
+ * + easier visual inspection that the bundle is "done"); pass
+ * `{ minify: false }` to keep the source readable while
+ * developing.
+ */
+export async function bundleSearchClient(options: { minify?: boolean } = {}): Promise<string> {
+  const minify = options.minify ?? true;
+
+  // The browser-side wrapper.  We hand it to esbuild via
+  // `stdin` — that lets us co-locate the source here without a
+  // physical entry file.  `resolveDir: HERE` makes the
+  // `forme-doc-search-client-js` import resolve from THIS
+  // package's `node_modules`, which is what we want.
+  const result = await esbuild({
+    stdin: {
+      contents: BROWSER_ENTRY_SOURCE,
+      resolveDir: HERE,
+      sourcefile: "search-bootstrap.ts",
+      loader: "ts",
+    },
+    bundle: true,
+    format: "iife",
+    target: "es2020",
+    platform: "browser",
+    minify,
+    legalComments: "none",
+    write: false,
+    // Defensive: we don't expect any externals (search-client
+    // and tokenizer are pure), so any unresolved import should
+    // throw rather than silently produce a runtime ReferenceError
+    // in the browser.
+    external: [],
+  });
+
+  if (result.outputFiles.length !== 1) {
+    throw new Error(`bundleSearchClient: expected 1 output file, got ${result.outputFiles.length}`);
+  }
+  return result.outputFiles[0]!.text;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// The browser-side bootstrap — pure ES module source.  esbuild bundles
+// THIS together with the imported `SearchClient` into a single IIFE.
+//
+// Kept inside a template string (rather than a separate `.ts` file)
+// because:
+//   (a) it's small and tightly coupled to the demo's exact CSS
+//       selectors / route layout — no consumer would reuse it
+//       verbatim;
+//   (b) the only thing that varies across demo runs is the manifest
+//       URL, which the bootstrap fetches at runtime — no per-build
+//       string interpolation needed, so a static template is fine.
+//
+// Style notes for whoever extends this:
+//   - Pure DOM APIs only (no jQuery, no framework).
+//   - No `innerHTML` from user data — every text insertion uses
+//     `textContent` to keep the dropdown XSS-safe even if a
+//     malicious pageId or matched-token slipped through.
+//   - Debounce on input — search isn't free; rapid typing should
+//     coalesce.
+//   - Graceful no-op when DOM doesn't have the search input
+//     (some pages may opt out by not setting `searchPlaceholder`).
+// ─────────────────────────────────────────────────────────────────────
+const BROWSER_ENTRY_SOURCE = String.raw`
+import { SearchClient } from "@coding-adventures/forme-doc-search-client-js";
+
+const MANIFEST_URL = "/search/manifest.json";
+const SHARD_URL_PREFIX = "/search/";
+const DEBOUNCE_MS = 120;
+const MAX_RESULTS = 10;
+const INPUT_SELECTOR = "input.search";
+
+// build.ts injects a tiny <script>window.__formeDocSearchBuildId=...</script>
+// right before loading us, so we can append the same cache-bust
+// query string to the JSON fetches.  Without it, Safari happily
+// reuses cached manifest/shard JSON even after a rebuild.
+function buildIdSuffix() {
+  const id = window.__formeDocSearchBuildId;
+  return typeof id === "string" && id.length > 0 ? "?v=" + encodeURIComponent(id) : "";
+}
+
+async function fetchShard(shardKey) {
+  const r = await fetch(SHARD_URL_PREFIX + encodeURIComponent(shardKey) + ".json" + buildIdSuffix());
+  if (!r.ok) throw new Error("shard fetch failed: " + r.status);
+  const raw = await r.json();
+  // Shape guard before the Object.entries call — without it, a
+  // malformed shard (postings: null, a number, a string)
+  // throws a confusing TypeError out of Object.entries.  With
+  // it, the message in the caller's console.warn is actionable.
+  if (raw === null || typeof raw !== "object" || raw.postings === null || typeof raw.postings !== "object") {
+    throw new Error("malformed shard: missing or non-object postings");
+  }
+  // The server emitted postings as a plain JSON object (Maps
+  // don't survive JSON.stringify).  Convert back to a Map so
+  // SearchClient.isLikelyShard accepts the shape.
+  return {
+    shardKey: raw.shardKey,
+    postings: new Map(Object.entries(raw.postings)),
+  };
+}
+
+async function init() {
+  const input = document.querySelector(INPUT_SELECTOR);
+  if (!input) return; // No search input on this page; nothing to wire.
+
+  // Render skeleton: a dropdown UL.  IMPORTANT — we append
+  // to BODY and use position:fixed rather than dropping the
+  // dropdown next to the input.  Two reasons:
+  //   (a) the input lives inside a display:flex header;
+  //       inserting the dropdown as a sibling would turn it
+  //       into a flex item and disrupt the header layout
+  //       (pushing the GitHub link off-screen, etc.).
+  //   (b) position:absolute would need a positioned ancestor —
+  //       fragile across themes.  position:fixed + body-level
+  //       placement is independent of any ancestor styling.
+  // We re-measure the input's bounding rect every time we
+  // show the dropdown so it stays anchored under the input
+  // even after window resize / sticky-header scrolling.
+  const dropdown = document.createElement("ul");
+  dropdown.className = "search-results";
+  dropdown.setAttribute("role", "listbox");
+  dropdown.hidden = true;
+  Object.assign(dropdown.style, {
+    position: "fixed", listStyle: "none", margin: "0", padding: "0",
+    background: "var(--bg, #fff)", border: "1px solid var(--border, #e5e5e5)",
+    borderRadius: "4px", boxShadow: "0 4px 12px rgba(0,0,0,.08)",
+    maxHeight: "60vh", overflowY: "auto", zIndex: "1000",
+    fontSize: "14px",
+    // top/left/width set dynamically by positionDropdown() before show.
+  });
+  document.body.appendChild(dropdown);
+
+  function positionDropdown() {
+    const rect = input.getBoundingClientRect();
+    dropdown.style.top = (rect.bottom + 4) + "px";
+    dropdown.style.left = rect.left + "px";
+    dropdown.style.width = rect.width + "px";
+  }
+
+  let manifestPromise = null;
+  function getManifest() {
+    if (manifestPromise === null) {
+      manifestPromise = fetch(MANIFEST_URL + buildIdSuffix()).then(function (r) {
+        if (!r.ok) throw new Error("manifest fetch failed: " + r.status);
+        return r.json();
+      });
+    }
+    return manifestPromise;
+  }
+
+  let client = null;
+  async function getClient() {
+    if (client !== null) return client;
+    const manifest = await getManifest();
+    client = new SearchClient({ manifest, fetchShard });
+    return client;
+  }
+
+  function clearDropdown() {
+    while (dropdown.firstChild) dropdown.removeChild(dropdown.firstChild);
+    dropdown.hidden = true;
+  }
+
+  function renderResults(results) {
+    clearDropdown();
+    if (results.length === 0) {
+      const li = document.createElement("li");
+      li.style.padding = "0.6rem 0.9rem";
+      li.style.color = "var(--muted, #666)";
+      li.textContent = "No matches.";
+      dropdown.appendChild(li);
+      positionDropdown();
+      dropdown.hidden = false;
+      return;
+    }
+    for (const r of results.slice(0, MAX_RESULTS)) {
+      const li = document.createElement("li");
+      li.setAttribute("role", "option");
+      const a = document.createElement("a");
+      // Scheme guard — defence-in-depth.  pageId comes from
+      // build-time routeFor() which always emits a leading "/",
+      // but if a future code path ever fed an attacker-controlled
+      // pageId, an href like "javascript:alert(1)" would execute
+      // on click.  Refuse anything that doesn't look like an
+      // app-relative path.
+      a.href = (typeof r.pageId === "string" && r.pageId.startsWith("/")) ? r.pageId : "#";
+      a.style.display = "block";
+      a.style.padding = "0.5rem 0.9rem";
+      a.style.color = "var(--fg, #222)";
+      a.style.textDecoration = "none";
+      a.addEventListener("mouseenter", function () {
+        a.style.background = "var(--sidebar-bg, #fafafa)";
+      });
+      a.addEventListener("mouseleave", function () {
+        a.style.background = "";
+      });
+
+      // textContent for both — defends against any user-controlled
+      // pageId / token leaking HTML.  No innerHTML anywhere.
+      const title = document.createElement("div");
+      title.style.fontWeight = "500";
+      title.textContent = r.pageId;
+      a.appendChild(title);
+
+      if (r.matchedTokens && r.matchedTokens.length > 0) {
+        const meta = document.createElement("div");
+        meta.style.fontSize = "12px";
+        meta.style.color = "var(--muted, #666)";
+        meta.textContent = "matched: " + r.matchedTokens.join(", ");
+        a.appendChild(meta);
+      }
+
+      li.appendChild(a);
+      dropdown.appendChild(li);
+    }
+    positionDropdown();
+    dropdown.hidden = false;
+  }
+
+  let debounceTimer = null;
+  let lastQueryId = 0;
+  async function handleInput() {
+    const q = input.value.trim();
+    if (q.length === 0) {
+      clearDropdown();
+      return;
+    }
+    const myQueryId = ++lastQueryId;
+    try {
+      const c = await getClient();
+      const results = await c.search(q);
+      if (myQueryId !== lastQueryId) return; // Stale — a newer query won.
+      renderResults(results);
+    } catch (err) {
+      // Defensive: never crash the page on a search failure.
+      // Console only; no UI alert that would startle the user.
+      console.warn("[forme-doc-search] query failed:", err);
+    }
+  }
+
+  input.addEventListener("input", function () {
+    if (debounceTimer !== null) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(handleInput, DEBOUNCE_MS);
+  });
+
+  // Click-outside dismissal.
+  document.addEventListener("click", function (e) {
+    if (e.target !== input && !dropdown.contains(e.target)) {
+      clearDropdown();
+    }
+  });
+
+  // ESC clears + closes the dropdown.
+  input.addEventListener("keydown", function (e) {
+    if (e.key === "Escape") {
+      input.value = "";
+      clearDropdown();
+    }
+  });
+
+  // Re-show dropdown when re-focusing if there's already text.
+  input.addEventListener("focus", function () {
+    if (input.value.trim().length > 0) handleInput();
+  });
+
+  // Re-anchor on viewport changes while the dropdown is open.
+  // Scrolling matters because the header is sticky; resize matters
+  // because the input width comes from the header layout.
+  window.addEventListener("scroll", function () { if (!dropdown.hidden) positionDropdown(); }, { passive: true });
+  window.addEventListener("resize", function () { if (!dropdown.hidden) positionDropdown(); });
+
+  // Expose for debugging only.  Tests / dev console can call
+  // window.__formeDocSearch.search("query") to inspect.
+  window.__formeDocSearch = { getClient };
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", init);
+} else {
+  init();
+}
+`;

--- a/code/programs/typescript/forme-doc-demo/tests/build.test.ts
+++ b/code/programs/typescript/forme-doc-demo/tests/build.test.ts
@@ -25,7 +25,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { generatePageBundle } from "@coding-adventures/forme-aot-page-bundle-emitter";
 
-import { build, routeFor, titleOf, injectHeadingIds, normaliseSidebarPaths, type MarkdownFile } from "../src/build.js";
+import { build, routeFor, titleOf, injectHeadingIds, normaliseSidebarPaths, buildIdFor, type MarkdownFile } from "../src/build.js";
 import { readCorpus, writeBundle, safeJoin, validateOutDir } from "../src/main.js";
 import { plainText } from "../src/plain-text.js";
 
@@ -317,22 +317,68 @@ describe("writeBundle", () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────
+// buildIdFor
+// ─────────────────────────────────────────────────────────────────────
+
+describe("buildIdFor", () => {
+  it("returns a 12-char hex string", () => {
+    const id = buildIdFor("some bundle source");
+    expect(id).toMatch(/^[0-9a-f]{12}$/);
+  });
+
+  it("is deterministic for the same input", () => {
+    expect(buildIdFor("hello")).toBe(buildIdFor("hello"));
+  });
+
+  it("differs when the bundle source changes (cache-bust correctness)", () => {
+    const a = buildIdFor("bundle version A");
+    const b = buildIdFor("bundle version B");
+    expect(a).not.toBe(b);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
 // plainText
 // ─────────────────────────────────────────────────────────────────────
 
 describe("plainText", () => {
-  it("extracts text from a flat node", () => {
+  it("extracts text from a flat node (text field)", () => {
     expect(plainText({ type: "text", text: "hello" })).toBe("hello");
+  });
+
+  it("extracts text from a flat node (value field — the IR's actual choice)", () => {
+    // commonmark-parser's TextNode uses `value`, not `text`.
+    // Both names supported defensively.
+    expect(plainText({ type: "text", value: "hello" })).toBe("hello");
   });
 
   it("recurses into children and joins with spaces", () => {
     const ast = {
       type: "doc",
       children: [
-        { type: "p", children: [{ type: "text", text: "hello" }, { type: "text", text: "world" }] },
+        { type: "p", children: [{ type: "text", value: "hello" }, { type: "text", value: "world" }] },
       ],
     };
     expect(plainText(ast)).toBe("hello world");
+  });
+
+  it("extracts text from a realistic commonmark-parser AST", () => {
+    // Shape mirrors what commonmark-parser actually emits — nested
+    // paragraphs with text children using `value`.  This is the
+    // regression test for the bug where plainText returned "" for
+    // every page because it only checked `text` and never `value`.
+    const ast = {
+      type: "document",
+      children: [
+        { type: "paragraph", children: [
+          { type: "text", value: "Hello world" },
+        ]},
+        { type: "heading", level: 2, children: [
+          { type: "text", value: "Install" },
+        ]},
+      ],
+    };
+    expect(plainText(ast)).toBe("Hello world Install");
   });
 
   it("returns empty string for null / undefined / non-object", () => {

--- a/code/programs/typescript/forme-doc-demo/tests/search-bundle.test.ts
+++ b/code/programs/typescript/forme-doc-demo/tests/search-bundle.test.ts
@@ -1,0 +1,267 @@
+/**
+ * search-bundle.test.ts — tests for the browser-side search
+ * bundle.
+ *
+ * Two layers:
+ *
+ *   1. UNIT tests for `bundleSearchClient` — runs esbuild,
+ *      verifies the output is well-formed JS, includes the
+ *      adapter that converts JSON-object postings back into a
+ *      Map (the bug that caused "No matches" for every query
+ *      in the first attempt).
+ *
+ *   2. END-TO-END test in JSDOM — loads the actual `dist/`
+ *      output, stubs `fetch` to read from disk, types into the
+ *      rendered search input, and asserts the dropdown
+ *      populates with real results.  This is the regression
+ *      test for the bug where `plainText` returned "" for
+ *      every page (because it read `node.text` instead of
+ *      `node.value`), leaving the search index with only
+ *      title tokens and most queries returning "No matches".
+ *
+ * The JSDOM test BUILDS the site fresh (rather than relying
+ * on a prior `npm start` to have produced `dist/`) so it
+ * works in CI with no setup steps.  It runs in a few seconds
+ * because the corpus is small.
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { JSDOM } from "jsdom";
+import * as fs from "node:fs/promises";
+import * as fsSync from "node:fs";
+import * as path from "node:path";
+
+import { bundleSearchClient } from "../src/search-bundle.js";
+import { build } from "../src/build.js";
+import { readCorpus, writeBundle } from "../src/main.js";
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+const CORPUS = path.join(REPO_ROOT, "corpus");
+
+// =====================================================================
+// 1. bundleSearchClient — unit tests
+// =====================================================================
+
+describe("bundleSearchClient", () => {
+  // esbuild is slow-ish to start (cold-cache ~300ms); cache the
+  // bundle across tests so each `it` block doesn't repeat the work.
+  let minified: string;
+  let readable: string;
+
+  beforeAll(async () => {
+    [minified, readable] = await Promise.all([
+      bundleSearchClient(),
+      bundleSearchClient({ minify: false }),
+    ]);
+  });
+
+  it("returns a non-empty string", () => {
+    expect(typeof minified).toBe("string");
+    expect(minified.length).toBeGreaterThan(1000);
+  });
+
+  it("wraps output as an IIFE (safe to load via <script>)", () => {
+    expect(minified.startsWith("(()=>{") || minified.startsWith("(function(){")).toBe(true);
+    expect(minified.trimEnd().endsWith(";")).toBe(true);
+  });
+
+  it("bundles SearchClient + tokenize (the only file: deps)", () => {
+    // Symbol names survive even under minification because
+    // they're class members / function arguments.  Search for
+    // text that has to be present in any working bundle.
+    expect(readable).toContain("SearchClient");
+    expect(readable).toContain("tokenize");
+  });
+
+  it("includes the Map adapter so postings JSON-objects become Maps", () => {
+    // The bug this protects against: SearchClient's isLikelyShard
+    // requires `postings instanceof Map`, but JSON.parse returns
+    // plain objects.  The adapter MUST be present.
+    expect(readable).toContain("new Map(Object.entries");
+  });
+
+  it("targets the right DOM selector for the page-shell search input", () => {
+    // page-shell renders `<input class="search" type="search">`
+    // — the bundle MUST query that selector verbatim.
+    expect(readable).toContain('"input.search"');
+  });
+
+  it("reads the build-id cache-bust from window.__formeDocSearchBuildId", () => {
+    expect(readable).toContain("__formeDocSearchBuildId");
+  });
+
+  it("is small enough to ship in every page (< 20KB minified)", () => {
+    expect(minified.length).toBeLessThan(20 * 1024);
+  });
+});
+
+// =====================================================================
+// 2. End-to-end in JSDOM — the regression test for "No matches"
+// =====================================================================
+
+describe("search bundle — end-to-end in JSDOM", () => {
+  let dom: JSDOM;
+  let window: JSDOM["window"];
+  let tmpDist: string;
+
+  beforeAll(async () => {
+    // Build the site to a tmp dir.  We use the program's real
+    // build pipeline rather than relying on a checked-in
+    // `dist/` so the test fails if anything in the pipeline
+    // breaks the search index.
+    tmpDist = await fs.mkdtemp(path.join(REPO_ROOT, ".tmp-search-e2e-"));
+    const files = await readCorpus(CORPUS);
+    const searchClientJs = await bundleSearchClient();
+    const bundle = build(files, {
+      siteTitle: "Test Docs",
+      searchClientJs,
+    });
+    await writeBundle(bundle, tmpDist);
+
+    // Spin up JSDOM with the rendered index.html.
+    const indexHtml = await fs.readFile(path.join(tmpDist, "index.html"), "utf8");
+    dom = new JSDOM(indexHtml, {
+      url: "http://test.local/",
+      runScripts: "outside-only", // we'll eval the bundle manually
+      pretendToBeVisual: true,
+    });
+    window = dom.window;
+
+    // Stub fetch so the bundle's manifest + shard fetches
+    // resolve from the tmp dist.  Strips the `?v=...` cache-
+    // bust query string before resolving the file path.
+    window.fetch = async function (url: unknown): Promise<unknown> {
+      const u = String(url);
+      const pathOnly = u.startsWith("http")
+        ? new URL(u).pathname
+        : u.split("?")[0]!;
+      const filePath = path.join(tmpDist, pathOnly.replace(/^\//, ""));
+      try {
+        const data = fsSync.readFileSync(filePath, "utf8");
+        return {
+          ok: true, status: 200,
+          json: async () => JSON.parse(data),
+          text: async () => data,
+        };
+      } catch {
+        return { ok: false, status: 404 };
+      }
+    } as unknown as typeof fetch;
+
+    // Load the bundle into the JSDOM window.  evalRunsInWindow
+    // ensures `document`, `window`, `fetch` all resolve to JSDOM.
+    const bundleJs = await fs.readFile(path.join(tmpDist, "search/client.js"), "utf8");
+    window.eval(bundleJs);
+
+    // Give init() a tick to run (it's async via DOMContentLoaded).
+    await waitFor(() => window.document.querySelector("ul.search-results") !== null);
+  });
+
+  it("renders the dropdown skeleton into the body", () => {
+    const dropdown = window.document.querySelector("ul.search-results");
+    expect(dropdown).not.toBeNull();
+    // Per the alignment fix, dropdown lives at body level
+    // (not inside the header).
+    expect(dropdown!.parentElement).toBe(window.document.body);
+  });
+
+  it('returns real results for "install"', async () => {
+    const results = await typeAndCollect("install");
+    expect(results.length).toBeGreaterThan(0);
+    // The installation page should be a hit (it's literally
+    // titled "Installation").
+    expect(results.some((r) => r.includes("/guide/installation"))).toBe(true);
+  });
+
+  it('returns real results for "widget" (body-text token)', async () => {
+    // REGRESSION TEST: "widget" appears only in page BODIES
+    // (not titles).  If plainText() returns "" for bodies —
+    // the original bug — this query returns 0 results.
+    const results = await typeAndCollect("widget");
+    expect(results.length).toBeGreaterThan(0);
+  });
+
+  it('returns real results for "deno" (body-only, single page)', async () => {
+    const results = await typeAndCollect("deno");
+    expect(results.length).toBe(1);
+    expect(results[0]).toContain("/guide/installation");
+  });
+
+  it('shows "No matches." for a query that hits nothing', async () => {
+    const results = await typeAndCollect("zzzzzzzzzzzz");
+    expect(results).toEqual(["No matches."]);
+  });
+
+  it("clears the dropdown when the input is emptied", async () => {
+    const input = window.document.querySelector("input.search") as HTMLInputElement;
+    input.value = "widget";
+    input.dispatchEvent(new window.Event("input", { bubbles: true }));
+    await waitFor(() => {
+      const d = window.document.querySelector("ul.search-results") as HTMLElement;
+      return d && !d.hidden;
+    });
+    // Now clear.
+    input.value = "";
+    input.dispatchEvent(new window.Event("input", { bubbles: true }));
+    await waitFor(() => {
+      const d = window.document.querySelector("ul.search-results") as HTMLElement;
+      return d.hidden === true;
+    });
+    const dropdown = window.document.querySelector("ul.search-results") as HTMLElement;
+    expect(dropdown.hidden).toBe(true);
+  });
+
+  // ---- helpers --------------------------------------------------
+
+  /**
+   * Type a query into the input, wait for the dropdown to
+   * populate with the NEW result set, and return the per-row
+   * text content.
+   *
+   * We snapshot the dropdown's current text BEFORE dispatching
+   * the input event, then poll until the text differs.  This
+   * defeats stale-content false-positives across consecutive
+   * `typeAndCollect` calls (e.g. typing "deno" after "install"
+   * — without the change check, the poll's `children.length > 0`
+   * condition is satisfied immediately by the leftover "install"
+   * results before the new query has run).
+   */
+  async function typeAndCollect(q: string): Promise<string[]> {
+    const input = window.document.querySelector("input.search") as HTMLInputElement;
+    const dropdown = window.document.querySelector("ul.search-results")!;
+    const before = snapshotDropdown(dropdown);
+    input.value = q;
+    input.dispatchEvent(new window.Event("input", { bubbles: true }));
+    await waitFor(() => {
+      const d = window.document.querySelector("ul.search-results") as HTMLElement;
+      if (!d || d.hidden) return false;
+      if (d.children.length === 0) return false;
+      return snapshotDropdown(d) !== before;
+    });
+    return snapshotDropdownRows(dropdown);
+  }
+
+  function snapshotDropdown(d: Element): string {
+    return Array.from(d.children).map((c) => c.textContent ?? "").join("\n");
+  }
+  function snapshotDropdownRows(d: Element): string[] {
+    return Array.from(d.children).map((c) => c.textContent ?? "");
+  }
+});
+
+/**
+ * Poll `cond` every 25ms up to `timeoutMs`.  Resolves when
+ * `cond` returns truthy.  Rejects on timeout.
+ *
+ * We poll instead of using a fixed `setTimeout` because the
+ * UI's debounce + microtask chain can vary by a few ms in
+ * JSDOM; busy-waiting is cheap and avoids flake.
+ */
+async function waitFor(cond: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (cond()) return;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  throw new Error(`waitFor: condition not met within ${timeoutMs}ms`);
+}


### PR DESCRIPTION
## Summary

Closes the search loop end-to-end so the page-shell's existing `<input class="search">` actually searches.  Bundles `forme-doc-search-client-js` (+ its only dep, `forme-doc-search-tokenizer`) via esbuild into a single ~9KB self-executing IIFE, written to `/search/client.js` and loaded by every page with `<script defer>`.

You asked for this — and you saw it working in the browser before this push.

## What's in this PR

**New files**:
- `src/search-bundle.ts` — esbuild bundler + browser UI bootstrap (find input, debounced search, floating dropdown).
- `tests/search-bundle.test.ts` — 13 tests (7 unit + 6 JSDOM end-to-end).

**Changed files**:
- `src/build.ts` — injects `<script src="/search/client.js?v=<sha256-12>" defer>` when bundle is provided; computes content-addressed cache-bust ID.
- `src/main.ts` — awaits `bundleSearchClient()` before `build()`.
- `src/plain-text.ts` — accepts both `node.text` AND `node.value` field names (regression fix; see "Bugs caught" below).
- `tests/build.test.ts` — added 3 tests for `buildIdFor` + 2 tests for `plainText`'s value-field support.
- `BUILD`, `package.json`, `package-lock.json` — added `forme-doc-search-client-js` runtime dep + `esbuild` + `jsdom@22` dev deps.

**Zero changes to any of the 11 `forme-doc-*` library packages.** Both `forme-doc-search-client-js` (`capability []`) and `forme-doc-site-emitter` (`capability []`) remain pure. The Map-vs-Object shape adapter lives in the demo's `fetchShard` callback at the consumer boundary, exactly where the spec intends.

## Bugs caught and fixed in dev (regression tests added)

| # | Bug | Fix |
|---|---|---|
| 1 | `plainText` returned `""` for every page body — `commonmark-parser`'s `TextNode` uses `node.value`, not `node.text` | `plainText` now accepts both fields. Index went from 10 → 345 unique tokens on the 6-page corpus |
| 2 | Safari pinned the old broken bundle across rebuilds, masking the fix for #1 | Content-addressed cache-bust: `?v=<sha256-of-bundle-bytes-sliced-to-12-hex>` on script tag + manifest + shard fetches |
| 3 | Dropdown disrupted the header flex layout | Append to `<body>` at `position: fixed`, anchored to input via `getBoundingClientRect()`, re-anchored on scroll/resize |
| 4 | CSS typo `header .search input` (descendant of `.search`) — actual element is `input.search` | Fixed selector + added focus ring |

## Security review (one pass — clean for new code)

| Category | Result |
|---|---|
| XSS in dropdown | All `textContent`; `a.href` scheme-guarded to `pageId.startsWith("/")` |
| `fetchShard` shape adapter | Pre-checks `raw.postings` shape before `Object.entries` |
| esbuild bundling | `external: []`, fixed `resolveDir`, no path injection |
| Cache-bust as XSS vector | `buildIdFor` provably emits `[0-9a-f]{12}`; safe under `JSON.stringify` + `encodeURIComponent` |
| Bundle execution | No `eval` / `new Function` / `setTimeout(string)`; `defer` ordering correct |
| CLI changes | esbuild reads only `node_modules` (same `fs:read` capability already declared) |
| DOM event listeners | `scroll` passive; attached once during `init()` |
| `plainText` value-field accept | Index-only effect; no XSS path |
| `jsdom@22` test-only dep | No known exploitable CVEs for our test-time use |

Two LOWs flagged by the review — **both fixed in the same push** (`a.href` scheme guard + `raw.postings` shape guard).

## Tests

**74 total** (was 56):
- 61 in `tests/build.test.ts` (+5 new: 3 `buildIdFor`, 2 `plainText` value-field)
- 13 in `tests/search-bundle.test.ts` (new file: 7 unit + 6 JSDOM end-to-end)

The JSDOM end-to-end suite is the **regression test** for the two production bugs: it builds the site fresh, stubs fetch to read from disk, types queries into the rendered input, and asserts the dropdown populates with real results. Includes:
- Real results for `install`
- Real results for `widget` (body-only token — would have returned 0 before plain-text fix)
- Exactly 1 result for `deno` (single-page body-only token)
- `"No matches."` for `zzzzzzzzzzzz`
- Clears on empty input

**Coverage**: 85.4% line / 92.3% branch / 90.5% function on `src/`. Programs target >80%; libraries target >95%. Per-file: `build.ts` 100% / 97.8% / 100%; `plain-text.ts` 100% / 100% / 100%; `search-bundle.ts` 93.1% / 66.7% / 100%; `main.ts` 65% (CLI bootstrap, exercised via `npm start`).

## Bundle stats

- **9.1KB minified** (one-time fetch per session)
- Targets ES2020, IIFE-wrapped, no globals leaked (except `window.__formeDocSearch` for debug)
- Loaded with `defer` so DOM is parsed first

## Test plan

- [x] `./node_modules/.bin/vitest run` — 74/74 pass
- [x] `/security-review` — clean after LOW fixes
- [x] Live verified end-to-end in Safari (search box populates dropdown with real results)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)