### PR TITLE
feat(closure-scope-analyzer): CLOC13.0 — analyzer body activates 5 passes

### DIFF
--- a/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
+++ b/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
@@ -2,6 +2,49 @@
 
 All notable changes to the `coding-adventures-closure-scope-analyzer` crate will be documented in this file.
 
+## [0.2.0] - 2026-06-02
+
+### Added — CLOC13.0 minimal analyzer body
+
+Replaces the v0.1.0 identity-style empty `analyze` with a real walk of `program.body` that surfaces **top-level declarations**:
+
+- `VariableDeclaration` (`var` / `let` / `const`) — one `Binding` per `VariableDeclarator`, with `VarKind → BindingKind` mapping (`Var → Var`, `Let → Let`, `Const → Const`). Multi-declarator forms (`const a = 1, b = 2;`) emit one binding each.
+- `FunctionDeclaration` — one `Binding` with `kind = Function` carrying the function name.
+- All bindings land in `ScopeId::GLOBAL`. The global scope's `bindings` list mirrors the global table.
+- `declared_at` is populated from the AST's `Identifier.cv` when CV tracing is on (otherwise stays `None`).
+- `BindingTarget::Identifier` is the only Phase 1 variant; the match is total today. When Phase 3 adds destructuring patterns, they'll need their own arms.
+
+### Activates 5 consumer passes simultaneously
+
+This PR is the wire-then-activate completion. The five pass bodies (CLOC13.A..E, PRs #4766, #4773, #4775, #4777, #4778) all consume `bindings` via the analyzer's public surface. They went from "candidate scan finds zero" to "candidate scan finds real top-level decls" with **zero PR-side churn** — no rebases, no API changes.
+
+`changed = false` is still hard-pinned in every consumer pass. Lighting up real bindings only makes the candidate scans non-empty; the apply step (CLOC13.{A,B,C,D,E}.1) is a per-pass follow-up.
+
+### Deferred to CLOC13.0.1 (tracked inline in `fn analyze`)
+
+1. **Function body scopes.** A `FunctionDeclaration` should create a `ScopeKind::Function` child scope holding params + nested decls. Today we only emit the function's name binding in `GLOBAL`.
+2. **Block scopes.** `let`/`const` inside a `BlockStatement` should land in a `ScopeKind::Block` child scope. Today nested blocks are ignored.
+3. **Var hoisting.** A `var x` inside a block must bind in the enclosing *function* scope. Pre-walk pattern documented inline.
+4. **`References`.** Identifier use sites should produce `Reference`s. Today the references vec is empty. This is the biggest remaining gap — `remove-unused-vars` and `inline` both gate on `uses == 0` / `uses == 1`, so zero references reads as "every binding is unused".
+5. **Catch-clause scope** (not in Phase 1 AST yet).
+6. **Strict-mode binding semantics** (function-in-block scope).
+
+### Tests added (7 new; 13 total, was 6)
+
+- `top_level_let_surfaces_as_binding_in_global` — end-to-end pin of the binding shape.
+- `top_level_var_let_const_map_to_three_kinds` — `VarKind → BindingKind` mapping.
+- `top_level_function_declaration_surfaces` — function-name binding shape.
+- `multi_declarator_emits_one_binding_per_declarator` — `const a = 1, b = 2;` form.
+- `binding_ids_are_dense_and_monotonic` — `BindingId(0), (1), (2)` contract.
+- `statement_items_are_skipped_for_now` — pin the deferred-Statement-walk contract; will fail when CLOC13.0.1 starts collecting references.
+- `references_are_empty_in_cloc13_0` — pin the deferred-References contract.
+
+All 6 v0.1.0 tests still pass unchanged.
+
+### Bumped 0.1.0 → 0.2.0
+
+Signature of `analyze` is unchanged; the v0.1.0 contract holds. Consumers don't need to recompile against a new API.
+
 ## [0.1.0] - 2026-06-01
 
 ### Added — CLOC13 unblocker: scaffold + stable API surface

--- a/code/packages/rust/closure-scope-analyzer/Cargo.toml
+++ b/code/packages/rust/closure-scope-analyzer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-scope-analyzer"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Lexical scope + symbol-table analyzer for the Closure Compiler clone. Per CLOC13 — produces a `ScopeAnalysis` consumed by the rename, inline, treeshake, collapse-properties, and remove-unused-vars passes."
 

--- a/code/packages/rust/closure-scope-analyzer/src/lib.rs
+++ b/code/packages/rust/closure-scope-analyzer/src/lib.rs
@@ -65,7 +65,9 @@
 //! CV tracing is off (the common production case), these stay `None`
 //! and the per-node memory is just a word.
 
-use coding_adventures_javascript_ast::{CvId, Program};
+use coding_adventures_javascript_ast::{
+    BindingTarget, CvId, Declaration, Program, ProgramItem, VarKind,
+};
 use serde::{Deserialize, Serialize};
 
 // ---------------------------------------------------------------------
@@ -264,16 +266,73 @@ impl ScopeAnalysis {
 
 /// Build a [`ScopeAnalysis`] for a program.
 ///
-/// **v0.1.0 scaffold:** returns a single global scope with no
-/// bindings or references.  The full traversal is tracked under
-/// CLOC13.0 and lands as a follow-up — the contract here is the
-/// **stable API surface** the five consumer passes (CLOC13.A through
-/// CLOC13.E) build against, so they can land in parallel.
+/// **v0.2.0 — CLOC13.0 minimal body.**  Walks `program.body` and
+/// surfaces *top-level* `var` / `let` / `const` / `function`
+/// declarations as [`Binding`]s in the [`ScopeId::GLOBAL`] scope.
+/// The signature still matches the v0.1.0 contract; CLOC13.A..E
+/// consumers see exactly the same API surface.
 ///
-/// Once the body is implemented, this signature will not change.
-/// Consumers should pin to the v0.1.0 contract.
-pub fn analyze(_program: &Program) -> ScopeAnalysis {
-    ScopeAnalysis {
+/// ### What this body covers (v0.2.0)
+///
+/// - **Top-level `VariableDeclaration`** (`var` / `let` / `const`).
+///   One [`Binding`] per [`VariableDeclarator`].  Destructuring
+///   patterns are gated by [`BindingTarget`] — Phase 1 only ships
+///   the `Identifier` variant, so the match is total today.
+/// - **Top-level `FunctionDeclaration`**.  One [`Binding`] with
+///   [`BindingKind::Function`].
+/// - All bindings land in [`ScopeId::GLOBAL`].  No nested scope is
+///   created yet — see "Deferred" below.
+///
+/// ### Deferred to CLOC13.0.1 (and tracked inline)
+///
+/// 1. **Function body scopes.**  A [`FunctionDeclaration`] should
+///    create a [`ScopeKind::Function`] child scope holding its
+///    [`FunctionParam`]s + nested `var`/`let`/`const`/function
+///    decls.  Today we only emit the function's name binding in
+///    GLOBAL.
+/// 2. **Block scopes.**  `let` and `const` inside a
+///    [`BlockStatement`] should land in a [`ScopeKind::Block`]
+///    child of the enclosing scope.  Today we ignore nested
+///    blocks entirely.
+/// 3. **Var hoisting.**  A `var x` inside a block must bind in
+///    the enclosing *function* scope, not the block.  Pattern when
+///    block scopes land: pre-walk the function body to collect
+///    `var` declarations, emit them against the function scope,
+///    then walk normally.
+/// 4. **`References`**.  Identifier use sites — every
+///    [`Expression::Identifier`] node — should produce a
+///    [`Reference`].  Today we emit zero references.  This is the
+///    biggest remaining gap for the consumer passes;
+///    `remove-unused-vars` and `inline` both gate on `uses == 0`
+///    or `uses == 1`, and zero references means every binding
+///    reads as "unused".
+/// 5. **Catch-clause scope** (not in Phase 1 AST yet).
+/// 6. **Strict-mode binding semantics** (function-in-block scope).
+///
+/// ### Why this minimal split
+///
+/// The five CLOC13.A..E pass bodies all wired their candidate
+/// scans to consume `bindings` (Const-only, Function/Class,
+/// every-binding, etc.).  Returning a populated `bindings` vec —
+/// even without references — activates the *kind-filter* half of
+/// every wired pass.  Adding references is mechanical and lands
+/// in CLOC13.0.1 as the second step.
+///
+/// **`changed` semantics in consumer passes is unchanged.**  The
+/// CLOC13.A..E bodies still hard-pin `changed = false` until
+/// *their* step-3 apply lands.  Lighting up real bindings doesn't
+/// change that — it just makes their candidate scans non-empty.
+///
+/// The signature still matches the v0.1.0 contract; consumers
+/// don't need to recompile against a new API.
+pub fn analyze(program: &Program) -> ScopeAnalysis {
+    // CLOC13.0 algorithm — one walk of the top-level program body.
+    //
+    // Plain code beats a visitor-pattern here: the AST is shallow
+    // (1 program → N items, each a Declaration or a Statement),
+    // and we only care about Declarations in this PR.  A future
+    // pass-internal walker can grow into a proper visitor.
+    let mut analysis = ScopeAnalysis {
         scopes: vec![Scope {
             kind: ScopeKind::Global,
             parent: None,
@@ -281,7 +340,74 @@ pub fn analyze(_program: &Program) -> ScopeAnalysis {
         }],
         bindings: Vec::new(),
         references: Vec::new(),
+    };
+
+    for item in &program.body {
+        // Only Declarations at the top level produce bindings in
+        // this PR.  Statement items are walked in CLOC13.0.1 when
+        // we add the reference-collection pass.
+        let decl = match item {
+            ProgramItem::Declaration(d) => d,
+            ProgramItem::Statement(_) => continue,
+        };
+
+        match decl {
+            Declaration::VariableDeclaration(var_decl) => {
+                // Map VarKind → BindingKind.  `var` is function-
+                // scoped per ECMAScript; `let`/`const` are block-
+                // scoped.  Since we're only emitting top-level
+                // bindings in CLOC13.0, all three land in GLOBAL.
+                // The function- vs block- distinction starts to
+                // matter when CLOC13.0.1 introduces nested
+                // scopes and var-hoisting.
+                let kind = match var_decl.kind {
+                    VarKind::Var => BindingKind::Var,
+                    VarKind::Let => BindingKind::Let,
+                    VarKind::Const => BindingKind::Const,
+                };
+
+                for declarator in &var_decl.declarations {
+                    // Phase 1 only ships `BindingTarget::Identifier`.
+                    // The match is exhaustive today; when CLOC09
+                    // Phase 3 adds destructuring patterns
+                    // (`ArrayPattern`, `ObjectPattern`), they'll
+                    // need their own arms here that recursively
+                    // collect every bound identifier.
+                    let BindingTarget::Identifier(id) = &declarator.id;
+
+                    let binding_id = BindingId(analysis.bindings.len() as u32);
+                    analysis.bindings.push(Binding {
+                        name: id.name.clone(),
+                        kind,
+                        scope: ScopeId::GLOBAL,
+                        declared_at: id.cv.clone(),
+                    });
+                    analysis.scopes[ScopeId::GLOBAL.0 as usize]
+                        .bindings
+                        .push(binding_id);
+                }
+            }
+            Declaration::FunctionDeclaration(fn_decl) => {
+                // Emit the function name as a Function-kind binding
+                // in the GLOBAL scope.  CLOC13.0.1 will also
+                // create a child Function scope holding params +
+                // nested decls; in CLOC13.0 we just surface the
+                // name so treeshake / inline can see it.
+                let binding_id = BindingId(analysis.bindings.len() as u32);
+                analysis.bindings.push(Binding {
+                    name: fn_decl.id.name.clone(),
+                    kind: BindingKind::Function,
+                    scope: ScopeId::GLOBAL,
+                    declared_at: fn_decl.id.cv.clone(),
+                });
+                analysis.scopes[ScopeId::GLOBAL.0 as usize]
+                    .bindings
+                    .push(binding_id);
+            }
+        }
     }
+
+    analysis
 }
 
 // ---------------------------------------------------------------------
@@ -391,6 +517,165 @@ mod tests {
         };
         let inner = ScopeId(1);
         assert_eq!(analysis.resolve("x", inner), Some(BindingId(1)));
+    }
+
+    // ---------------------------------------------------------------
+    // CLOC13.0 body tests — top-level declaration surfacing.
+    // ---------------------------------------------------------------
+
+    use coding_adventures_javascript_ast::{
+        BindingTarget, BlockStatement, Declaration, FunctionDeclaration, Identifier,
+        ProgramItem, VarKind, VariableDeclaration, VariableDeclarator,
+    };
+
+    fn ident(name: &str) -> Identifier {
+        Identifier {
+            cv: None,
+            name: name.to_string(),
+        }
+    }
+
+    fn program_with(items: Vec<ProgramItem>) -> Program {
+        let mut p = empty_program();
+        p.body = items;
+        p
+    }
+
+    fn var_decl(kind: VarKind, names: &[&str]) -> ProgramItem {
+        ProgramItem::Declaration(Declaration::VariableDeclaration(VariableDeclaration {
+            cv: None,
+            kind,
+            declarations: names
+                .iter()
+                .map(|n| VariableDeclarator {
+                    cv: None,
+                    id: BindingTarget::Identifier(ident(n)),
+                    init: None,
+                })
+                .collect(),
+        }))
+    }
+
+    fn fn_decl(name: &str) -> ProgramItem {
+        ProgramItem::Declaration(Declaration::FunctionDeclaration(FunctionDeclaration {
+            cv: None,
+            id: ident(name),
+            params: Vec::new(),
+            body: BlockStatement {
+                cv: None,
+                body: Vec::new(),
+            },
+            generator: false,
+            is_async: false,
+        }))
+    }
+
+    #[test]
+    fn top_level_let_surfaces_as_binding_in_global() {
+        // `let x = 1;` (init elided) — pin the Binding shape end-to-end.
+        let prog = program_with(vec![var_decl(VarKind::Let, &["x"])]);
+        let analysis = analyze(&prog);
+        assert_eq!(analysis.bindings.len(), 1);
+        assert_eq!(analysis.bindings[0].name, "x");
+        assert_eq!(analysis.bindings[0].kind, BindingKind::Let);
+        assert_eq!(analysis.bindings[0].scope, ScopeId::GLOBAL);
+        // The global scope's bindings list mirrors the global table.
+        assert_eq!(
+            analysis.scopes[ScopeId::GLOBAL.0 as usize].bindings,
+            vec![BindingId(0)]
+        );
+    }
+
+    #[test]
+    fn top_level_var_let_const_map_to_three_kinds() {
+        let prog = program_with(vec![
+            var_decl(VarKind::Var, &["a"]),
+            var_decl(VarKind::Let, &["b"]),
+            var_decl(VarKind::Const, &["c"]),
+        ]);
+        let analysis = analyze(&prog);
+        let kinds: Vec<_> = analysis.bindings.iter().map(|b| b.kind).collect();
+        assert_eq!(
+            kinds,
+            vec![BindingKind::Var, BindingKind::Let, BindingKind::Const],
+        );
+    }
+
+    #[test]
+    fn top_level_function_declaration_surfaces() {
+        // `function f() {}` — kind == Function, scope == GLOBAL.
+        let prog = program_with(vec![fn_decl("f")]);
+        let analysis = analyze(&prog);
+        assert_eq!(analysis.bindings.len(), 1);
+        assert_eq!(analysis.bindings[0].name, "f");
+        assert_eq!(analysis.bindings[0].kind, BindingKind::Function);
+    }
+
+    #[test]
+    fn multi_declarator_emits_one_binding_per_declarator() {
+        // `const a = 1, b = 2;` → two bindings, both Const.
+        let prog = program_with(vec![var_decl(VarKind::Const, &["a", "b"])]);
+        let analysis = analyze(&prog);
+        assert_eq!(analysis.bindings.len(), 2);
+        assert_eq!(analysis.bindings[0].name, "a");
+        assert_eq!(analysis.bindings[1].name, "b");
+        assert!(
+            analysis
+                .bindings
+                .iter()
+                .all(|b| b.kind == BindingKind::Const)
+        );
+    }
+
+    #[test]
+    fn binding_ids_are_dense_and_monotonic() {
+        // 3 decls → BindingId(0), BindingId(1), BindingId(2). Pins the
+        // contract that consumers can index bindings by their position.
+        let prog = program_with(vec![
+            var_decl(VarKind::Let, &["x"]),
+            fn_decl("f"),
+            var_decl(VarKind::Const, &["k"]),
+        ]);
+        let analysis = analyze(&prog);
+        let scope_list = &analysis.scopes[ScopeId::GLOBAL.0 as usize].bindings;
+        assert_eq!(*scope_list, vec![BindingId(0), BindingId(1), BindingId(2)]);
+    }
+
+    #[test]
+    fn statement_items_are_skipped_for_now() {
+        // ExpressionStatement at top level doesn't produce bindings in
+        // CLOC13.0. Reference-collection lands in CLOC13.0.1. Pinning
+        // this absence here so adding reference walks doesn't silently
+        // break the skip-statements contract.
+        use coding_adventures_javascript_ast::{
+            ExpressionStatement, Expression, NumericLiteral, Statement,
+        };
+        let stmt = ProgramItem::Statement(Statement::expression_statement(
+            ExpressionStatement {
+                cv: None,
+                expression: Expression::NumericLiteral(NumericLiteral {
+                    cv: None,
+                    value: 1.0,
+                    raw: "1".to_string(),
+                }),
+            },
+        ));
+        let prog = program_with(vec![stmt]);
+        let analysis = analyze(&prog);
+        assert!(analysis.bindings.is_empty());
+        assert!(analysis.references.is_empty());
+    }
+
+    #[test]
+    fn references_are_empty_in_cloc13_0() {
+        // Pin the deferred-to-CLOC13.0.1 contract.  Once references
+        // start being collected, this test will fail loudly — which is
+        // the right signal: it forces the contributor to update every
+        // consumer pass's expectation that references == empty under
+        // analyzer v0.2.0.
+        let prog = program_with(vec![var_decl(VarKind::Let, &["x"])]);
+        let analysis = analyze(&prog);
+        assert!(analysis.references.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
**The wire-then-activate completion.** Replaces the v0.1.0 identity-empty `analyze` with a real walk of `program.body` that surfaces top-level declarations as `Binding`s in `ScopeId::GLOBAL`. The 5 sibling pass bodies (CLOC13.A..E, PRs #4766, #4773, #4775, #4777, #4778) already consume the API — their candidate scans flip from "finds zero" to "finds real top-level decls" with **zero PR-side churn**. No rebases. No API changes. The signature of `analyze` is unchanged.

## What this body covers (v0.2.0)
- **`VariableDeclaration`** (`var` / `let` / `const`) — one `Binding` per `VariableDeclarator` with the `VarKind → BindingKind` mapping. Multi-declarator forms (`const a = 1, b = 2;`) emit one binding each.
- **`FunctionDeclaration`** — one `Binding` with `kind = Function` carrying the function name.
- All bindings land in `ScopeId::GLOBAL`. The global scope's `bindings` list mirrors the global table.
- `declared_at` is populated from the AST's `Identifier.cv` when CV tracing is on.

The `let BindingTarget::Identifier(id) = ...;` is an irrefutable pattern (Phase 1 only ships that variant). When Phase 3 adds destructuring patterns, this becomes a compile error — the right failsafe.

## Deferred to CLOC13.0.1 (tracked inline in `fn analyze`)
1. **Function-body scopes** (params + nested decls → child Function scope).
2. **Block scopes** (let/const in `BlockStatement` → child Block scope).
3. **Var hoisting** (var in block binds to enclosing function scope).
4. **References** — Identifier use sites. Biggest remaining gap; `remove-unused-vars` and `inline` gate on `uses` count. A test (`references_are_empty_in_cloc13_0`) pins the deferred contract so 13.0.1 fails loudly when it starts collecting refs.
5. Catch-clause scope (not in Phase 1 AST).
6. Strict-mode binding semantics.

## `changed = false` discipline intact
Every consumer pass still hard-pins `changed = false`. Lighting up real bindings only flips their candidate scans non-empty; the apply step (CLOC13.{A,B,C,D,E}.1) is a per-pass follow-up.

## Test plan
- [x] `cargo test -p coding-adventures-closure-scope-analyzer` — 13 tests pass (6 v0.1.0 + 7 new).
- [x] All 5 consumer pass suites still green: rename (8), inline (9), treeshake (9), collapse-properties (9), remove-unused-vars (10). Total 45 tests across consumers — no regressions.
- [x] Security review PASS — no panics (irrefutable match → compile-error failsafe for future variants), bounded O(top-level decls) walk, no unsafe, no I/O, hard-pin invariant intact.
- [ ] CI green across ubuntu / macos / windows + CodeQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)