### PR TITLE
feat(ml_framework_core): pure-Ruby Tensor + factories + shape ops + operator overloads (Ruby pilot PR #4/8)

### DIFF
--- a/code/packages/ruby/ml_framework_core/BUILD
+++ b/code/packages/ruby/ml_framework_core/BUILD
@@ -1,0 +1,1 @@
+bundle install --quiet && bundle exec rake test

--- a/code/packages/ruby/ml_framework_core/BUILD_windows
+++ b/code/packages/ruby/ml_framework_core/BUILD_windows
@@ -1,0 +1,1 @@
+bundle install --quiet && bundle exec rake test

--- a/code/packages/ruby/ml_framework_core/CHANGELOG.md
+++ b/code/packages/ruby/ml_framework_core/CHANGELOG.md
@@ -1,0 +1,102 @@
+# Changelog
+
+## Unreleased
+
+### Added — v0.1.0: pure-Ruby Tensor class
+
+First release.  Ships the bottom layer of the Ruby ML framework stack: a
+PyTorch-shaped `Tensor` class implemented entirely in Ruby.  No Rust
+calls, no native ext.  Layered design — PRs #5-#8 will add the autograd
+engine, forward + backward op dispatch, and benchmarks on top.
+
+#### Public API
+
+```ruby
+require "coding_adventures/ml_framework_core"
+
+T = CodingAdventures::MLFrameworkCore::Tensor
+```
+
+- **Construction**: `T.new(data, shape: nil, dtype: :f32, requires_grad: false)`
+- **Factories**: `zeros`, `ones`, `full`, `eye` (square or rectangular),
+  `arange` (1/2/3-arg, supports negative step), `randn` (deterministic
+  with `seed:`, via Box-Muller), `from_array`
+- **Shape ops**: `reshape`, `transpose` (2-D only in v0.1), `flatten`,
+  `squeeze` (all-1 or specific axis), `unsqueeze` (negative axes OK)
+- **Operator overloads**: `+`, `-`, `*`, `/`, `**`, unary `-` — tensor⊗tensor
+  (same shape) and tensor⊗scalar
+- **Conversions**: `to_a` (flat copy), `to_nested_a` (shape-respecting)
+- **Introspection**: `shape`, `dtype`, `ndim`, `numel`, `==`, `eql?`,
+  `hash`, `inspect`
+- **Autograd-prep slots**: `requires_grad`, `grad`, `grad_fn` — present
+  as storage for PR #5 to wire up; no autograd logic in this PR
+
+#### Architecture choices
+
+- **f64 in memory, :f32 dtype**: Ruby's `Float` is f64; using it as the
+  in-memory representation avoids per-op packing.  The lossy f32
+  conversion happens at the Rust dispatch boundary (PR #6).
+- **Same-shape only for binary ops**: no NumPy-style broadcasting in
+  v0.1.  Adding it now would couple Tensor to the shape-broadcasting
+  algorithm; we pull it in when ops dispatch lands.
+- **No indexing or slicing**: PyTorch's `__getitem__` is 50+ lines of
+  arg-shape handling.  Deferred to after PR #8.
+- **2-D-only transpose**: higher-rank transpose needs generic strided
+  index math; we don't need it for any PR #5-#7 use case.
+- **Pure-Ruby `randn` via Box-Muller**: two textbook lines of trig;
+  avoids pulling in a distribution library.
+
+#### File layout
+
+```
+ml_framework_core/
+├── coding_adventures_ml_framework_core.gemspec
+├── Gemfile                                       # gemspec + path override
+├── Rakefile                                      # minitest task
+├── lib/coding_adventures/
+│   ├── ml_framework_core.rb                      # entry point
+│   └── ml_framework_core/
+│       ├── version.rb
+│       └── tensor.rb                             # the Tensor class
+├── test/tensor_test.rb                           # ~50 minitests, 6 sections
+├── BUILD / BUILD_windows                         # bundle install + rake test
+├── required_capabilities.json                    # empty (no FFI/net/fs)
+├── README.md
+└── CHANGELOG.md
+```
+
+#### Test coverage (six minitest sections, ~50 tests)
+
+1. **Construction**: flat, nested (auto-shape), scalar, deep-nested,
+   ragged-rejection, explicit-shape length validation, dtype validation,
+   `requires_grad`/`grad` defaults.
+2. **Factories**: every factory exercised, including arange edge cases
+   (zero step → raise, negative step, wrong arity → raise) and randn
+   determinism + mean sanity check on 1000 samples.
+3. **Shape ops**: reshape (including back-round-trip), flatten,
+   transpose (default, explicit perm, double = identity, invalid perm
+   rejection, higher-rank NotImplementedError), squeeze (all dims,
+   specific axis, negative axis, non-unit axis rejection), unsqueeze
+   (positive, end, negative, round-trip).
+4. **Arithmetic**: every op (+, -, *, /, **, unary -), tensor⊗tensor and
+   tensor⊗scalar paths, shape-mismatch raise, unsupported-operand-type raise.
+5. **Equality + inspect**: shape-aware ==, hash equality, inspect shape
+   and dtype, inspect truncation for long data.
+6. **Round-trip**: `to_nested_a` round-trips 2-D and 3-D, reshape
+   preserves `to_a`.
+
+#### Runtime dependency
+
+- `coding_adventures_matrix_rust_ruby >= 0.1` — declared in the gemspec
+  so the dependency graph is correct from day one, even though v0.1
+  doesn't call it.  PR #6 wires it up.
+
+#### What's next
+
+- PR #5: `autograd.rb` — `Function` base class, `apply`, topological
+  sort, `Tensor#backward`.  Mirrors `code/packages/python/ml-framework-core/src/ml_framework_core/autograd.py`.
+- PR #6: `ops.rb` — 15+ Function subclasses (Add, Sub, Mul, Div, Neg,
+  Abs, Pow, MatMul, ReLU, Sigmoid, Tanh, GELU, Softmax, Sum, Mean).
+  Each dispatches large tensors through `MatrixRustRuby.run_graph_on_cpu`.
+- PR #7: backward dispatch + end-to-end MLP training test.
+- PR #8: benchmark script + RubyGems publishing polish.

--- a/code/packages/ruby/ml_framework_core/Gemfile
+++ b/code/packages/ruby/ml_framework_core/Gemfile
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+# Pull deps from the gemspec — including the production runtime dep on
+# coding_adventures_matrix_rust_ruby.  Until that gem is published to
+# RubyGems, satisfy the dep from the workspace via a path override below.
+gemspec
+
+# Workspace-local override: use the matrix_rust_ruby gem sitting one
+# directory up.  Necessary because RubyGems doesn't yet have v0.1
+# published, but the gemspec needs to declare the runtime dep correctly
+# for when it eventually is.
+gem "coding_adventures_matrix_rust_ruby", path: "../matrix_rust_ruby"

--- a/code/packages/ruby/ml_framework_core/README.md
+++ b/code/packages/ruby/ml_framework_core/README.md
@@ -1,0 +1,133 @@
+# ml_framework_core — idiomatic Ruby Tensor + autograd
+
+A small, PyTorch-shaped Ruby ML library that runs the heavy stuff on the
+Rust `matrix-cpu` engine and falls back to pure Ruby for small or
+debugging workloads.
+
+```ruby
+require "coding_adventures/ml_framework_core"
+include CodingAdventures::MLFrameworkCore       # or use MLFrameworkCore alias
+
+x = Tensor.new([[1, 2, 3], [4, 5, 6]])
+y = Tensor.eye(3)
+
+x.matmul(y) == x                # forthcoming (PR #6)
+(x + 1.0).to_nested_a           # works today
+```
+
+## Where this v0.1 sits in the multi-language stack
+
+```text
+┌─────────────────────────────────────────────────────────────────┐
+│  ml_framework_core (this gem)        ← v0.1 = Tensor only       │
+│    Tensor + factories + shape ops + operator overloads          │
+│    PR #5: autograd engine                                       │
+│    PR #6: forward op dispatch via matrix_rust_ruby              │
+│    PR #7: backward dispatch + end-to-end MLP test               │
+│    PR #8: benchmark + RubyGems publishing polish                │
+│    ↓                                                             │
+│  matrix_rust_ruby (Ruby gem)               ← PR #3 (merged)     │
+│    MatrixRustRuby.run_graph_on_cpu(envelope)                    │
+│    ↓                                                             │
+│  matrix_rust_ruby_native (Rust cdylib)     ← PR #2 (merged)     │
+│    ↓                                                             │
+│  c-bridge (Rust workspace crate)           ← PR #1 (merged)     │
+│    ↓                                                             │
+│  matrix-cpu execution engine                                    │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## What v0.1 ships
+
+This PR (#4 of 8 in the Ruby pilot) is intentionally pure Ruby — no
+native ext, no Rust calls.  That keeps it small, reviewable, and
+independently testable.
+
+### `Tensor` class
+
+```ruby
+T = CodingAdventures::MLFrameworkCore::Tensor
+
+# Construction
+T.new([1, 2, 3])                        # 1-D from flat
+T.new([[1, 2], [3, 4]])                 # 2-D from nested (shape inferred)
+T.new([1, 2, 3, 4], shape: [2, 2])      # flat + explicit shape
+
+# Factories
+T.zeros(2, 3)
+T.ones(3)
+T.full([2, 2], 7.5)
+T.eye(3)                                # 3x3 identity
+T.eye(2, 3)                             # rectangular
+T.arange(5)                             # 0, 1, 2, 3, 4
+T.arange(2, 10, 2)                      # 2, 4, 6, 8
+T.randn(3, 4, seed: 42)                 # standard-normal via Box-Muller
+T.from_array([[1, 2], [3, 4]])          # alias for new(nested)
+
+# Shape ops
+t.reshape(3, 4)
+t.transpose                             # 2-D only in v0.1
+t.flatten
+t.squeeze(axis = nil)
+t.unsqueeze(axis)
+
+# Operator overloads — element-wise, same shape only in v0.1
+a + b   a - b   a * b   a / b   a**2   -a
+a + 5   a - 5   a * 5   a / 5   a**2          # scalar broadcasts
+
+# Conversions + introspection
+t.shape          # => [2, 3]
+t.dtype          # => :f32
+t.ndim           # => 2
+t.numel          # => 6
+t.to_a           # flat Array<Float>
+t.to_nested_a    # nested Array matching shape
+
+# Autograd-prep slots (PR #5 wires them up; here they're just storage)
+t.requires_grad        # => false by default
+t.requires_grad = true
+t.grad                 # => nil until backward() runs
+t.grad_fn              # => nil for leaf tensors
+```
+
+## What's intentionally NOT in v0.1
+
+| Feature           | Lands in | Why deferred                         |
+|-------------------|----------|--------------------------------------|
+| Broadcasting      | PR #6    | Couples Tensor to shape algebra      |
+| Indexing/slicing  | post-#8  | 50+ lines of arg-shape handling      |
+| `sum` / `mean`    | PR #6    | These will be Function subclasses    |
+| Autograd `apply`  | PR #5    | Needs its own focused PR             |
+| Rust dispatch     | PR #6    | Needs autograd graph first           |
+| Higher-rank `transpose` | post-#8 | Strided index math not needed yet |
+
+## Storage model
+
+- `@data` is a flat `Array<Float>` (Ruby Floats are f64).
+- `@shape` is an `Array<Integer>`.
+- `@dtype` is `:f32` (matches matrix-cpu; in-memory f64 just happens to be
+  Ruby's only float primitive).
+
+The lossy f64→f32 conversion only happens at the Rust dispatch boundary
+(PR #6), where we pack each f64 into 4 bytes of little-endian f32 before
+hex-encoding for the JSON envelope.
+
+## Running the test suite
+
+```bash
+cd code/packages/ruby/ml_framework_core
+bundle install
+bundle exec rake test
+```
+
+The suite has ~50 tests covering:
+
+- Construction (flat, nested, scalar, explicit shape, ragged-rejection)
+- Every factory (zeros, ones, full, eye, arange, randn, from_array)
+- Every shape op (reshape, transpose, flatten, squeeze, unsqueeze)
+- Every operator overload (+, -, *, /, **, unary -, scalar broadcast)
+- Equality, hash, inspect
+- Round-trip properties (`reshape(t.shape) == t`,
+  `unsqueeze(0).squeeze(0) == t`, `transpose.transpose == t`,
+  `to_nested_a → new → to_nested_a` is identity)
+- Version constant + `MLFrameworkCore` short-alias

--- a/code/packages/ruby/ml_framework_core/Rakefile
+++ b/code/packages/ruby/ml_framework_core/Rakefile
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Rakefile — minimal test runner.  No compile task this PR (no native ext yet).
+require "rake/testtask"
+
+Rake::TestTask.new(:test) do |t|
+  t.libs << "test"
+  t.libs << "lib"
+  t.test_files = FileList["test/**/*_test.rb"]
+end
+
+task default: :test

--- a/code/packages/ruby/ml_framework_core/coding_adventures_ml_framework_core.gemspec
+++ b/code/packages/ruby/ml_framework_core/coding_adventures_ml_framework_core.gemspec
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require_relative "lib/coding_adventures/ml_framework_core/version"
+
+# coding_adventures_ml_framework_core — idiomatic Ruby Tensor + autograd
+# on top of the Rust matrix-cpu execution engine.
+#
+# Layered design — this gem (v0.1) ships only the bottom Tensor layer.
+# PRs #5-#8 will layer on:
+#   - PR #5: autograd engine (Function.apply, tensor.backward)
+#   - PR #6: forward op dispatch (envelope-based calls into matrix_rust_ruby)
+#   - PR #7: backward dispatch + end-to-end MLP test
+#   - PR #8: benchmark + RubyGems publishing polish
+#
+# v0.1 is intentionally pure Ruby — no native ext, no Rust calls.  That
+# keeps this PR small, reviewable, and independently testable.  The
+# matrix_rust_ruby gem is listed as a runtime dependency so the dependency
+# graph is correct from day one; we just don't *call* it until PR #6.
+Gem::Specification.new do |spec|
+  spec.name          = "coding_adventures_ml_framework_core"
+  spec.version       = CodingAdventures::MLFrameworkCore::VERSION
+  spec.authors       = ["Adhithya Rajasekaran"]
+  spec.summary       = "Idiomatic Ruby Tensor and autograd on top of the Rust matrix-cpu engine"
+  spec.description   = "Pure-Ruby Tensor class with factories (zeros/ones/eye/arange/randn/...), " \
+                       "shape ops (reshape/transpose/flatten/squeeze/unsqueeze), and operator " \
+                       "overloads (+/-/*///**/-). v0.1 is pure Ruby. Future versions dispatch " \
+                       "large ops through matrix_rust_ruby to the Rust matrix-cpu engine."
+  spec.homepage      = "https://github.com/adhithyan15/coding-adventures"
+  spec.license       = "MIT"
+  spec.required_ruby_version = ">= 2.6.0"
+
+  spec.files         = Dir[
+    "lib/**/*.rb",
+    "README.md",
+    "CHANGELOG.md"
+  ]
+  spec.require_paths = ["lib"]
+
+  spec.metadata = {
+    "source_code_uri" => "https://github.com/adhithyan15/coding-adventures",
+    "rubygems_mfa_required" => "true"
+  }
+
+  # Runtime dep on the Rust binding gem.  Listed even though v0.1 doesn't
+  # call into it — keeps the dependency graph honest, and means downstream
+  # users only need one `gem install` to get the full eventual stack.
+  spec.add_runtime_dependency "coding_adventures_matrix_rust_ruby", ">= 0.1"
+
+  spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "rake", "~> 13.0"
+end

--- a/code/packages/ruby/ml_framework_core/lib/coding_adventures/ml_framework_core.rb
+++ b/code/packages/ruby/ml_framework_core/lib/coding_adventures/ml_framework_core.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# coding_adventures/ml_framework_core — entry point
+# =====================================================
+#
+# Require this file to get the public API:
+#
+#   require "coding_adventures/ml_framework_core"
+#
+#   t = CodingAdventures::MLFrameworkCore::Tensor.zeros(2, 3)
+#   t.shape   # => [2, 3]
+#   (t + 1.0).to_a   # => [1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+#
+# v0.1 ships only the Tensor class.  PRs #5-#8 will add `autograd.rb`,
+# `ops.rb`, and the dispatch wiring; each will be a single new
+# `require_relative` line in this file.
+
+require_relative "ml_framework_core/version"
+require_relative "ml_framework_core/tensor"
+
+# Short alias for callers who don't want to type the full namespace.
+# Mirrors PyTorch's `import torch as t` convention.
+MLFrameworkCore = CodingAdventures::MLFrameworkCore unless defined?(MLFrameworkCore)

--- a/code/packages/ruby/ml_framework_core/lib/coding_adventures/ml_framework_core/tensor.rb
+++ b/code/packages/ruby/ml_framework_core/lib/coding_adventures/ml_framework_core/tensor.rb
@@ -1,0 +1,461 @@
+# frozen_string_literal: true
+
+# Tensor — N-dimensional float array with shape, the universal currency
+# of every deep-learning library.
+# ============================================================================
+#
+# # Why this exists
+#
+# A Tensor is what you'd get if you bolted a `shape` onto a flat Ruby Array
+# of Floats.  That's the whole idea.  The shape lets you treat the same
+# underlying bytes as a 2x3 matrix, a 6-vector, a 1x6 row, a 6x1 column —
+# whatever the math wants.
+#
+# # Storage model
+#
+# - `@data`  — flat Array of Float, length = `numel` = product(shape).
+# - `@shape` — Array of positive Integer; can be empty for a 0-d scalar.
+# - `@dtype` — Symbol; only :f32 supported in v0.1 (matches matrix-cpu).
+#
+# We use Ruby's native Float (which is f64) for the in-memory representation
+# even though `@dtype` is :f32.  That's deliberate:
+#   - Ruby has no f32 primitive; using f64 avoids the round-trip cost of
+#     packing/unpacking for every elementwise op.
+#   - The lossy step happens at the Rust dispatch boundary (PR #6), where
+#     we hex-encode each f64 into 4 bytes of f32 before sending it across.
+#   - For pure-Ruby v0.1, all storage is f64 and no precision is lost.
+#
+# # Autograd-prep slots (this PR sets them up; PR #5 uses them)
+#
+# - `@requires_grad` — if true, ops that consume this tensor will build an
+#   autograd graph.  Just a boolean here; the actual graph machinery
+#   lives in PR #5 (autograd.rb).
+# - `@grad`          — Tensor of same shape, accumulated gradient.  nil
+#   until backward() runs.
+# - `@grad_fn`       — the Function (subclass of autograd.rb's Function)
+#   that produced this tensor; nil for leaf tensors.
+#
+# These are present so PR #5 can wire up autograd WITHOUT touching this
+# file.  No autograd LOGIC happens here.
+#
+# # What's NOT here (deferred)
+#
+# - Broadcasting:  v0.1 requires identical shapes for binary ops.  Adding
+#   it now would couple Tensor to the shape-broadcasting algorithm; we
+#   pull it in when ops dispatch lands (PR #6).
+# - Indexing (`t[1, 2]`, slicing):  the Python version has a 50-line
+#   `__getitem__` with integer / slice / list / tuple handling.  Adding
+#   it here would double the file size for no autograd payoff; deferred
+#   to a later PR.
+# - Reductions (`sum`, `mean`):  these will be Function subclasses in
+#   PR #6, not Tensor methods.
+
+require "coding_adventures/ml_framework_core/version"
+
+module CodingAdventures
+  module MLFrameworkCore
+    class Tensor
+      # ----------------------------------------------------------------------
+      # Construction
+      # ----------------------------------------------------------------------
+
+      # @param data [Array<Numeric>, Array<Array<...>>, Numeric] a flat Array,
+      #   a nested Array, or a single scalar.  Nested arrays are flattened
+      #   and the shape is inferred from their nesting depth.
+      # @param shape [Array<Integer>, nil] explicit shape, or nil to infer.
+      # @param dtype [Symbol] only :f32 is supported in v0.1.
+      # @param requires_grad [Boolean] whether to track this tensor for autograd.
+      def initialize(data, shape: nil, dtype: :f32, requires_grad: false)
+        raise ArgumentError, "dtype #{dtype.inspect} not supported; v0.1 supports :f32 only" unless dtype == :f32
+
+        # Two construction paths:
+        #
+        # 1. `Tensor.new(nested_or_flat_array)` — infer shape from nesting,
+        #    flatten the data.  This is the common case.
+        # 2. `Tensor.new(flat_array, shape: [...])` — caller already has
+        #    flat data and tells us the shape explicitly.  Used by all
+        #    the factories below and by reshape/transpose.
+        if shape.nil?
+          @shape = self.class.infer_shape(data)
+          @data  = self.class.flatten_data(data, @shape)
+        else
+          @shape = shape.map(&:to_i)
+          flat   = data.is_a?(Array) ? data.flatten : [data]
+          expected = @shape.reduce(1, :*)
+          if flat.length != expected
+            raise ArgumentError,
+                  "data length #{flat.length} does not match shape #{@shape.inspect} (expected #{expected})"
+          end
+          @data = flat.map { |x| x.to_f }
+        end
+
+        @dtype         = dtype
+        @requires_grad = !!requires_grad
+        @grad          = nil
+        @grad_fn       = nil
+      end
+
+      # ----------------------------------------------------------------------
+      # Attribute readers — all the things users want to introspect
+      # ----------------------------------------------------------------------
+
+      attr_reader :shape, :dtype, :grad, :grad_fn
+      attr_accessor :requires_grad
+
+      def ndim
+        @shape.length
+      end
+
+      def numel
+        @shape.empty? ? 1 : @shape.reduce(1, :*)
+      end
+
+      # ----------------------------------------------------------------------
+      # Conversions
+      # ----------------------------------------------------------------------
+
+      # Flat Array view of the underlying data.  Returns a copy so callers
+      # can mutate without breaking us.
+      def to_a
+        @data.dup
+      end
+
+      # Nested Array matching `shape`.  Round-trip: `Tensor.new(t.to_nested_a) == t`.
+      #
+      # The recursion eats one shape dim per level: shape [2, 3] becomes
+      # an array of 2 arrays of 3 floats.
+      def to_nested_a
+        return @data[0] if @shape.empty?    # 0-d scalar
+        return @data.dup if @shape.length == 1
+
+        chunk_size = @shape[1..].reduce(1, :*)
+        sub_shape  = @shape[1..]
+        Array.new(@shape[0]) do |i|
+          slice = @data[(i * chunk_size)...((i + 1) * chunk_size)]
+          self.class.new(slice, shape: sub_shape).to_nested_a
+        end
+      end
+
+      # ----------------------------------------------------------------------
+      # Equality + inspection
+      # ----------------------------------------------------------------------
+
+      # Two tensors are equal iff they have the same shape AND the same
+      # element values.  Shape mismatch beats value mismatch in the check
+      # so the failure message is more useful.
+      def ==(other)
+        return false unless other.is_a?(Tensor)
+        return false unless other.shape == @shape
+
+        @data == other.to_a
+      end
+
+      alias eql? ==
+
+      def hash
+        [@shape, @data].hash
+      end
+
+      # Compact representation suitable for irb / pp.
+      def inspect
+        preview = @data.first(6).map { |v| format("%g", v) }.join(", ")
+        suffix  = @data.length > 6 ? ", ..." : ""
+        "#<Tensor shape=#{@shape.inspect} dtype=#{@dtype} data=[#{preview}#{suffix}]>"
+      end
+
+      alias to_s inspect
+
+      # ----------------------------------------------------------------------
+      # Shape ops — produce new Tensors with the same underlying numbers
+      # in a different shape.
+      # ----------------------------------------------------------------------
+
+      # Same elements, new shape.  Raises if numel doesn't match.
+      def reshape(*new_shape)
+        new_shape = new_shape.flatten.map(&:to_i)
+        new_numel = new_shape.reduce(1, :*)
+        if new_numel != numel
+          raise ArgumentError,
+                "reshape: new shape #{new_shape.inspect} has #{new_numel} elements but tensor has #{numel}"
+        end
+        self.class.new(@data.dup, shape: new_shape, dtype: @dtype)
+      end
+
+      # Collapse to 1-D.
+      def flatten
+        self.class.new(@data.dup, shape: [numel], dtype: @dtype)
+      end
+
+      # Permute axes.  2-D only in v0.1 (i.e. `transpose` with no args
+      # swaps the two dims of a matrix; `transpose(1, 0)` does the same
+      # explicitly).  Higher-rank transpose lands when ops dispatch does.
+      def transpose(*perm)
+        if perm.empty?
+          raise ArgumentError, "transpose with no args is only defined for 2-D tensors (got #{@shape.inspect})" unless ndim == 2
+
+          perm = [1, 0]
+        elsif perm.length != ndim
+          raise ArgumentError, "transpose perm length #{perm.length} != ndim #{ndim}"
+        end
+
+        # Sanity-check perm is a permutation of [0, ndim).
+        unless perm.sort == (0...ndim).to_a
+          raise ArgumentError, "transpose perm #{perm.inspect} is not a permutation of (0...#{ndim})"
+        end
+
+        # For v0.1 we only need the 2-D case; assert it and do the
+        # straightforward transpose.  Higher-rank transpose involves
+        # generic strided index math; deferred to ops dispatch.
+        unless ndim == 2
+          raise NotImplementedError, "transpose on rank-#{ndim} tensors not yet implemented (v0.1: 2-D only)"
+        end
+
+        rows, cols = @shape
+        new_data = Array.new(rows * cols)
+        (0...rows).each do |r|
+          (0...cols).each do |c|
+            new_data[c * rows + r] = @data[r * cols + c]
+          end
+        end
+        self.class.new(new_data, shape: [cols, rows], dtype: @dtype)
+      end
+
+      # Drop size-1 dims.  With no axis, drops ALL size-1 dims.
+      # With an integer axis, raises if that axis isn't size 1.
+      def squeeze(axis = nil)
+        if axis.nil?
+          new_shape = @shape.reject { |d| d == 1 }
+        else
+          axis = axis.to_i
+          axis += ndim if axis.negative?
+          raise IndexError, "squeeze axis #{axis} out of range [-#{ndim}, #{ndim})" if axis.negative? || axis >= ndim
+          raise ArgumentError, "cannot squeeze axis #{axis} of size #{@shape[axis]}" unless @shape[axis] == 1
+
+          new_shape = @shape.dup
+          new_shape.delete_at(axis)
+        end
+        # Numel didn't change → can reuse data directly.
+        self.class.new(@data.dup, shape: new_shape, dtype: @dtype)
+      end
+
+      # Insert a size-1 axis at position `axis`.  Negative indices count
+      # from the end (PyTorch convention).
+      def unsqueeze(axis)
+        axis = axis.to_i
+        # Allow axis == ndim (insert at end); range is [-ndim-1, ndim].
+        axis += ndim + 1 if axis.negative?
+        raise IndexError, "unsqueeze axis #{axis} out of range [-#{ndim + 1}, #{ndim + 1}]" if axis.negative? || axis > ndim
+
+        new_shape = @shape.dup
+        new_shape.insert(axis, 1)
+        self.class.new(@data.dup, shape: new_shape, dtype: @dtype)
+      end
+
+      # ----------------------------------------------------------------------
+      # Operator overloads — element-wise, same shape only (v0.1)
+      # ----------------------------------------------------------------------
+
+      def +(other)
+        binary_op(other) { |a, b| a + b }
+      end
+
+      def -(other)
+        binary_op(other) { |a, b| a - b }
+      end
+
+      def *(other)
+        binary_op(other) { |a, b| a * b }
+      end
+
+      def /(other)
+        binary_op(other) { |a, b| a / b.to_f }
+      end
+
+      def **(other)
+        binary_op(other) { |a, b| a**b }
+      end
+
+      def -@
+        self.class.new(@data.map { |v| -v }, shape: @shape, dtype: @dtype)
+      end
+
+      # ----------------------------------------------------------------------
+      # Class-level factory methods
+      # ----------------------------------------------------------------------
+
+      class << self
+        # @return [Tensor] tensor of zeros with the given shape.
+        def zeros(*shape)
+          shape = shape.flatten.map(&:to_i)
+          new(Array.new(shape.reduce(1, :*), 0.0), shape: shape)
+        end
+
+        def ones(*shape)
+          shape = shape.flatten.map(&:to_i)
+          new(Array.new(shape.reduce(1, :*), 1.0), shape: shape)
+        end
+
+        # @param shape [Array<Integer>] target shape (as a single Array arg)
+        # @param fill_value [Numeric] value to fill with
+        def full(shape, fill_value)
+          shape = Array(shape).map(&:to_i)
+          fv    = fill_value.to_f
+          new(Array.new(shape.reduce(1, :*), fv), shape: shape)
+        end
+
+        # 2-D "identity-like" tensor.  When n == m this is the identity
+        # matrix; for rectangular shapes it's the diagonal-of-ones
+        # rectangle that NumPy / PyTorch eye() return.
+        def eye(n, m = nil)
+          m ||= n
+          data = Array.new(n * m, 0.0)
+          [n, m].min.times do |i|
+            data[i * m + i] = 1.0
+          end
+          new(data, shape: [n, m])
+        end
+
+        # arange(stop) or arange(start, stop) or arange(start, stop, step).
+        # Mirrors Python's range + NumPy's arange semantics: stop is
+        # EXCLUSIVE.
+        def arange(*args)
+          start, stop, step =
+            case args.length
+            when 1 then [0, args[0], 1]
+            when 2 then [args[0], args[1], 1]
+            when 3 then [args[0], args[1], args[2]]
+            else raise ArgumentError, "arange: wrong number of arguments (#{args.length} for 1..3)"
+            end
+          raise ArgumentError, "arange step cannot be zero" if step.zero?
+          # Defence-in-depth: Float::INFINITY for stop would loop forever
+          # and grow the result Array until OOM; NaN would silently produce
+          # an empty Array (confusing).  Reject both up-front.
+          [start, stop, step].each do |v|
+            if v.respond_to?(:finite?) && !v.finite?
+              raise ArgumentError, "arange bounds must be finite, got #{v.inspect}"
+            end
+          end
+
+          data = []
+          x = start.to_f
+          if step.positive?
+            while x < stop
+              data << x
+              x += step
+            end
+          else
+            while x > stop
+              data << x
+              x += step
+            end
+          end
+          new(data, shape: [data.length])
+        end
+
+        # Convenience alias for `Tensor.new(nested_array)`.
+        def from_array(nested)
+          new(nested)
+        end
+
+        # Standard-normal samples via Box-Muller.
+        #
+        # Why Box-Muller, not Ruby's `Random#rand`?
+        #   `Random#rand` is uniform on [0, 1); we want N(0, 1).  Box-Muller
+        #   transforms two uniforms into two normals via
+        #     z0 = sqrt(-2 ln u1) * cos(2π u2)
+        #     z1 = sqrt(-2 ln u1) * sin(2π u2)
+        #   It's a textbook two-line algorithm; no need to pull in a
+        #   distribution library.
+        #
+        # @param seed [Integer, nil] if non-nil, deterministic output.
+        def randn(*shape, seed: nil)
+          shape = shape.flatten.map(&:to_i)
+          rng   = seed.nil? ? Random.new : Random.new(seed)
+          numel = shape.reduce(1, :*)
+          data  = Array.new(numel)
+          i = 0
+          while i < numel
+            u1 = rng.rand
+            u1 = Float::MIN if u1.zero?    # ln(0) is -∞; nudge into the domain
+            u2 = rng.rand
+            mag = Math.sqrt(-2.0 * Math.log(u1))
+            data[i] = mag * Math.cos(2.0 * Math::PI * u2)
+            data[i + 1] = mag * Math.sin(2.0 * Math::PI * u2) if i + 1 < numel
+            i += 2
+          end
+          new(data, shape: shape)
+        end
+
+        # ====================================================================
+        # Internal helpers used by `initialize` — exposed as class methods
+        # so they're testable in isolation.
+        # ====================================================================
+
+        # Infer the shape of an arbitrary-depth nested Array.  Validates
+        # that every sub-array at the same depth has the same length
+        # (i.e. the structure is rectangular, not ragged).
+        def infer_shape(data)
+          return [] unless data.is_a?(Array)
+          return [0] if data.empty?
+
+          shape = []
+          probe = data
+          while probe.is_a?(Array)
+            shape << probe.length
+            probe = probe.first
+          end
+
+          # Validate rectangularity: walk every element at depth k and
+          # confirm it has the expected length.
+          validate_rectangular(data, shape, 0)
+
+          shape
+        end
+
+        def validate_rectangular(node, shape, depth)
+          return if depth >= shape.length
+
+          unless node.is_a?(Array) && node.length == shape[depth]
+            raise ArgumentError, "ragged nested array: expected length #{shape[depth]} at depth #{depth}"
+          end
+
+          node.each { |child| validate_rectangular(child, shape, depth + 1) }
+        end
+
+        # Flatten arbitrarily-nested data into a 1-D Array<Float>, asserting
+        # length matches the inferred shape's numel.
+        def flatten_data(data, shape)
+          flat = data.is_a?(Array) ? data.flatten : [data]
+          expected = shape.empty? ? 1 : shape.reduce(1, :*)
+          if flat.length != expected
+            raise ArgumentError,
+                  "data length #{flat.length} does not match inferred shape #{shape.inspect} (numel #{expected})"
+          end
+          flat.map { |x| x.to_f }
+        end
+      end
+
+      private
+
+      # Element-wise binary op against another Tensor of the same shape, or
+      # against a scalar (broadcasts to every element).  No NumPy-style
+      # broadcasting in v0.1.
+      def binary_op(other)
+        if other.is_a?(Tensor)
+          unless other.shape == @shape
+            raise ArgumentError,
+                  "shape mismatch: #{@shape.inspect} vs #{other.shape.inspect} (broadcasting not in v0.1)"
+          end
+          new_data = @data.each_with_index.map { |a, i| yield(a, other.to_a[i]) }
+          self.class.new(new_data, shape: @shape, dtype: @dtype)
+        elsif other.is_a?(Numeric)
+          b = other.to_f
+          new_data = @data.map { |a| yield(a, b) }
+          self.class.new(new_data, shape: @shape, dtype: @dtype)
+        else
+          raise TypeError, "cannot combine Tensor with #{other.class}"
+        end
+      end
+    end
+  end
+end

--- a/code/packages/ruby/ml_framework_core/lib/coding_adventures/ml_framework_core/version.rb
+++ b/code/packages/ruby/ml_framework_core/lib/coding_adventures/ml_framework_core/version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module CodingAdventures
+  module MLFrameworkCore
+    VERSION = "0.1.0"
+  end
+end

--- a/code/packages/ruby/ml_framework_core/required_capabilities.json
+++ b/code/packages/ruby/ml_framework_core/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "ruby/ml_framework_core",
+  "capabilities": [],
+  "justification": "Pure-Ruby Tensor library (v0.1). No FFI, no network, no filesystem, no process spawning. Future PRs (#6: forward op dispatch) will add an `ffi/call` capability for the matrix_rust_ruby native ext once large-tensor ops dispatch into Rust; v0.1 has no outward-facing surface beyond the in-process Ruby API."
+}

--- a/code/packages/ruby/ml_framework_core/test/tensor_test.rb
+++ b/code/packages/ruby/ml_framework_core/test/tensor_test.rb
@@ -1,0 +1,385 @@
+# frozen_string_literal: true
+
+# tensor_test.rb — exhaustive minitest coverage for the v0.1 Tensor class.
+# =========================================================================
+#
+# Mirrors the test categories from
+# code/packages/python/ml-framework-core/tests/test_tensor.py but adapted
+# to v0.1's reduced scope (no broadcasting, no indexing, no reductions).
+#
+# Sections, in test-discovery order:
+#   - Construction + shape inference
+#   - Factories: zeros, ones, full, eye, arange, randn, from_array
+#   - Shape ops: reshape, transpose, flatten, squeeze, unsqueeze
+#   - Operator overloads (+, -, *, /, **, unary -)
+#   - Equality + inspect
+#   - Round-trip properties (the actually-important integration tests)
+
+require "minitest/autorun"
+require "coding_adventures/ml_framework_core"
+
+T = CodingAdventures::MLFrameworkCore::Tensor
+
+class TensorConstructionTest < Minitest::Test
+  def test_construct_from_flat_array_with_explicit_shape
+    t = T.new([1.0, 2.0, 3.0, 4.0], shape: [2, 2])
+    assert_equal [2, 2], t.shape
+    assert_equal 4, t.numel
+    assert_equal 2, t.ndim
+    assert_equal :f32, t.dtype
+    assert_equal [1.0, 2.0, 3.0, 4.0], t.to_a
+  end
+
+  def test_construct_from_nested_array_infers_shape
+    t = T.new([[1, 2, 3], [4, 5, 6]])
+    assert_equal [2, 3], t.shape
+    assert_equal [1.0, 2.0, 3.0, 4.0, 5.0, 6.0], t.to_a
+  end
+
+  def test_construct_from_deeply_nested_array
+    # Three-deep nesting → rank-3 tensor.
+    t = T.new([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])
+    assert_equal [2, 2, 2], t.shape
+    assert_equal 8, t.numel
+  end
+
+  def test_construct_from_scalar
+    # Wrapping a scalar gives a 1-element 1-D tensor (Python equivalent
+    # for scalar inputs, since we don't have 0-d tensors in v0.1).
+    t = T.new(7.0, shape: [1])
+    assert_equal [1], t.shape
+    assert_equal [7.0], t.to_a
+  end
+
+  def test_ragged_nested_array_raises
+    assert_raises(ArgumentError) { T.new([[1, 2], [3]]) }
+  end
+
+  def test_data_length_mismatch_with_explicit_shape_raises
+    assert_raises(ArgumentError) { T.new([1, 2, 3], shape: [2, 2]) }
+  end
+
+  def test_unsupported_dtype_raises
+    assert_raises(ArgumentError) { T.new([1.0], dtype: :f64) }
+  end
+
+  def test_requires_grad_defaults_to_false
+    assert_equal false, T.new([1.0]).requires_grad
+  end
+
+  def test_requires_grad_can_be_set
+    t = T.new([1.0])
+    t.requires_grad = true
+    assert_equal true, t.requires_grad
+  end
+
+  def test_grad_is_nil_until_set
+    assert_nil T.new([1.0]).grad
+  end
+end
+
+class TensorFactoriesTest < Minitest::Test
+  def test_zeros
+    t = T.zeros(2, 3)
+    assert_equal [2, 3], t.shape
+    assert_equal [0.0] * 6, t.to_a
+  end
+
+  def test_zeros_accepts_single_array_arg
+    t = T.zeros([2, 3])
+    assert_equal [2, 3], t.shape
+  end
+
+  def test_ones
+    t = T.ones(3)
+    assert_equal [3], t.shape
+    assert_equal [1.0, 1.0, 1.0], t.to_a
+  end
+
+  def test_full
+    t = T.full([2, 2], 7.5)
+    assert_equal [2, 2], t.shape
+    assert_equal [7.5, 7.5, 7.5, 7.5], t.to_a
+  end
+
+  def test_eye_square_is_identity_matrix
+    t = T.eye(3)
+    assert_equal [3, 3], t.shape
+    assert_equal [1.0, 0.0, 0.0,
+                  0.0, 1.0, 0.0,
+                  0.0, 0.0, 1.0], t.to_a
+  end
+
+  def test_eye_rectangular
+    t = T.eye(2, 3)
+    assert_equal [2, 3], t.shape
+    # 1s on the diagonal of the smaller dim, 0s elsewhere.
+    assert_equal [1.0, 0.0, 0.0,
+                  0.0, 1.0, 0.0], t.to_a
+  end
+
+  def test_arange_stop_only
+    t = T.arange(5)
+    assert_equal [5], t.shape
+    assert_equal [0.0, 1.0, 2.0, 3.0, 4.0], t.to_a
+  end
+
+  def test_arange_start_stop
+    t = T.arange(2, 5)
+    assert_equal [2.0, 3.0, 4.0], t.to_a
+  end
+
+  def test_arange_with_step
+    t = T.arange(0, 10, 2)
+    assert_equal [0.0, 2.0, 4.0, 6.0, 8.0], t.to_a
+  end
+
+  def test_arange_negative_step
+    t = T.arange(5, 0, -1)
+    assert_equal [5.0, 4.0, 3.0, 2.0, 1.0], t.to_a
+  end
+
+  def test_arange_zero_step_raises
+    assert_raises(ArgumentError) { T.arange(0, 5, 0) }
+  end
+
+  def test_arange_wrong_arity_raises
+    assert_raises(ArgumentError) { T.arange }
+    assert_raises(ArgumentError) { T.arange(1, 2, 3, 4) }
+  end
+
+  def test_from_array_is_same_as_new
+    a = T.from_array([[1, 2], [3, 4]])
+    b = T.new([[1, 2], [3, 4]])
+    assert_equal a, b
+  end
+
+  def test_randn_shape_is_respected
+    t = T.randn(3, 4, seed: 42)
+    assert_equal [3, 4], t.shape
+    assert_equal 12, t.numel
+    # Sanity: values aren't all the same (very unlikely with N(0,1)).
+    assert t.to_a.uniq.length > 1
+  end
+
+  def test_randn_is_deterministic_with_seed
+    a = T.randn(5, seed: 123)
+    b = T.randn(5, seed: 123)
+    assert_equal a.to_a, b.to_a
+  end
+
+  def test_randn_is_nondeterministic_without_seed
+    # Theoretically could collide, but the probability with 5 f64
+    # samples is astronomically small.
+    a = T.randn(5)
+    b = T.randn(5)
+    refute_equal a.to_a, b.to_a
+  end
+
+  def test_randn_mean_roughly_zero
+    # Box-Muller mean → 0 in the limit; with 1000 samples, |mean| < 0.2
+    # is a generous bound (~6σ for N(0, 1/sqrt(1000))).
+    t = T.randn(1000, seed: 7)
+    mean = t.to_a.sum / t.numel
+    assert mean.abs < 0.2, "mean #{mean} should be near 0 for randn"
+  end
+end
+
+class TensorShapeOpsTest < Minitest::Test
+  def test_reshape_preserves_data
+    t = T.arange(6).reshape(2, 3)
+    assert_equal [2, 3], t.shape
+    assert_equal [0.0, 1.0, 2.0, 3.0, 4.0, 5.0], t.to_a
+  end
+
+  def test_reshape_accepts_single_array
+    t = T.arange(6).reshape([3, 2])
+    assert_equal [3, 2], t.shape
+  end
+
+  def test_reshape_numel_mismatch_raises
+    assert_raises(ArgumentError) { T.arange(6).reshape(2, 4) }
+  end
+
+  def test_reshape_then_back_round_trip
+    t = T.arange(12)
+    assert_equal t, t.reshape(3, 4).reshape(12)
+  end
+
+  def test_reshape_to_same_shape_is_equal
+    t = T.arange(6).reshape(2, 3)
+    assert_equal t, t.reshape(t.shape)
+  end
+
+  def test_flatten
+    t = T.new([[1, 2], [3, 4]]).flatten
+    assert_equal [4], t.shape
+    assert_equal [1.0, 2.0, 3.0, 4.0], t.to_a
+  end
+
+  def test_transpose_2d
+    t = T.new([[1, 2, 3], [4, 5, 6]]).transpose
+    assert_equal [3, 2], t.shape
+    # Original was row-major [1,2,3,4,5,6]; transposed reads column-by-column.
+    assert_equal [1.0, 4.0, 2.0, 5.0, 3.0, 6.0], t.to_a
+  end
+
+  def test_transpose_explicit_perm
+    t = T.new([[1, 2], [3, 4]]).transpose(1, 0)
+    assert_equal [[1.0, 3.0], [2.0, 4.0]], t.to_nested_a
+  end
+
+  def test_transpose_double_is_identity
+    original = T.new([[1, 2, 3], [4, 5, 6]])
+    assert_equal original, original.transpose.transpose
+  end
+
+  def test_transpose_rejects_invalid_perm
+    t = T.new([[1, 2], [3, 4]])
+    assert_raises(ArgumentError) { t.transpose(0, 0) }
+    assert_raises(ArgumentError) { t.transpose(0, 1, 2) }
+  end
+
+  def test_transpose_higher_rank_not_yet_supported
+    t = T.zeros(2, 2, 2)
+    assert_raises(NotImplementedError) { t.transpose(2, 1, 0) }
+  end
+
+  def test_squeeze_no_arg_drops_all_size_1
+    t = T.zeros(1, 3, 1, 2)
+    assert_equal [3, 2], t.squeeze.shape
+  end
+
+  def test_squeeze_axis_drops_that_axis_only
+    t = T.zeros(1, 3, 1)
+    assert_equal [3, 1], t.squeeze(0).shape
+    assert_equal [1, 3], t.squeeze(2).shape
+  end
+
+  def test_squeeze_negative_axis
+    t = T.zeros(3, 1)
+    assert_equal [3], t.squeeze(-1).shape
+  end
+
+  def test_squeeze_nonunit_axis_raises
+    assert_raises(ArgumentError) { T.zeros(3, 2).squeeze(0) }
+  end
+
+  def test_unsqueeze_inserts_axis
+    t = T.zeros(3)
+    assert_equal [1, 3], t.unsqueeze(0).shape
+    assert_equal [3, 1], t.unsqueeze(1).shape
+    assert_equal [3, 1], t.unsqueeze(-1).shape   # equivalent to ndim
+  end
+
+  def test_unsqueeze_then_squeeze_round_trip
+    t = T.arange(6).reshape(2, 3)
+    assert_equal t, t.unsqueeze(0).squeeze(0)
+  end
+end
+
+class TensorArithmeticTest < Minitest::Test
+  def test_add_tensors
+    a = T.new([1, 2, 3])
+    b = T.new([10, 20, 30])
+    assert_equal [11.0, 22.0, 33.0], (a + b).to_a
+  end
+
+  def test_add_scalar
+    a = T.new([1, 2, 3])
+    assert_equal [11.0, 12.0, 13.0], (a + 10).to_a
+  end
+
+  def test_sub
+    a = T.new([5, 7, 9])
+    b = T.new([1, 2, 3])
+    assert_equal [4.0, 5.0, 6.0], (a - b).to_a
+  end
+
+  def test_mul
+    a = T.new([2, 3, 4])
+    b = T.new([5, 6, 7])
+    assert_equal [10.0, 18.0, 28.0], (a * b).to_a
+  end
+
+  def test_div
+    a = T.new([10, 20, 30])
+    b = T.new([2, 4, 5])
+    assert_equal [5.0, 5.0, 6.0], (a / b).to_a
+  end
+
+  def test_pow
+    a = T.new([2, 3, 4])
+    assert_equal [4.0, 9.0, 16.0], (a**2).to_a
+  end
+
+  def test_unary_neg
+    a = T.new([1, -2, 3])
+    assert_equal [-1.0, 2.0, -3.0], (-a).to_a
+  end
+
+  def test_shape_mismatch_raises
+    assert_raises(ArgumentError) { T.zeros(2, 3) + T.zeros(3, 2) }
+  end
+
+  def test_unsupported_operand_type_raises
+    assert_raises(TypeError) { T.zeros(2) + "not a number" }
+  end
+end
+
+class TensorEqualityAndInspectTest < Minitest::Test
+  def test_equality_compares_shape_and_data
+    assert_equal T.new([1, 2, 3]), T.new([1, 2, 3])
+    refute_equal T.new([1, 2, 3]), T.new([1, 2, 4])
+    refute_equal T.new([1, 2, 3]), T.new([1, 2, 3], shape: [3, 1])
+  end
+
+  def test_equality_with_non_tensor_is_false
+    refute_equal T.new([1]), [1.0]
+  end
+
+  def test_hash_equality_for_equal_tensors
+    a = T.new([1, 2, 3])
+    b = T.new([1, 2, 3])
+    assert_equal a.hash, b.hash
+  end
+
+  def test_inspect_includes_shape_and_dtype
+    s = T.zeros(2, 3).inspect
+    assert_match(/shape=\[2, 3\]/, s)
+    assert_match(/dtype=f32/, s)
+  end
+
+  def test_inspect_truncates_long_data
+    s = T.arange(100).inspect
+    assert_match(/\.\.\./, s)
+  end
+end
+
+class TensorRoundTripTest < Minitest::Test
+  def test_to_nested_a_round_trips
+    original = [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]
+    assert_equal original, T.new(original).to_nested_a
+  end
+
+  def test_to_nested_a_for_3d
+    original = [[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]]
+    assert_equal original, T.new(original).to_nested_a
+  end
+
+  def test_reshape_preserves_to_a
+    t = T.arange(12)
+    assert_equal t.to_a, t.reshape(3, 4).to_a
+  end
+end
+
+class TensorVersionTest < Minitest::Test
+  def test_version_constant_is_defined
+    assert_kind_of String, CodingAdventures::MLFrameworkCore::VERSION
+    assert_match(/\A\d+\.\d+\.\d+\z/, CodingAdventures::MLFrameworkCore::VERSION)
+  end
+
+  def test_short_alias_module_is_defined
+    assert_equal CodingAdventures::MLFrameworkCore, MLFrameworkCore
+  end
+end


### PR DESCRIPTION
## Summary

- New pure-Ruby gem `coding_adventures_ml_framework_core` shipping the bottom layer of the Ruby ML framework stack: a PyTorch-shaped `Tensor` class.
- No native ext, no Rust calls, no FFI — intentionally minimal for v0.1. Layered design: PRs #5–#8 add autograd, op dispatch, backward, benchmarks.
- 63 minitests (94 assertions, all passing locally) covering construction, every factory, every shape op, every operator overload, equality, and round-trip properties.

## Architecture

```
ml_framework_core (THIS PR)
  Tensor + factories + shape ops + operator overloads
  ↓ PRs #5-#8 layer on autograd, ops, backward, benchmarks
matrix_rust_ruby (gem, #4783 merged)
  ↓
matrix_rust_ruby_native (cdylib, #4776 merged)
  ↓
c-bridge (workspace crate, #4769 merged)
  ↓
matrix-ir-json → matrix-ir → matrix-runtime → matrix-cpu
```

## Public API (v0.1)

```ruby
require "coding_adventures/ml_framework_core"
T = CodingAdventures::MLFrameworkCore::Tensor

# Factories
T.zeros(2, 3); T.ones(3); T.eye(3); T.arange(0, 10, 2); T.randn(3, 4, seed: 42)

# Shape ops
t.reshape(3, 4); t.transpose; t.flatten; t.squeeze; t.unsqueeze(0)

# Operators (element-wise, same shape only in v0.1)
a + b; a - b; a * b; a / b; a**2; -a;  a + 5  # scalar broadcasts
```

## Test coverage

63 minitests across 6 sections: construction, factories, shape ops, arithmetic, equality+inspect, round-trip properties. All pass locally.

## Security review

Passed. One INFO-level hardening applied (arange rejects NaN/Infinity bounds). Other INFO items are documented library-scope expectations.

## Test plan

- [x] All Ruby files pass `ruby -c`
- [x] Gemspec parses via `Gem::Specification.load`
- [x] `ruby -Ilib -Itest test/tensor_test.rb`: 63 runs, 94 assertions, 0 failures
- [x] Security review passed
- [ ] CI: build (ubuntu/macos/windows) `bundle install && rake test` — pending
- [ ] CI: CodeQL ruby Analyze — pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)