### PR TITLE
A1++ first slice: iir-to-riscv wide consts + comparisons + ecall print_i64

### DIFF
--- a/code/packages/rust/iir-to-riscv/CHANGELOG.md
+++ b/code/packages/rust/iir-to-riscv/CHANGELOG.md
@@ -3,6 +3,72 @@
 All notable changes to this crate are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.3.0] — 2026-06-02 (A1++ first slice — wide consts + comparisons + `ecall print_i64`)
+
+### Added — three more op families on RV32I
+
+A1++ as originally scoped was a large bundle (comparisons, branches,
+calls, stack spilling, wide consts, ecall).  This release lands the
+three self-contained pieces:
+
+1. **Wide constants via `lui + addi`.**  Any i32 literal now lowers
+   cleanly.  Values that fit in i12 still use the single-`addi` form;
+   anything wider gets the canonical `lui rd, upper20; addi rd, rd,
+   lower12` sequence with the standard carry adjustment when low12 is
+   negative.  Values outside i32 still produce `ImmediateOutOfRange`
+   (64-bit register-pair handling lands in A1++.5).
+2. **Comparisons** — `eq`/`ne`/`lt`/`le`/`gt`/`ge` (and their
+   `cmp_`-prefixed aliases per gap G1) producing i32 `0`/`1` results
+   in a register:
+   * `lt`/`gt` → `slt` (or `sltu` for `u*` operands)
+   * `le`/`ge` → `slt` + `xori 1`
+   * `eq` → `xor` + `sltiu 1`
+   * `ne` → `xor` + `sltu x0, t`
+   All idioms reuse the dest register for the synth intermediate so no
+   extra temp is needed — important until A1++.5 ships stack spilling.
+3. **`call_builtin "print_i64"` via `ecall`** — completes the
+   cross-backend print_i64 parity:
+
+   | Backend            | Print sentinel |
+   |--------------------|----------------|
+   | iir-to-wasm        | `env.__print_i64` host import |
+   | iir-to-jvm-class-file | `invokestatic env/BasicRuntime.println(J)V` |
+   | iir-to-cil-bytecode | `call void env.BasicRuntime::PrintI64(int64)` |
+   | iir-to-llvm        | `declare void @__print_i64(i64)` + extern call |
+   | **iir-to-riscv (this)** | `ecall` with `a7 = ECALL_PRINT_I64_NUM = 1` |
+
+   We pick syscall `1` (Linux `__NR_write` slot) because a future
+   real-syscall pass can fold this into `write(2)` without a
+   convention change.
+
+### What is NOT in this PR (deferred to A1++.5)
+
+* **Branches and label resolution.**  `label` / `jmp` / `jmp_if_*`
+  need a two-pass over the function body to compute PC-relative
+  offsets for `beq`/`bne`/`jal`.
+* **Calls + stack spilling.**  Cross-function `jal` + `ra` save/restore
+  needs a real stack frame, which forces an allocator rework.
+* **64-bit register-pair handling.**  i64 literals + arithmetic on
+  RV32 needs register pairs.
+
+Splitting A1++ this way keeps the data-flow + ecall slice independently
+reviewable — branches and stack spilling are orthogonal concerns that
+benefit from landing as their own PR.
+
+### Tests added (26 total, was 17)
+
+* Wide const (2): `4096` → just `lui` (no `addi`); `4097` → `lui + addi`.
+* Comparisons (5): signed `slt`, unsigned `sltu`, `eq` synthesis,
+  `ne` synthesis, `cmp_`-prefix alias parity.
+* `ecall print_i64` (2): exact 5-word sequence pinned; unknown builtin
+  rejected.
+
+Pre-existing tests rewritten:
+* `const_out_of_imm12_range_is_rejected` → `const_out_of_i32_range_is_rejected`
+  (the threshold moved up from i12 to i32 after lui+addi landed).
+* `validate_rejects_unsupported_op` flipped to use `safepoint`
+  (since `call_builtin` is now supported).
+
 ## [0.2.0] — 2026-06-02 (A1+ — const/mov/add/sub/ret + linear register allocator)
 
 ### Added — first real instruction lowering

--- a/code/packages/rust/iir-to-riscv/Cargo.toml
+++ b/code/packages/rust/iir-to-riscv/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iir-to-riscv"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
-description = "IIR → RV32I machine code backend — lowers IIRModule to a Vec<u32> of encoded 32-bit RISC-V instructions.  v0.2.0 (A1+): adds real lowering for const (addi imm12) / mov (addi rd,rs1,0) / add+sub (R-type) / ret (mv a0 + jalr); linear register allocator over t0..t6; param ABI mapping to a0..a7."
+description = "IIR → RV32I machine code backend — lowers IIRModule to a Vec<u32> of encoded 32-bit RISC-V instructions.  v0.3.0 (A1++ first slice): adds wide constants via lui+addi (any i32 now lowers cleanly), comparison ops eq/ne/lt/le/gt/ge producing i32 0/1 (slt/sltu + xor synth), and call_builtin print_i64 via ecall with a7=1 syscall convention.  Defers branches/calls/stack-spilling to A1++.5."
 
 [lib]
 name = "iir_to_riscv"

--- a/code/packages/rust/iir-to-riscv/src/lib.rs
+++ b/code/packages/rust/iir-to-riscv/src/lib.rs
@@ -76,7 +76,10 @@ use std::collections::HashMap;
 use std::fmt;
 
 use interpreter_ir::{IIRFunction, IIRInstr, IIRModule, Operand};
-use riscv_simulator::encoding::{encode_add, encode_addi, encode_jalr, encode_sub};
+use riscv_simulator::encoding::{
+    encode_add, encode_addi, encode_ecall, encode_jalr, encode_lui,
+    encode_slt, encode_sltiu, encode_sltu, encode_sub, encode_xor, encode_xori,
+};
 
 // ===========================================================================
 // Register layout
@@ -193,8 +196,37 @@ fn is_supported_type(t: &str) -> bool {
 // ===========================================================================
 
 const SUPPORTED_OPS: &[&str] = &[
+    // A1+
     "const", "mov", "ret", "ret_void", "add", "sub",
+    // A1++ — comparisons (both naked and cmp_-prefixed per G1)
+    "eq", "ne", "lt", "le", "gt", "ge",
+    "cmp_eq", "cmp_ne", "cmp_lt", "cmp_le", "cmp_gt", "cmp_ge",
+    // A1++ — host call
+    "call_builtin",
 ];
+
+/// Syscall number used by the RV32I `ecall` for `call_builtin print_i64`.
+///
+/// The convention: the host (a future riscv-simulator launcher) decodes
+/// `a7 == 1` as "print signed 64-bit integer in a0/a1 to stdout".  We
+/// pick this value because:
+///
+/// * `1` is the canonical Linux RV32 `__NR_write` index, easy to
+///   remember.  We're not implementing actual `write(fd, buf, len)`;
+///   we're piggybacking on the same convention slot so a future
+///   real-syscall pass can fold this into a true `write`.
+/// * Other backends pick their own sentinel: wasm uses
+///   `env.__print_i64` (a host import), JVM uses
+///   `env/BasicRuntime.println(J)V`, CLR uses
+///   `env.BasicRuntime::PrintI64(int64)`, LLVM uses
+///   `@__print_i64` extern.  The RV32I sentinel completes the parity.
+///
+/// Today we only emit `a0` (the low 32 bits).  64-bit pair handling
+/// is deferred to A1++.5 alongside i64 arithmetic.
+const ECALL_PRINT_I64_NUM: i32 = 1;
+
+/// Builtins the RV32I backend knows how to lower via `ecall`.
+const SUPPORTED_BUILTINS: &[&str] = &["print_i64"];
 
 // ===========================================================================
 // validate_for_riscv
@@ -346,11 +378,15 @@ fn lower_instr(
     match instr.op.as_str() {
         // ── const dest, Int(n) ──────────────────────────────────────────
         //
-        // Lower to `addi rd, x0, imm12`.  This is the canonical
-        // small-constant lowering on RISC-V: `x0` is hardwired to zero,
-        // so `addi rd, x0, n` computes `n`.  For values outside the
-        // 12-bit signed range we'd need `lui + addi`; v0.2.0 returns
-        // ImmediateOutOfRange instead and defers that to A1++.
+        // Three lowering paths by literal width:
+        //
+        //   * `n` fits in i12 ([-2048, 2047]) — single `addi rd, x0, n`.
+        //   * `n` fits in i32 — `lui rd, upper20 + carry; addi rd, rd, lower12`.
+        //     The lower-12-bit field is sign-extended by `addi`, so when the
+        //     low bit is set we increment `upper20` to compensate.  This is
+        //     the standard RISC-V wide-immediate idiom.
+        //   * `n` outside i32 — `ImmediateOutOfRange`.  64-bit literals
+        //     need a register-pair shuffle and arrive in A1++.5.
         "const" => {
             let dest = instr.dest.as_deref().ok_or_else(|| IIRRiscvError::InvalidOperand {
                 function: state.fn_name.into(),
@@ -364,14 +400,14 @@ fn lower_instr(
                     detail: "const srcs[0] must be Int or Bool".into(),
                 }),
             };
-            if !(-2048..=2047).contains(&n) {
+            if !((i32::MIN as i64)..=(i32::MAX as i64)).contains(&n) {
                 return Err(IIRRiscvError::ImmediateOutOfRange {
                     function: state.fn_name.into(),
                     value: n,
                 });
             }
             let rd = state.alloc_temp(dest)?;
-            out.push(encode_addi(rd, X0_ZERO, n as i32));
+            emit_const_i32(rd, n as i32, out);
             Ok(())
         }
 
@@ -456,9 +492,184 @@ fn lower_instr(
             Ok(())
         }
 
+        // ── eq/ne/lt/le/gt/ge (and cmp_-prefixed variants per G1) ───────
+        //
+        // Each produces an i32 0/1 result in `dest` — same convention as
+        // the wasm and LLVM backends.  Sign comes from the IIR type_hint
+        // (u*-prefixed types use `sltu`; i*-prefixed types use `slt`).
+        //
+        // Output uses dest both as src and dst for the xor/xori synth
+        // patterns so no extra temp is needed — matters because A1++
+        // hasn't shipped stack spilling yet, so the temp pool is still
+        // 7 deep.
+        "eq" | "ne" | "lt" | "le" | "gt" | "ge"
+        | "cmp_eq" | "cmp_ne" | "cmp_lt" | "cmp_le" | "cmp_gt" | "cmp_ge" => {
+            let bare = instr.op.strip_prefix("cmp_").unwrap_or(instr.op.as_str());
+            lower_cmp(bare, instr, state, out)
+        }
+
+        // ── call_builtin "<name>" — host call via ecall ─────────────────
+        //
+        // Layout: srcs = [Var("<builtin>"), Var(val)], dest = None.
+        // For `print_i64`: load the syscall number ECALL_PRINT_I64_NUM
+        // into a7, ensure the value is in a0, then `ecall`.
+        "call_builtin" => lower_call_builtin(instr, state, out),
+
         other => Err(IIRRiscvError::UnsupportedOp {
             function: state.fn_name.into(),
             op: other.into(),
         }),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// A1++ helpers — wide consts, comparisons, ecall
+// ---------------------------------------------------------------------------
+
+fn is_unsigned_type_hint(t: &str) -> bool {
+    t.starts_with('u')
+}
+
+/// Materialize an i32 constant into `rd` using the smallest RV32I sequence.
+///
+/// * If `n` fits in i12 (`[-2048, 2047]`) we emit a single
+///   `addi rd, x0, n`.
+/// * Otherwise we emit the canonical `lui + addi` wide-immediate idiom:
+///   ```text
+///   lui  rd, upper20_with_carry
+///   addi rd, rd, lower12_signed
+///   ```
+///   The lower-12-bit slot is sign-extended by `addi`, so when it is
+///   negative we add 1 to the upper 20 bits to compensate.  This is the
+///   exact sequence GNU and LLVM assemblers emit for `li rd, imm32`.
+fn emit_const_i32(rd: u32, n: i32, out: &mut Vec<u32>) {
+    if (-2048..=2047).contains(&n) {
+        out.push(encode_addi(rd, X0_ZERO, n));
+        return;
+    }
+    // Compute lower12 (signed) and upper20 with carry.
+    let lower = n & 0xFFF;
+    let lower_signed: i32 = if lower & 0x800 != 0 { lower - 0x1000 } else { lower };
+    // Adjust upper: if lower was negative (sign-extended) we add 1.
+    // Wrapping_add handles the (rare) lui imm wraparound at i32::MAX boundary.
+    let upper: u32 = ((n.wrapping_sub(lower_signed)) as u32) >> 12;
+    out.push(encode_lui(rd, upper & 0xFFFFF));
+    if lower_signed != 0 {
+        out.push(encode_addi(rd, rd, lower_signed));
+    }
+}
+
+fn lower_cmp(
+    bare: &str,
+    instr: &IIRInstr,
+    state: &mut FnState,
+    out: &mut Vec<u32>,
+) -> Result<(), IIRRiscvError> {
+    let dest = instr.dest.as_deref().ok_or_else(|| IIRRiscvError::InvalidOperand {
+        function: state.fn_name.into(),
+        detail: format!("{bare} requires a dest"),
+    })?;
+    let a = match instr.srcs.first() {
+        Some(Operand::Var(s)) => s.clone(),
+        _ => return Err(IIRRiscvError::InvalidOperand {
+            function: state.fn_name.into(),
+            detail: format!("{bare} srcs[0] must be Var"),
+        }),
+    };
+    let b = match instr.srcs.get(1) {
+        Some(Operand::Var(s)) => s.clone(),
+        _ => return Err(IIRRiscvError::InvalidOperand {
+            function: state.fn_name.into(),
+            detail: format!("{bare} srcs[1] must be Var"),
+        }),
+    };
+    let rs1 = state.lookup(&a)?;
+    let rs2 = state.lookup(&b)?;
+    let rd  = state.alloc_temp(dest)?;
+    let is_u = is_unsigned_type_hint(&instr.type_hint);
+
+    // Comparison idioms — all produce i32 0/1 in `rd`.  Sign comes from
+    // the operand type hint (u* → unsigned variant of slt).  We reuse
+    // `rd` as both src and dst for the xor/xori synth patterns so no
+    // extra temp is needed (matters until A1++ ships stack spilling).
+    match bare {
+        "lt" => {
+            // a < b
+            out.push(if is_u { encode_sltu(rd, rs1, rs2) } else { encode_slt(rd, rs1, rs2) });
+        }
+        "gt" => {
+            // a > b   ⇔   b < a
+            out.push(if is_u { encode_sltu(rd, rs2, rs1) } else { encode_slt(rd, rs2, rs1) });
+        }
+        "le" => {
+            // a <= b  ⇔   !(b < a)
+            out.push(if is_u { encode_sltu(rd, rs2, rs1) } else { encode_slt(rd, rs2, rs1) });
+            out.push(encode_xori(rd, rd, 1));
+        }
+        "ge" => {
+            // a >= b  ⇔   !(a < b)
+            out.push(if is_u { encode_sltu(rd, rs1, rs2) } else { encode_slt(rd, rs1, rs2) });
+            out.push(encode_xori(rd, rd, 1));
+        }
+        "eq" => {
+            // a == b  ⇔   sltiu(a ^ b, 1)
+            out.push(encode_xor(rd, rs1, rs2));
+            out.push(encode_sltiu(rd, rd, 1));
+        }
+        "ne" => {
+            // a != b  ⇔   sltu(x0, a ^ b)
+            out.push(encode_xor(rd, rs1, rs2));
+            out.push(encode_sltu(rd, X0_ZERO, rd));
+        }
+        _ => unreachable!("lower_cmp called with non-cmp op {bare}"),
+    }
+    Ok(())
+}
+
+fn lower_call_builtin(
+    instr: &IIRInstr,
+    state: &mut FnState,
+    out: &mut Vec<u32>,
+) -> Result<(), IIRRiscvError> {
+    let name = match instr.srcs.first() {
+        Some(Operand::Var(s)) => s.clone(),
+        _ => return Err(IIRRiscvError::InvalidOperand {
+            function: state.fn_name.into(),
+            detail: "call_builtin requires srcs[0] = Operand::Var(builtin_name)".into(),
+        }),
+    };
+    if !SUPPORTED_BUILTINS.contains(&name.as_str()) {
+        return Err(IIRRiscvError::UnsupportedOp {
+            function: state.fn_name.into(),
+            op: format!("call_builtin {name:?}: not in RV32I backend whitelist"),
+        });
+    }
+    match name.as_str() {
+        "print_i64" => {
+            // Sequence:
+            //   addi a0, val_reg, 0     ; ensure value is in a0 (skip if already)
+            //   addi a7, x0, ECALL_PRINT_I64_NUM
+            //   ecall
+            //
+            // `a7` is the RV32 syscall-number register by convention; we
+            // pick `1` (Linux __NR_write slot) as the print_i64 sentinel.
+            // A future real-syscall pass can fold this into write(2).
+            let val_name = match instr.srcs.get(1) {
+                Some(Operand::Var(s)) => s.clone(),
+                _ => return Err(IIRRiscvError::InvalidOperand {
+                    function: state.fn_name.into(),
+                    detail: "call_builtin \"print_i64\" requires srcs[1] = Operand::Var(val)".into(),
+                }),
+            };
+            let val_reg = state.lookup(&val_name)?;
+            if val_reg != ARG_REGISTERS[0] {
+                out.push(encode_addi(ARG_REGISTERS[0], val_reg, 0));
+            }
+            // a7 is x17 = ARG_REGISTERS[7].
+            out.push(encode_addi(ARG_REGISTERS[7], X0_ZERO, ECALL_PRINT_I64_NUM));
+            out.push(encode_ecall());
+            Ok(())
+        }
+        _ => unreachable!("SUPPORTED_BUILTINS guard above prevents this"),
     }
 }

--- a/code/packages/rust/iir-to-riscv/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-riscv/tests/test_backend.rs
@@ -78,12 +78,12 @@ fn validate_accepts_supported_ret_void_function() {
 #[test]
 fn validate_rejects_unsupported_op() {
     let f = IIRFunction::new("main", vec![], "void", vec![
-        IIRInstr::new("call_builtin", None, vec![], "void"),
+        IIRInstr::new("safepoint", None, vec![], "void"),
         IIRInstr::new("ret_void", None, vec![], "void"),
     ]);
     let errors = validate_for_riscv(&module_with(f));
     assert!(errors.iter().any(|e| e.contains("UnsupportedOp")),
-        "expected UnsupportedOp for `call_builtin`; got: {errors:?}");
+        "expected UnsupportedOp for `safepoint`; got: {errors:?}");
 }
 
 #[test]
@@ -164,16 +164,20 @@ fn const_of_negative_small_int_is_supported() {
 }
 
 #[test]
-fn const_out_of_imm12_range_is_rejected() {
+fn const_out_of_i32_range_is_rejected() {
+    // After A1++ added lui+addi, the rejection threshold moved up from
+    // i12::MAX to i32::MAX.  Values that fit in i32 lower cleanly via
+    // the wide-immediate idiom; values outside i32 still need 64-bit
+    // pair handling (A1++.5).
+    let v = (i32::MAX as i64) + 1;
     let f = IIRFunction::new("f", vec![], "i32", vec![
-        // 0x1000 = 4096 — outside [-2048, 2047].
-        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(4096)], "i32"),
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(v)], "i32"),
         IIRInstr::new("ret",   None,             vec![Operand::Var("v".into())], "i32"),
     ]);
     let err = lower_iir_to_riscv(&module_with(f), &IIRRiscvConfig::default())
-        .expect_err("oversized const should fail");
+        .expect_err("oversized (>i32) const should fail");
     match err {
-        IIRRiscvError::ImmediateOutOfRange { value, .. } => assert_eq!(value, 4096),
+        IIRRiscvError::ImmediateOutOfRange { value, .. } => assert_eq!(value, v),
         other => panic!("expected ImmediateOutOfRange, got: {other:?}"),
     }
 }
@@ -323,4 +327,197 @@ fn errors_display_without_panic() {
     let _ = format!("{}", IIRRiscvError::ImmediateOutOfRange {
         function: "f".into(), value: 99_999,
     });
+}
+
+// ===========================================================================
+// 12. A1++ — wide constants via lui+addi
+// ===========================================================================
+//
+// After A1++ shipped lui+addi, `const v = 4096` no longer rejects — it
+// lowers to `lui + (optionally) addi` for the upper 20 / lower 12 split.
+// Carry handling: when low12 is negative (top bit set) we add 1 to
+// upper20.  The two tests below pin both the no-addi and with-addi
+// paths.
+
+#[test]
+fn const_4096_lowers_via_lui_then_addi_skipped() {
+    // 4096 == 0x1000 — exactly upper20=1, lower12=0 → just lui, no addi.
+    let f = IIRFunction::new("f", vec![], "i32", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(4096)], "i32"),
+        IIRInstr::new("ret",   None,             vec![Operand::Var("v".into())], "i32"),
+    ]);
+    let words = lower(&module_with(f));
+    // Expected: lui t0, 1 ;  mv a0, t0 (addi) ;  ret
+    assert_eq!(words.len(), 3,
+        "4096 should lower as `lui t0, 1` + mv + ret (no extra addi); got {words:#x?}");
+}
+
+#[test]
+fn const_4097_lowers_via_lui_plus_addi() {
+    // 4097 == 0x1001 — upper20=1, lower12=1 (positive 1), no carry.
+    let f = IIRFunction::new("f", vec![], "i32", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(4097)], "i32"),
+        IIRInstr::new("ret",   None,             vec![Operand::Var("v".into())], "i32"),
+    ]);
+    let words = lower(&module_with(f));
+    // Expected: lui t0, 1 ;  addi t0, t0, 1 ;  mv a0, t0 ;  ret
+    assert_eq!(words.len(), 4,
+        "4097 should lower as lui + addi + mv + ret; got {words:#x?}");
+}
+
+// ===========================================================================
+// 13. A1++ — comparison ops produce 0/1 in a register
+// ===========================================================================
+
+#[test]
+fn cmp_lt_signed_emits_slt() {
+    let f = IIRFunction::new(
+        "f",
+        vec![("a".into(), "i32".into()), ("b".into(), "i32".into())],
+        "i32",
+        vec![
+            IIRInstr::new("lt", Some("v".into()),
+                vec![Operand::Var("a".into()), Operand::Var("b".into())], "i32"),
+            IIRInstr::new("ret", None, vec![Operand::Var("v".into())], "i32"),
+        ],
+    );
+    let words = lower(&module_with(f));
+    let expected = riscv_simulator::encoding::encode_slt(T0, A0, A1);
+    assert_eq!(words[0], expected,
+        "expected slt t0, a0, a1; got 0x{:08x}", words[0]);
+}
+
+#[test]
+fn cmp_lt_unsigned_emits_sltu() {
+    let f = IIRFunction::new(
+        "f",
+        vec![("a".into(), "u32".into()), ("b".into(), "u32".into())],
+        "u32",
+        vec![
+            IIRInstr::new("lt", Some("v".into()),
+                vec![Operand::Var("a".into()), Operand::Var("b".into())], "u32"),
+            IIRInstr::new("ret", None, vec![Operand::Var("v".into())], "u32"),
+        ],
+    );
+    let words = lower(&module_with(f));
+    let expected = riscv_simulator::encoding::encode_sltu(T0, A0, A1);
+    assert_eq!(words[0], expected,
+        "expected sltu t0, a0, a1; got 0x{:08x}", words[0]);
+}
+
+#[test]
+fn cmp_eq_synthesizes_xor_plus_sltiu() {
+    let f = IIRFunction::new(
+        "f",
+        vec![("a".into(), "i32".into()), ("b".into(), "i32".into())],
+        "i32",
+        vec![
+            IIRInstr::new("eq", Some("v".into()),
+                vec![Operand::Var("a".into()), Operand::Var("b".into())], "i32"),
+            IIRInstr::new("ret", None, vec![Operand::Var("v".into())], "i32"),
+        ],
+    );
+    let words = lower(&module_with(f));
+    let xor = riscv_simulator::encoding::encode_xor(T0, A0, A1);
+    let sltiu_ = riscv_simulator::encoding::encode_sltiu(T0, T0, 1);
+    assert_eq!(words[0], xor);
+    assert_eq!(words[1], sltiu_);
+}
+
+#[test]
+fn cmp_ne_synthesizes_xor_plus_sltu_with_x0() {
+    let f = IIRFunction::new(
+        "f",
+        vec![("a".into(), "i32".into()), ("b".into(), "i32".into())],
+        "i32",
+        vec![
+            IIRInstr::new("ne", Some("v".into()),
+                vec![Operand::Var("a".into()), Operand::Var("b".into())], "i32"),
+            IIRInstr::new("ret", None, vec![Operand::Var("v".into())], "i32"),
+        ],
+    );
+    let words = lower(&module_with(f));
+    let xor = riscv_simulator::encoding::encode_xor(T0, A0, A1);
+    let sltu_x0 = riscv_simulator::encoding::encode_sltu(T0, X0, T0);
+    assert_eq!(words[0], xor);
+    assert_eq!(words[1], sltu_x0);
+}
+
+#[test]
+fn cmp_prefixed_alias_lowers_like_naked() {
+    // `cmp_lt` should produce identical bytes to `lt`.
+    let f1 = IIRFunction::new(
+        "g",
+        vec![("a".into(), "i32".into()), ("b".into(), "i32".into())],
+        "i32",
+        vec![
+            IIRInstr::new("cmp_lt", Some("v".into()),
+                vec![Operand::Var("a".into()), Operand::Var("b".into())], "i32"),
+            IIRInstr::new("ret", None, vec![Operand::Var("v".into())], "i32"),
+        ],
+    );
+    let w1 = lower(&module_with(f1));
+    let f2 = IIRFunction::new(
+        "g",
+        vec![("a".into(), "i32".into()), ("b".into(), "i32".into())],
+        "i32",
+        vec![
+            IIRInstr::new("lt", Some("v".into()),
+                vec![Operand::Var("a".into()), Operand::Var("b".into())], "i32"),
+            IIRInstr::new("ret", None, vec![Operand::Var("v".into())], "i32"),
+        ],
+    );
+    let w2 = lower(&module_with(f2));
+    assert_eq!(w1, w2, "`cmp_lt` should lower identically to `lt`");
+}
+
+// ===========================================================================
+// 14. A1++ — call_builtin "print_i64" → ecall on RV32I
+// ===========================================================================
+
+#[test]
+fn call_builtin_print_i64_emits_ecall_with_a7_syscall() {
+    use riscv_simulator::encoding::{encode_addi, encode_ecall};
+    const A7: u32 = 17;
+    let f = IIRFunction::new("main", vec![], "void", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(42)], "i32"),
+        IIRInstr::new("call_builtin", None,
+            vec![Operand::Var("print_i64".into()), Operand::Var("v".into())], "void"),
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ]);
+    let words = lower(&module_with(f));
+    // Sequence:
+    //   addi t0, x0, 42       ; v = 42
+    //   addi a0, t0, 0        ; mv a0, v
+    //   addi a7, x0, 1        ; syscall #1 (print_i64)
+    //   ecall
+    //   ret
+    let expected = vec![
+        encode_addi(T0, X0, 42),
+        encode_addi(A0, T0, 0),
+        encode_addi(A7, X0, 1),
+        encode_ecall(),
+        CANONICAL_RET,
+    ];
+    assert_eq!(words, expected,
+        "print_i64 sequence mismatch; got {words:#x?}, expected {expected:#x?}");
+}
+
+#[test]
+fn call_builtin_unknown_name_is_unsupported() {
+    let f = IIRFunction::new("main", vec![], "void", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(0)], "i32"),
+        IIRInstr::new("call_builtin", None,
+            vec![Operand::Var("not_a_real_builtin".into())], "void"),
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ]);
+    let err = lower_iir_to_riscv(&module_with(f), &IIRRiscvConfig::default())
+        .expect_err("unknown builtin should fail");
+    match err {
+        IIRRiscvError::UnsupportedOp { op, .. } => {
+            assert!(op.contains("not_a_real_builtin"),
+                "error should mention the unknown name; got: {op}");
+        }
+        other => panic!("expected UnsupportedOp, got: {other:?}"),
+    }
 }

--- a/code/specs/iir-to-riscv.md
+++ b/code/specs/iir-to-riscv.md
@@ -52,8 +52,9 @@ IIRModule
 | Version | Scope | Status |
 |---------|-------|--------|
 | v0.1.0 (A1) | crate skeleton: any module → single `ret` (`0x0000_8067`) | **merged** |
-| **v0.2.0 (A1+ — this PR)** | const/mov/add/sub/ret + linear register allocator (a0..a7 + t0..t6) | this PR |
-| v0.3.0 (A1++) | comparisons, branches, calls + stack-spilling allocator + `ecall` for print + `lui`/`addi` for wide consts | future |
+| v0.2.0 (A1+) | const/mov/add/sub/ret + linear register allocator | **merged** |
+| **v0.3.0 (A1++ first slice — this PR)** | wide consts (`lui+addi`) + comparisons (slt/sltu + xor synth) + `ecall print_i64` | this PR |
+| v0.3.1 (A1++.5) | branches (`label`/`jmp`/`jmp_if_*` + 2-pass offsets) + calls (`jal` + ra save/restore + stack spilling) + i64 register pairs | future |
 | v0.4.0 (A1+++) | `lang-aot --target=riscv32` wiring | future |
 | (later) | RV32M (mul/div), RV32A (atomics), RV32F (floats), DWARF emission via aot-debug | future |
 


### PR DESCRIPTION
## Summary

- **A1++ first slice** of [`MULTILANG-ARCHITECTURE-BACKENDS.md`](code/specs/MULTILANG-ARCHITECTURE-BACKENDS.md). Lands three self-contained pieces of the A1++ bundle; branches, calls, and stack spilling are deferred to **A1++.5** since they're orthogonal and benefit from landing as their own PR.
- After this PR, **BASIC's `PRINT` reaches real instructions on all five backends** (wasm + JVM + CLR + LLVM IR + RV32I).

## What's in this PR

### 1. Wide constants via `lui + addi`

Any i32 literal now lowers cleanly. i12 values still use the single `addi rd, x0, n` path; wider values use the canonical `lui rd, upper20; addi rd, rd, lower12` sequence with the standard carry handling when low12 is negative.

### 2. Comparisons producing i32 0/1

`eq` / `ne` / `lt` / `le` / `gt` / `ge` (and `cmp_`-prefixed aliases per G1):

| IIR op | i32 lowering | u32 lowering |
|--------|--------------|--------------|
| `lt`   | `slt`        | `sltu`       |
| `gt`   | `slt rd, rs2, rs1` | `sltu rd, rs2, rs1` |
| `le`   | `slt rd, rs2, rs1; xori rd, rd, 1` | same with `sltu` |
| `ge`   | `slt; xori 1` | `sltu; xori 1` |
| `eq`   | `xor rd, rs1, rs2; sltiu rd, rd, 1` | same |
| `ne`   | `xor rd, rs1, rs2; sltu rd, x0, rd` | same |

All synth idioms **reuse the dest register** so no extra temp is needed — matters until A1++.5 ships stack spilling.

### 3. `call_builtin "print_i64"` via `ecall`

Completes the cross-backend print_i64 parity:

| Backend | Print sentinel |
|---------|----------------|
| iir-to-wasm | `env.__print_i64` host import |
| iir-to-jvm-class-file | `invokestatic env/BasicRuntime.println(J)V` |
| iir-to-cil-bytecode | `call void env.BasicRuntime::PrintI64(int64)` |
| iir-to-llvm | `declare void @__print_i64(i64)` + extern call |
| **iir-to-riscv (this PR)** | `ecall` with `a7 = 1` (Linux `__NR_write` slot) |

## Deferred to A1++.5

- Branches (`label` / `jmp` / `jmp_if_*` with 2-pass offset resolution)
- Calls + `ra` save/restore + stack spilling
- 64-bit register-pair handling

## Test plan
- [x] `cargo test -p iir-to-riscv` — 26 unit + 1 doctest, all green (was 17 + 1)
- [x] Wide const (2): `4096` (no `addi`) + `4097` (lui + addi)
- [x] Comparisons (5): signed slt, unsigned sltu, eq xor+sltiu, ne xor+sltu-x0, cmp_-prefix alias
- [x] `print_i64`: exact 5-word sequence pinned (`addi t0, x0, 42; mv a0, t0; addi a7, x0, 1; ecall; ret`)
- [x] Unknown builtin name rejected
- [x] /security-review passed

## Spec status row

| Version | Scope | Status |
|---------|-------|--------|
| v0.1.0 (A1) | skeleton | **merged** |
| v0.2.0 (A1+) | const/mov/add/sub/ret + allocator | **merged** |
| **v0.3.0 (A1++ first slice — this PR)** | wide consts + comparisons + `ecall print_i64` | this PR |
| v0.3.1 (A1++.5) | branches + calls + stack spilling + i64 pairs | future |
| v0.4.0 (A1+++) | `lang-aot --target=riscv32` wiring | future |

🤖 Generated with [Claude Code](https://claude.com/claude-code)