### PR TITLE
feat(visicalc-compose): cross-backend VisiCalc demo on Compose for Desktop

### DIFF
--- a/demo/visicalc-compose/.gitignore
+++ b/demo/visicalc-compose/.gitignore
@@ -1,0 +1,7 @@
+.gradle/
+.gradle-out/
+build/
+.idea/
+*.iml
+local.properties
+out/

--- a/demo/visicalc-compose/BUILD
+++ b/demo/visicalc-compose/BUILD
@@ -1,0 +1,2 @@
+gradle --quiet --no-daemon compileKotlin
+

--- a/demo/visicalc-compose/README.md
+++ b/demo/visicalc-compose/README.md
@@ -1,0 +1,82 @@
+# VisiCalc — Compose for Desktop demo
+
+Sixth cross-backend visual demo (Phase 2 / VC2-compose), running on
+[Compose Multiplatform for Desktop](https://www.jetbrains.com/lp/compose-multiplatform/).
+
+## What it shows
+
+A `Window` (from `androidx.compose.ui.window`) containing:
+
+- A hand-written **`FormulaBar`** composable
+  (`src/main/kotlin/FormulaBar.kt`) — placeholder for the eventual
+  `mosaic-compile --backend compose` output.
+- A hand-written **`Grid`** composable (`src/main/kotlin/Grid.kt`),
+  visually matching what the eventual Compose Grid emitter should
+  produce.
+
+Tap a cell — the formula bar updates with its value, the selected
+cell gets the excel-blue highlight. Type in the formula bar — it
+updates the local `mutableStateOf`.
+
+5×5 sample spreadsheet hard-coded in `src/main/kotlin/Main.kt`'s
+`sampleRows`, matching the data in every other VisiCalc demo so all
+seven look visually identical.
+
+## What this demo does NOT yet do
+
+- **No `mosaic-compile --backend compose`** exists in the repo.
+  Everything in `src/main/kotlin/` is hand-written.  When the
+  Compose emitter lands, `FormulaBar.kt` will be replaced by
+  `src/main/kotlin/generated/FormulaBar.kt` and this demo will
+  shift to a half-generated, half-hand-written shape like
+  `demo/visicalc-swiftui` does today.
+- **No strict-Flux dispatch yet.**  Local state via
+  `remember { mutableStateOf(...) }` for v0.1.0.  When the Compose
+  emitter is generating a real `dispatch: (Event) -> Unit`
+  parameter, the host will switch to a `MosaicStore<AppState>` from
+  the `mosaic-flux-compose` runtime (which is already pulled in as
+  an `includeBuild` composite-build dep, just not exercised yet).
+
+## How to run the app
+
+```bash
+./gradlew run                  # launches the desktop window
+./gradlew packageDistributionForCurrentOS    # native installer
+```
+
+Compose Multiplatform handles the JVM + native bundling for macOS
+(`.dmg`), Linux (`.deb`), and Windows (`.msi`).
+
+## Prerequisites
+
+- JDK 17+ (Compose 1.6 requires Java 17 minimum).
+- Gradle is fetched automatically by `./gradlew`; no system install
+  needed.
+- macOS / Linux / Windows.  No Android SDK required — Compose
+  Multiplatform for Desktop targets the JVM directly.
+
+## Why "Compose for Desktop" rather than Jetpack Compose for Android?
+
+Same `androidx.compose.*` packages, same composable functions, same
+`MaterialTheme`.  The runtime API is identical.  We target Desktop
+here so the demo runs locally with no emulator and screenshots come
+out of a real OS window.  An Android variant is a straight port:
+swap `WindowGroup`/`Window` for an `Activity` + `setContent`, the
+composables themselves are unchanged.
+
+## File tree
+
+```
+demo/visicalc-compose/
+├── README.md                     ← this file
+├── BUILD                          ← `./gradlew run` from the build-tool
+├── .gitignore                     ← .gradle/, .gradle-out/, build/, etc.
+├── settings.gradle.kts            ← includes ../../code/packages/kotlin/mosaic-flux-compose
+├── build.gradle.kts               ← kotlin("jvm") + org.jetbrains.compose plugin
+├── scripts/
+│   └── build.sh                   ← stub for future mosaic-compile --backend compose
+└── src/main/kotlin/
+    ├── Main.kt                    ← `application { Window { ... } }`
+    ├── FormulaBar.kt              ← hand-written FormulaBar composable
+    └── Grid.kt                    ← hand-written Grid composable
+```

--- a/demo/visicalc-compose/build.gradle.kts
+++ b/demo/visicalc-compose/build.gradle.kts
@@ -1,0 +1,65 @@
+// build.gradle.kts — VisiCalc demo on Compose for Desktop (JVM).
+//
+// Sixth cross-backend visual demo (Phase 2 / VC2-compose).  Mirrors
+// the React / HTML / WebComponent / SwiftUI / Qt / Flutter / XAML
+// visuals: dark theme, 5×5 sample dataset hard-coded, A1 selected,
+// formula bar showing "=SUM(B1:B5)".
+//
+// Unlike its siblings, this demo is **entirely hand-written** for
+// v0.1.0 — no `mosaic-compile --backend compose` exists yet.  The
+// FormulaBar and Grid composables live in `src/main/kotlin/` and
+// visually match what the eventual Compose emitter should produce.
+// When `mosaic-emit-compose` lands, the FormulaBar will be replaced
+// by `src/main/kotlin/generated/FormulaBar.kt` and this demo will
+// shift to a half-generated, half-hand-written shape like SwiftUI.
+//
+// Compose for Desktop targets the JVM; `./gradlew run` opens a
+// native window via `Window { ... }` from `androidx.compose.ui.window`.
+
+plugins {
+    kotlin("jvm") version "2.0.0"
+    id("org.jetbrains.compose") version "1.6.11"
+    id("org.jetbrains.kotlin.plugin.compose") version "2.0.0"
+}
+
+group = "org.mosaic.demo"
+version = "0.1.0"
+
+// Redirect Gradle's output directory away from `build/` because the
+// repo's case-insensitive filesystem (macOS HFS+) treats `build` and
+// the required `BUILD` script as the same name.  This is the same
+// trap that bit mosaic-flux-compose (see lessons.md).
+layout.buildDirectory.set(file(".gradle-out"))
+
+repositories {
+    mavenCentral()
+    google()
+    maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
+}
+
+dependencies {
+    implementation(compose.desktop.currentOs)
+    implementation("org.mosaic.flux:mosaic-flux-compose:0.1.0")
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+    }
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+compose.desktop {
+    application {
+        mainClass = "MainKt"
+
+        // Native-distribution packaging (.dmg / .msi / .deb) is
+        // intentionally left unconfigured for v0.1.0.  The demo's
+        // sole job is to render the window via `./gradlew run`; the
+        // packaging story belongs to a follow-up PR.
+    }
+}

--- a/demo/visicalc-compose/scripts/build.sh
+++ b/demo/visicalc-compose/scripts/build.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# build.sh — placeholder for the eventual Compose emitter wire-up.
+#
+# Today there is no `mosaic-compile --backend compose`, so this
+# script is a no-op that documents the path.  When the Compose
+# emitter lands, this will mirror the sibling backends' build.sh:
+# run `mosaic-compile --backend compose` against the Mosaic
+# component sources and drop the generated Kotlin into
+# `src/main/kotlin/generated/`.
+#
+# Usage:
+#   bash scripts/build.sh
+#
+# Then to run the demo:
+#   ./gradlew run
+
+set -euo pipefail
+
+echo "build.sh — no-op for v0.1.0."
+echo ""
+echo "  mosaic-emit-compose does not yet exist; FormulaBar.kt and"
+echo "  Grid.kt under src/main/kotlin/ are hand-written placeholders."
+echo "  Follow the cross-backend demo plan to see what the generated"
+echo "  output is expected to look like."
+echo ""
+echo "To run the demo:"
+echo "  ./gradlew run"

--- a/demo/visicalc-compose/settings.gradle.kts
+++ b/demo/visicalc-compose/settings.gradle.kts
@@ -1,0 +1,11 @@
+// settings.gradle.kts — single-project Gradle build for the
+// VisiCalc Compose for Desktop demo.
+//
+// We pull the `mosaic-flux-compose` runtime in as an included build
+// (Gradle's composite-build feature) so this demo always exercises
+// the version of the runtime that lives next to it in the repo, not
+// some published artifact.  See:
+//   https://docs.gradle.org/current/userguide/composite_builds.html
+rootProject.name = "visicalc-compose"
+
+includeBuild("../../code/packages/kotlin/mosaic-flux-compose")

--- a/demo/visicalc-compose/src/main/kotlin/FormulaBar.kt
+++ b/demo/visicalc-compose/src/main/kotlin/FormulaBar.kt
@@ -1,0 +1,96 @@
+// FormulaBar.kt — hand-written placeholder for the FormulaBar
+// composable that mosaic-emit-compose will eventually generate.
+//
+// Visual contract per UI26 §2.2 + Grid.dark.msl:
+//
+//   ┌──────┬─────────────────────────────────────┐
+//   │  A1  │  =SUM(B1:B5)                         │
+//   └──────┴─────────────────────────────────────┘
+//   ←cell→ ←formula text field, focusable, edits→
+//
+// Wire shape mirrors the other backends:
+//
+//   FormulaBar(cellAddress, formula, onFormulaChange, onCommit, onCancel)
+//
+// The eventual generated composable should accept exactly these
+// parameters so the host (Main.kt) can swap to the generated version
+// without touching its call site.
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun FormulaBar(
+    cellAddress: String,
+    formula: String,
+    onFormulaChange: (String) -> Unit,
+    onCommit: () -> Unit,
+    onCancel: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(Color(0xFF252526)),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        // Cell-address chip on the left.  Fixed 48dp width so the
+        // formula field aligns with the row-label column of the
+        // grid below.
+        Box(
+            modifier = Modifier
+                .width(48.dp)
+                .padding(8.dp),
+        ) {
+            Text(
+                text = cellAddress,
+                color = Color(0xFFCCCCCC),
+                fontSize = 12.sp,
+                fontFamily = FontFamily.Monospace,
+            )
+        }
+
+        // Formula text field.  BasicTextField is the Compose primitive
+        // — no platform-decoration like background or border, which
+        // matches the dark-theme contract.  We add our own inner
+        // padding and a subtle background tint.
+        BasicTextField(
+            value = formula,
+            onValueChange = onFormulaChange,
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(Color(0xFF1E1E1E))
+                .padding(8.dp),
+            textStyle = TextStyle(
+                color = Color(0xFFCCCCCC),
+                fontSize = 12.sp,
+                fontFamily = FontFamily.Monospace,
+            ),
+            singleLine = true,
+            // Commit + cancel handlers are wired below via a
+            // KeyEvent listener on the underlying field; for v0.1.0
+            // we keep the wiring at the Modifier level out of scope
+            // (Compose Desktop's onPreviewKeyEvent ergonomics deserve
+            // their own pass when the emitter lands).
+        )
+
+        // Suppress unused-parameter warnings until the key handlers
+        // are wired in v0.2.0.
+        @Suppress("UNUSED_EXPRESSION") onCommit
+        @Suppress("UNUSED_EXPRESSION") onCancel
+    }
+}

--- a/demo/visicalc-compose/src/main/kotlin/Grid.kt
+++ b/demo/visicalc-compose/src/main/kotlin/Grid.kt
@@ -1,0 +1,165 @@
+// Grid.kt — hand-written placeholder for the Grid composable.
+//
+// Renders a fixed-size 5×5 grid with column headers (A B C D E),
+// row numbers (1 2 3 4 5), and one cell per (row, col).  The selected
+// cell gets the excel-blue highlight (`#264F78` background +
+// `#007ACC` border) matching Grid.dark.msl.
+//
+// Visual contract is shared with the other VisiCalc demos.  When
+// mosaic-emit-compose grows a `Grid` primitive lowering, this file
+// becomes the generated artifact; until then we hand-write it.
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+private val cellWidth = 96.dp
+private val cellHeight = 22.dp
+private val headerHeight = 24.dp
+private val rowLabelWidth = 96.dp
+
+// Excel-style theme tokens (mirror demo/visicalc/mosaic/Grid.dark.msl
+// and the corresponding Qt / SwiftUI / Flutter palettes).
+private val headerBg     = Color(0xFF2D2D30)
+private val headerFg     = Color(0xFF9D9D9D)
+private val cellBg       = Color(0xFF1E1E1E)
+private val cellBgAlt    = Color(0xFF252526)
+private val cellBorder   = Color(0xFF3F3F46)
+private val cellFg       = Color(0xFFCCCCCC)
+private val selectedBg   = Color(0xFF264F78)
+private val selectedBdr  = Color(0xFF007ACC)
+private val selectedFg   = Color.White
+
+@Composable
+fun Grid(
+    rows: List<List<String>>,
+    selectedRow: Int,
+    selectedCol: Int,
+    onCellTap: (row: Int, col: Int) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .border(1.dp, cellBorder)
+            .background(cellBg),
+    ) {
+        HeaderRow()
+        rows.forEachIndexed { rowIdx, row ->
+            DataRow(
+                rowIdx = rowIdx,
+                row = row,
+                selectedRow = selectedRow,
+                selectedCol = selectedCol,
+                onCellTap = onCellTap,
+            )
+        }
+    }
+}
+
+@Composable
+private fun HeaderRow() {
+    Row(modifier = Modifier.fillMaxWidth().height(headerHeight)) {
+        // Top-left empty corner cell (above the row-number column).
+        HeaderCell(text = "")
+        listOf("A", "B", "C", "D", "E").forEach { letter ->
+            HeaderCell(text = letter)
+        }
+    }
+}
+
+@Composable
+private fun HeaderCell(text: String) {
+    Box(
+        modifier = Modifier
+            .width(cellWidth)
+            .height(headerHeight)
+            .background(headerBg)
+            .border(1.dp, cellBorder),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = text,
+            color = headerFg,
+            fontSize = 12.sp,
+            fontFamily = FontFamily.Monospace,
+        )
+    }
+}
+
+@Composable
+private fun DataRow(
+    rowIdx: Int,
+    row: List<String>,
+    selectedRow: Int,
+    selectedCol: Int,
+    onCellTap: (Int, Int) -> Unit,
+) {
+    val zebraBg = if (rowIdx % 2 == 0) cellBg else cellBgAlt
+    Row(modifier = Modifier.fillMaxWidth().height(cellHeight)) {
+        // Row-number cell on the left.
+        Box(
+            modifier = Modifier
+                .width(rowLabelWidth)
+                .height(cellHeight)
+                .background(headerBg)
+                .border(1.dp, cellBorder),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = (rowIdx + 1).toString(),
+                color = headerFg,
+                fontSize = 12.sp,
+                fontFamily = FontFamily.Monospace,
+            )
+        }
+        row.forEachIndexed { colIdx, value ->
+            val isSelected = rowIdx == selectedRow && colIdx == selectedCol
+            DataCell(
+                value = value,
+                isSelected = isSelected,
+                zebraBg = zebraBg,
+                onClick = { onCellTap(rowIdx, colIdx) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun DataCell(
+    value: String,
+    isSelected: Boolean,
+    zebraBg: Color,
+    onClick: () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .width(cellWidth)
+            .height(cellHeight)
+            .background(if (isSelected) selectedBg else zebraBg)
+            .border(1.dp, if (isSelected) selectedBdr else cellBorder)
+            .clickable(onClick = onClick)
+            .padding(end = 4.dp),
+        contentAlignment = Alignment.CenterEnd,
+    ) {
+        Text(
+            text = value,
+            color = if (isSelected) selectedFg else cellFg,
+            fontSize = 12.sp,
+            fontFamily = FontFamily.Monospace,
+        )
+    }
+}

--- a/demo/visicalc-compose/src/main/kotlin/Main.kt
+++ b/demo/visicalc-compose/src/main/kotlin/Main.kt
@@ -1,0 +1,108 @@
+// Main.kt — entry point for the VisiCalc Compose Desktop demo.
+//
+// Mounts the FormulaBar above a hand-written 5×5 grid.  Both are
+// driven from local Compose state (`remember { mutableStateOf(...) }`);
+// when the mosaic-emit-compose backend lands, the FormulaBar will be
+// replaced by a generated composable and the local state will move
+// to a `MosaicStore<AppState>` per the strict-Flux contract.
+//
+// Visual contract: identical to the React / HTML / WebComponent /
+// SwiftUI / Qt / Flutter demos — dark theme, A1 selected (excel-blue
+// highlight), formula bar reads "A1 / =SUM(B1:B5)".
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.material.darkColors
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.application
+import androidx.compose.ui.window.WindowState
+import androidx.compose.ui.window.rememberWindowState
+
+// The 5×5 sample dataset shared with every other visicalc-* demo.
+// Hard-coded here for the v0.1.0 visual parity exercise — when the
+// strict-Flux contract is wired up, this moves into `AppState.cells`.
+private val sampleRows: List<List<String>> = listOf(
+    listOf("15", "3",  "12", "8",  "5"),
+    listOf("8",  "14", "7",  "22", "11"),
+    listOf("12", "9",  "18", "6",  "25"),
+    listOf("4",  "11", "3",  "17", "9"),
+    listOf("7",  "5",  "13", "10", "19"),
+)
+
+fun main() = application {
+    Window(
+        onCloseRequest = ::exitApplication,
+        title = "VisiCalc — Mosaic Compose demo",
+        state = rememberWindowState(width = 720.dp, height = 520.dp),
+    ) {
+        MaterialTheme(colors = darkColors(background = Color(0xFF1E1E1E))) {
+            Surface(
+                color = Color(0xFF1E1E1E),
+                modifier = Modifier.fillMaxSize(),
+            ) {
+                VisiCalcApp()
+            }
+        }
+    }
+}
+
+@androidx.compose.runtime.Composable
+private fun VisiCalcApp() {
+    // Local state: selected cell + formula text.  Updates from the
+    // formula bar feed `formulaText`; clicks on the grid update both
+    // the selection and the formula text.  This is the strict-Flux
+    // pattern at micro scale — the components don't mutate state
+    // directly, they invoke callbacks that the host owns.
+    var selectedRow by remember { mutableStateOf(0) }
+    var selectedCol by remember { mutableStateOf(0) }
+    var formulaText by remember { mutableStateOf("=SUM(B1:B5)") }
+
+    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+        // Title row — kebab-cased label up top, matching the
+        // sibling demos' "VISICALC · MOSAIC <BACKEND> DEMO" style.
+        Text(
+            text = "VISICALC · MOSAIC COMPOSE DEMO",
+            color = Color(0xFF9D9D9D),
+            fontSize = 11.sp,
+            fontFamily = FontFamily.Monospace,
+        )
+
+        Box(modifier = Modifier.padding(top = 8.dp)) {
+            FormulaBar(
+                cellAddress = "${('A' + selectedCol)}${selectedRow + 1}",
+                formula = formulaText,
+                onFormulaChange = { newValue -> formulaText = newValue },
+                onCommit = { /* no-op for v0.1.0 */ },
+                onCancel = { formulaText = sampleRows[selectedRow][selectedCol] },
+            )
+        }
+
+        Box(modifier = Modifier.padding(top = 16.dp)) {
+            Grid(
+                rows = sampleRows,
+                selectedRow = selectedRow,
+                selectedCol = selectedCol,
+                onCellTap = { row, col ->
+                    selectedRow = row
+                    selectedCol = col
+                    formulaText = sampleRows[row][col]
+                },
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Sixth cross-backend VisiCalc visual demo, sibling to the React/HTML/WebComponent/SwiftUI/Qt/Flutter/XAML hosts. Adds `demo/visicalc-compose/` running on Compose Multiplatform for Desktop (JVM).

## Why hand-written

`mosaic-compile --backend compose` does not yet exist (today's backends: `webcomponent / html / react / paint / xaml / swiftui / qt / flutter`). Rather than block the cross-backend visual story on the new emitter, this demo ships the visual contract as hand-written composables that match exactly what `mosaic-emit-compose` should eventually generate. When that emitter lands, `FormulaBar.kt` becomes `src/main/kotlin/generated/FormulaBar.kt` and this demo shifts to the half-generated / half-hand-written shape the SwiftUI/Qt/Flutter demos already use.

## What's here

- `settings.gradle.kts` — composite build pulling in the just-merged `mosaic-flux-compose` runtime via `includeBuild("../../code/packages/kotlin/mosaic-flux-compose")`. Not exercised yet (local `mutableStateOf` is enough for v0.1.0's visual goal) but the dep is wired so the strict-Flux integration can land later without a build-graph change.
- `build.gradle.kts` — Kotlin 2.0 + `org.jetbrains.compose` 1.6.11; output redirected to `.gradle-out/` (HFS+ `BUILD`/`build` collision trap, lessons.md).
- `src/main/kotlin/Main.kt` — `application { Window { ... } }` with dark MaterialTheme; mounts FormulaBar above Grid.
- `src/main/kotlin/FormulaBar.kt` — Row(cellAddress chip, BasicTextField). Same prop shape as the auto-generated FormulaBars in the sibling demos so the host call-site won't move when the emitter takes over.
- `src/main/kotlin/Grid.kt` — 5×5 grid matching Grid.dark.msl tokens.
- `BUILD`, `scripts/build.sh`, `README.md` — documented build-tool target + future emitter wire-up.

## Verification

- `gradle --no-daemon compileKotlin` → BUILD SUCCESSFUL
- `gradle run` opens the desktop window; screenshot matches every other visicalc demo — dark theme, title row, formula bar "A1 / =SUM(B1:B5)", 5×5 grid with values 15/3/12/8/5 etc., A1 highlighted excel-blue.

## Loop progress — VisiCalc cross-backend

| Backend | Demo | Status |
| --- | --- | --- |
| React | `demo/visicalc` | ✅ |
| HTML | `demo/visicalc-html` | ✅ |
| WebComponent | `demo/visicalc-webcomp` | ✅ |
| SwiftUI | `demo/visicalc-swiftui` | ✅ |
| Qt | `demo/visicalc-qt` | ✅ (after #4785) |
| Flutter | `demo/visicalc-flutter` | ✅ (after #4788) |
| XAML | `demo/visicalc-xaml` | (skipped — Windows) |
| **Compose** | **`demo/visicalc-compose`** | **this PR** |

## Test plan

- [x] Local `gradle compileKotlin` green
- [x] Local `gradle run` opens window; visual matches sibling demos
- [x] Security review PASSED
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)