### PR TITLE
feat(ml_framework_core): autograd engine — Function.apply + Tensor#backward (Ruby pilot PR #5/8)

### DIFF
--- a/code/packages/ruby/ml_framework_core/CHANGELOG.md
+++ b/code/packages/ruby/ml_framework_core/CHANGELOG.md
@@ -2,6 +2,111 @@
 
 ## Unreleased
 
+### Added — v0.2.0: autograd engine (Function.apply + Tensor#backward)
+
+PR #5 of 8 in the Ruby pilot.  Adds reverse-mode automatic differentiation
+on top of v0.1's Tensor class.  All math still pure Ruby; PR #6 layers on
+the ~15 concrete Function subclasses that route large ops through Rust.
+
+#### New API
+
+```ruby
+# Base class for every differentiable op
+class CodingAdventures::MLFrameworkCore::Function
+  # Subclasses override these two:
+  def forward(*inputs)            # → Tensor
+  def backward(output_grad)       # → Array<Tensor, nil>
+
+  # Class method that wires up the autograd graph and runs forward:
+  def self.apply(*inputs)         # → Tensor
+end
+
+# Built-in subclass for testing the machinery (PR #6 adds the real ops):
+class Identity < Function
+end
+
+# Tensor extensions:
+x.backward(grad = nil)            # kicks off backprop; mutates leaf .grad
+Tensor.ones_like(t)               # shape-matching ones tensor
+Tensor.zeros_like(t)              # shape-matching zeros tensor
+```
+
+#### How it works
+
+`Function.apply(*inputs)`:
+
+  1. Instantiates the Function (so it can hold state for backward).
+  2. Calls `forward(*inputs)` — subclass-defined; returns Tensor.
+  3. If any input has `requires_grad`, sets `output.requires_grad = true`
+     and `output.grad_fn = function_instance`.
+  4. Returns the output Tensor.
+
+`Tensor#backward(grad = nil)`:
+
+  1. Defaults `grad` to ones-like(self).
+  2. DFS post-order to build the topological list of Tensors upstream
+     through the `grad_fn` chain.
+  3. Walks topo list in REVERSE; for each non-leaf, calls
+     `grad_fn.backward(node_grad)` to get per-input grads, accumulates
+     them into a per-parent `grad_map`.
+  4. For each leaf with `requires_grad`, copies the accumulated grad
+     into the leaf's public `.grad` slot (accumulating on top if a
+     previous backward already wrote there — supports repeated
+     backward without zero_grad between).
+
+Algorithm is O(V + E) where V is the number of operations and E the
+number of tensor edges.  Mirrors PyTorch's reference algorithm and the
+Python reference at
+`code/packages/python/ml-framework-core/src/ml_framework_core/autograd.py`.
+
+#### Architecture choices
+
+- **Tensor reopened in autograd.rb** rather than edited in tensor.rb.
+  Keeps the v0.1 Tensor file storage-only; concentrates autograd-related
+  additions in one reviewable file.
+- **`grad_map` keyed on `object_id`**, so the same Tensor reaching a
+  Function via two paths (e.g. `Add.apply(x, x)`) gets its gradients
+  summed correctly.
+- **Identity subclass** ships for testing the machinery without
+  introducing op-math; the real ops land in PR #6.
+
+#### Tests added (18 minitests, 31 assertions, all passing)
+
+- `AutogradApplyTest` (5):
+  - requires_grad propagates through Identity
+  - no grad_fn when no input requires grad
+  - apply() returns a NEW tensor (object identity ≠ value equality)
+  - Function subclass must implement forward (NotImplementedError)
+  - Function subclass must implement backward (NotImplementedError)
+- `TensorBackwardSanityTest` (3):
+  - backward on non-grad tensor raises
+  - backward with mismatched grad shape raises
+  - backward returns nil
+- `AutogradEndToEndTest` (6):
+  - identity backward writes ones to leaf grad
+  - identity backward with explicit seed grad
+  - backward twice accumulates into leaf grad
+  - chain of identities propagates
+  - shared parent accumulates from both paths (x → Id → a; x → Id → b)
+  - leaf node without requires_grad is skipped
+- `AutogradFunctionIntrospectionTest` (2):
+  - Function#inspect shows class name + parent count
+  - Function#initialize has empty parents + saved_for_backward
+- `TensorHelperFactoriesTest` (2):
+  - ones_like / zeros_like
+
+Existing 63 Tensor tests continue to pass — no regressions.
+
+#### What's next
+
+- PR #6: `ops.rb` — 15+ Function subclasses (Add, Sub, Mul, Div, Neg,
+  Abs, Pow, MatMul, ReLU, Sigmoid, Tanh, GELU, Softmax, Sum, Mean).
+  Each `forward` builds a matrix-ir-json envelope matching the Python
+  `_rust_backend.py` shapes and dispatches large tensors through
+  `MatrixRustRuby.run_graph_on_cpu`.
+- PR #7: backward dispatch on every op subclass + end-to-end MLP test.
+- PR #8: benchmark + RubyGems polish.
+
 ### Added — v0.1.0: pure-Ruby Tensor class
 
 First release.  Ships the bottom layer of the Ruby ML framework stack: a

--- a/code/packages/ruby/ml_framework_core/lib/coding_adventures/ml_framework_core.rb
+++ b/code/packages/ruby/ml_framework_core/lib/coding_adventures/ml_framework_core.rb
@@ -17,6 +17,7 @@
 
 require_relative "ml_framework_core/version"
 require_relative "ml_framework_core/tensor"
+require_relative "ml_framework_core/autograd"
 
 # Short alias for callers who don't want to type the full namespace.
 # Mirrors PyTorch's `import torch as t` convention.

--- a/code/packages/ruby/ml_framework_core/lib/coding_adventures/ml_framework_core/autograd.rb
+++ b/code/packages/ruby/ml_framework_core/lib/coding_adventures/ml_framework_core/autograd.rb
@@ -1,0 +1,262 @@
+# frozen_string_literal: true
+
+# autograd.rb — reverse-mode automatic differentiation for Tensor
+# =================================================================
+#
+# This file adds two pieces of machinery to ml_framework_core:
+#
+#   1. The `Function` base class.  Every differentiable op (Add, MatMul,
+#      ReLU, ...) is a `Function` subclass that defines `forward` and
+#      `backward`.  PR #6 implements the ~15 specific subclasses; here
+#      we just provide the base class and one Identity subclass for
+#      testing the machinery.
+#
+#   2. `Tensor#backward(grad = nil)` — kicks off backpropagation from a
+#      tensor (typically a scalar loss).  Walks the autograd graph in
+#      reverse topological order, calling each Function's `backward` to
+#      compute input gradients and accumulating them into leaf tensors'
+#      `grad` slot.
+#
+# # Why it's so small
+#
+# All the heavy lifting in autograd is per-op math (PR #6/#7).  The
+# *framework* itself — apply() plumbing + topo sort + reverse walk — is
+# under 100 lines.  This is a property of well-designed reverse-mode AD:
+# every paper that ever described autograd shows this exact algorithm.
+#
+# # Mirrors the Python structure
+#
+# This file deliberately mirrors
+# `code/packages/python/ml-framework-core/src/ml_framework_core/autograd.py`
+# in:
+#   - Function base class shape (saved_tensors + saved_metadata)
+#   - apply()'s steps: probe requires_grad → run forward → wire grad_fn
+#   - backward()'s topo-sort + reverse-walk algorithm
+#   - gradient accumulation rule (sum across paths into a node)
+#
+# Differences are purely Ruby idiom:
+#   - `id()` → `object_id`
+#   - `dict` → `Hash`
+#   - `set` → `Set` (or just keying a Hash on object_id)
+#   - module function `backward(tensor)` → `Tensor#backward` method
+
+require "set"
+require_relative "tensor"
+
+module CodingAdventures
+  module MLFrameworkCore
+    # ========================================================================
+    # Reopen Tensor — autograd needs setters for grad / grad_fn and a
+    # `Tensor.ones_like` convenience factory.  Keeping them here (instead
+    # of in tensor.rb) keeps the v0.1 Tensor PR strictly storage-only,
+    # and concentrates the autograd-related additions in one file for
+    # easy review.
+    # ========================================================================
+    class Tensor
+      # Setters for the autograd-only attributes.  Public so Function.apply
+      # and the backward() walker can write them; users shouldn't need to.
+      attr_writer :grad, :grad_fn
+
+      # `Tensor.ones_like(t)` — a tensor of 1.0s with the same shape as `t`.
+      # The PyTorch convention for `backward()` with no explicit gradient.
+      def self.ones_like(other)
+        ones(*other.shape)
+      end
+
+      # `Tensor.zeros_like(t)` — companion to ones_like; used here for the
+      # leaf-grad initialization branch in backward().
+      def self.zeros_like(other)
+        zeros(*other.shape)
+      end
+
+      # Tensor#backward(grad = nil) — kick off backprop.
+      #
+      # Algorithm:
+      #   1. If grad is nil, default to ones-like (PyTorch convention; valid
+      #      strictly only for scalar tensors but we allow any shape here
+      #      for simplicity, matching what PR #6's tests will need).
+      #   2. Topological sort upward through grad_fn chain — DFS, post-order.
+      #   3. Walk topo list in reverse; for each tensor with a grad_fn,
+      #      call grad_fn.backward(tensor.grad), get input grads, accumulate
+      #      into each parent's grad slot via the grad_map.
+      #   4. For leaf tensors with requires_grad, copy the accumulated
+      #      gradient into the tensor's `grad` slot (accumulating if a
+      #      previous backward already wrote there — supports repeated
+      #      backward() calls without zero_grad in between).
+      #
+      # Returns nil (mutates in place; matches PyTorch).
+      def backward(grad = nil)
+        unless requires_grad
+          raise RuntimeError, "backward() called on a tensor that doesn't require grad"
+        end
+
+        grad ||= Tensor.ones_like(self)
+        unless grad.shape == shape
+          raise ArgumentError,
+                "backward grad shape #{grad.shape.inspect} != tensor shape #{shape.inspect}"
+        end
+
+        # Topological order: each tensor appears AFTER its parents in
+        # the list, so walking in REVERSE processes children before parents.
+        topo_order = []
+        visited    = Set.new
+        build_topo = lambda do |t|
+          # Visiting set keyed by object_id so duplicate sub-graphs (e.g.
+          # `x + x`) are handled correctly — visit each Tensor exactly once.
+          oid = t.object_id
+          next if visited.include?(oid)
+
+          visited.add(oid)
+          if t.grad_fn
+            t.grad_fn.parents.each { |p| build_topo.call(p) }
+          end
+          topo_order << t
+        end
+        build_topo.call(self)
+
+        # grad_map: tensor.object_id → accumulated gradient Tensor.
+        # Starts with our seed gradient at the root.
+        grad_map = { object_id => grad }
+
+        topo_order.reverse_each do |node|
+          node_grad = grad_map[node.object_id]
+          next if node_grad.nil?
+
+          if node.grad_fn.nil?
+            # Leaf tensor — store/accumulate into its public grad slot.
+            next unless node.requires_grad
+
+            if node.grad.nil?
+              node.grad = Tensor.new(node_grad.to_a, shape: node_grad.shape)
+            else
+              # Accumulate: support repeated backward() calls (e.g. when
+              # training a model and not calling zero_grad between steps).
+              node.grad = node.grad + node_grad
+            end
+            next
+          end
+
+          # Non-leaf — ask the Function for input grads and distribute them
+          # into the grad_map for the parents.
+          input_grads = node.grad_fn.backward(node_grad)
+          input_grads = [input_grads] unless input_grads.is_a?(Array)
+          node.grad_fn.parents.each_with_index do |parent, i|
+            input_grad = input_grads[i]
+            next if input_grad.nil?
+
+            existing = grad_map[parent.object_id]
+            grad_map[parent.object_id] =
+              if existing.nil?
+                input_grad
+              else
+                # Two paths converged on this parent — sum the gradients.
+                # (E.g. in `x + x`, the same `x` reaches the add twice.)
+                existing + input_grad
+              end
+          end
+        end
+
+        nil
+      end
+    end
+
+    # ========================================================================
+    # The Function base class — extend this for every differentiable op.
+    # ========================================================================
+    class Function
+      # @return [Array<Tensor>] the input tensors that produced the output.
+      #   backward() distributes gradients to these in the same order.
+      attr_accessor :parents
+
+      # @return [Hash{Symbol => Object}] subclass-defined values cached in
+      #   forward() for use in backward() — typically input shapes, the
+      #   activation values needed for derivative computation (e.g.
+      #   sigmoid backward needs the output value), etc.
+      attr_accessor :saved_for_backward
+
+      def initialize
+        @parents = []
+        @saved_for_backward = {}
+      end
+
+      # Class method — the canonical entry point for invoking an op.
+      #
+      # Algorithm:
+      #   1. Instantiate the Function (so it can hold state for backward).
+      #   2. Call its `forward(*inputs)` to compute the output Tensor.
+      #   3. If any input has `requires_grad`, mark the output the same
+      #      way and wire `output.grad_fn = self` so `Tensor#backward` can
+      #      find us later.
+      #
+      # Returns the output Tensor.
+      def self.apply(*inputs)
+        fn = new
+
+        # Stash the parent inputs so backward() can distribute grads to
+        # them in the same order.  Note: we save the actual Tensor
+        # objects; identity (object_id) matters for shared-parameter
+        # scenarios like `x + x` where the same Tensor appears twice.
+        fn.parents = inputs.dup
+
+        output = fn.forward(*inputs)
+
+        # If ANY input tracks gradients, the output tracks them too — and
+        # we record this Function as the source of the output, so backward
+        # can walk back through us.
+        needs_grad = inputs.any? { |t| t.is_a?(Tensor) && t.requires_grad }
+        if needs_grad
+          output.requires_grad = true
+          output.grad_fn = fn
+        end
+
+        output
+      end
+
+      # Subclasses override this.  Compute the forward result.
+      # @return [Tensor]
+      def forward(*_inputs)
+        raise NotImplementedError, "#{self.class} must implement #forward"
+      end
+
+      # Subclasses override this.  Given the gradient of the loss w.r.t.
+      # this Function's output, return an Array of gradients w.r.t. each
+      # input tensor (in the same order as `parents`).  Return `nil` in
+      # a slot for any input that doesn't need a gradient.
+      # @return [Array<Tensor, nil>]
+      def backward(_output_grad)
+        raise NotImplementedError, "#{self.class} must implement #backward"
+      end
+
+      # Friendly default for pp / inspect.
+      def inspect
+        "#<#{self.class.name} parents=#{@parents.length}>"
+      end
+    end
+
+    # ========================================================================
+    # Identity — the simplest possible Function subclass.
+    #
+    # forward(x)  → x' where x' is a fresh Tensor with the same data
+    # backward(g) → [g]   (the upstream gradient passes through unchanged)
+    #
+    # Used by the autograd test suite to exercise the apply() / backward()
+    # machinery without bringing in any op-specific math.  The real ops
+    # land in PR #6 (ops.rb).
+    # ========================================================================
+    class Identity < Function
+      def forward(x)
+        # Return a NEW Tensor wrapping a copy of x's data, so the
+        # autograd graph has a distinct node — pointer-equality
+        # (`y.equal?(x)`) is false even though `y == x` is true.
+        Tensor.new(x.to_a, shape: x.shape, dtype: x.dtype)
+      end
+
+      def backward(output_grad)
+        # Identity's derivative is 1, so the gradient passes through
+        # unchanged.  Wrap as an Array so apply() can distribute it to
+        # parents[0] uniformly.
+        [output_grad]
+      end
+    end
+  end
+end

--- a/code/packages/ruby/ml_framework_core/lib/coding_adventures/ml_framework_core/version.rb
+++ b/code/packages/ruby/ml_framework_core/lib/coding_adventures/ml_framework_core/version.rb
@@ -2,6 +2,6 @@
 
 module CodingAdventures
   module MLFrameworkCore
-    VERSION = "0.1.0"
+    VERSION = "0.2.0"
   end
 end

--- a/code/packages/ruby/ml_framework_core/test/autograd_test.rb
+++ b/code/packages/ruby/ml_framework_core/test/autograd_test.rb
@@ -1,0 +1,188 @@
+# frozen_string_literal: true
+
+# autograd_test.rb — exercises Function.apply + Tensor#backward
+# =============================================================
+#
+# These tests use only the `Identity` Function subclass (forward = clone,
+# backward = pass-through) so the test suite is decoupled from any
+# op-specific math.  PR #6 adds the real ops and their parity/gradient
+# tests; this file just proves the *machinery* works.
+#
+# Categories:
+#   - apply() wiring: requires_grad propagation, grad_fn attachment
+#   - Tensor#backward sanity: must require requires_grad, must accept seed
+#   - End-to-end: backward populates leaf .grad
+#   - Accumulation: repeated backward sums grads
+#   - Chain: multi-step graphs propagate correctly
+#   - Shared parents: `x → Identity → y, x → Identity → z` accumulates
+
+require "minitest/autorun"
+require "coding_adventures/ml_framework_core"
+
+T  = CodingAdventures::MLFrameworkCore::Tensor unless defined?(T)
+Fn = CodingAdventures::MLFrameworkCore::Function
+Id = CodingAdventures::MLFrameworkCore::Identity
+
+class AutogradApplyTest < Minitest::Test
+  def test_requires_grad_propagates_through_identity
+    x = T.new([1.0, 2.0, 3.0])
+    x.requires_grad = true
+    y = Id.apply(x)
+
+    assert y.requires_grad, "output should inherit requires_grad from input"
+    assert_kind_of Id, y.grad_fn
+    assert_equal [x], y.grad_fn.parents
+  end
+
+  def test_no_grad_fn_when_no_input_requires_grad
+    x = T.new([1.0, 2.0, 3.0])    # requires_grad defaults to false
+    y = Id.apply(x)
+
+    refute y.requires_grad
+    assert_nil y.grad_fn
+  end
+
+  def test_apply_returns_a_new_tensor
+    x = T.new([1.0, 2.0])
+    x.requires_grad = true
+    y = Id.apply(x)
+    refute y.equal?(x), "Identity#forward returns a new tensor, not the same object"
+    assert_equal x, y, "...but the data should compare equal"
+  end
+
+  def test_function_subclass_must_implement_forward
+    bad_class = Class.new(Fn)
+    assert_raises(NotImplementedError) { bad_class.apply(T.new([1.0])) }
+  end
+
+  def test_function_subclass_must_implement_backward
+    # Anonymous subclass — has to fully qualify Tensor because it's NOT
+    # nested under the MLFrameworkCore module (where bare `Tensor` would
+    # resolve via constant lookup).
+    no_back = Class.new(Fn) do
+      def forward(x)
+        CodingAdventures::MLFrameworkCore::Tensor.new(x.to_a, shape: x.shape)
+      end
+    end
+    x = T.new([1.0]); x.requires_grad = true
+    y = no_back.apply(x)
+    assert_raises(NotImplementedError) { y.backward }
+  end
+end
+
+class TensorBackwardSanityTest < Minitest::Test
+  def test_backward_on_non_grad_tensor_raises
+    x = T.new([1.0, 2.0, 3.0])
+    refute x.requires_grad
+    assert_raises(RuntimeError) { x.backward }
+  end
+
+  def test_backward_with_mismatched_grad_shape_raises
+    x = T.new([1.0, 2.0]); x.requires_grad = true
+    y = Id.apply(x)
+    assert_raises(ArgumentError) { y.backward(T.ones(3)) }   # wrong shape
+  end
+
+  def test_backward_returns_nil
+    x = T.new([1.0, 2.0]); x.requires_grad = true
+    y = Id.apply(x)
+    assert_nil y.backward
+  end
+end
+
+class AutogradEndToEndTest < Minitest::Test
+  def test_identity_backward_writes_ones_to_leaf_grad
+    x = T.new([1.0, 2.0, 3.0]); x.requires_grad = true
+    y = Id.apply(x)
+    y.backward
+    # d(identity(x))/dx == 1 everywhere; with seed grad = ones, x.grad = ones.
+    assert_equal T.ones(3), x.grad
+  end
+
+  def test_identity_backward_with_explicit_seed_grad
+    x = T.new([1.0, 2.0]); x.requires_grad = true
+    y = Id.apply(x)
+    y.backward(T.full([2], 5.0))
+    # Identity's local derivative is 1; seed grad = [5, 5] passes through.
+    assert_equal T.full([2], 5.0), x.grad
+  end
+
+  def test_backward_twice_accumulates_into_leaf_grad
+    x = T.new([1.0, 2.0]); x.requires_grad = true
+    y = Id.apply(x)
+    y.backward
+    y.backward
+    # PyTorch convention: repeated backward sums into .grad (caller is
+    # expected to zero_grad between training steps).
+    assert_equal T.full([2], 2.0), x.grad
+  end
+
+  def test_chain_of_identities_propagates
+    x = T.new([1.0, 2.0, 3.0]); x.requires_grad = true
+    y = Id.apply(Id.apply(Id.apply(x)))
+    y.backward
+    # Chain rule with all-identity is still all-ones.
+    assert_equal T.ones(3), x.grad
+  end
+
+  def test_shared_parent_accumulates_from_both_paths
+    # Build:    x ─┬─ Id ─→ a
+    #              └─ Id ─→ b
+    # Then put a and b into a single op so backprop visits both paths.
+    # The easiest way without op-dispatch is to manually invoke backward
+    # on a, then on b, and confirm the SAME leaf x.grad accumulates.
+    x = T.new([1.0, 2.0]); x.requires_grad = true
+    a = Id.apply(x)
+    b = Id.apply(x)
+    a.backward
+    b.backward
+    # Two ones-vectors summed into x.grad.
+    assert_equal T.full([2], 2.0), x.grad
+  end
+
+  def test_leaf_node_without_requires_grad_is_skipped
+    # An intermediate non-grad input shouldn't be assigned a grad.
+    x = T.new([1.0, 2.0])          # no requires_grad → leaf, no grad
+    y = T.new([1.0, 2.0]); y.requires_grad = true
+    z1 = Id.apply(x)
+    _z2 = z1                       # no chain back to y; just verify x.grad stays nil
+    refute z1.requires_grad
+    assert_nil x.grad
+
+    # And confirm a grad-tracking branch still works in isolation.
+    w = Id.apply(y)
+    w.backward
+    assert_equal T.ones(2), y.grad
+  end
+end
+
+class AutogradFunctionIntrospectionTest < Minitest::Test
+  def test_function_inspect_shows_class_and_parent_count
+    x = T.new([1.0]); x.requires_grad = true
+    y = Id.apply(x)
+    assert_match(/Identity/, y.grad_fn.inspect)
+    assert_match(/parents=1/, y.grad_fn.inspect)
+  end
+
+  def test_function_init_has_empty_parents_and_saved
+    fn = Fn.new
+    assert_equal [], fn.parents
+    assert_equal({}, fn.saved_for_backward)
+  end
+end
+
+class TensorHelperFactoriesTest < Minitest::Test
+  def test_ones_like
+    x = T.zeros(2, 3)
+    o = T.ones_like(x)
+    assert_equal x.shape, o.shape
+    assert_equal [1.0] * 6, o.to_a
+  end
+
+  def test_zeros_like
+    x = T.ones(4)
+    z = T.zeros_like(x)
+    assert_equal x.shape, z.shape
+    assert_equal [0.0] * 4, z.to_a
+  end
+end


### PR DESCRIPTION
## Summary

- New `Function` base class with `apply` classmethod that wires up the autograd graph (sets `output.grad_fn` + `requires_grad`).
- `Identity` Function subclass for testing the machinery without bringing in op-specific math.
- `Tensor#backward(grad = nil)` — DFS topological sort + reverse walk; accumulates gradients into leaf `.grad` slots; supports repeated backward without zero_grad (PyTorch convention).
- `Tensor.ones_like` / `Tensor.zeros_like` factories.
- 18 minitests, 31 assertions, all passing. 63 existing Tensor tests continue to pass.

## How it works

`Function.apply(*inputs)`: instantiate → forward → wire `grad_fn` if any input requires grad.

`Tensor#backward(grad = nil)`:
1. Default grad to `ones_like(self)`
2. DFS post-order to build topological list upstream
3. Walk REVERSE; call each `grad_fn.backward(node_grad)`, distribute results into `grad_map` keyed on `object_id`
4. Copy/accumulate into leaf `.grad`

O(V + E) where V is operations, E is tensor edges. Mirrors the Python reference `autograd.py`.

## Architecture choices

- **Tensor reopened in autograd.rb** (not edited in tensor.rb) — keeps v0.1 storage-only, concentrates autograd additions in one file
- **`grad_map` keyed on `object_id`** — same Tensor reaching via two paths (e.g. `Add(x, x)`) accumulates correctly
- **Identity ships for testing** — real ops land in PR #6

## Test plan

- [x] All Ruby files pass `ruby -c`
- [x] `test/tensor_test.rb`: 63/63 pass (no regressions)
- [x] `test/autograd_test.rb`: 18/18 pass
- [x] Security review passed
- [ ] CI: build (ubuntu/macos/windows) — pending
- [ ] CI: CodeQL ruby Analyze — pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)