### PR TITLE
feat(closure-pass-collapse-properties): CLOC13.D — consume scope-analyzer

### DIFF
--- a/code/packages/rust/closure-pass-collapse-properties/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-collapse-properties/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to the `coding-adventures-closure-pass-collapse-properties` crate will be documented in this file.
 
+## [0.2.0] - 2026-06-01
+
+### Added (CLOC13.D — consume `closure-scope-analyzer`)
+- Wired the pass to `coding-adventures-closure-scope-analyzer` (new `[dependencies]` entry). `run` now invokes `analyze(ctx.program)` and walks the returned `ScopeAnalysis` to identify **alias candidates** — bindings whose initializer is a stable member-expression chain safe to flatten.
+- Algorithm (steps 1 + 2; step 3 deferred to CLOC13.D.1):
+  1. Per-binding use-count derived from `analysis.references` (a binding never referenced is *not* a candidate — that's remove-unused-vars' job, CLOC13.E).
+  2. Candidate scan: only `BindingKind::Const` is admitted. `Var` / `Let` could be reassigned mid-program, which would silently desync the alias from its target; `Function` / `Param` / `Class` need additional shape analysis the analyzer doesn't yet expose. `#[non_exhaustive]` future variants fall through the wildcard arm as non-candidates — conservative-by-default.
+- `PassStats::nodes_touched` now reports `1 + bindings.len() + references.len()` (root + every binding + every reference visited). Real cost surfacing for the scheduler instead of the v0.1.0 placeholder `1`.
+
+### Critical safety pin (lesson from CLOC13.E security review)
+- `changed` is **hard-pinned to `false`** until step 3 (the actual program mutation) lands. The pass identifies candidates and returns the program *unchanged*. Reporting `changed = true` while returning an unchanged program would cause the scheduler under `IterationPolicy::FixedPoint` to re-run forever — each iteration would find the same candidates, claim a change, return the same program, repeat. Documented in both the source (`fn run`) and here so the next contributor doesn't reintroduce the bug. Pinning lifts only when step 3 actually mutates the program.
+
+### Why this is safe to merge ahead of the analyzer body
+- The current `closure-scope-analyzer` v0.1.0 returns empty `bindings` + `references`. The candidate scan therefore produces zero aliases, the candidates vec stays empty, `nodes_touched` is small, and the program passes through unchanged — identical observable behavior to v0.1.0. The wiring becomes **effective** the moment CLOC13.0 lands the analyzer body — no churn here, no rebase needed.
+
+### Dependencies
+- Added `coding-adventures-closure-scope-analyzer = { path = "../closure-scope-analyzer" }` to `[dependencies]`. Crate bumped `0.1.0 → 0.2.0`.
+
 ## [0.1.0] - 2026-05-23
 
 ### Added

--- a/code/packages/rust/closure-pass-collapse-properties/Cargo.toml
+++ b/code/packages/rust/closure-pass-collapse-properties/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "coding-adventures-closure-pass-collapse-properties"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Property-collapse pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Collapses repeated property-access chains on stable namespace objects into shorter local bindings to shrink output and avoid redundant lookups."
 
 [dependencies]
 coding-adventures-closure-pass-pipeline = { path = "../closure-pass-pipeline" }
+coding-adventures-closure-scope-analyzer = { path = "../closure-scope-analyzer" }
 coding-adventures-javascript-ast = { path = "../javascript-ast" }
 coding-adventures-type-sidecar = { path = "../type-sidecar" }
 coding_adventures_correlation_vector = { path = "../correlation-vector" }

--- a/code/packages/rust/closure-pass-collapse-properties/src/lib.rs
+++ b/code/packages/rust/closure-pass-collapse-properties/src/lib.rs
@@ -106,6 +106,7 @@
 use coding_adventures_closure_pass_pipeline::{
     IterationPolicy, Pass, PassContext, PassError, PassOutput, PassStats,
 };
+use coding_adventures_closure_scope_analyzer::{analyze, BindingId, BindingKind};
 
 /// `Pass::depends_on` value. Kept as a `const` so future tests
 /// and sibling crates can reference the dependency name without
@@ -160,19 +161,94 @@ impl Pass for CollapsePropertiesPass {
     }
 
     fn run(&self, ctx: PassContext<'_>) -> Result<PassOutput, PassError> {
-        // v1: no MemberExpression / Identifier /
-        // VariableDeclaration nodes in the AST yet, so there's
-        // nothing to collapse. Pass through unchanged. The real
-        // gather + rewrite slots in here once javascript-ast
-        // grows the variants.
+        // CLOC13.D wiring: consume the shared `ScopeAnalysis` from
+        // `closure-scope-analyzer` to identify *alias candidates* —
+        // bindings whose initializer is a stable member-expression
+        // chain that can be safely flattened.
+        //
+        // The algorithm (steps 1 + 2 here; step 3 deferred):
+        //
+        //   1. Walk `analysis.bindings`. A binding is a *candidate*
+        //      for collapsing when ALL of:
+        //        a. kind == Const  (Var/Let could be reassigned;
+        //           the alias would silently diverge from the
+        //           target. Const guarantees the binding's value
+        //           doesn't move.)
+        //        b. The binding has at least one reference (we
+        //           don't collapse a never-used alias — that's
+        //           remove-unused-vars' job).
+        //   2. Track candidates in a Vec<BindingId> for the
+        //      observability path.
+        //   3. Apply collapse — deferred to CLOC13.D.1 because
+        //      cleanly rewriting member-access chains needs a
+        //      binding → initializer-expression backreference
+        //      that the analyzer doesn't yet ship.
+        //
+        // **Critical (lesson from CLOC13.E security review):**
+        // `changed` is hard-pinned to `false` until step 3 lands.
+        // Reporting `changed = true` while returning an unchanged
+        // program would cause the scheduler under
+        // `IterationPolicy::FixedPoint` to re-run forever — each
+        // iteration would find the same candidates, claim a
+        // change, return the same program, repeat. Documented in
+        // both the code and the CHANGELOG so the next contributor
+        // doesn't reintroduce the bug.
+        //
+        // **Why this is safe with the v0.1.0 analyzer body.** The
+        // current `analyze` returns empty bindings + references,
+        // so the candidate scan finds zero aliases, the candidates
+        // vec is empty, `nodes_touched` is small, and the program
+        // passes through unchanged. The wiring becomes *effective*
+        // (real candidate-finding) the moment CLOC13.0 lands the
+        // analyzer body — no churn here.
+
+        let analysis = analyze(ctx.program);
+
+        // Step 1: use-count per binding (for the "has at least one
+        // reference" gate).
+        let mut use_count: Vec<usize> = vec![0; analysis.bindings.len()];
+        for reference in &analysis.references {
+            if let Some(BindingId(idx)) = reference.binding {
+                if let Some(slot) = use_count.get_mut(idx as usize) {
+                    *slot += 1;
+                }
+            }
+        }
+
+        // Step 2: candidate scan.
+        let mut alias_candidates: Vec<BindingId> = Vec::new();
+        for (idx, binding) in analysis.bindings.iter().enumerate() {
+            let id = BindingId(idx as u32);
+            let uses = use_count.get(idx).copied().unwrap_or(0);
+            if uses == 0 {
+                continue; // not aliased anywhere — let remove-unused-vars handle it
+            }
+            // `#[non_exhaustive]` on BindingKind: future variants
+            // conservatively passthrough via wildcard.
+            match binding.kind {
+                BindingKind::Const => alias_candidates.push(id),
+                // Var/Let can be reassigned mid-program — collapsing
+                // would create an alias that diverges from the
+                // source. Function/Param/Class need additional
+                // shape analysis the analyzer doesn't expose.
+                _ => {}
+            }
+        }
+
+        // Step 3 deferred — keep `changed = false`.
+        let _alias_candidates = alias_candidates;
+
         Ok(PassOutput {
             program: ctx.program.clone(),
             contributions: Vec::new(),
             changed: false,
             diagnostics: Vec::new(),
             stats: PassStats {
-                // Visited the program root; no chains collapsed.
-                nodes_touched: 1,
+                // Visited the program root + every binding + every
+                // reference. Real cost numbers for the scheduler.
+                nodes_touched: (1
+                    + analysis.bindings.len()
+                    + analysis.references.len()) as u32,
             },
         })
     }


### PR DESCRIPTION
## Summary
- Wires `closure-pass-collapse-properties` to the shared `closure-scope-analyzer` (CLOC13 unblocker, merged via #4763). `run` now invokes `analyze(ctx.program)` and walks the returned `ScopeAnalysis` to identify **alias candidates** — `Const` bindings with at least one reference, safe to flatten.
- `changed` is **hard-pinned to `false`** until the actual apply step (step 3, CLOC13.D.1) lands. Lesson from CLOC13.E security review: reporting `changed = true` while returning an unchanged program causes the scheduler under `IterationPolicy::FixedPoint` to re-run forever. Pinning + comment + CHANGELOG note prevents reintroduction.
- `PassStats::nodes_touched` now reports `1 + bindings.len() + references.len()` — real cost surfacing.

## Algorithm (steps 1 + 2; step 3 deferred to CLOC13.D.1)
1. Per-binding use-count from `analysis.references` — a never-referenced binding is **not** a collapse candidate (that's remove-unused-vars' job, CLOC13.E).
2. Candidate scan — only `BindingKind::Const`. `Var`/`Let` could be reassigned mid-program; `Function`/`Param`/`Class` need shape analysis the analyzer doesn't yet expose. `#[non_exhaustive]` future variants fall through the wildcard arm as non-candidates.

## Why safe to merge now
- The current `closure-scope-analyzer` v0.1.0 returns empty `bindings` + `references`, so the candidate scan finds zero aliases, the candidates vec is empty, and the program passes through unchanged — identical observable behavior to v0.1.0. The wiring becomes **effective** the moment CLOC13.0 lands the analyzer body — no churn here, no rebase.

## Test plan
- [x] `cargo test -p coding-adventures-closure-pass-collapse-properties` — all 9 tests pass unchanged (identity preserved under empty analysis).
- [x] Security review (Agent): PASS — `changed = false` literal not derived, bounds-checked collection access via `.get()`/`.get_mut()`, `#[non_exhaustive]` handled via conservative wildcard, no unsafe, no I/O.
- [ ] CI green across ubuntu / macos / windows + CodeQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)