### PR TITLE
feat(closure-pass-treeshake): CLOC13.C — consume scope-analyzer

### DIFF
--- a/code/packages/rust/closure-pass-treeshake/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-treeshake/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to the `coding-adventures-closure-pass-treeshake` crate will be documented in this file.
 
+## [0.2.0] - 2026-06-01
+
+### Added (CLOC13.C — consume `closure-scope-analyzer`)
+- Wired the pass to `coding-adventures-closure-scope-analyzer` (new `[dependencies]` entry). `run` now invokes `analyze(ctx.program)` and walks the returned `ScopeAnalysis` to identify **module-shape candidates** — bindings whose kind (`Function` / `Class`) is the shape that becomes a module export once `javascript-ast` grows `ImportDeclaration` / `ExportDeclaration` variants.
+- Algorithm (mark phase; sweep deferred to CLOC13.C.1):
+  1. Walk `analysis.bindings`. A binding is a *module-shape candidate* when its `kind` is `BindingKind::Function` or `BindingKind::Class`. These are the only shapes ESM allows as named top-level exports. `Var`/`Let`/`Const` *can* be exported but cross over to remove-unused-vars and collapse-properties; the cleanest split is kind-based.
+  2. Track candidates in `Vec<BindingId>` for the observability path.
+  3. *Sweep deferred*: removing a function/class binding cleanly requires the AST to grow `ImportDeclaration` / `ExportDeclaration` nodes (otherwise treeshake can't distinguish an exported function from an internal one).
+- `PassStats::nodes_touched` now reports `1 + bindings.len() + references.len()` (root + every binding + every reference visited). Real cost surfacing for the scheduler instead of the v0.1.0 placeholder `1`.
+
+### Critical safety pin (lesson from CLOC13.E security review)
+- `changed` is **hard-pinned to `false`** until step 3 (the actual program mutation) lands. The pass identifies candidates and returns the program *unchanged*. Reporting `changed = true` while returning an unchanged program would cause the scheduler under `IterationPolicy::FixedPoint` to re-run forever — each iteration would find the same candidates, claim a change, return the same program, repeat. Documented in both the source (`fn run`) and here so the next contributor doesn't reintroduce the bug. Pinning lifts only when step 3 actually mutates the program.
+
+### Why this is safe to merge ahead of the analyzer body
+- The current `closure-scope-analyzer` v0.1.0 returns empty `bindings` + `references`. The candidate scan therefore produces zero shapes, the candidates vec stays empty, `nodes_touched` is small, and the program passes through unchanged — identical observable behavior to v0.1.0. The wiring becomes **effective** the moment CLOC13.0 lands the analyzer body — no churn here, no rebase needed.
+
+### Dependencies
+- Added `coding-adventures-closure-scope-analyzer = { path = "../closure-scope-analyzer" }` to `[dependencies]`. Crate bumped `0.1.0 → 0.2.0`.
+
 ## [0.1.0] - 2026-05-23
 
 ### Added

--- a/code/packages/rust/closure-pass-treeshake/Cargo.toml
+++ b/code/packages/rust/closure-pass-treeshake/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "coding-adventures-closure-pass-treeshake"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Tree-shaking pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Removes module exports and imports that aren't reachable from the program's entry points, eliminating whole-module dead weight that intra-module DCE can't see."
 
 [dependencies]
 coding-adventures-closure-pass-pipeline = { path = "../closure-pass-pipeline" }
+coding-adventures-closure-scope-analyzer = { path = "../closure-scope-analyzer" }
 coding-adventures-javascript-ast = { path = "../javascript-ast" }
 coding-adventures-type-sidecar = { path = "../type-sidecar" }
 coding_adventures_correlation_vector = { path = "../correlation-vector" }

--- a/code/packages/rust/closure-pass-treeshake/src/lib.rs
+++ b/code/packages/rust/closure-pass-treeshake/src/lib.rs
@@ -70,6 +70,7 @@
 use coding_adventures_closure_pass_pipeline::{
     IterationPolicy, Pass, PassContext, PassError, PassOutput, PassStats,
 };
+use coding_adventures_closure_scope_analyzer::{analyze, BindingId, BindingKind};
 
 /// `Pass::depends_on` value. CLOC06 canonical order pins DCE
 /// before tree-shake. Kept as a `const` so future tests / sibling
@@ -131,19 +132,85 @@ impl Pass for TreeshakePass {
     }
 
     fn run(&self, ctx: PassContext<'_>) -> Result<PassOutput, PassError> {
-        // v1: no ImportDeclaration / ExportDeclaration nodes in
-        // the AST yet, so there's nothing to shake. Pass through
-        // unchanged. The real two-phase walk slots in here once
-        // javascript-ast grows module syntax.
+        // CLOC13.C wiring: consume the shared `ScopeAnalysis` from
+        // `closure-scope-analyzer` to identify *module-shape
+        // candidates* — bindings whose kind (`Function` / `Class`)
+        // is the shape that becomes a module export once
+        // `javascript-ast` grows `ImportDeclaration` /
+        // `ExportDeclaration` variants.
+        //
+        // The algorithm (mark phase; sweep deferred):
+        //
+        //   1. Walk `analysis.bindings`. A binding is a
+        //      *module-shape candidate* when:
+        //        a. kind == Function OR kind == Class  (these are
+        //           the only binding shapes ESM allows to be
+        //           exported as a named export from the top
+        //           level. `Var`/`Let`/`Const` *can* be exported
+        //           but cross over to remove-unused-vars and
+        //           collapse-properties; the cleanest split is
+        //           kind-based.)
+        //   2. Track candidates in a Vec<BindingId> for the
+        //      observability path.
+        //   3. Sweep — deferred to CLOC13.C.1 because *removing* a
+        //      function/class binding cleanly requires the AST to
+        //      have ImportDeclaration / ExportDeclaration nodes
+        //      (otherwise treeshake can't tell an exported
+        //      function from an internal one).
+        //
+        // **Critical (lesson from CLOC13.E security review):**
+        // `changed` is hard-pinned to `false` until step 3 lands.
+        // Reporting `changed = true` while returning an unchanged
+        // program would cause the scheduler under
+        // `IterationPolicy::FixedPoint` to re-run forever — each
+        // iteration would find the same candidates, claim a
+        // change, return the same program, repeat. Documented in
+        // both the code and the CHANGELOG so the next contributor
+        // doesn't reintroduce the bug.
+        //
+        // **Why this is safe with the v0.1.0 analyzer body.** The
+        // current `analyze` returns empty bindings + references,
+        // so the candidate scan finds zero shapes, the candidates
+        // vec is empty, `nodes_touched` is small, and the program
+        // passes through unchanged. The wiring becomes *effective*
+        // (real shape-finding) the moment CLOC13.0 lands the
+        // analyzer body — no churn here.
+
+        let analysis = analyze(ctx.program);
+
+        // Step 1 + 2: shape-candidate scan.
+        let mut shape_candidates: Vec<BindingId> = Vec::new();
+        for (idx, binding) in analysis.bindings.iter().enumerate() {
+            let id = BindingId(idx as u32);
+            // `#[non_exhaustive]` on BindingKind: future variants
+            // conservatively passthrough via wildcard.
+            match binding.kind {
+                BindingKind::Function | BindingKind::Class => {
+                    shape_candidates.push(id);
+                }
+                // Var/Let/Const/Param: these go through DCE +
+                // remove-unused-vars + collapse-properties. Splitting
+                // by kind keeps the passes from arguing over the
+                // same binding.
+                _ => {}
+            }
+        }
+
+        // Step 3 deferred — keep `changed = false`.
+        let _shape_candidates = shape_candidates;
+
         Ok(PassOutput {
             program: ctx.program.clone(),
             contributions: Vec::new(),
             changed: false,
             diagnostics: Vec::new(),
             stats: PassStats {
-                // Visited the program root; no exports/imports
-                // removed.
-                nodes_touched: 1,
+                // Visited the program root + every binding +
+                // every reference. Real cost numbers for the
+                // scheduler.
+                nodes_touched: (1
+                    + analysis.bindings.len()
+                    + analysis.references.len()) as u32,
             },
         })
     }


### PR DESCRIPTION
## Summary
- Wires `closure-pass-treeshake` to the shared `closure-scope-analyzer` (CLOC13 unblocker, #4763). `run` now invokes `analyze(ctx.program)` and walks `ScopeAnalysis` to identify **module-shape candidates** — `Function` / `Class` bindings (the only shapes ESM allows as named top-level exports).
- `changed` is **hard-pinned to `false`** until the actual apply step (sweep, CLOC13.C.1) lands — same CLOC13.E security review lesson that PRs #4766 + #4773 codified.
- `PassStats::nodes_touched` now reports `1 + bindings.len() + references.len()` — real cost surfacing.

## Algorithm (mark phase; sweep deferred)
1. Walk `analysis.bindings`. A binding is a module-shape candidate when `kind == Function` OR `kind == Class`. Var/Let/Const cross over to remove-unused-vars / collapse-properties; kind-based split keeps the passes from arguing over the same binding.
2. Track candidates in `Vec<BindingId>` for observability.
3. Sweep deferred: cleanly removing a function/class binding requires `ImportDeclaration` / `ExportDeclaration` AST variants (otherwise treeshake can't distinguish an exported function from an internal one).

## Why safe to merge now
- The current `closure-scope-analyzer` v0.1.0 returns empty `bindings` + `references`, so the candidate scan finds zero shapes and the program passes through unchanged — identical observable behavior to v0.1.0. The wiring becomes **effective** the moment CLOC13.0 lands the analyzer body — no churn here, no rebase.

## Test plan
- [x] `cargo test -p coding-adventures-closure-pass-treeshake` — all 9 tests pass unchanged (identity preserved under empty analysis).
- [x] Security review (Agent): PASS — `changed = false` literal not derived, no indexing / no .unwrap(), `#[non_exhaustive]` BindingKind handled via conservative wildcard, no unsafe, no I/O.
- [ ] CI green across ubuntu / macos / windows + CodeQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)