### PR TITLE
A1+: iir-to-riscv const/mov/add/sub/ret + linear register allocator

### DIFF
--- a/code/packages/rust/iir-to-riscv/CHANGELOG.md
+++ b/code/packages/rust/iir-to-riscv/CHANGELOG.md
@@ -3,6 +3,76 @@
 All notable changes to this crate are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.2.0] — 2026-06-02 (A1+ — const/mov/add/sub/ret + linear register allocator)
+
+### Added — first real instruction lowering
+
+| IIR op | RV32I lowering |
+|--------|----------------|
+| `const dest, Int(n)` (12-bit imm) | `addi rd, x0, n` |
+| `add dest, a, b`  | R-type `add rd, rs1, rs2` |
+| `sub dest, a, b`  | R-type `sub rd, rs1, rs2` |
+| `mov dest, src`   | `addi rd, rs1, 0` (canonical move) |
+| `ret <var>` (int) | `addi a0, var_reg, 0` (skipped when var already in a0) + `jalr x0, x1, 0` |
+| `ret_void`        | `jalr x0, x1, 0` |
+
+#### Register allocation (linear, no spilling)
+
+* Function parameters land in `a0..a7` (`x10..x17`) per the RISC-V
+  calling convention; the validator caps params at 8 (`TooManyParams`
+  error otherwise).
+* Locals get the next free temp from
+  `[t0, t1, t2, t3, t4, t5, t6]` = `[x5, x6, x7, x28, x29, x30, x31]`.
+  Pool exhaustion → `OutOfRegisters`.  A real stack-spilling allocator
+  lands in A1++.
+
+#### Type rules
+
+Supported: `void`, `i8`, `u8`, `i16`, `u16`, `i32`, `u32`.  Everything is
+treated as a 32-bit value at this scope (RV32I native width).
+`i64`/`u64`/`f32`/`f64` are deferred — 64-bit needs register pairs and
+floats need the F-extension.
+
+#### Why skip the `mv` when `ret`'ing the first param
+
+`identity(x: i32) -> i32 { ret x }` lowers to just one word — the
+canonical `ret` (`0x0000_8067`).  We don't emit `mv a0, a0` because
+`x` already lives in `a0` (it's the first param).  This is a small but
+visible win for the trivial pass-through case.
+
+#### Public error variants added
+
+* `IIRRiscvError::UndefinedVariable` — var used before bound.
+* `IIRRiscvError::TooManyParams` — `>8` function params.
+* `IIRRiscvError::OutOfRegisters` — `>7` locals after params.
+* `IIRRiscvError::ImmediateOutOfRange` — `const` value outside
+  `[-2048, 2047]`.  `lui+addi` synthesis lands in A1++.
+
+#### Tests added (17 total, was 6)
+
+* Validator (5): empty, accept, reject-op, reject-type, reject-too-many-params.
+* Empty module emits no words (contract for trivial input).
+* `ret_void`-only function emits just the canonical `0x0000_8067`.
+* `const` + `ret`: pinned the exact three-word sequence
+  `addi t0, x0, 7; addi a0, t0, 0; jalr x0, x1, 0`.
+* `const` of `-2048` (smallest valid imm12) lowers cleanly.
+* `const` of `4096` (overflow) → `ImmediateOutOfRange`.
+* `add` of two params: pinned the exact `add t0, a0, a1` word.
+* `sub` of two params: pinned the exact `sub t0, a0, a1` word.
+* `mov` produces the canonical `addi rd, rs1, 0`.
+* Identity-of-first-param skips the redundant `mv` (one-word output).
+* Register-pool exhaustion is rejected with `OutOfRegisters`.
+* Config + error-display smoke.
+
+#### Why scope branches & comparisons to A1++
+
+The data-flow core (arith + ret with register allocation) is its own
+review surface.  Branches add label resolution and PC-relative offset
+computation — orthogonal concerns that benefit from landing as a
+separate slice.
+
+[plan]: ../../../specs/MULTILANG-ARCHITECTURE-BACKENDS.md
+
 ## [0.1.0] — 2026-06-01 (A1 — crate skeleton)
 
 ### Added — `ret`-only emission

--- a/code/packages/rust/iir-to-riscv/Cargo.toml
+++ b/code/packages/rust/iir-to-riscv/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iir-to-riscv"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
-description = "IIR → RV32I machine code backend — lowers IIRModule to a Vec<u32> of encoded 32-bit RISC-V instructions.  v0.1.0 (A1): crate skeleton emitting a single `ret` (jalr x0, x1, 0); instruction lowering deferred to v0.2.0+."
+description = "IIR → RV32I machine code backend — lowers IIRModule to a Vec<u32> of encoded 32-bit RISC-V instructions.  v0.2.0 (A1+): adds real lowering for const (addi imm12) / mov (addi rd,rs1,0) / add+sub (R-type) / ret (mv a0 + jalr); linear register allocator over t0..t6; param ABI mapping to a0..a7."
 
 [lib]
 name = "iir_to_riscv"

--- a/code/packages/rust/iir-to-riscv/src/lib.rs
+++ b/code/packages/rust/iir-to-riscv/src/lib.rs
@@ -1,106 +1,111 @@
-//! # iir-to-riscv — IIR → RV32I machine code backend (v0.1.0 skeleton).
+//! # iir-to-riscv — IIR → RV32I machine code backend.
 //!
 //! Lowers an [`interpreter_ir::IIRModule`] to a `Vec<u32>` of encoded
 //! 32-bit RISC-V instructions, suitable to drop into the in-tree
-//! [`riscv-simulator`] or to write out as a flat `.bin` for `qemu-riscv32`.
+//! [`riscv-simulator`] or to write out as a flat `.bin` for
+//! `qemu-riscv32`.
 //!
-//! ## Why an architecture backend?
+//! ## Scope of v0.2.0 (A1+)
 //!
-//! The wasm / JVM / CLR / BEAM / LLVM backends all target *software*
-//! runtimes that own register allocation and instruction selection.
-//! RISC-V is the first **architecture** backend — output is real hardware
-//! ISA, decoded directly by the bundled `riscv-simulator` (RV32I + M-mode
-//! traps) or by QEMU / a physical SiFive / Espressif RISC-V chip.
+//! v0.1.0 (A1) emitted a single `ret` regardless of input.  v0.2.0
+//! (A1+) is the first slice of real lowering:
 //!
-//! Strategic priority among architecture backends: RISC-V is the most
-//! open of the candidates (royalty-free spec, broad simulator
-//! availability, growing hardware footprint).  Once it works, A2-A5
-//! (Intel 8008, ARMv7, Intel 4004, GE-225) follow the same shape.
+//! | IIR op | RV32I lowering |
+//! |--------|----------------|
+//! | `const dest, Int(n)` (12-bit imm) | `addi rd, x0, n` |
+//! | `add dest, a, b` | `add rd, rs1, rs2` |
+//! | `sub dest, a, b` | `sub rd, rs1, rs2` |
+//! | `mov dest, src`  | `addi rd, rs1, 0` (canonical move) |
+//! | `ret <var>` (int) | `addi a0, var_reg, 0` (mv to a0) + `jalr x0, x1, 0` |
+//! | `ret_void` | `jalr x0, x1, 0` |
 //!
-//! ## Why a `Vec<u32>` output (not textual asm)?
+//! ### Register allocation (linear, no spilling)
 //!
-//! - **Round-trips with the simulator.**  `riscv-simulator` decodes raw
-//!   32-bit words; emitting them directly skips the assembler step.
-//! - **Deterministic test surface.**  `assert!(words[0] == 0x00008067)`
-//!   for `ret` reads cleanly in test failures.
-//! - **No textual-format coupling.**  GNU / LLVM assembly syntax diverge
-//!   on edge cases; raw words avoid both.
+//! * Function parameters land in `a0..a7` (`x10..x17`) per the RISC-V
+//!   calling convention.
+//! * Locals (anything bound to a new `dest`) get the next free
+//!   temporary register from `[t0, t1, t2, t3, t4, t5, t6]` =
+//!   `[x5, x6, x7, x28, x29, x30, x31]`.  When the pool is exhausted
+//!   we return [`IIRRiscvError::UnsupportedOp`] — a real register
+//!   allocator with spilling lands in A1++.
 //!
-//! A textual `.s` emitter could be added as a sibling later without
-//! breaking callers.
+//! ### Comparisons, branches, calls
 //!
-//! ## Scope of v0.1.0 (A1)
+//! Not yet in v0.2.0.  Lands in v0.3.0 (A1++) alongside `ecall` for
+//! `print_i64`.  This keeps the v0.2.0 PR focused on the data-flow
+//! core (arith + ret) so the register-allocator behaviour is
+//! reviewable in isolation.
 //!
-//! This release is a **skeleton**: any IIR module lowers to a single
-//! `ret` (encoded as `jalr x0, x1, 0`, which is the standard RV32I
-//! return-from-function pseudo-instruction).  No instruction selection
-//! yet; that arrives in A1+ (arith / cmp / control flow), A1++ (calls +
-//! locals + ecall print), and A1+++ (lang-aot `--target=riscv32`
-//! wiring).
+//! ## Why `Vec<u32>` (not textual asm)?
+//!
+//! - Round-trips with `riscv-simulator`'s decoder.
+//! - Deterministic test surface (`assert!(words[0] == 0x...)`).
+//! - No GNU-vs-LLVM assembler syntax coupling.
 //!
 //! ## Quick start
 //!
 //! ```
-//! use interpreter_ir::IIRModule;
-//! use iir_to_riscv::{validate_for_riscv, lower_iir_to_riscv, IIRRiscvConfig};
+//! use interpreter_ir::{IIRModule, IIRFunction, IIRInstr, Operand};
+//! use iir_to_riscv::{lower_iir_to_riscv, IIRRiscvConfig};
 //!
+//! // fn answer() -> i32 { const v = 7; ret v }
+//! let f = IIRFunction::new(
+//!     "answer",
+//!     vec![],
+//!     "i32",
+//!     vec![
+//!         IIRInstr::new("const", Some("v".into()), vec![Operand::Int(7)], "i32"),
+//!         IIRInstr::new("ret",   None,             vec![Operand::Var("v".into())], "i32"),
+//!     ],
+//! );
 //! let module = IIRModule {
 //!     name: "demo".into(),
-//!     functions: vec![],
-//!     entry_point: None,
-//!     language: "demo".into(),
+//!     functions: vec![f],
+//!     entry_point: Some("answer".into()),
+//!     language: "test".into(),
 //!     exports: vec![],
 //!     imports: vec![],
 //! };
-//!
-//! assert!(validate_for_riscv(&module).is_empty());
-//!
 //! let words = lower_iir_to_riscv(&module, &IIRRiscvConfig::default())
 //!     .expect("lowering should succeed");
-//! // 0x00008067 == `jalr x0, x1, 0` == RV32I `ret`.
-//! assert_eq!(words, vec![0x0000_8067]);
-//! ```
-//!
-//! ## Pipeline position
-//!
-//! ```text
-//! IIRModule
-//!   → validate_for_riscv()       pre-flight, returns Vec<String>
-//!   → lower_iir_to_riscv()       returns Vec<u32> of RV32I words
-//!   → (optional) riscv-simulator::execute() OR write to .bin OR link with `ld`
+//! // Three words: addi t0, x0, 7;  addi a0, t0, 0;  jalr x0, x1, 0
+//! assert_eq!(words.len(), 3);
 //! ```
 
-use interpreter_ir::IIRModule;
+use std::collections::HashMap;
 use std::fmt;
 
-use riscv_simulator::encoding::encode_jalr;
+use interpreter_ir::{IIRFunction, IIRInstr, IIRModule, Operand};
+use riscv_simulator::encoding::{encode_add, encode_addi, encode_jalr, encode_sub};
 
 // ===========================================================================
-// Register names — symbolic constants for x0, x1 to keep the call sites
-// readable without depending on a wider register-file abstraction.
+// Register layout
 // ===========================================================================
-//
-// RV32I has 32 integer registers x0..x31.  The ABI assigns roles:
-//   x0  — hardwired zero
-//   x1  — return address (`ra`)
-//   x2  — stack pointer (`sp`)
-//   x10 — first argument / first return value (`a0`)
-//   ...
-//
-// v0.1.0 only needs `x0` (rd of the trap-less `jalr`) and `x1` (rs1
-// holding the return address).  Future versions will expand this.
+
+// Hardwired zero (x0) and return address (x1) used by the ret encoding.
 const X0_ZERO: u32 = 0;
 const X1_RA:   u32 = 1;
+
+/// Argument / return-value registers `a0..a7` per the RISC-V calling
+/// convention.  The first 8 function parameters land here, in order; the
+/// return value (for non-void functions) is moved into `a0` before the
+/// epilogue's `ret`.
+const ARG_REGISTERS: [u32; 8] = [10, 11, 12, 13, 14, 15, 16, 17];
+
+/// Caller-saved temporary registers `t0..t6` per the RV32I ABI:
+/// `t0..t2` = `x5..x7`, `t3..t6` = `x28..x31`.  This pool is what the
+/// naive linear allocator hands out for local variables (anything other
+/// than function parameters or the canonical return slot `a0`).
+///
+/// 7 slots is generous for the v0.2.0 IIR subset (no calls yet, so no
+/// caller-save concerns).  A1++ replaces this with a real allocator.
+const TEMP_REGISTERS: [u32; 7] = [5, 6, 7, 28, 29, 30, 31];
 
 // ===========================================================================
 // IIRRiscvConfig
 // ===========================================================================
 
 /// Configuration for the IIR → RV32I lowering pass.
-///
-/// Currently only the assembly module name is configurable — it's stored
-/// for future symbol-table emission but has no effect on v0.1.0's
-/// minimal output.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IIRRiscvConfig {
     /// Module name — reserved for future ELF / linker artefact emission.
@@ -108,19 +113,14 @@ pub struct IIRRiscvConfig {
 }
 
 impl IIRRiscvConfig {
-    /// Build a config with a custom module name.
     pub fn new(module_name: impl Into<String>) -> Self {
-        Self {
-            module_name: module_name.into(),
-        }
+        Self { module_name: module_name.into() }
     }
 }
 
 impl Default for IIRRiscvConfig {
     fn default() -> Self {
-        Self {
-            module_name: "iir_module".into(),
-        }
+        Self { module_name: "iir_module".into() }
     }
 }
 
@@ -128,35 +128,46 @@ impl Default for IIRRiscvConfig {
 // IIRRiscvError
 // ===========================================================================
 
-/// Errors that can occur during IIR → RV32I lowering.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum IIRRiscvError {
-    /// The module failed pre-flight validation.
     ValidationFailed(Vec<String>),
-    /// An IIR opcode not yet supported by this backend.  v0.1.0 doesn't
-    /// lower any instructions, so a non-empty function body returns this.
     UnsupportedOp { function: String, op: String },
-    /// A type hint that does not map to any RV32I representation.
     UnsupportedType { function: String, type_hint: String },
-    /// An operand has an unexpected shape.
     InvalidOperand { function: String, detail: String },
+    /// A variable name was used before it was bound by `const`, `mov`,
+    /// or a function param.
+    UndefinedVariable { function: String, name: String },
+    /// Too many function params (>8) — RV32I caller convention only
+    /// passes the first 8 in `a0..a7`.  Real lowering would spill onto
+    /// the stack; v0.2.0 rejects this case.
+    TooManyParams { function: String, count: usize },
+    /// Too many locals — the v0.2.0 register pool (7 temps) is full.
+    /// A1++ replaces this with a stack-spilling allocator.
+    OutOfRegisters { function: String, name: String },
+    /// An `Operand::Int(n)` literal exceeds the RV32I 12-bit signed
+    /// immediate range (-2048..2047).  v0.2.0 doesn't synthesise the
+    /// `lui` + `addi` pair for wider constants — A1++ adds it.
+    ImmediateOutOfRange { function: String, value: i64 },
 }
 
 impl fmt::Display for IIRRiscvError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::ValidationFailed(errs) => {
-                write!(f, "validation failed:\n  {}", errs.join("\n  "))
-            }
-            Self::UnsupportedOp { function, op } => {
-                write!(f, "unsupported op in function {function:?}: {op}")
-            }
-            Self::UnsupportedType { function, type_hint } => {
-                write!(f, "unsupported type in function {function:?}: {type_hint}")
-            }
-            Self::InvalidOperand { function, detail } => {
-                write!(f, "invalid operand in function {function:?}: {detail}")
-            }
+            Self::ValidationFailed(errs) => write!(f, "validation failed:\n  {}", errs.join("\n  ")),
+            Self::UnsupportedOp { function, op } =>
+                write!(f, "unsupported op in function {function:?}: {op}"),
+            Self::UnsupportedType { function, type_hint } =>
+                write!(f, "unsupported type in function {function:?}: {type_hint}"),
+            Self::InvalidOperand { function, detail } =>
+                write!(f, "invalid operand in function {function:?}: {detail}"),
+            Self::UndefinedVariable { function, name } =>
+                write!(f, "undefined variable {name:?} in function {function:?}"),
+            Self::TooManyParams { function, count } =>
+                write!(f, "function {function:?} has {count} params; RV32I caller convention supports up to 8 in a0..a7 (stack spilling lands in A1++)"),
+            Self::OutOfRegisters { function, name } =>
+                write!(f, "out of temporary registers (t0..t6) while binding {name:?} in function {function:?}; stack spilling lands in A1++"),
+            Self::ImmediateOutOfRange { function, value } =>
+                write!(f, "literal {value} exceeds RV32I 12-bit signed immediate range (-2048..2047) in function {function:?}; lui+addi lowering lands in A1++"),
         }
     }
 }
@@ -164,67 +175,290 @@ impl fmt::Display for IIRRiscvError {
 impl std::error::Error for IIRRiscvError {}
 
 // ===========================================================================
+// Supported types
+// ===========================================================================
+
+/// Type hints the v0.2.0 backend understands.  Everything is treated as
+/// a 32-bit value at this scope (RV32I native width); u8/u16/i8/i16
+/// flow through unchanged since we don't sign-extend or mask yet.
+///
+/// `i64`/`u64`/`f32`/`f64` are deferred: real 64-bit on RV32 needs
+/// register pairs, and floats need the F-extension.
+fn is_supported_type(t: &str) -> bool {
+    matches!(t, "void" | "i8" | "u8" | "i16" | "u16" | "i32" | "u32")
+}
+
+// ===========================================================================
+// Supported opcodes
+// ===========================================================================
+
+const SUPPORTED_OPS: &[&str] = &[
+    "const", "mov", "ret", "ret_void", "add", "sub",
+];
+
+// ===========================================================================
 // validate_for_riscv
 // ===========================================================================
 
 /// Pre-flight validation for IIR → RV32I lowering.
 ///
-/// **v0.1.0 stub**: always returns an empty `Vec` — there are no
-/// validation rules yet because no instructions are lowered.  Future
-/// versions will add rules as opcodes come online (see
-/// `MULTILANG-ARCHITECTURE-BACKENDS.md` §A1).
+/// Returns a `Vec<String>` of human-readable error messages.  An empty
+/// vector means the module is safe to pass to [`lower_iir_to_riscv`].
 ///
-/// Mirrors the shape of the other IIR backends'
-/// `validate_for_{wasm,jvm,clr,beam,llvm}` so callers can switch
-/// backends without changing their pre-flight logic.
-pub fn validate_for_riscv(_module: &IIRModule) -> Vec<String> {
-    Vec::new()
+/// # Checks
+///
+/// 1. Every instruction's `op` is in [`SUPPORTED_OPS`].
+/// 2. Every instruction's `type_hint` is in [`is_supported_type`].
+/// 3. Every function's return type is supported.
+/// 4. Every function's param types are supported, and there are at
+///    most 8 of them.
+pub fn validate_for_riscv(module: &IIRModule) -> Vec<String> {
+    let mut errors = Vec::new();
+    for f in &module.functions {
+        if !is_supported_type(&f.return_type) {
+            errors.push(format!(
+                "UnsupportedType: function {:?}, return type {:?} not supported",
+                f.name, f.return_type
+            ));
+        }
+        if f.params.len() > 8 {
+            errors.push(format!(
+                "TooManyParams: function {:?} has {} params; max 8 in v0.2.0",
+                f.name, f.params.len()
+            ));
+        }
+        for (pname, pty) in &f.params {
+            if !is_supported_type(pty) {
+                errors.push(format!(
+                    "UnsupportedType: function {:?}, param {:?} type {:?} not supported",
+                    f.name, pname, pty
+                ));
+            }
+        }
+        for instr in &f.instructions {
+            if !SUPPORTED_OPS.contains(&instr.op.as_str()) {
+                errors.push(format!(
+                    "UnsupportedOp: function {:?}, op {:?} not in v0.2.0 whitelist (supported: {:?})",
+                    f.name, instr.op, SUPPORTED_OPS
+                ));
+            }
+            if !is_supported_type(&instr.type_hint) {
+                errors.push(format!(
+                    "UnsupportedType: function {:?}, instr {:?} type_hint {:?} not supported",
+                    f.name, instr.op, instr.type_hint
+                ));
+            }
+        }
+    }
+    errors
 }
 
 // ===========================================================================
 // lower_iir_to_riscv
 // ===========================================================================
 
-/// Lower an [`IIRModule`] to a `Vec<u32>` of encoded RV32I instructions.
+/// Lower an [`IIRModule`] to a `Vec<u32>` of RV32I instruction words.
 ///
-/// **v0.1.0 scope**: emits a single `ret` regardless of the input.
-/// This is the smallest "valid RISC-V" output we can produce — enough
-/// to load into [`riscv_simulator`], single-step, and confirm the
-/// encoding round-trips.  Real lowering arrives in v0.2.0+ (A1+).
-///
-/// # The encoded word
-///
-/// `ret` is the standard RV32I assembly pseudo-instruction for
-/// "return from function".  It encodes as `jalr x0, x1, 0`:
-///
-/// - `rd  = x0` — discard the next PC (we don't care where ret was called
-///   from for future call chains; the simulator already tracks call
-///   depth).
-/// - `rs1 = x1 (ra)` — jump to the return address held in the standard
-///   ABI register `ra`.
-/// - `imm = 0` — no offset.
-///
-/// The bit pattern is `0x0000_8067`.  Verify in Volume I §2.5 of the
-/// RISC-V User-Level ISA spec (page 30 in the 2019-12-13 ratified
-/// edition).  We assert this in tests rather than trust the encoding
-/// blindly.
+/// Lowers every function in order, concatenating their word sequences.
+/// Each function is independent — no cross-function calls in v0.2.0 (that
+/// requires real PC-relative `jal` + symbol resolution, which lands in
+/// A1++).
 pub fn lower_iir_to_riscv(
     module: &IIRModule,
     _cfg: &IIRRiscvConfig,
 ) -> Result<Vec<u32>, IIRRiscvError> {
-    // Even though the v0.1.0 validator is a stub, we run it
-    // unconditionally so the contract is established: callers can rely
-    // on `lower_iir_to_riscv` returning `ValidationFailed` for any rule
-    // the validator catches.  Wiring it now means later versions can
-    // add rules without changing the API.
     let errors = validate_for_riscv(module);
     if !errors.is_empty() {
         return Err(IIRRiscvError::ValidationFailed(errors));
     }
 
-    // The single emitted instruction.  Computed via the encoder rather
-    // than hardcoded as a literal so any future revision of
-    // `encode_jalr` (e.g. typo fix) flows through automatically.
-    let ret = encode_jalr(X0_ZERO, X1_RA, 0);
-    Ok(vec![ret])
+    let mut words = Vec::new();
+    for f in &module.functions {
+        let fn_words = lower_function(f)?;
+        words.extend(fn_words);
+    }
+    // An empty module emits no words at all.  This is the trivial-input
+    // contract: callers that want a minimum 1-instruction `.text` should
+    // wrap the result accordingly.
+    Ok(words)
+}
+
+/// Per-function state shared by `lower_function` and `lower_instr`.
+struct FnState<'a> {
+    fn_name: &'a str,
+    /// IIR var name → assigned RV32I register index (`x*`).
+    env: HashMap<String, u32>,
+    /// Next free index into [`TEMP_REGISTERS`].  When this exceeds the
+    /// pool length we return `OutOfRegisters` — A1++ replaces this with
+    /// a stack-spilling allocator.
+    next_temp: usize,
+}
+
+impl FnState<'_> {
+    /// Reserve a fresh temporary register for `name`.
+    fn alloc_temp(&mut self, name: &str) -> Result<u32, IIRRiscvError> {
+        if self.next_temp >= TEMP_REGISTERS.len() {
+            return Err(IIRRiscvError::OutOfRegisters {
+                function: self.fn_name.into(),
+                name: name.into(),
+            });
+        }
+        let reg = TEMP_REGISTERS[self.next_temp];
+        self.next_temp += 1;
+        self.env.insert(name.into(), reg);
+        Ok(reg)
+    }
+
+    /// Resolve a variable name to its register.
+    fn lookup(&self, name: &str) -> Result<u32, IIRRiscvError> {
+        self.env.get(name).copied().ok_or_else(|| IIRRiscvError::UndefinedVariable {
+            function: self.fn_name.into(),
+            name: name.into(),
+        })
+    }
+}
+
+/// Lower one IIR function.  Emits the body words; no prologue/epilogue
+/// stack-frame setup yet (v0.2.0 has no locals on the stack).
+fn lower_function(func: &IIRFunction) -> Result<Vec<u32>, IIRRiscvError> {
+    let mut state = FnState {
+        fn_name: &func.name,
+        env: HashMap::new(),
+        next_temp: 0,
+    };
+    // Bind parameters to a0..a7.  Validator already guarantees count <= 8.
+    for (i, (pname, _)) in func.params.iter().enumerate() {
+        state.env.insert(pname.clone(), ARG_REGISTERS[i]);
+    }
+    let mut words = Vec::with_capacity(func.instructions.len() + 1);
+    for instr in &func.instructions {
+        lower_instr(instr, &mut state, &mut words)?;
+    }
+    Ok(words)
+}
+
+/// Emit one IIR instruction's worth of RV32I words.
+fn lower_instr(
+    instr: &IIRInstr,
+    state: &mut FnState,
+    out: &mut Vec<u32>,
+) -> Result<(), IIRRiscvError> {
+    match instr.op.as_str() {
+        // ── const dest, Int(n) ──────────────────────────────────────────
+        //
+        // Lower to `addi rd, x0, imm12`.  This is the canonical
+        // small-constant lowering on RISC-V: `x0` is hardwired to zero,
+        // so `addi rd, x0, n` computes `n`.  For values outside the
+        // 12-bit signed range we'd need `lui + addi`; v0.2.0 returns
+        // ImmediateOutOfRange instead and defers that to A1++.
+        "const" => {
+            let dest = instr.dest.as_deref().ok_or_else(|| IIRRiscvError::InvalidOperand {
+                function: state.fn_name.into(),
+                detail: "const requires a dest".into(),
+            })?;
+            let n = match instr.srcs.first() {
+                Some(Operand::Int(n)) => *n,
+                Some(Operand::Bool(b)) => if *b { 1 } else { 0 },
+                _ => return Err(IIRRiscvError::InvalidOperand {
+                    function: state.fn_name.into(),
+                    detail: "const srcs[0] must be Int or Bool".into(),
+                }),
+            };
+            if !(-2048..=2047).contains(&n) {
+                return Err(IIRRiscvError::ImmediateOutOfRange {
+                    function: state.fn_name.into(),
+                    value: n,
+                });
+            }
+            let rd = state.alloc_temp(dest)?;
+            out.push(encode_addi(rd, X0_ZERO, n as i32));
+            Ok(())
+        }
+
+        // ── mov dest, src — `addi rd, rs1, 0` (canonical move) ──────────
+        "mov" => {
+            let dest = instr.dest.as_deref().ok_or_else(|| IIRRiscvError::InvalidOperand {
+                function: state.fn_name.into(),
+                detail: "mov requires a dest".into(),
+            })?;
+            let src = match instr.srcs.first() {
+                Some(Operand::Var(s)) => s.clone(),
+                _ => return Err(IIRRiscvError::InvalidOperand {
+                    function: state.fn_name.into(),
+                    detail: "mov srcs[0] must be Var".into(),
+                }),
+            };
+            let rs1 = state.lookup(&src)?;
+            let rd = state.alloc_temp(dest)?;
+            out.push(encode_addi(rd, rs1, 0));
+            Ok(())
+        }
+
+        // ── add / sub ───────────────────────────────────────────────────
+        //
+        // `add dest, a, b` → R-type `add rd, rs1, rs2`.
+        // `sub dest, a, b` → R-type `sub rd, rs1, rs2`.
+        // Signedness is irrelevant for both (two's-complement on RV32I).
+        "add" | "sub" => {
+            let dest = instr.dest.as_deref().ok_or_else(|| IIRRiscvError::InvalidOperand {
+                function: state.fn_name.into(),
+                detail: format!("{} requires a dest", instr.op),
+            })?;
+            let a = match instr.srcs.first() {
+                Some(Operand::Var(s)) => s.clone(),
+                _ => return Err(IIRRiscvError::InvalidOperand {
+                    function: state.fn_name.into(),
+                    detail: format!("{} srcs[0] must be Var", instr.op),
+                }),
+            };
+            let b = match instr.srcs.get(1) {
+                Some(Operand::Var(s)) => s.clone(),
+                _ => return Err(IIRRiscvError::InvalidOperand {
+                    function: state.fn_name.into(),
+                    detail: format!("{} srcs[1] must be Var", instr.op),
+                }),
+            };
+            let rs1 = state.lookup(&a)?;
+            let rs2 = state.lookup(&b)?;
+            let rd  = state.alloc_temp(dest)?;
+            let word = if instr.op == "add" {
+                encode_add(rd, rs1, rs2)
+            } else {
+                encode_sub(rd, rs1, rs2)
+            };
+            out.push(word);
+            Ok(())
+        }
+
+        // ── ret <var> — move var to a0 (mv pseudo), then ret ────────────
+        "ret" => {
+            let src = match instr.srcs.first() {
+                Some(Operand::Var(s)) => s.clone(),
+                _ => return Err(IIRRiscvError::InvalidOperand {
+                    function: state.fn_name.into(),
+                    detail: "ret srcs[0] must be Var".into(),
+                }),
+            };
+            let rs1 = state.lookup(&src)?;
+            // mv a0, rs1   →   addi a0, rs1, 0
+            // Skip the move if the value already lives in a0 — common
+            // when the return value comes from arg0 of a 1-param fn.
+            if rs1 != ARG_REGISTERS[0] {
+                out.push(encode_addi(ARG_REGISTERS[0], rs1, 0));
+            }
+            out.push(encode_jalr(X0_ZERO, X1_RA, 0));
+            Ok(())
+        }
+
+        // ── ret_void — just `ret` ────────────────────────────────────────
+        "ret_void" => {
+            out.push(encode_jalr(X0_ZERO, X1_RA, 0));
+            Ok(())
+        }
+
+        other => Err(IIRRiscvError::UnsupportedOp {
+            function: state.fn_name.into(),
+            op: other.into(),
+        }),
+    }
 }

--- a/code/packages/rust/iir-to-riscv/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-riscv/tests/test_backend.rs
@@ -1,10 +1,22 @@
-//! Integration tests for `iir-to-riscv` v0.1.0 (A1 skeleton).
+//! Integration tests for `iir-to-riscv`.
 //!
-//! Smoke-level — confirms the validator stub, the emitter shape, and the
-//! exact encoded word for `ret`.
+//! Test groups (grow with each release):
+//!
+//! 1. Validator behaviour
+//! 2. Empty module emits nothing
+//! 3. `ret_void`-only function — just the canonical 0x0000_8067
+//! 4. const + ret (A1+ — pinned exact addi encoding)
+//! 5. add / sub (A1+ — R-type opcodes)
+//! 6. mov (A1+ — addi rd, rs1, 0 idiom)
+//! 7. Param → return value (a0 stays in a0; no extra `mv`)
+//! 8. Out-of-range immediate is rejected
+//! 9. Register-pool exhaustion is rejected
+//! 10. Too many params is rejected
+//! 11. Config + error display smoke
 
-use interpreter_ir::IIRModule;
+use interpreter_ir::{IIRFunction, IIRInstr, IIRModule, Operand};
 use iir_to_riscv::{lower_iir_to_riscv, validate_for_riscv, IIRRiscvConfig, IIRRiscvError};
+use riscv_simulator::encoding::{encode_add, encode_addi, encode_jalr, encode_sub};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -21,8 +33,34 @@ fn empty_module() -> IIRModule {
     }
 }
 
+fn module_with(f: IIRFunction) -> IIRModule {
+    let entry = f.name.clone();
+    IIRModule {
+        name: "test".into(),
+        functions: vec![f],
+        entry_point: Some(entry),
+        language: "test".into(),
+        exports: vec![],
+        imports: vec![],
+    }
+}
+
+fn lower(module: &IIRModule) -> Vec<u32> {
+    lower_iir_to_riscv(module, &IIRRiscvConfig::default()).expect("lowering should succeed")
+}
+
+// Register-name constants used by the assertions below.
+const X0:  u32 = 0;
+const X1:  u32 = 1;
+const A0:  u32 = 10;
+const A1:  u32 = 11;
+const T0:  u32 = 5;
+const T1:  u32 = 6;
+
+const CANONICAL_RET: u32 = 0x0000_8067;
+
 // ===========================================================================
-// 1. Validator stub
+// 1. Validator behaviour
 // ===========================================================================
 
 #[test]
@@ -30,59 +68,236 @@ fn validate_returns_empty_for_empty_module() {
     assert!(validate_for_riscv(&empty_module()).is_empty());
 }
 
-// ===========================================================================
-// 2. Lowering shape and the exact `ret` encoding
-// ===========================================================================
-
-/// v0.1.0 emits exactly one instruction.
 #[test]
-fn lower_emits_exactly_one_word() {
-    let words = lower_iir_to_riscv(&empty_module(), &IIRRiscvConfig::default())
-        .expect("lowering");
-    assert_eq!(words.len(), 1, "v0.1.0 must emit exactly one word; got: {words:?}");
+fn validate_accepts_supported_ret_void_function() {
+    let f = IIRFunction::new("main", vec![], "void",
+        vec![IIRInstr::new("ret_void", None, vec![], "void")]);
+    assert!(validate_for_riscv(&module_with(f)).is_empty());
 }
 
-/// The emitted word is `0x0000_8067` — the canonical RV32I encoding of
-/// `ret` (`jalr x0, x1, 0`).
-///
-/// Bit layout (RV32I I-type, opcode JALR = 0b1100111):
-/// ```text
-/// 31           20 19  15 14  12 11   7 6      0
-///  imm[11:0]=0  | rs1=1 | f3=0 | rd=0 | 1100111
-/// ```
-///
-/// = `0000_0000_0000_00001_000_00000_1100111`
-/// = `0x0000_8067`.
 #[test]
-fn lower_emits_the_canonical_ret_word() {
-    let words = lower_iir_to_riscv(&empty_module(), &IIRRiscvConfig::default())
-        .expect("lowering");
-    assert_eq!(
-        words[0], 0x0000_8067,
-        "expected canonical `ret` encoding 0x00008067; got 0x{:08x}",
-        words[0]
+fn validate_rejects_unsupported_op() {
+    let f = IIRFunction::new("main", vec![], "void", vec![
+        IIRInstr::new("call_builtin", None, vec![], "void"),
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ]);
+    let errors = validate_for_riscv(&module_with(f));
+    assert!(errors.iter().any(|e| e.contains("UnsupportedOp")),
+        "expected UnsupportedOp for `call_builtin`; got: {errors:?}");
+}
+
+#[test]
+fn validate_rejects_unsupported_type() {
+    let f = IIRFunction::new("main", vec![], "f64",
+        vec![IIRInstr::new("ret_void", None, vec![], "void")]);
+    let errors = validate_for_riscv(&module_with(f));
+    assert!(errors.iter().any(|e| e.contains("UnsupportedType")),
+        "expected UnsupportedType for f64 ret; got: {errors:?}");
+}
+
+#[test]
+fn validate_rejects_too_many_params() {
+    let params: Vec<(String, String)> = (0..9)
+        .map(|i| (format!("p{i}"), "i32".into())).collect();
+    let f = IIRFunction::new("main", params, "void",
+        vec![IIRInstr::new("ret_void", None, vec![], "void")]);
+    let errors = validate_for_riscv(&module_with(f));
+    assert!(errors.iter().any(|e| e.contains("TooManyParams")),
+        "expected TooManyParams; got: {errors:?}");
+}
+
+// ===========================================================================
+// 2. Empty module emits nothing
+// ===========================================================================
+
+#[test]
+fn empty_module_emits_no_words() {
+    let words = lower(&empty_module());
+    assert!(words.is_empty(),
+        "empty module should produce empty word list; got: {words:?}");
+}
+
+// ===========================================================================
+// 3. ret_void-only function
+// ===========================================================================
+
+#[test]
+fn ret_void_only_function_emits_just_the_canonical_ret() {
+    let f = IIRFunction::new("main", vec![], "void",
+        vec![IIRInstr::new("ret_void", None, vec![], "void")]);
+    let words = lower(&module_with(f));
+    assert_eq!(words, vec![CANONICAL_RET],
+        "expected just the canonical 0x0000_8067; got: {words:#x?}");
+}
+
+// ===========================================================================
+// 4. const + ret — pinned exact encoding
+// ===========================================================================
+
+/// `fn answer() -> i32 { const v = 7; ret v }`
+/// expected sequence:
+///   addi t0, x0, 7       ; bind v ← 7
+///   addi a0, t0, 0       ; mv a0, v
+///   jalr x0, x1, 0       ; ret
+#[test]
+fn const_plus_ret_emits_three_pinned_words() {
+    let f = IIRFunction::new("answer", vec![], "i32", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(7)], "i32"),
+        IIRInstr::new("ret",   None,             vec![Operand::Var("v".into())], "i32"),
+    ]);
+    let words = lower(&module_with(f));
+    assert_eq!(words.len(), 3, "expected 3 words; got {words:#x?}");
+    assert_eq!(words[0], encode_addi(T0, X0, 7), "first word should be `addi t0, x0, 7`");
+    assert_eq!(words[1], encode_addi(A0, T0, 0), "second word should be `addi a0, t0, 0` (mv)");
+    assert_eq!(words[2], CANONICAL_RET);
+}
+
+#[test]
+fn const_of_negative_small_int_is_supported() {
+    let f = IIRFunction::new("f", vec![], "i32", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(-2048)], "i32"),
+        IIRInstr::new("ret",   None,             vec![Operand::Var("v".into())], "i32"),
+    ]);
+    let words = lower(&module_with(f));
+    assert_eq!(words[0], encode_addi(T0, X0, -2048),
+        "minimum 12-bit signed imm (-2048) must encode cleanly");
+}
+
+#[test]
+fn const_out_of_imm12_range_is_rejected() {
+    let f = IIRFunction::new("f", vec![], "i32", vec![
+        // 0x1000 = 4096 — outside [-2048, 2047].
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(4096)], "i32"),
+        IIRInstr::new("ret",   None,             vec![Operand::Var("v".into())], "i32"),
+    ]);
+    let err = lower_iir_to_riscv(&module_with(f), &IIRRiscvConfig::default())
+        .expect_err("oversized const should fail");
+    match err {
+        IIRRiscvError::ImmediateOutOfRange { value, .. } => assert_eq!(value, 4096),
+        other => panic!("expected ImmediateOutOfRange, got: {other:?}"),
+    }
+}
+
+// ===========================================================================
+// 5. add / sub — R-type opcodes
+// ===========================================================================
+
+/// `fn f(a: i32, b: i32) -> i32 { v = a + b; ret v }`
+/// expected sequence:
+///   add t0, a0, a1       ; v ← a + b
+///   addi a0, t0, 0       ; mv a0, v
+///   ret
+#[test]
+fn add_two_params_emits_r_type_add_then_mv_then_ret() {
+    let f = IIRFunction::new(
+        "f",
+        vec![("a".into(), "i32".into()), ("b".into(), "i32".into())],
+        "i32",
+        vec![
+            IIRInstr::new("add", Some("v".into()),
+                vec![Operand::Var("a".into()), Operand::Var("b".into())], "i32"),
+            IIRInstr::new("ret", None, vec![Operand::Var("v".into())], "i32"),
+        ],
     );
+    let words = lower(&module_with(f));
+    assert_eq!(words.len(), 3);
+    assert_eq!(words[0], encode_add(T0, A0, A1),
+        "first word should be `add t0, a0, a1`");
+    assert_eq!(words[1], encode_addi(A0, T0, 0));
+    assert_eq!(words[2], CANONICAL_RET);
+}
+
+#[test]
+fn sub_two_params_emits_r_type_sub() {
+    let f = IIRFunction::new(
+        "f",
+        vec![("a".into(), "i32".into()), ("b".into(), "i32".into())],
+        "i32",
+        vec![
+            IIRInstr::new("sub", Some("v".into()),
+                vec![Operand::Var("a".into()), Operand::Var("b".into())], "i32"),
+            IIRInstr::new("ret", None, vec![Operand::Var("v".into())], "i32"),
+        ],
+    );
+    let words = lower(&module_with(f));
+    assert_eq!(words[0], encode_sub(T0, A0, A1));
 }
 
 // ===========================================================================
-// 3. Config defaults
+// 6. mov — `addi rd, rs1, 0`
+// ===========================================================================
+
+#[test]
+fn mov_emits_addi_zero_canonical_move() {
+    let f = IIRFunction::new(
+        "f",
+        vec![("x".into(), "i32".into())],
+        "i32",
+        vec![
+            IIRInstr::new("mov", Some("y".into()),
+                vec![Operand::Var("x".into())], "i32"),
+            IIRInstr::new("ret", None, vec![Operand::Var("y".into())], "i32"),
+        ],
+    );
+    let words = lower(&module_with(f));
+    // mov y, x  ⇒  addi t0, a0, 0
+    assert_eq!(words[0], encode_addi(T0, A0, 0),
+        "mov should be canonical `addi rd, rs1, 0`");
+}
+
+// ===========================================================================
+// 7. Identity: ret of param[0] skips the redundant `mv a0, a0`
+// ===========================================================================
+
+#[test]
+fn ret_of_first_param_skips_redundant_mv() {
+    let f = IIRFunction::new(
+        "identity",
+        vec![("x".into(), "i32".into())],
+        "i32",
+        vec![IIRInstr::new("ret", None, vec![Operand::Var("x".into())], "i32")],
+    );
+    let words = lower(&module_with(f));
+    // Just the ret — no `mv a0, a0` since x already lives in a0.
+    assert_eq!(words, vec![CANONICAL_RET],
+        "identity(x) should emit only ret; got: {words:#x?}");
+}
+
+// ===========================================================================
+// 8. Register-pool exhaustion is rejected
+// ===========================================================================
+
+#[test]
+fn out_of_registers_when_pool_exhausted() {
+    // 8 consts in a row — TEMP_REGISTERS holds only 7.
+    let mut body = vec![];
+    for i in 0..8 {
+        body.push(IIRInstr::new(
+            "const",
+            Some(format!("v{i}")),
+            vec![Operand::Int(i as i64)],
+            "i32",
+        ));
+    }
+    body.push(IIRInstr::new("ret_void", None, vec![], "void"));
+    let f = IIRFunction::new("greedy", vec![], "void", body);
+
+    let err = lower_iir_to_riscv(&module_with(f), &IIRRiscvConfig::default())
+        .expect_err("8 locals should exhaust the pool");
+    match err {
+        IIRRiscvError::OutOfRegisters { .. } => {}
+        other => panic!("expected OutOfRegisters, got: {other:?}"),
+    }
+}
+
+// ===========================================================================
+// 9. Config + error display smoke
 // ===========================================================================
 
 #[test]
 fn default_config_has_nonempty_module_name() {
-    let cfg = IIRRiscvConfig::default();
-    assert!(!cfg.module_name.is_empty());
+    assert!(!IIRRiscvConfig::default().module_name.is_empty());
 }
-
-#[test]
-fn new_sets_module_name() {
-    let cfg = IIRRiscvConfig::new("custom");
-    assert_eq!(cfg.module_name, "custom");
-}
-
-// ===========================================================================
-// 4. Error display
-// ===========================================================================
 
 #[test]
 fn errors_display_without_panic() {
@@ -95,5 +310,17 @@ fn errors_display_without_panic() {
     });
     let _ = format!("{}", IIRRiscvError::InvalidOperand {
         function: "f".into(), detail: "bad".into(),
+    });
+    let _ = format!("{}", IIRRiscvError::UndefinedVariable {
+        function: "f".into(), name: "ghost".into(),
+    });
+    let _ = format!("{}", IIRRiscvError::TooManyParams {
+        function: "f".into(), count: 9,
+    });
+    let _ = format!("{}", IIRRiscvError::OutOfRegisters {
+        function: "f".into(), name: "v8".into(),
+    });
+    let _ = format!("{}", IIRRiscvError::ImmediateOutOfRange {
+        function: "f".into(), value: 99_999,
     });
 }

--- a/code/specs/iir-to-riscv.md
+++ b/code/specs/iir-to-riscv.md
@@ -51,9 +51,9 @@ IIRModule
 
 | Version | Scope | Status |
 |---------|-------|--------|
-| **v0.1.0 (A1 — this PR)** | crate skeleton: any module → single `ret` (`jalr x0, x1, 0` = `0x0000_8067`) | this PR |
-| v0.2.0 (A1+) | function entry/exit prologue/epilogue + arith + cmp + control flow | future |
-| v0.3.0 (A1++) | calls + locals on stack + `ecall` for print | future |
+| v0.1.0 (A1) | crate skeleton: any module → single `ret` (`0x0000_8067`) | **merged** |
+| **v0.2.0 (A1+ — this PR)** | const/mov/add/sub/ret + linear register allocator (a0..a7 + t0..t6) | this PR |
+| v0.3.0 (A1++) | comparisons, branches, calls + stack-spilling allocator + `ecall` for print + `lui`/`addi` for wide consts | future |
 | v0.4.0 (A1+++) | `lang-aot --target=riscv32` wiring | future |
 | (later) | RV32M (mul/div), RV32A (atomics), RV32F (floats), DWARF emission via aot-debug | future |
 


### PR DESCRIPTION
## Summary

- **A1+** of [`MULTILANG-ARCHITECTURE-BACKENDS.md`](code/specs/MULTILANG-ARCHITECTURE-BACKENDS.md). First slice of real RV32I lowering — extends v0.1.0 (skeleton) to v0.2.0.
- Adds working register allocation + four instruction families lowered to real RV32I encodings.
- 17 unit + 1 doctest (was 6 + 1), all green. Every new opcode pattern is pinned with exact-encoding assertions.

## Op coverage added

| IIR op | RV32I lowering |
|--------|----------------|
| `const dest, Int(n)` (12-bit imm) | `addi rd, x0, n` |
| `mov dest, src` | `addi rd, rs1, 0` (canonical move) |
| `add dest, a, b` | R-type `add rd, rs1, rs2` |
| `sub dest, a, b` | R-type `sub rd, rs1, rs2` |
| `ret <var>` (int) | optional `mv a0` (skipped if already a0) + `jalr x0, x1, 0` |
| `ret_void` | `jalr x0, x1, 0` |

## Register allocation (linear, no spilling)

| Slot | Registers | Cap |
|------|-----------|-----|
| Function params | `a0..a7` (`x10..x17`) | validator rejects `>8` (`TooManyParams`) |
| Locals | `t0..t6` (`x5..x7, x28..x31`) | `>7` → `OutOfRegisters` |

A1++ will replace this with a stack-spilling allocator.

## Type rules

Supported: `void`, `i{8,16,32}`, `u{8,16,32}`. Everything is 32-bit (RV32 native width).
`i64`/`u64`/`f32`/`f64` deferred — 64-bit needs register pairs, floats need the F-extension.

## Nice detail — identity skips redundant `mv`

`identity(x: i32) -> i32 { ret x }` lowers to **one word** — just the canonical `0x0000_8067`. `x` already lives in `a0` (it's the first param), so we skip the redundant `mv a0, a0`.

## New error variants

- `UndefinedVariable`
- `TooManyParams`
- `OutOfRegisters`
- `ImmediateOutOfRange`

## Test plan
- [x] `cargo test -p iir-to-riscv` — 17 unit + 1 doctest, all green
- [x] Exact-encoding pinning on every new opcode pattern (any future revision to `riscv-simulator`'s encoders surfaces immediately)
- [x] `const(-2048)` lowers cleanly (smallest valid imm12); `const(4096)` rejected as `ImmediateOutOfRange`
- [x] Pool exhaustion rejected with `OutOfRegisters`
- [x] /security-review passed (no findings)

## Spec status row

| Version | Scope | Status |
|---------|-------|--------|
| v0.1.0 (A1) | skeleton | **merged** |
| **v0.2.0 (A1+ — this PR)** | const/mov/add/sub/ret + allocator | this PR |
| v0.3.0 (A1++) | comparisons + branches + calls + stack spilling + `lui+addi` + `ecall print` | future |
| v0.4.0 (A1+++) | `lang-aot --target=riscv32` wiring | future |

🤖 Generated with [Claude Code](https://claude.com/claude-code)