### PR TITLE
feat(visicalc-swiftui): cross-compile for iOS — same source, two platforms

### DIFF
--- a/code/packages/rust/mosaic-emit-swiftui/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-swiftui/src/pipeline.rs
@@ -924,10 +924,29 @@ fn emit_host_input(node: &LayoutNode, indent: usize) -> Result<String, PipelineE
     }
 
     // `.onExitCommand { dispatch(.e) }` — macOS Escape-key handler.
+    //
+    // `.onExitCommand` is a macOS-only modifier (it observes the
+    // Escape key via the AppKit responder chain).  Emitting it
+    // unconditionally breaks iOS / iPadOS / tvOS / watchOS builds
+    // with "value of type ... has no member 'onExitCommand'".  We
+    // wrap it in a `#if os(macOS)` compile-time guard so the same
+    // generated file targets the whole Apple platform fleet.
+    //
+    // To keep the rest of the chain readable, we close the current
+    // chain line, emit the guarded modifier on its own block, and
+    // open a no-op continuation if any further chained modifiers
+    // get added in the future.  Today `onCancel` is the last
+    // modifier we emit, so the trailing newline pattern just
+    // closes the expression.
     if let Some(emit_name) = find_emit_ref_prop(node, "onCancel") {
         let case_name = to_camel_case_first_lower(&strip_on_prefix(emit_name));
         validate_emit_name(&case_name)?;
-        line.push_str(&format!(".onExitCommand {{ dispatch(.{case_name}) }}"));
+        line.push('\n');
+        line.push_str(&format!("{pad}    #if os(macOS)\n"));
+        line.push_str(&format!(
+            "{pad}    .onExitCommand {{ dispatch(.{case_name}) }}\n"
+        ));
+        line.push_str(&format!("{pad}    #endif"));
     }
 
     line.push('\n');
@@ -2939,6 +2958,66 @@ mod tests {
         assert!(
             out.contains(".onSubmit { dispatch(.commit) }"),
             "expected void-form .onSubmit dispatch, got:\n{out}"
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // Test 18b — onCancel emits `.onExitCommand` guarded by
+    // `#if os(macOS)`.
+    //
+    // `.onExitCommand` is macOS-only.  Emitting it unconditionally
+    // broke iOS builds with "value of type ... has no member
+    // 'onExitCommand'".  Now wrapped in a `#if os(macOS)` compile-time
+    // guard so the same generated file targets the whole Apple
+    // platform fleet — macOS, iOS, iPadOS, tvOS, watchOS.
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn host_input_on_cancel_wraps_on_exit_command_in_os_macos_guard() {
+        let layout = layout_with(
+            "F",
+            container_node(
+                "Box",
+                vec![leaf(
+                    "HostInput",
+                    vec![
+                        prop_slot_ref("value", "value"),
+                        prop_emit_ref("onCancel", "onCancel"),
+                    ],
+                )],
+            ),
+        );
+        let out = from_pipeline(
+            &component(
+                "F",
+                vec![slot("value", SlotType::Text, true)],
+                vec![emit("onCancel", vec![])],
+            ),
+            &layout,
+            &empty_style("F"),
+        )
+        .unwrap()
+        .output;
+        assert!(
+            out.contains("#if os(macOS)"),
+            "expected #if os(macOS) guard around .onExitCommand, got:\n{out}"
+        );
+        assert!(
+            out.contains(".onExitCommand { dispatch(.cancel) }"),
+            "expected .onExitCommand dispatch inside the guard, got:\n{out}"
+        );
+        assert!(
+            out.contains("#endif"),
+            "expected #endif closing the guard, got:\n{out}"
+        );
+        // Regression: the guard must actually wrap onExitCommand,
+        // not be elsewhere in the file.
+        let if_pos = out.find("#if os(macOS)").unwrap();
+        let cmd_pos = out.find(".onExitCommand").unwrap();
+        let endif_pos = out.find("#endif").unwrap();
+        assert!(
+            if_pos < cmd_pos && cmd_pos < endif_pos,
+            "expected #if/.onExitCommand/#endif in order:\n{out}"
         );
     }
 

--- a/demo/visicalc-swiftui/README.md
+++ b/demo/visicalc-swiftui/README.md
@@ -31,12 +31,28 @@ and writes `Sources/VisiCalc/Generated/FormulaBar.swift`.
 
 ## How to run the app
 
+### macOS
+
 ```bash
 swift run                 # macOS terminal target
-open Package.swift        # open in Xcode for iOS Simulator
 ```
 
-Requires Swift 5.9+ / Xcode 15+. Install via App Store on macOS.
+### iOS Simulator
+
+```bash
+xcodebuild -scheme VisiCalc \
+  -destination 'generic/platform=iOS Simulator' \
+  build
+```
+
+Or open `Package.swift` in Xcode and pick an iOS simulator from
+the run-destination menu.  Both `VisiCalcApp.swift` and the
+generated `FormulaBar.swift` are cross-platform — `AppKit` /
+`.onExitCommand` are guarded by `#if os(macOS)` so the same
+source ships to macOS, iOS, iPadOS, tvOS, and watchOS.
+
+Requires Swift 5.9+ / Xcode 15+.  iOS Simulator runtime is
+optional but recommended.  Install via App Store on macOS.
 
 ## Known emitter glitch
 

--- a/demo/visicalc-swiftui/Sources/VisiCalc/VisiCalcApp.swift
+++ b/demo/visicalc-swiftui/Sources/VisiCalc/VisiCalcApp.swift
@@ -1,34 +1,40 @@
 // VisiCalcApp.swift — top-level SwiftUI app entry (VC2-swiftui).
 //
-// @main App scaffold. The ContentView next door does the real work;
-// this file wires the WindowGroup AND attaches an
-// NSApplicationDelegate that elevates the running process to a
-// regular foreground app.
+// Cross-platform: macOS + iOS.  SwiftUI's `App` protocol works
+// identically on both, so the `body: some Scene` block is shared.
+// Only the platform-specific lifecycle wiring differs:
 //
-// Why the AppDelegate? `swift run` launches the binary without an
-// .app bundle / Info.plist, so macOS treats the process as
-// BackgroundOnly by default. The SwiftUI WindowGroup still creates
-// a window but it never appears in the Dock and never activates,
-// which makes the demo hard to find when launched from a terminal.
-// The delegate's `applicationDidFinishLaunching` flips the
-// activation policy to `.regular` (Dock icon + menu bar + window
-// focus) and forces activation. Production .app bundles get the
-// same behaviour via their Info.plist's `LSUIElement = false` so
-// this is a no-op there.
+//   - macOS: an `NSApplicationDelegate` that flips the activation
+//     policy to `.regular` so `swift run` puts the demo in the
+//     Dock and brings the window forward (no .app bundle, no
+//     Info.plist, so the default is BackgroundOnly).
+//   - iOS:  no delegate needed — the system always treats apps as
+//     foreground.
+//
+// The `ContentView` next door does the real visual work and is
+// pure SwiftUI (no AppKit / UIKit imports), so it compiles
+// unchanged on both platforms.
 
 import SwiftUI
+
+#if os(macOS)
 import AppKit
 
+/// macOS-only lifecycle delegate.  See file-header comment for why
+/// it's needed under `swift run`.
 final class VisiCalcAppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApplication.shared.setActivationPolicy(.regular)
         NSApplication.shared.activate(ignoringOtherApps: true)
     }
 }
+#endif
 
 @main
 struct VisiCalcApp: App {
+    #if os(macOS)
     @NSApplicationDelegateAdaptor(VisiCalcAppDelegate.self) var appDelegate
+    #endif
 
     var body: some Scene {
         WindowGroup("VisiCalc") {


### PR DESCRIPTION
## Summary

The VisiCalc SwiftUI demo previously built only for macOS. Adding an iOS Simulator destination exposed two real cross-platform gaps — both fixed here.

### Bug 1: mosaic-emit-swiftui emits macOS-only `.onExitCommand` unconditionally

`SwiftUI's TextField.onExitCommand` is macOS-only (it observes the Escape key via the AppKit responder chain). The emitter wrote it unconditionally for every `HostInput { onCancel: ... }` lowering, breaking iOS / iPadOS / tvOS / watchOS builds with:

```
value of type 'TextField' has no member 'onExitCommand'
```

**Fix:** wrap the emission in a `#if os(macOS)` / `#endif` Swift compile-time guard. Same generated file now compiles for every Apple platform.

### Bug 2: VisiCalcApp.swift unconditionally imports AppKit

The app entry point imported `AppKit` and adapted an `NSApplicationDelegate` unconditionally — both AppKit-only. The `body: some Scene { WindowGroup { ContentView() } }` is pure SwiftUI and works on both platforms.

**Fix:** wrap the imports, the `VisiCalcAppDelegate` class, and the `@NSApplicationDelegateAdaptor` property in `#if os(macOS)`. ContentView is unchanged (already cross-platform).

## Verification

| Build | Result |
| --- | --- |
| `swift build` (macOS arm64) | ✅ Build complete! (0.81s) |
| `xcodebuild -scheme VisiCalc -destination 'generic/platform=iOS Simulator' build` | ✅ ** BUILD SUCCEEDED ** |

Tests: 83/83 pass on `mosaic-emit-swiftui` (82 baseline + 1 new test asserting the `#if os(macOS)` / `.onExitCommand` / `#endif` trio appears in order).

README updated with the iOS Simulator run command.

## Why this matters for the cross-platform parity story

VisiCalc is the first guinea pig for Mosaic UI's cross-platform story. The user explicitly asked for "mobile apps natively" — this PR is the first PR that delivers that for iOS via SwiftUI without any per-platform forking of the demo's source tree.

## Test plan

- [x] `cargo test -p mosaic-emit-swiftui` green
- [x] `swift build` (macOS) green
- [x] `xcodebuild ... -destination 'generic/platform=iOS Simulator' build` green
- [x] Security review PASSED
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)