### PR TITLE
feat(closure-pass-inline): CLOC13.B — consume scope-analyzer

### DIFF
--- a/code/packages/rust/closure-pass-inline/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline` crate will be documented in this file.
 
+## [0.2.0] - 2026-06-01
+
+### Added (CLOC13.B — consume `closure-scope-analyzer`)
+- Wired the pass to `coding-adventures-closure-scope-analyzer` (new `[dependencies]` entry). `run` now invokes `analyze(ctx.program)` and walks the returned `ScopeAnalysis` to identify **inline candidates** — function/class-shaped bindings that are called from exactly one site, the unambiguous-win case where substituting the body saves call overhead and exposes concrete arguments to downstream constant-fold.
+- Algorithm (mark phase; substitute deferred to CLOC13.B.1):
+  1. Per-binding use-count derived from `analysis.references`. The single-use property is the gate that makes inlining cheap (clone once vs. duplicating the body N times).
+  2. Candidate scan: a binding qualifies when `kind == Function || kind == Class` AND `uses == 1`. `Param` is excluded (params aren't callable bodies). `Var`/`Let`/`Const` of function-expressions lower to `Function` once the analyzer grows expression tracking; until then those are handled by `collapse-properties` (CLOC13.D) for their alias form. `#[non_exhaustive]` future variants are conservatively skipped via the wildcard arm — same default as treeshake / collapse-properties.
+  3. *Substitute deferred*: cleanly replacing a `CallExpression` with the callee's body requires both the AST to grow `CallExpression` / `FunctionDeclaration` variants AND the analyzer to surface a binding → defining-node backreference.
+- Multi-use inlining is a budget decision (size threshold × call-site count); the single-use case is the cheapest substitution to land first.
+- `PassStats::nodes_touched` now reports `1 + bindings.len() + references.len()` (root + every binding + every reference visited). Real cost surfacing instead of the v0.1.0 placeholder `1`.
+
+### Critical safety pin (lesson from CLOC13.E security review)
+- `changed` is **hard-pinned to `false`** until step 3 (the actual program mutation) lands. The pass identifies candidates and returns the program *unchanged*. Reporting `changed = true` while returning an unchanged program would cause the scheduler under `IterationPolicy::FixedPoint` to re-run forever — each iteration would find the same candidates, claim a change, return the same program, repeat. Documented in both the source and here.
+
+### Why this is safe to merge ahead of the analyzer body
+- The current `closure-scope-analyzer` v0.1.0 returns empty `bindings` + `references`. The candidate scan therefore produces zero call targets, the candidates vec stays empty, and the program passes through unchanged — identical observable behavior to v0.1.0. The wiring becomes **effective** the moment CLOC13.0 lands the analyzer body — no churn here, no rebase needed.
+
+### Dependencies
+- Added `coding-adventures-closure-scope-analyzer = { path = "../closure-scope-analyzer" }` to `[dependencies]`. Crate bumped `0.1.0 → 0.2.0`.
+
 ## [0.1.0] - 2026-05-23
 
 ### Added

--- a/code/packages/rust/closure-pass-inline/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "coding-adventures-closure-pass-inline"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Function-inlining pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Substitutes small or single-use function bodies at their call sites to enable downstream folding and shrink call overhead."
 
 [dependencies]
 coding-adventures-closure-pass-pipeline = { path = "../closure-pass-pipeline" }
+coding-adventures-closure-scope-analyzer = { path = "../closure-scope-analyzer" }
 coding-adventures-javascript-ast = { path = "../javascript-ast" }
 coding-adventures-type-sidecar = { path = "../type-sidecar" }
 coding_adventures_correlation_vector = { path = "../correlation-vector" }

--- a/code/packages/rust/closure-pass-inline/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline/src/lib.rs
@@ -91,6 +91,7 @@
 use coding_adventures_closure_pass_pipeline::{
     IterationPolicy, Pass, PassContext, PassError, PassOutput, PassStats,
 };
+use coding_adventures_closure_scope_analyzer::{analyze, BindingId, BindingKind};
 
 /// `Pass::depends_on` value. Kept as a `const` so future tests
 /// and dependent crates can refer to it without retyping the
@@ -154,19 +155,108 @@ impl Pass for InlinePass {
     }
 
     fn run(&self, ctx: PassContext<'_>) -> Result<PassOutput, PassError> {
-        // v1: no FunctionDeclaration / CallExpression /
-        // Identifier nodes in the AST yet, so there's nothing to
-        // inline. Pass through unchanged. The real call-graph
-        // walk + per-call substitution slots in here once
-        // javascript-ast grows the variants.
+        // CLOC13.B wiring: consume the shared `ScopeAnalysis` from
+        // `closure-scope-analyzer` to identify *inline candidates*
+        // — function/class-shaped bindings that are called from
+        // exactly one site, where substituting the body in place
+        // saves the call overhead and lets downstream constant-fold
+        // see the now-concrete arguments.
+        //
+        // The algorithm (mark phase; substitute deferred):
+        //
+        //   1. Per-binding use-count derived from
+        //      `analysis.references`. The single-use property is
+        //      the gate that makes inlining cheap (clone once vs.
+        //      duplicating the body N times).
+        //   2. Candidate scan. A binding is an inline candidate
+        //      when ALL of:
+        //        a. kind == Function OR kind == Class — these are
+        //           the body-shaped kinds inlining substitutes
+        //           into call/new sites. (`Var`/`Let`/`Const`
+        //           bindings of *function expressions* lower to
+        //           Function once the analyzer grows expression
+        //           tracking; until then they're tracked as
+        //           Const/Let and CLOC13.D handles their alias
+        //           form.) `Param` is excluded — params aren't
+        //           callable bodies. `#[non_exhaustive]` future
+        //           variants are conservatively skipped (same
+        //           default as treeshake / collapse-properties).
+        //        b. uses == 1. Multi-use inlining is a budget
+        //           decision (size threshold × call-site count);
+        //           the single-use case is the unambiguous win
+        //           and the cheapest substitution to land first.
+        //   3. Substitute — deferred to CLOC13.B.1 because cleanly
+        //      replacing a CallExpression with the callee's body
+        //      requires both the AST to grow CallExpression /
+        //      FunctionDeclaration variants AND the analyzer to
+        //      surface a binding → defining-node backreference.
+        //
+        // **Critical (lesson from CLOC13.E security review):**
+        // `changed` is hard-pinned to `false` until step 3 lands.
+        // Reporting `changed = true` while returning an unchanged
+        // program would cause the scheduler under
+        // `IterationPolicy::FixedPoint` to re-run forever — each
+        // iteration would find the same candidates, claim a
+        // change, return the same program, repeat. Documented in
+        // both the code and the CHANGELOG so the next contributor
+        // doesn't reintroduce the bug.
+        //
+        // **Why this is safe with the v0.1.0 analyzer body.** The
+        // current `analyze` returns empty bindings + references,
+        // so the candidate scan finds zero call targets, the
+        // candidates vec is empty, `nodes_touched` is small, and
+        // the program passes through unchanged. The wiring
+        // becomes *effective* (real candidate-finding) the moment
+        // CLOC13.0 lands the analyzer body — no churn here.
+
+        let analysis = analyze(ctx.program);
+
+        // Step 1: use-count per binding.
+        let mut use_count: Vec<usize> = vec![0; analysis.bindings.len()];
+        for reference in &analysis.references {
+            if let Some(BindingId(idx)) = reference.binding {
+                if let Some(slot) = use_count.get_mut(idx as usize) {
+                    *slot += 1;
+                }
+            }
+        }
+
+        // Step 2: single-use function/class scan.
+        let mut inline_candidates: Vec<BindingId> = Vec::new();
+        for (idx, binding) in analysis.bindings.iter().enumerate() {
+            let id = BindingId(idx as u32);
+            let uses = use_count.get(idx).copied().unwrap_or(0);
+            if uses != 1 {
+                continue; // multi-use is a budget decision deferred to a later PR
+            }
+            // `#[non_exhaustive]` on BindingKind: conservative
+            // wildcard, future variants skipped.
+            match binding.kind {
+                BindingKind::Function | BindingKind::Class => {
+                    inline_candidates.push(id);
+                }
+                // Var/Let/Const/Param: not function-body bindings;
+                // var/let/const-of-function-expr lowering waits
+                // for analyzer expression tracking.
+                _ => {}
+            }
+        }
+
+        // Step 3 deferred — keep `changed = false`.
+        let _inline_candidates = inline_candidates;
+
         Ok(PassOutput {
             program: ctx.program.clone(),
             contributions: Vec::new(),
             changed: false,
             diagnostics: Vec::new(),
             stats: PassStats {
-                // Visited the program root; no calls inlined.
-                nodes_touched: 1,
+                // Visited the program root + every binding +
+                // every reference. Real cost numbers for the
+                // scheduler.
+                nodes_touched: (1
+                    + analysis.bindings.len()
+                    + analysis.references.len()) as u32,
             },
         })
     }


### PR DESCRIPTION
## Summary
- Wires `closure-pass-inline` to the shared `closure-scope-analyzer` (CLOC13 unblocker, #4763). `run` now invokes `analyze(ctx.program)` and walks `ScopeAnalysis` to identify **inline candidates** — `Function` / `Class` bindings called from exactly one site. The unambiguous-win case where substituting the body saves call overhead and exposes concrete arguments to downstream constant-fold.
- `changed` is **hard-pinned to `false`** until the actual substitute step (CLOC13.B.1) lands — pin is critical here because policy is `FixedPoint` (CLOC13.E lesson).
- `PassStats::nodes_touched` now reports `1 + bindings.len() + references.len()` — real cost surfacing.

## Algorithm (mark phase; substitute deferred)
1. Per-binding use-count from `analysis.references`. Single-use is the gate that makes inlining cheap.
2. Candidate: `kind == Function | Class` AND `uses == 1`. Multi-use inlining is a budget decision; single-use is the cheapest substitution to land first. `Param` excluded. `Var`/`Let`/`Const` of function-expressions cross over to `collapse-properties` (CLOC13.D) for their alias form. `#[non_exhaustive]` future variants conservatively skipped.
3. Substitute deferred: cleanly replacing `CallExpression` with the callee's body requires both the AST to grow `CallExpression` / `FunctionDeclaration` variants AND the analyzer to surface a binding → defining-node backreference.

## Closes the CLOC13.A..E parallel-stream set
With this PR, all 5 pass bodies (E #4766 merged, D #4773, C #4775, A #4777, B #this) consume the scope-analyzer scaffold. The next move is CLOC13.0 — the real analyzer body — which will flip every wiring from "candidate scan finds zero" to "candidate scan finds real work" with no PR-side churn.

## Test plan
- [x] `cargo test -p coding-adventures-closure-pass-inline` — all 9 tests pass unchanged.
- [x] Security review (Agent): PASS — `changed = false` literal, bounds-checked collection access, `#[non_exhaustive]` BindingKind handled via conservative wildcard, no unsafe, no I/O.
- [ ] CI green across ubuntu / macos / windows + CodeQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)