### PR TITLE
feat(closure-pass-remove-unused-vars): CLOC13.E.1 — apply step, changed unpinned

### DIFF
--- a/code/packages/rust/closure-pass-remove-unused-vars/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-remove-unused-vars/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 All notable changes to the `coding-adventures-closure-pass-remove-unused-vars` crate will be documented in this file.
 
+## [0.3.0] - 2026-06-02
+
+### Added (CLOC13.E.1 — the apply step, `changed` unpinned)
+
+This PR is the **first apply step** lifting the `changed = false` hard-pin from any of the five CLOC13.x pass bodies. Walks `ctx.program.body` and actually removes dead bindings:
+
+- **Build dead-name set.** Restricts `dead_bindings` (the candidate vec from step 2) to bindings with `scope == ScopeId::GLOBAL`, then collects their names into a `HashSet<String>`. Without a binding → declarator backreference (the analyzer hasn't grown one yet), we match by name + scope. Scope restriction keeps this correct under future analyzer extensions that surface nested bindings — only top-level names are ever acted on here.
+- **Walk + rewrite.** Build a new `body` vec rather than `Vec::retain_mut` so the split case is straightforward:
+  - `Declaration::VariableDeclaration`: partition declarators into kept vs. dropped by name.
+    - All dead → drop the whole item.
+    - All live → push original item verbatim.
+    - Mixed → emit a new `VariableDeclaration` with surviving declarators, preserving the original's `kind` and `cv`.
+  - `Declaration::FunctionDeclaration`: passthrough. `Function`-kind bindings are filtered out at step 2; function-declaration removal is the treeshake pass's job.
+  - `ProgramItem::Statement`: passthrough. Statement walking lands in CLOC13.0.1 alongside references.
+- **Output.** `changed = removed_count > 0`. Genuinely-mutated program is `Cow`-style returned via `ctx.program.clone()` + body replacement.
+
+### Hard-pin lifted; safety preserved
+
+`changed` is now derived from `removed_count`. This is safe because we genuinely mutate when we report it: zero removals → `changed = false` (identical to v0.2.0 behavior), at-least-one removal → `changed = true` (and the program is *actually* different).
+
+**Why it stays safe under `IterationPolicy::FixedPoint`.** Each iteration reduces the binding set strictly. A removed `VariableDeclaration` produces no new bindings, so the next iteration's eligibility scan finds fewer dead entries. Fixed point reaches in at most one additional iteration after the first non-empty removal — bindings can only stop being dead by gaining a reference, which a removal never adds.
+
+### Cross-PR interaction with CLOC13.0 (#4787)
+
+Today (`#4787` not yet merged) the scope-analyzer still returns empty bindings. So `dead_names` is empty, the body walk runs the passthrough path on every item, `removed_count == 0`, and `changed == false`. Observable behavior is identical to v0.2.0.
+
+Once `#4787` lands, the analyzer surfaces real top-level bindings, and any without a reference become eligible for removal. The apply step starts firing the moment the analyzer's body lands and `bindings`/`references` go non-empty. No follow-up rebase needed.
+
+### Tests added (5 new; 15 total, was 10)
+
+- `apply_step_passthrough_keeps_used_let_under_empty_analysis` — pins the no-op path; will fail after `#4787` lands without a referenced-`x` fixture, which is the right signal for the follow-up PR.
+- `apply_step_keeps_function_declaration` — `Function`-kind bindings are never eligible (treeshake's job).
+- `apply_step_passes_statements_through_untouched` — pins the deferred-Statement-walk contract.
+- `apply_step_preserves_multi_declarator_when_no_dead_names` — multi-declarator passthrough.
+- `apply_step_changed_is_false_when_program_unchanged` — `changed` invariant under empty-analysis.
+
+All 10 v0.2.0 tests still pass unchanged.
+
+### Bumped 0.2.0 → 0.3.0
+
+API of `run` is unchanged (still `Pass::run`). Behavior under empty analysis is unchanged. The version bump signals that the pass *will* mutate the program under non-empty analysis.
+
 ## [0.2.0] - 2026-06-01
 
 ### Added — CLOC13.E: wire pass to consume `closure-scope-analyzer`

--- a/code/packages/rust/closure-pass-remove-unused-vars/Cargo.toml
+++ b/code/packages/rust/closure-pass-remove-unused-vars/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-remove-unused-vars"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Unreferenced-variable cleanup pass for the Closure Compiler clone. Per CLOC06's canonical pass set. The final sweep: deletes variable bindings that have zero post-DCE / post-inline references and whose initializers are pure."
 

--- a/code/packages/rust/closure-pass-remove-unused-vars/src/lib.rs
+++ b/code/packages/rust/closure-pass-remove-unused-vars/src/lib.rs
@@ -95,10 +95,17 @@
 //! 3. Two- and three-pass integration tests that prove the
 //!    ordering.
 
+use std::collections::HashSet;
+
 use coding_adventures_closure_pass_pipeline::{
     IterationPolicy, Pass, PassContext, PassError, PassOutput, PassStats,
 };
-use coding_adventures_closure_scope_analyzer::{analyze, BindingId, BindingKind};
+use coding_adventures_closure_scope_analyzer::{
+    analyze, BindingId, BindingKind, ScopeId,
+};
+use coding_adventures_javascript_ast::{
+    BindingTarget, Declaration, ProgramItem,
+};
 
 /// `Pass::depends_on` value — both DCE and inline must run first
 /// per CLOC06 canonical order. Kept as a `const` so future tests
@@ -243,39 +250,131 @@ impl Pass for RemoveUnusedVarsPass {
             }
         }
 
-        // Step 3: APPLY is deferred to CLOC13.E.1.  Cleanly
-        // dropping a binding needs a binding → declarator
-        // backreference the analyzer doesn't yet ship.
+        // Step 3 — APPLY.  CLOC13.E.1 lifts the hard-pin on
+        // `changed` and actually mutates the program.
         //
-        // **Critical: keep `changed = false` until step 3 actually
-        // mutates the program.** Reporting `changed = true` while
-        // returning an unchanged program would lie to the
-        // scheduler — under `IterationPolicy::FixedPoint`, the
-        // scheduler would re-run this pass forever because the
-        // program never converges (each iteration would identify
-        // the same `dead_bindings`, claim a change, return the
-        // same program, repeat). That latent footgun would fire
-        // the moment the analyzer's body lands and starts
-        // populating bindings — exactly the kind of cross-PR
-        // break that's hard to bisect.
+        // Strategy.  Without a binding → declarator backreference
+        // (the analyzer hasn't grown one yet), we match by name +
+        // scope.  Restrict the dead set to bindings in
+        // `ScopeId::GLOBAL` (the only scope CLOC13.0 populates;
+        // when CLOC13.0.1 introduces nested scopes, those
+        // bindings will still be in their own scope, so this
+        // filter stays correct — we only ever act on top-level
+        // names).  Build a `HashSet<String>` of dead names.  Walk
+        // `program.body`:
         //
-        // We still compute `dead_bindings` for observability:
-        // when CLOC13.0 lands, this number will start tracking
-        // real findings (visible via `stats.nodes_touched` and
-        // in future contributions). When CLOC13.E.1 then wires
-        // step 3, flipping `changed` becomes safe because the
-        // program will actually mutate.
-        let _dead_bindings = dead_bindings; // observable through nodes_touched; not yet acted on
+        //   - `Declaration::VariableDeclaration` with declarators
+        //     drawn from `BindingTarget::Identifier`: keep only
+        //     declarators whose identifier name is NOT dead.
+        //     - If every declarator is dead → drop the whole item.
+        //     - If some are dead → produce a new
+        //       `VariableDeclaration` with the surviving
+        //       declarators.  Initializers of dropped declarators
+        //       are dropped wholesale; this matches the
+        //       remove-unused-vars contract (the pass only fires
+        //       on declarations whose initializers are
+        //       side-effect-free per the type sidecar / DCE
+        //       ordering, CLOC06 §"What the pass relies on").
+        //   - `Declaration::FunctionDeclaration`: not in scope for
+        //     this PR — `Function`-kind bindings are filtered out
+        //     at step 2.  Function-declaration removal is the
+        //     treeshake pass's job.
+        //   - `ProgramItem::Statement`: untouched.  Statement
+        //     walking lands in CLOC13.0.1 alongside references.
+        //
+        // **Pin lifted; safety preserved.**  `changed = removed >
+        // 0` is now safe because we genuinely mutated when we
+        // say we did.  If `removed == 0` (the analyzer surfaced
+        // no dead bindings, or none were `BindingKind::Var/Let/
+        // Const` in GLOBAL), we return the program unchanged
+        // with `changed = false`, identical to v0.2.0 behavior.
+        //
+        // **Why this stays safe under FixedPoint.**  Each
+        // iteration reduces the binding set strictly — a removed
+        // VariableDeclaration produces no new bindings, so the
+        // next iteration's eligibility scan finds fewer dead
+        // entries.  The fixed point is reached in at most one
+        // additional iteration after the first non-empty
+        // removal: bindings can only stop being dead by gaining
+        // a reference, which a removal never adds.
+
+        // Build the dead-name set, restricted to GLOBAL.
+        let mut dead_names: HashSet<String> = HashSet::new();
+        for binding_id in &dead_bindings {
+            let binding = &analysis.bindings[binding_id.0 as usize];
+            if binding.scope == ScopeId::GLOBAL {
+                dead_names.insert(binding.name.clone());
+            }
+        }
+
+        // Walk + rewrite `program.body`.  Build a new vec rather
+        // than `Vec::retain_mut` so the splitting case (some
+        // declarators dead, some live) is straightforward.
+        let mut new_body: Vec<ProgramItem> = Vec::with_capacity(ctx.program.body.len());
+        let mut removed_count: usize = 0;
+        for item in &ctx.program.body {
+            let decl = match item {
+                ProgramItem::Statement(_) => {
+                    new_body.push(item.clone());
+                    continue;
+                }
+                ProgramItem::Declaration(d) => d,
+            };
+            match decl {
+                Declaration::VariableDeclaration(var_decl) => {
+                    // Partition declarators into kept vs. dropped.
+                    let mut kept = Vec::with_capacity(var_decl.declarations.len());
+                    for declarator in &var_decl.declarations {
+                        let BindingTarget::Identifier(id) = &declarator.id;
+                        if dead_names.contains(&id.name) {
+                            removed_count += 1;
+                        } else {
+                            kept.push(declarator.clone());
+                        }
+                    }
+                    if kept.is_empty() {
+                        // Entire declaration is dead — drop it.
+                        continue;
+                    }
+                    if kept.len() == var_decl.declarations.len() {
+                        // No declarators dropped — keep the
+                        // original item verbatim.
+                        new_body.push(item.clone());
+                    } else {
+                        // Split: emit a new VariableDeclaration
+                        // with only the surviving declarators,
+                        // preserving the original's `kind` and
+                        // `cv`.
+                        let mut split = var_decl.clone();
+                        split.declarations = kept;
+                        new_body.push(ProgramItem::Declaration(
+                            Declaration::VariableDeclaration(split),
+                        ));
+                    }
+                }
+                Declaration::FunctionDeclaration(_) => {
+                    // Function-kind bindings were filtered out at
+                    // step 2; nothing to do here.  Passthrough.
+                    new_body.push(item.clone());
+                }
+            }
+        }
+
+        // Construct the output program with the rewritten body.
+        let mut new_program = ctx.program.clone();
+        new_program.body = new_body;
+
+        let changed = removed_count > 0;
 
         Ok(PassOutput {
-            program: ctx.program.clone(),
+            program: new_program,
             contributions: Vec::new(),
-            changed: false,
+            changed,
             diagnostics: Vec::new(),
             stats: PassStats {
-                // Visited the program root + every binding + every
-                // reference. Gives the scheduler real visit counts
-                // for cost accounting.
+                // Visited the program root + every binding +
+                // every reference. Gives the scheduler real
+                // visit counts for cost accounting.
                 nodes_touched: (1
                     + analysis.bindings.len()
                     + analysis.references.len()) as u32,
@@ -499,5 +598,187 @@ mod tests {
         let _b: RemoveUnusedVarsPass = RemoveUnusedVarsPass::new();
         let _c = _b;
         let _d = _c.clone();
+    }
+
+    // -----------------------------------------------------------------
+    // CLOC13.E.1 — apply-step tests.
+    //
+    // These exercise the body-walk machinery (split / drop /
+    // passthrough).  They run against the *current*
+    // closure-scope-analyzer build, which today (CLOC13.0
+    // not-yet-merged) returns empty bindings — meaning the
+    // dead-name set is empty and the body walks every item
+    // through the passthrough path.  That's the right test
+    // surface for now: it pins the no-op-when-no-dead-bindings
+    // contract.
+    //
+    // Real-removal tests (assertions that an actually-unused
+    // `let x` gets dropped) land in a follow-up once CLOC13.0
+    // is on main, because they need the analyzer to surface
+    // real bindings.  Adding them today would be brittle:
+    // they'd fail until #4787 merges, succeed afterward.  Pin
+    // the contracts we can pin now; let the follow-up pin the
+    // rest once it can.
+    // -----------------------------------------------------------------
+
+    use coding_adventures_javascript_ast::{
+        BindingTarget, Declaration, Expression, FunctionDeclaration, Identifier,
+        NumericLiteral, ProgramItem, BlockStatement, VarKind, VariableDeclaration,
+        VariableDeclarator,
+    };
+
+    fn ident(name: &str) -> Identifier {
+        Identifier {
+            cv: None,
+            name: name.to_string(),
+        }
+    }
+
+    fn var_decl(kind: VarKind, names_with_init: &[(&str, Option<f64>)]) -> ProgramItem {
+        ProgramItem::Declaration(Declaration::VariableDeclaration(VariableDeclaration {
+            cv: None,
+            kind,
+            declarations: names_with_init
+                .iter()
+                .map(|(n, init)| VariableDeclarator {
+                    cv: None,
+                    id: BindingTarget::Identifier(ident(n)),
+                    init: init.map(|v| {
+                        Expression::NumericLiteral(NumericLiteral {
+                            cv: None,
+                            value: v,
+                            raw: v.to_string(),
+                        })
+                    }),
+                })
+                .collect(),
+        }))
+    }
+
+    fn fn_decl(name: &str) -> ProgramItem {
+        ProgramItem::Declaration(Declaration::FunctionDeclaration(FunctionDeclaration {
+            cv: None,
+            id: ident(name),
+            params: Vec::new(),
+            body: BlockStatement {
+                cv: None,
+                body: Vec::new(),
+            },
+            generator: false,
+            is_async: false,
+        }))
+    }
+
+    fn program_with(items: Vec<ProgramItem>) -> Program {
+        let mut p = program();
+        p.body = items;
+        p
+    }
+
+    fn run_pass(prog: Program) -> coding_adventures_closure_pass_pipeline::PassOutput {
+        // Drive the pass directly (not via the pipeline) so the test
+        // pins the pass's own contract, not the scheduler's.
+        let pass = RemoveUnusedVarsPass::new();
+        let sidecar = Sidecar::new();
+        let mut cv = CVLog::new(true);
+        let ctx = coding_adventures_closure_pass_pipeline::PassContext {
+            program: &prog,
+            sidecar: &sidecar,
+            cv: &mut cv,
+        };
+        pass.run(ctx).expect("pass ran")
+    }
+
+    #[test]
+    fn apply_step_passthrough_keeps_used_let_under_empty_analysis() {
+        // `let x;` at the top level.  Today the analyzer returns
+        // empty bindings, so `dead_names` is empty, so `x` is kept.
+        // After #4787 merges, the analyzer surfaces `x` but it's
+        // not referenced either → `x` would become dead.  This
+        // test passes today (no-op path) and will FAIL after the
+        // analyzer activation lands — exactly the right signal for
+        // the follow-up PR to introduce a referenced-`x` fixture
+        // (e.g., via an ExpressionStatement reading `x`) to keep
+        // assertion semantics stable.
+        let prog = program_with(vec![var_decl(VarKind::Let, &[("x", None)])]);
+        let out = run_pass(prog.clone());
+        assert!(!out.changed, "no analyzer bindings → no removals");
+        assert_eq!(out.program.body.len(), 1);
+    }
+
+    #[test]
+    fn apply_step_keeps_function_declaration() {
+        // `function f() {}` — kind == Function is filtered out at
+        // step 2 of the pass (functions are treeshake's job, not
+        // remove-unused-vars').  Even after the analyzer body
+        // lands, this should never be eligible for removal here.
+        let prog = program_with(vec![fn_decl("f")]);
+        let out = run_pass(prog);
+        assert!(!out.changed);
+        assert_eq!(out.program.body.len(), 1);
+        match &out.program.body[0] {
+            ProgramItem::Declaration(Declaration::FunctionDeclaration(fd)) => {
+                assert_eq!(fd.id.name, "f");
+            }
+            _ => panic!("expected the function declaration to survive"),
+        }
+    }
+
+    #[test]
+    fn apply_step_passes_statements_through_untouched() {
+        // Statement items are explicitly out of scope for the
+        // apply step — CLOC13.0.1 lands the reference walker that
+        // touches them.  Pin the passthrough contract.
+        use coding_adventures_javascript_ast::{ExpressionStatement, Statement};
+        let stmt = ProgramItem::Statement(Statement::expression_statement(
+            ExpressionStatement {
+                cv: None,
+                expression: Expression::NumericLiteral(NumericLiteral {
+                    cv: None,
+                    value: 1.0,
+                    raw: "1".to_string(),
+                }),
+            },
+        ));
+        let prog = program_with(vec![stmt]);
+        let out = run_pass(prog);
+        assert!(!out.changed);
+        assert_eq!(out.program.body.len(), 1);
+    }
+
+    #[test]
+    fn apply_step_preserves_multi_declarator_when_no_dead_names() {
+        // `const a = 1, b = 2;` — multi-declarator form.  Today
+        // (no analyzer bindings) both stay.  After CLOC13.0
+        // lands, the analyzer would surface both — and if neither
+        // is referenced, both get dropped together via the
+        // "every declarator dead → drop whole item" path.  When
+        // one is referenced and one isn't, the split path fires.
+        // Pinning the no-op behavior now; behavior tests for
+        // the split path follow in the CLOC13.0.1 wave.
+        let prog = program_with(vec![var_decl(
+            VarKind::Const,
+            &[("a", Some(1.0)), ("b", Some(2.0))],
+        )]);
+        let out = run_pass(prog.clone());
+        assert!(!out.changed);
+        assert_eq!(out.program.body, prog.body);
+    }
+
+    #[test]
+    fn apply_step_changed_is_false_when_program_unchanged() {
+        // Pin the invariant: `changed` is true iff at least one
+        // declarator was removed.  Under empty analysis, no
+        // removals → `changed = false`.  This is the same
+        // discipline as the v0.2.0 hard-pin, just now derived
+        // from real state rather than asserted.
+        let prog = program_with(vec![
+            var_decl(VarKind::Let, &[("x", None)]),
+            fn_decl("f"),
+            var_decl(VarKind::Const, &[("k", Some(7.0))]),
+        ]);
+        let out = run_pass(prog.clone());
+        assert!(!out.changed);
+        assert_eq!(out.program.body, prog.body);
     }
 }


### PR DESCRIPTION
## Summary
**The first apply step.** Lifts the `changed = false` hard-pin codified across all CLOC13.x bodies and actually mutates the program. Walks `ctx.program.body`, drops `VariableDeclaration` items whose declarators are all in the dead set, splits mixed-use forms. `changed = removed_count > 0`.

## Strategy (until the analyzer ships binding → declarator backrefs)
- Filter `dead_bindings` (the candidate vec from step 2) to bindings where `scope == ScopeId::GLOBAL`.
- Collect their names into a `HashSet<String>`.
- Walk `program.body`:
  - **`VariableDeclaration`**: partition declarators by `BindingTarget::Identifier.name` ∈ dead_names. All dead → drop item. Mixed → emit new `VariableDeclaration` with surviving declarators, preserving original `kind` + `cv`. All live → push verbatim.
  - **`FunctionDeclaration`**: passthrough. Function-kind bindings filtered out at step 2.
  - **`Statement`**: passthrough. Statement walking lands in CLOC13.0.1 alongside references.

## Why this stays safe under `FixedPoint`
Each iteration reduces the binding set strictly. A removed `VariableDeclaration` produces no new bindings, so next iteration's eligibility scan finds fewer dead entries. Fixed point reaches in at most one additional iteration after the first non-empty removal.

## Cross-PR interaction with #4787 (CLOC13.0)
Today, with #4787 not yet merged, the scope-analyzer still returns empty bindings → `dead_names` empty → passthrough on every item → `removed_count == 0` → `changed == false`. Observable behavior identical to v0.2.0. **Once #4787 lands, the apply step starts firing immediately** — no rebase needed.

## Tests (15 total, was 10)
- `apply_step_passthrough_keeps_used_let_under_empty_analysis` — pins the no-op path; will fail after #4787 lands without a referenced-`x` fixture (the right signal for the follow-up PR).
- `apply_step_keeps_function_declaration` — `Function`-kind never eligible (treeshake's job).
- `apply_step_passes_statements_through_untouched` — deferred-Statement-walk contract.
- `apply_step_preserves_multi_declarator_when_no_dead_names` — multi-declarator passthrough.
- `apply_step_changed_is_false_when_program_unchanged` — `changed` invariant under empty-analysis.

All 10 v0.2.0 tests still pass unchanged.

## Test plan
- [x] `cargo test -p coding-adventures-closure-pass-remove-unused-vars` — 15 pass.
- [x] Security review (Agent): PASS — `changed = removed_count > 0` only true under genuine mutation, FixedPoint strict-monotonic, name+scope matching sound under current scope-analyzer (GLOBAL-only, unique names per scope), mixed-declarator split preserves all original fields, no panics, no unsafe.
- [ ] CI green across ubuntu / macos / windows + CodeQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)