### PR TITLE
feat(closure-pass-rename): CLOC13.A — consume scope-analyzer

### DIFF
--- a/code/packages/rust/closure-pass-rename/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename` crate will be documented in this file.
 
+## [0.2.0] - 2026-06-01
+
+### Added (CLOC13.A — consume `closure-scope-analyzer`)
+- Wired the pass to `coding-adventures-closure-scope-analyzer` (new `[dependencies]` entry). `run` now invokes `analyze(ctx.program)` and walks the returned `ScopeAnalysis` to identify **rename candidates** — every binding the analyzer surfaces.
+- Algorithm (collect phase; substitute deferred to CLOC13.A.1):
+  1. Walk `analysis.bindings`. Every binding is a candidate. (`#[non_exhaustive]` BindingKind: future variants are admitted by default — they all need renaming. This is the *opposite* default from treeshake / collapse-properties, which conservatively *skip* unknown kinds. Rename is conservative-toward-compression rather than conservative-toward-skip — a missed rename is wasted bytes, not a correctness issue.)
+  2. Track candidates in `Vec<BindingId>` for observability.
+  3. *Substitute deferred*: cleanly rewriting Identifier nodes needs the AST to grow `Identifier` / `VariableDeclarator` variants AND the analyzer to surface a binding → uses backreference (currently absent).
+- `PassStats::nodes_touched` now reports `1 + bindings.len() + references.len()` (root + every binding + every reference visited). Real cost surfacing for the scheduler instead of the v0.1.0 placeholder `1`.
+
+### Critical safety pin (lesson from CLOC13.E security review — adapted for OneShot)
+- `changed` is **hard-pinned to `false`** until step 3 (the actual program mutation) lands. Even though this pass's `iteration_policy` is `OneShot` — so the FixedPoint infinite-loop concern doesn't apply — the discipline of "don't lie to the scheduler about mutation" is the same. Pipeline consumers may key off `changed` for cache invalidation or to skip downstream serialization; reporting `true` without mutation would force unnecessary work. Documented in both the source (`fn run`) and here so the next contributor doesn't reintroduce the bug.
+
+### Why this is safe to merge ahead of the analyzer body
+- The current `closure-scope-analyzer` v0.1.0 returns empty `bindings` + `references`. The candidate scan therefore produces zero names, the candidates vec stays empty, `nodes_touched` is small, and the program passes through unchanged — identical observable behavior to v0.1.0. The wiring becomes **effective** the moment CLOC13.0 lands the analyzer body — no churn here, no rebase needed.
+
+### Dependencies
+- Added `coding-adventures-closure-scope-analyzer = { path = "../closure-scope-analyzer" }` to `[dependencies]`. Crate bumped `0.1.0 → 0.2.0`.
+
 ## [0.1.0] - 2026-05-23
 
 ### Added

--- a/code/packages/rust/closure-pass-rename/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "coding-adventures-closure-pass-rename"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Variable renaming pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces non-exported binding names with shorter identifiers to reduce output size while preserving externally-visible names and semantics."
 
 [dependencies]
 coding-adventures-closure-pass-pipeline = { path = "../closure-pass-pipeline" }
+coding-adventures-closure-scope-analyzer = { path = "../closure-scope-analyzer" }
 coding-adventures-javascript-ast = { path = "../javascript-ast" }
 coding-adventures-type-sidecar = { path = "../type-sidecar" }
 coding_adventures_correlation_vector = { path = "../correlation-vector" }

--- a/code/packages/rust/closure-pass-rename/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename/src/lib.rs
@@ -72,6 +72,7 @@
 use coding_adventures_closure_pass_pipeline::{
     IterationPolicy, Pass, PassContext, PassError, PassOutput, PassStats,
 };
+use coding_adventures_closure_scope_analyzer::{analyze, BindingId};
 
 /// `Pass::depends_on` value. Empty in v1 — see crate-level docs
 /// for why. Kept as a `const` so future tests/crates can refer to
@@ -128,19 +129,74 @@ impl Pass for RenamePass {
     }
 
     fn run(&self, ctx: PassContext<'_>) -> Result<PassOutput, PassError> {
-        // v1: no Identifier / VariableDeclarator / Function*
-        // nodes in the AST yet, so there's nothing to rename. Pass
-        // through unchanged. The real two-pass walk (collect →
-        // substitute) slots in here once javascript-ast grows the
-        // variants.
+        // CLOC13.A wiring: consume the shared `ScopeAnalysis` from
+        // `closure-scope-analyzer` to identify *rename candidates*
+        // — every binding the analyzer surfaces. Rename's job is
+        // global (every non-external binding gets a shorter name),
+        // so the candidate set is *all* bindings minus the
+        // externally-visible ones. v0.2.0 collects the full set
+        // without filtering — the externals filter waits for the
+        // type-sidecar to grow an `external` attribute (CLOC04 left
+        // it open).
+        //
+        // The algorithm (collect phase; substitute deferred):
+        //
+        //   1. Walk `analysis.bindings`. Every binding is a
+        //      candidate. (`#[non_exhaustive]` BindingKind: future
+        //      variants are admitted by default — they all need
+        //      renaming. This is the *opposite* default from
+        //      treeshake/collapse, which conservatively *skip*
+        //      unknown kinds. Rename is conservative-toward-
+        //      compression rather than conservative-toward-skip.)
+        //   2. Track candidates in a Vec<BindingId> for the
+        //      observability path.
+        //   3. Substitute — deferred to CLOC13.A.1 because cleanly
+        //      rewriting Identifier nodes needs the AST to grow
+        //      Identifier / VariableDeclarator variants AND the
+        //      analyzer to surface a binding → uses backreference.
+        //
+        // **Critical (lesson from CLOC13.E security review):**
+        // `changed` is hard-pinned to `false` until step 3 lands.
+        // Even though this pass's `iteration_policy` is OneShot
+        // (so the FixedPoint infinite-loop concern doesn't apply),
+        // the discipline of "don't lie to the scheduler about
+        // mutation" is the same. Pipeline consumers may key off
+        // `changed` for cache invalidation or to skip downstream
+        // serialization; reporting `true` without mutation would
+        // force unnecessary work. Documented in both the source
+        // and the CHANGELOG.
+        //
+        // **Why this is safe with the v0.1.0 analyzer body.** The
+        // current `analyze` returns empty bindings + references,
+        // so the candidate scan finds zero names, the candidates
+        // vec is empty, `nodes_touched` is small, and the program
+        // passes through unchanged. The wiring becomes *effective*
+        // (real candidate-finding) the moment CLOC13.0 lands the
+        // analyzer body — no churn here.
+
+        let analysis = analyze(ctx.program);
+
+        // Steps 1 + 2: every binding is a rename candidate.
+        let mut rename_candidates: Vec<BindingId> = Vec::new();
+        for (idx, _binding) in analysis.bindings.iter().enumerate() {
+            rename_candidates.push(BindingId(idx as u32));
+        }
+
+        // Step 3 deferred — keep `changed = false`.
+        let _rename_candidates = rename_candidates;
+
         Ok(PassOutput {
             program: ctx.program.clone(),
             contributions: Vec::new(),
             changed: false,
             diagnostics: Vec::new(),
             stats: PassStats {
-                // Visited the program root; no identifiers renamed.
-                nodes_touched: 1,
+                // Visited the program root + every binding +
+                // every reference. Real cost numbers for the
+                // scheduler.
+                nodes_touched: (1
+                    + analysis.bindings.len()
+                    + analysis.references.len()) as u32,
             },
         })
     }


### PR DESCRIPTION
## Summary
- Wires `closure-pass-rename` to the shared `closure-scope-analyzer` (CLOC13 unblocker, #4763). `run` now invokes `analyze(ctx.program)` and walks `ScopeAnalysis` to identify **rename candidates** — every binding the analyzer surfaces. Rename's job is global; the externals filter waits for the type-sidecar to grow an `external` attribute (CLOC04 left it open).
- `changed` is **hard-pinned to `false`** until the actual substitute step (CLOC13.A.1) lands. This pass is `OneShot` (not `FixedPoint`), so the CLOC13.E infinite-loop concern doesn't literally apply — but the discipline of "don't lie to the scheduler about mutation" is the same. Cache invalidation / downstream-skip consumers key off `changed`.
- `PassStats::nodes_touched` now reports `1 + bindings.len() + references.len()` — real cost surfacing.

## Algorithm (collect phase; substitute deferred)
1. Walk `analysis.bindings`. Every binding is a rename candidate.
2. Track candidates in `Vec<BindingId>` for observability.
3. Substitute deferred — cleanly rewriting Identifier nodes needs the AST to grow `Identifier` / `VariableDeclarator` variants AND the analyzer to surface a binding → uses backreference (currently absent).

Note vs CLOC13.C/D: those passes conservatively **skip** unknown `#[non_exhaustive]` BindingKind variants. Rename does the opposite — admits every binding by default (no `match` on kind). A missed rename is wasted bytes; not a correctness issue.

## Why safe to merge now
- The current `closure-scope-analyzer` v0.1.0 returns empty `bindings` + `references`, so the candidate scan finds zero names and the program passes through unchanged — identical observable behavior to v0.1.0. The wiring becomes **effective** the moment CLOC13.0 lands the analyzer body — no churn here, no rebase.

## Test plan
- [x] `cargo test -p coding-adventures-closure-pass-rename` — all 8 tests pass unchanged.
- [x] Security review (Agent): PASS — `changed = false` literal, no indexing / no .unwrap(), no `#[non_exhaustive]` match concern (no kind filter), no unsafe, no I/O.
- [ ] CI green across ubuntu / macos / windows + CodeQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)