### PR TITLE
feat(matrix-rust-ruby-native): Rust half of matrix_rust_ruby gem (Ruby pilot PR #2/8)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -423,6 +423,7 @@ members = [
     "matrix-runtime",
     "matrix-rust-napi",
     "matrix-rust-python",
+    "matrix-rust-ruby-native",
     "metal-compute",
     "paint-metal",
     "paint-vm-direct2d-c",

--- a/code/packages/rust/matrix-rust-ruby-native/BUILD
+++ b/code/packages/rust/matrix-rust-ruby-native/BUILD
@@ -1,0 +1,1 @@
+cargo build -p matrix-rust-ruby-native --release

--- a/code/packages/rust/matrix-rust-ruby-native/BUILD_windows
+++ b/code/packages/rust/matrix-rust-ruby-native/BUILD_windows
@@ -1,0 +1,1 @@
+cargo build -p matrix-rust-ruby-native --release

--- a/code/packages/rust/matrix-rust-ruby-native/CHANGELOG.md
+++ b/code/packages/rust/matrix-rust-ruby-native/CHANGELOG.md
@@ -1,0 +1,85 @@
+# Changelog
+
+## Unreleased
+
+### Added — v0.1.0: Ruby ↔ matrix-cpu native extension
+
+First release.  Ships the Rust half of the forthcoming `matrix_rust_ruby`
+Ruby gem.
+
+#### What it exports
+
+Exactly one Ruby method, registered at extension-load time:
+
+```ruby
+MatrixRustRuby.run_graph_on_cpu(envelope_json_str) -> envelope_json_str
+```
+
+`envelope_json_str` is a matrix-ir-json envelope: a JSON string
+containing the graph definition + hex-encoded input tensors.  The
+return value is a JSON envelope with hex-encoded outputs.  On any
+error (malformed JSON, missing fields, invalid hex, executor failure)
+the method raises a Ruby `RuntimeError` with a descriptive message.
+
+#### Architecture: thin shim over `c-bridge`
+
+The implementation is ~30 LOC.  All graph parsing, planning, and CPU
+execution happens in the workspace `c-bridge` crate's pure-Rust
+`run_graph_on_cpu_via_json_envelope` function (~50 LOC of envelope
+plumbing on top of `matrix-ir-json` + `matrix-cpu`).  We just:
+
+1. `str_from_rb` the Ruby argument into a Rust `String`
+2. Call `c_bridge::run_graph_on_cpu_via_json_envelope`
+3. Translate `Result<String, String>` into either `str_to_rb` or
+   `raise_runtime_error`
+
+Putting the work in `c-bridge` keeps envelope shape + error semantics
+defined in exactly one place across every language binding (Ruby
+today; Lua, Go, Swift on deck).
+
+#### Why depend on `c-bridge` rather than the lower-level matrix-* crates?
+
+The first instinct is to depend directly on `matrix-ir-json`,
+`matrix-runtime`, and `matrix-cpu` and copy the envelope helper.  We
+chose `c-bridge` because:
+
+- **Single source of truth.**  Envelope shape changes (new ops, new
+  tensor dtypes) flow through one crate, not N.
+- **Panic safety inherited.**  `c-bridge`'s core is wrapped in
+  `catch_unwind`; we get that for free.
+- **Easier future refactor.**  When we DRY into a `matrix-rust-core`
+  crate (likely once Lua + Go bindings land), changing the path is
+  one edit.
+
+#### Safety
+
+- **Zero `unsafe` in this crate.**  Every Ruby C API call goes through
+  the workspace `ruby-bridge` safe wrappers
+  (`define_module`, `define_singleton_method_raw`, `str_to_rb`,
+  `str_from_rb`, `raise_runtime_error`).
+- **Never panics across FFI.**  `c-bridge` wraps its executor in
+  `std::panic::catch_unwind`; panics become `Err(String)` and then a
+  Ruby `RuntimeError`.
+- **Type-checks input.**  Non-String envelope argument → clean
+  `RuntimeError`, not undefined behaviour.
+
+#### Build script (`build.rs`)
+
+Copied verbatim from `conduit_native`'s build.rs — same Windows /
+macOS linking dance.  On macOS we pass `-undefined dynamic_lookup` so
+Ruby symbols stay unresolved in the .dylib (the host ruby process
+resolves them at dlopen time).  On Windows we discover Ruby's import
+library via `rbconfig` and link against it.  Linux needs nothing.
+
+#### Crate type
+
+`cdylib` only (no `rlib`).  Nothing in the Rust workspace depends on
+this crate — it exists purely to be dlopen()'d by Ruby.  Hence the
+single crate type.
+
+#### What's next
+
+- PR #3: `matrix_rust_ruby` Ruby gem — `.gemspec`, `extconf.rb`,
+  `lib/coding_adventures/matrix_rust_ruby.rb`, minitest suite.
+- PRs #4–#8: `ml_framework_core` for Ruby — idiomatic Tensor +
+  autograd that calls into this gem for the hot loop.

--- a/code/packages/rust/matrix-rust-ruby-native/Cargo.toml
+++ b/code/packages/rust/matrix-rust-ruby-native/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "matrix-rust-ruby-native"
+version = "0.1.0"
+edition = "2021"
+publish = false
+description = "Rust native extension half of the matrix_rust_ruby gem — bridges Ruby ↔ matrix-cpu via ruby-bridge + c-bridge."
+
+[lib]
+# `cdylib` because Ruby loads native extensions as dynamic libraries.
+# No `rlib` — nothing in the Rust workspace depends on this crate; it's a
+# leaf that exists purely so the matrix_rust_ruby gem's extconf.rb can
+# `cargo build --release` it and shove the resulting .{so,dylib,dll} into
+# Ruby's extension path.
+name = "matrix_rust_ruby_native"
+crate-type = ["cdylib"]
+
+[dependencies]
+# `ruby-bridge` — workspace crate that wraps the Ruby C API in safe-ish
+# helpers (define_module, str_to_rb, raise_error, ...).  Same crate that
+# `conduit_native` uses; chosen here for consistency with the established
+# Ruby-bridging pattern.
+ruby-bridge = { path = "../ruby-bridge" }
+
+# `c-bridge` — the workspace crate that owns the pure-Rust function
+# `run_graph_on_cpu_via_json_envelope`.  We depend on c-bridge (not on the
+# lower-level matrix-* crates directly) so that the envelope shape and
+# error semantics stay defined in exactly one place: any future change to
+# c-bridge automatically propagates to every per-language native ext.
+c-bridge = { path = "../c-bridge" }
+
+[build-dependencies]

--- a/code/packages/rust/matrix-rust-ruby-native/README.md
+++ b/code/packages/rust/matrix-rust-ruby-native/README.md
@@ -1,0 +1,107 @@
+# matrix-rust-ruby-native — Rust half of the `matrix_rust_ruby` gem
+
+This crate is the Rust-side native extension that powers the
+`matrix_rust_ruby` Ruby gem.  It exposes exactly one method to Ruby:
+
+```ruby
+MatrixRustRuby.run_graph_on_cpu(envelope_json_str) -> envelope_json_str
+```
+
+Pass in a matrix-ir-json envelope (a JSON string containing a graph
+definition plus hex-encoded input tensors), get back a JSON envelope
+with the hex-encoded outputs.  On any error — malformed JSON, missing
+fields, invalid hex, executor failure — raises a Ruby `RuntimeError`.
+
+## How it fits into the multi-language stack
+
+```text
+┌──────────────────────────────────────────────────────────────────┐
+│  ml_framework_core (Ruby gem)              ← PRs #4–#8           │
+│    idiomatic Tensor + autograd, Ruby ergonomics                  │
+│    ↓                                                              │
+│  matrix_rust_ruby (Ruby gem)               ← PR #3                │
+│    require_relative the native extension below                   │
+│    ↓                                                              │
+│  matrix_rust_ruby_native.{so,bundle,dll}   ← THIS CRATE           │
+│    Ruby module: MatrixRustRuby                                   │
+│    Singleton method: run_graph_on_cpu(envelope_str)              │
+│    ↓                                                              │
+│  c-bridge (Rust workspace crate)           ← PR #1 (merged)       │
+│    pure-Rust run_graph_on_cpu_via_json_envelope                  │
+│    ↓                                                              │
+│  matrix-ir-json → matrix-ir → matrix-runtime → matrix-cpu        │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+Three things to notice:
+
+1. **All the heavy lifting lives in `c-bridge`.**  This crate is ~30 LOC
+   of Rust that just translates between `VALUE` and `String` and
+   raises a Ruby exception on `Err`.  That keeps envelope shape and
+   error semantics defined in exactly one place across every future
+   language binding (Ruby today; Lua, Go, Swift on deck).
+
+2. **No `unsafe` in this crate.**  Every Ruby C API call goes through
+   the workspace `ruby-bridge` crate's safe wrappers
+   (`define_module`, `str_to_rb`, `str_from_rb`, `raise_error`, ...).
+   `ruby-bridge` owns the `unsafe`; we get to write boring code.
+
+3. **No panics across the FFI boundary.**  `c-bridge` already wraps
+   its core in `std::panic::catch_unwind` and surfaces panics as
+   `Err(String)`, so a runaway panic in the executor turns into a
+   Ruby `RuntimeError`, never undefined behaviour.
+
+## Building
+
+```bash
+cargo build -p matrix-rust-ruby-native --release
+# Produces target/release/libmatrix_rust_ruby_native.{so,dylib,dll}
+```
+
+In practice you don't build it by hand — the `matrix_rust_ruby` gem's
+`extconf.rb` runs this command for you when the gem is installed.
+
+### Why a workspace crate (not just an `ext/` directory inside the gem)?
+
+The conduit gem follows the more common pattern of nesting its Rust
+native ext inside `ext/conduit_native/`.  We went the other way for
+`matrix-rust-ruby-native`:
+
+* **Workspace integration.**  As a workspace member it gets `cargo
+  check`-ed and `cargo test`-ed by CI on every PR alongside every
+  other Rust crate.  An `ext/`-nested crate would need separate CI
+  wiring.
+* **Path deps stay short.**  `path = "../c-bridge"` is one hop;
+  `path = "../../../../rust/c-bridge"` (the conduit-style path)
+  works but is hard to grep.
+* **One Rust toolchain across the workspace.**  No risk of the
+  gem-installed Rust drifting from the workspace's edition / MSRV.
+
+The gem (PR #3) will reference the built `.so` by absolute path,
+discovered via `cargo metadata`.  This is documented in the gem's
+`extconf.rb`.
+
+## Memory + thread safety
+
+* **Thread-safe.**  Each call to `run_graph_on_cpu` constructs a
+  fresh `CpuExecutor` inside `c-bridge`; no shared mutable state
+  between calls.  Ruby can call this from any thread.
+* **No allocator mixing.**  The crate never hands a raw pointer to
+  Ruby.  Strings cross the boundary as Ruby `String` objects
+  (allocated by Ruby) and Rust `String` (allocated by Rust); each side
+  frees what it owns.
+
+## Tests
+
+The Ruby-level integration tests live in the `matrix_rust_ruby` gem
+(PR #3).  This crate is a thin shim; once Ruby's loaded the `.so` and
+calls our singleton method, all the interesting behaviour is in
+`c-bridge`, which has its own 8 + 7 unit/integration tests
+(`cargo test -p c-bridge`).
+
+## What's next
+
+PR #3 will create the `matrix_rust_ruby` Ruby gem: `.gemspec`,
+`extconf.rb`, `lib/coding_adventures/matrix_rust_ruby.rb`, and
+`test/test_matrix_rust_ruby.rb`.  Once that lands, PRs #4–#8 build
+the idiomatic `ml_framework_core` Ruby layer on top.

--- a/code/packages/rust/matrix-rust-ruby-native/build.rs
+++ b/code/packages/rust/matrix-rust-ruby-native/build.rs
@@ -1,0 +1,192 @@
+// =============================================================================
+// build.rs — platform-specific linking for a Ruby native extension
+// =============================================================================
+//
+// Building a Ruby native extension on Unix vs. Windows is a story of two very
+// different linkers.
+//
+//   * On macOS:    we want Ruby's symbols (rb_define_module, ...) to remain
+//                  *unresolved* in the .dylib.  The Ruby interpreter loads
+//                  the .dylib at runtime via dlopen() and resolves those
+//                  symbols against its own process image — i.e. against
+//                  whichever libruby (or statically-linked ruby executable)
+//                  is in charge.  The magic incantation is the linker pair
+//                  `-undefined dynamic_lookup`.
+//
+//   * On Linux:    the dynamic loader auto-resolves undefined symbols at
+//                  dlopen() time, so we need no extra link args.
+//
+//   * On Windows:  the .dll *must* resolve every symbol at link time —
+//                  there is no equivalent of dynamic_lookup.  So we ask
+//                  rbconfig where Ruby's import library lives and link
+//                  against it (MSVC) or against `libruby.dll.a` (MinGW).
+//                  This is the same dance conduit_native does; we copy it
+//                  verbatim because Windows Ruby linking is fiddly and
+//                  one working incantation per workspace is plenty.
+//
+// We don't need to do anything for cargo dependency tracking — c-bridge
+// and ruby-bridge are normal Rust deps, picked up via Cargo.toml.
+
+use std::path::PathBuf;
+
+fn main() {
+    match std::env::var("CARGO_CFG_TARGET_OS")
+        .unwrap_or_default()
+        .as_str()
+    {
+        "macos" => {
+            // -undefined dynamic_lookup: tolerate Ruby symbols being unresolved
+            // at .dylib link time; the host ruby process will provide them.
+            println!("cargo:rustc-cdylib-link-arg=-undefined");
+            println!("cargo:rustc-cdylib-link-arg=dynamic_lookup");
+        }
+        "windows" => link_ruby_on_windows(),
+        _ => {
+            // Linux + BSDs: nothing to do.  Dynamic loader will handle it.
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Windows: discover the active Ruby's bin/lib/SO_NAME via rbconfig and link.
+// -----------------------------------------------------------------------------
+
+fn link_ruby_on_windows() {
+    let Some(ruby) = find_ruby() else {
+        return;
+    };
+    let (Some(bin_dir), Some(lib_dir), Some(so_name)) = (
+        get_ruby_config(&ruby, "bindir"),
+        get_ruby_config(&ruby, "libdir"),
+        get_ruby_config(&ruby, "RUBY_SO_NAME"),
+    ) else {
+        return;
+    };
+
+    let out_dir = std::env::var("OUT_DIR").unwrap();
+    let target_env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
+    println!("cargo:rustc-link-search=native={lib_dir}");
+    println!("cargo:rustc-link-search=native={bin_dir}");
+
+    if target_env == "msvc" {
+        // MSVC needs a .lib import library.  Try to generate one from a .def;
+        // if that fails (no `lib.exe` on PATH), fall back to /FORCE:UNRESOLVED.
+        if generate_msvc_lib(&format!("{so_name}.dll"), &so_name, &out_dir) {
+            println!("cargo:rustc-link-search=native={out_dir}");
+            println!("cargo:rustc-link-lib={so_name}");
+        } else {
+            println!("cargo:rustc-link-lib=dylib={so_name}");
+        }
+        println!("cargo:rustc-cdylib-link-arg=/FORCE:UNRESOLVED");
+    } else if let Some(import_library) = get_ruby_config(&ruby, "LIBRUBY") {
+        // MinGW: LIBRUBY is e.g. "libruby.dll.a" — link that file directly.
+        let import_library = PathBuf::from(lib_dir).join(import_library);
+        println!("cargo:rustc-cdylib-link-arg={}", import_library.display());
+    } else {
+        println!("cargo:rustc-link-lib=dylib={so_name}");
+    }
+}
+
+/// Generate a minimal MSVC `.lib` from a `.def` for the Ruby symbols we
+/// actually call.  Matches the conduit_native symbol list exactly — keeping
+/// these in sync means a developer adding a new Ruby C API call has one
+/// place to think about, not two.
+fn generate_msvc_lib(dll_name: &str, so_name: &str, out_dir: &str) -> bool {
+    // (symbol, is_data_export).  Functions are exports of code; constants like
+    // rb_cObject are data exports and need the DATA keyword in the .def.
+    let symbols: &[(&str, bool)] = &[
+        ("rb_define_module", false),
+        ("rb_define_module_under", false),
+        ("rb_define_class_under", false),
+        ("rb_define_method", false),
+        ("rb_define_singleton_method", false),
+        ("rb_define_module_function", false),
+        ("rb_define_alloc_func", false),
+        ("rb_path2class", false),
+        ("rb_utf8_str_new", false),
+        ("rb_string_value_cstr", false),
+        ("rb_ary_new", false),
+        ("rb_ary_push", false),
+        ("rb_ary_entry", false),
+        ("rb_intern", false),
+        ("rb_funcallv", false),
+        ("rb_num2long", false),
+        ("rb_int2inum", false),
+        ("rb_float_new", false),
+        ("rb_num2dbl", false),
+        ("rb_hash_new", false),
+        ("rb_hash_aset", false),
+        ("rb_data_object_wrap", false),
+        ("rb_check_typeddata", false),
+        ("rb_raise", false),
+        ("rb_str_strlen", false),
+        ("rb_thread_call_without_gvl", false),
+        ("rb_thread_call_with_gvl", false),
+        ("rb_protect", false),
+        ("rb_errinfo", false),
+        ("rb_set_errinfo", false),
+        ("rb_cObject", true),
+        ("rb_eStandardError", true),
+        ("rb_eArgError", true),
+        ("rb_eRuntimeError", true),
+    ];
+
+    let def_path = PathBuf::from(out_dir).join(format!("{so_name}.def"));
+    let mut def_content = format!("LIBRARY {dll_name}\nEXPORTS\n");
+    for (sym, is_data) in symbols {
+        if *is_data {
+            def_content.push_str(&format!("    {sym} DATA\n"));
+        } else {
+            def_content.push_str(&format!("    {sym}\n"));
+        }
+    }
+    if std::fs::write(&def_path, def_content).is_err() {
+        return false;
+    }
+
+    let lib_path = PathBuf::from(out_dir).join(format!("{so_name}.lib"));
+    for program in ["lib.exe", "lib"] {
+        let result = std::process::Command::new(program)
+            .args([
+                &format!("/def:{}", def_path.display()),
+                &format!("/out:{}", lib_path.display()),
+                "/machine:x64",
+                "/nologo",
+            ])
+            .output();
+        if matches!(result, Ok(output) if output.status.success() && lib_path.exists()) {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn get_ruby_config(ruby: &str, key: &str) -> Option<String> {
+    let script = format!("require 'rbconfig'; print RbConfig::CONFIG['{key}']");
+    let output = std::process::Command::new(ruby)
+        .args(["-e", &script])
+        .output()
+        .ok()?;
+    let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!value.is_empty()).then_some(value)
+}
+
+fn find_ruby() -> Option<String> {
+    for finder in ["where", "which"] {
+        if let Ok(output) = std::process::Command::new(finder).arg("ruby").output() {
+            if output.status.success() {
+                let path = String::from_utf8_lossy(&output.stdout)
+                    .lines()
+                    .next()
+                    .unwrap_or("")
+                    .trim()
+                    .to_string();
+                if !path.is_empty() {
+                    return Some(path);
+                }
+            }
+        }
+    }
+    None
+}

--- a/code/packages/rust/matrix-rust-ruby-native/required_capabilities.json
+++ b/code/packages/rust/matrix-rust-ruby-native/required_capabilities.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/matrix-rust-ruby-native",
+  "capabilities": [
+    {
+      "category": "ffi",
+      "action": "export",
+      "target": "Init_matrix_rust_ruby_native + Ruby singleton method run_graph_on_cpu",
+      "justification": "This crate exists to be dlopen()'d by Ruby. It exports the Init_matrix_rust_ruby_native entry point and registers MatrixRustRuby.run_graph_on_cpu as a singleton method — no other surface."
+    },
+    {
+      "category": "ffi",
+      "action": "call",
+      "target": "Ruby C API (via ruby-bridge)",
+      "justification": "Defining the Ruby module and singleton method requires calling rb_define_module, rb_define_singleton_method, rb_utf8_str_new, rb_string_value_cstr, rb_raise — all funneled through the workspace ruby-bridge crate's safe wrappers."
+    },
+    {
+      "category": "ffi",
+      "action": "call",
+      "target": "c-bridge::run_graph_on_cpu_via_json_envelope (pure-Rust workspace fn)",
+      "justification": "The actual graph execution is delegated to the c-bridge workspace crate so envelope shape + error semantics stay defined in exactly one place across every language binding."
+    }
+  ],
+  "justification": "Native extension crate. The only outward-facing surface is one Ruby singleton method (run_graph_on_cpu) registered at Init time. No network, no filesystem, no process spawning. Build script links Ruby's C API on macOS (dynamic_lookup) and Windows (rbconfig-discovered libruby); on Linux the dynamic loader handles symbol resolution automatically."
+}

--- a/code/packages/rust/matrix-rust-ruby-native/src/lib.rs
+++ b/code/packages/rust/matrix-rust-ruby-native/src/lib.rs
@@ -1,0 +1,158 @@
+//! matrix-rust-ruby-native — Ruby ↔ matrix-cpu native extension
+//! ============================================================
+//!
+//! ## The one-line story
+//!
+//! This crate exposes exactly one Ruby method:
+//!
+//! ```ruby
+//! MatrixRustRuby.run_graph_on_cpu(envelope_json_str) -> envelope_json_str
+//! ```
+//!
+//! It takes a matrix-ir-json envelope (a JSON string describing a graph plus
+//! its hex-encoded input tensors), runs it on the Rust `matrix-cpu` engine,
+//! and returns a JSON envelope with the hex-encoded outputs.  On error
+//! (malformed envelope, missing fields, hex decoding failure, …) it raises
+//! a Ruby `RuntimeError`.
+//!
+//! ## Why is the implementation so small?
+//!
+//! All the actual work — JSON parsing, graph construction, planning,
+//! executing on `matrix-cpu`, re-encoding outputs — lives in the workspace
+//! crate [`c-bridge`].  We just call its `run_graph_on_cpu_via_json_envelope`
+//! function and translate its `Result<String, String>` into either a Ruby
+//! string or a Ruby exception.
+//!
+//! Putting the heavy lifting in `c-bridge` means three things stay in lockstep
+//! across every language binding:
+//!
+//!   1. **Envelope shape** — Ruby and Python (and tomorrow's Lua / Go /
+//!      Swift bindings) all send and receive the *exact* same JSON.
+//!   2. **Error semantics** — every binding turns "malformed envelope" into
+//!      a runtime-level error in the host language.
+//!   3. **Performance characteristics** — the CPU executor is constructed
+//!      identically per call, so benchmarks across languages compare apples
+//!      to apples.
+//!
+//! ## What about safety?
+//!
+//! The Ruby C API is, by Rust standards, deeply unsafe: it traffics in raw
+//! `VALUE` integers, longjmps on exceptions, and has fiddly rules about
+//! holding the GVL.  We minimize exposure here by:
+//!
+//!   * **Doing all real work in pure Rust** before touching Ruby.  The
+//!     envelope-execution call returns a plain `Result<String, String>`;
+//!     only the conversion of that result into a Ruby value happens via FFI.
+//!   * **Letting `ruby-bridge` own the unsafe.**  Every Ruby C API call here
+//!     goes through a safe-ish wrapper in `ruby-bridge` (`str_to_rb`,
+//!     `str_from_rb`, `raise_error`, `define_module`, ...).  This crate
+//!     contains zero `unsafe` blocks.
+//!   * **Catching panics at the FFI boundary.**  `c-bridge` already wraps
+//!     its core in `std::panic::catch_unwind` and surfaces panics as
+//!     `Err(String)`, so we never let a panic cross into Ruby (where it
+//!     would be UB).
+//!
+//! ## Architecture: how this fits the multi-language stack
+//!
+//! ```text
+//!   ┌─────────────────────────────────────────────────────────────┐
+//!   │  matrix_rust_ruby (Ruby gem)            ← PR #3            │
+//!   │    ↓ require_relative                                       │
+//!   │  matrix_rust_ruby_native.{so,bundle}    ← THIS CRATE        │
+//!   │    ↓ Rust function call                                     │
+//!   │  c-bridge::run_graph_on_cpu_via_json_envelope               │
+//!   │    ↓ pure Rust                                              │
+//!   │  matrix-ir-json → matrix-ir → matrix-runtime → matrix-cpu   │
+//!   └─────────────────────────────────────────────────────────────┘
+//! ```
+//!
+//! On top of this gem will sit `ml_framework_core` for Ruby — an idiomatic
+//! Tensor + autograd library (PRs #4–#8).
+//!
+//! ## Entry point
+//!
+//! Ruby calls `Init_matrix_rust_ruby_native` when it dlopen()s the .so;
+//! that's where we register the module and method.
+
+use std::os::raw::c_void;
+
+use ruby_bridge::VALUE;
+
+// =============================================================================
+// The singleton method:  MatrixRustRuby.run_graph_on_cpu(envelope_str)
+// =============================================================================
+//
+// Ruby's calling convention for an `argc=1` C function defined via
+// `rb_define_singleton_method` is:
+//
+//     extern "C" fn(self_value, arg1) -> VALUE
+//
+// `self_value` here is the module object itself (MatrixRustRuby).  We don't
+// need it — singleton methods on modules act like module functions.
+extern "C" fn run_graph_on_cpu(_self_val: VALUE, envelope_val: VALUE) -> VALUE {
+    // Step 1.  Decode the Ruby string argument into a Rust &str.
+    //
+    // `str_from_rb` returns None if the argument is not a String (e.g. the
+    // caller passed nil, an Integer, ...).  Treat that as a TypeError-like
+    // condition by raising RuntimeError with an explanatory message — the
+    // Ruby-side wrapper in the matrix_rust_ruby gem can choose to upgrade
+    // this to a TypeError if/when desired, but RuntimeError keeps things
+    // simple at this layer.
+    let envelope = match ruby_bridge::str_from_rb(envelope_val) {
+        Some(s) => s,
+        None => ruby_bridge::raise_runtime_error(
+            "MatrixRustRuby.run_graph_on_cpu: envelope must be a String",
+        ),
+    };
+
+    // Step 2.  Run the graph.  All real work happens here — JSON parse,
+    // graph construction, planning, CPU execution, output re-encoding.
+    //
+    // c-bridge wraps its core in catch_unwind, so a panic in the executor
+    // becomes Err(String) rather than crossing the FFI boundary.
+    // Crate name in Cargo.toml is `c-bridge` (package) → `matrix_c_bridge`
+    // (lib).  The `[lib] name = "matrix_c_bridge"` override is what we
+    // import here; it matches the .so/.dylib basename produced by
+    // `cargo build -p c-bridge`.
+    let result = matrix_c_bridge::run_graph_on_cpu_via_json_envelope(&envelope);
+
+    // Step 3.  Translate Result<String, String> into Ruby.
+    match result {
+        Ok(output_envelope) => ruby_bridge::str_to_rb(&output_envelope),
+        Err(msg) => ruby_bridge::raise_runtime_error(&format!(
+            "MatrixRustRuby.run_graph_on_cpu failed: {msg}"
+        )),
+    }
+}
+
+// =============================================================================
+// Init_matrix_rust_ruby_native — Ruby's dlopen() entry point
+// =============================================================================
+//
+// Ruby looks for a function named `Init_<basename>` in every .so it loads as
+// a native extension.  Our gem will require_relative the `.so` whose basename
+// is `matrix_rust_ruby_native`, so this function must be named exactly
+// `Init_matrix_rust_ruby_native`.
+//
+// What we do here:
+//
+//   1. Define a top-level Ruby module `MatrixRustRuby`.
+//   2. Attach `run_graph_on_cpu(envelope_str)` as a singleton method on it.
+//
+// We deliberately put the module at the top level (not under
+// `CodingAdventures::MatrixRustRuby`) so that the gem-side Ruby code can
+// write `MatrixRustRuby.run_graph_on_cpu(...)` directly — short,
+// pronounceable, and matches the README examples in c-bridge.
+#[no_mangle]
+pub extern "C" fn Init_matrix_rust_ruby_native() {
+    let module = ruby_bridge::define_module("MatrixRustRuby");
+
+    // argc=1 → one Ruby-side argument.  Cast through *const c_void because
+    // that's what define_singleton_method_raw takes.
+    ruby_bridge::define_singleton_method_raw(
+        module,
+        "run_graph_on_cpu",
+        run_graph_on_cpu as *const c_void,
+        1,
+    );
+}


### PR DESCRIPTION
## Summary

- New workspace cdylib `matrix-rust-ruby-native` that exposes one Ruby method: `MatrixRustRuby.run_graph_on_cpu(envelope_json_str)`.
- Delegates all real work to the already-merged `c-bridge` crate's pure-Rust `run_graph_on_cpu_via_json_envelope`.
- Zero `unsafe` blocks; all Ruby C API access goes through `ruby-bridge`'s safe wrappers.

## Architecture

```
ml_framework_core (Ruby gem)        ← PRs #4-#8 (planned)
  ↓
matrix_rust_ruby (Ruby gem)         ← PR #3 (next)
  ↓
matrix_rust_ruby_native (THIS PR)
  ↓
c-bridge::run_graph_on_cpu_via_json_envelope   ← #4769 (merged)
  ↓
matrix-ir-json → matrix-ir → matrix-runtime → matrix-cpu
```

This is PR #2 of 8 in the Ruby pilot for ML framework libraries with idiomatic language ergonomics that share the Rust matrix-cpu engine underneath.

## Safety

- Zero `unsafe` blocks in this crate
- c-bridge already wraps its core in `catch_unwind` → no panic-across-FFI
- Non-String envelope arg → clean RuntimeError (not UB)
- `build.rs` is a verbatim copy of conduit_native's (no new attack surface)

## Test plan

- [x] `cargo build -p matrix-rust-ruby-native` passes
- [x] `cargo check -p matrix-rust-ruby-native` passes
- [x] Workspace member added in alphabetical order
- [x] Security review passed (no unsafe, no injection vectors, no allocator mixing)
- [ ] CI: build (ubuntu/macos/windows) passes — pending
- [ ] CI: CodeQL passes — pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)