### PR TITLE
A1++.5: iir-to-riscv label/jmp/jmp_if_* with two-pass label resolution

### DIFF
--- a/code/packages/rust/iir-to-riscv/CHANGELOG.md
+++ b/code/packages/rust/iir-to-riscv/CHANGELOG.md
@@ -3,6 +3,62 @@
 All notable changes to this crate are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.3.1] — 2026-06-02 (A1++.5 control-flow slice — `label` / `jmp` / `jmp_if_*` with two-pass label resolution)
+
+### Added — control flow within a single function
+
+Lands the control-flow piece of the A1++ bundle.  Cross-function `call`
+and stack spilling remain deferred to A1++.5.5 — splitting them keeps
+each PR's review surface focused.
+
+| IIR op | RV32I lowering |
+|--------|----------------|
+| `label "L"` | byte-offset marker, emits zero machine words |
+| `jmp "L"` | `jal x0, +offset` (J-type, ±1 MiB range) |
+| `jmp_if_true cond, "L"` | `bne cond, x0, +offset` (B-type, ±4 KiB range) |
+| `jmp_if_false cond, "L"` | `beq cond, x0, +offset` (B-type, ±4 KiB range) |
+
+### Implementation — two-pass label resolution
+
+Single traversal of IIR, two visits of the words vector:
+
+1. Each `label` records `labels[name] = out.len() * 4` (current byte
+   offset).  Zero machine words emitted.
+2. Each branch (`jmp` / `jmp_if_*`) pushes a placeholder zero word and
+   records `(word_idx, target_label, BranchKind)` in
+   `state.branches`.
+3. After all instructions are lowered, `lower_function` walks
+   `state.branches` and re-emits each placeholder via the right
+   encoder with the resolved offset.
+
+This keeps the per-instruction lowerer simple — no special "is this a
+forward branch?" logic — and produces the same byte layout as a real
+two-pass assembler.
+
+### New error variants
+
+* `IIRRiscvError::UndefinedLabel` — branch to a `label` that was never
+  defined in the same function.
+* `IIRRiscvError::BranchOutOfRange` — target so far away it would overflow
+  the encoding (`±4096` bytes for `beq`/`bne`, `±1 MiB` for `jal`).
+
+### Tests added (31 total, was 26)
+
+* `jmp_around_a_dead_block_patches_jal_with_real_offset` — pinned the
+  exact `jal x0, +8` encoding for a forward jump over a dead block.
+* `jmp_if_true_emits_bne_with_resolved_offset`
+* `jmp_if_false_emits_beq_with_resolved_offset`
+* `backward_jmp_emits_negative_offset` — infinite loop case (`jal x0, +0`).
+* `undefined_label_is_rejected` — error path.
+
+### What is NOT in this PR (deferred to A1++.5.5)
+
+* **Cross-function calls.**  `call` with `jal` + `ra` save/restore needs
+  a real stack frame.
+* **Stack-spilling register allocator.**  Locals beyond `t0..t6` still
+  produce `OutOfRegisters`.
+* **64-bit register-pair handling.**
+
 ## [0.3.0] — 2026-06-02 (A1++ first slice — wide consts + comparisons + `ecall print_i64`)
 
 ### Added — three more op families on RV32I

--- a/code/packages/rust/iir-to-riscv/Cargo.toml
+++ b/code/packages/rust/iir-to-riscv/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iir-to-riscv"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
-description = "IIR → RV32I machine code backend — lowers IIRModule to a Vec<u32> of encoded 32-bit RISC-V instructions.  v0.3.0 (A1++ first slice): adds wide constants via lui+addi (any i32 now lowers cleanly), comparison ops eq/ne/lt/le/gt/ge producing i32 0/1 (slt/sltu + xor synth), and call_builtin print_i64 via ecall with a7=1 syscall convention.  Defers branches/calls/stack-spilling to A1++.5."
+description = "IIR → RV32I machine code backend — lowers IIRModule to a Vec<u32> of encoded 32-bit RISC-V instructions.  v0.3.1 (A1++.5 control-flow slice): adds label/jmp/jmp_if_true/jmp_if_false with two-pass label resolution, PC-relative offset computation via beq/bne/jal, and BranchOutOfRange/UndefinedLabel errors.  Calls + stack spilling still deferred."
 
 [lib]
 name = "iir_to_riscv"

--- a/code/packages/rust/iir-to-riscv/src/lib.rs
+++ b/code/packages/rust/iir-to-riscv/src/lib.rs
@@ -77,8 +77,9 @@ use std::fmt;
 
 use interpreter_ir::{IIRFunction, IIRInstr, IIRModule, Operand};
 use riscv_simulator::encoding::{
-    encode_add, encode_addi, encode_ecall, encode_jalr, encode_lui,
-    encode_slt, encode_sltiu, encode_sltu, encode_sub, encode_xor, encode_xori,
+    encode_add, encode_addi, encode_beq, encode_bne, encode_ecall, encode_jal,
+    encode_jalr, encode_lui, encode_slt, encode_sltiu, encode_sltu, encode_sub,
+    encode_xor, encode_xori,
 };
 
 // ===========================================================================
@@ -151,6 +152,12 @@ pub enum IIRRiscvError {
     /// immediate range (-2048..2047).  v0.2.0 doesn't synthesise the
     /// `lui` + `addi` pair for wider constants — A1++ adds it.
     ImmediateOutOfRange { function: String, value: i64 },
+    /// A `jmp` / `jmp_if_*` referenced a label that was never defined
+    /// by a `label "<name>"` instruction in the same function.
+    UndefinedLabel { function: String, label: String },
+    /// A branch's target is too far away to encode.  B-type (beq/bne)
+    /// gives ±4096 bytes; J-type (jal) gives ±1 MiB.
+    BranchOutOfRange { function: String, label: String, offset: i64, max: i64 },
 }
 
 impl fmt::Display for IIRRiscvError {
@@ -171,6 +178,10 @@ impl fmt::Display for IIRRiscvError {
                 write!(f, "out of temporary registers (t0..t6) while binding {name:?} in function {function:?}; stack spilling lands in A1++"),
             Self::ImmediateOutOfRange { function, value } =>
                 write!(f, "literal {value} exceeds RV32I 12-bit signed immediate range (-2048..2047) in function {function:?}; lui+addi lowering lands in A1++"),
+            Self::UndefinedLabel { function, label } =>
+                write!(f, "branch to undefined label {label:?} in function {function:?}"),
+            Self::BranchOutOfRange { function, label, offset, max } =>
+                write!(f, "branch to label {label:?} in function {function:?} would require offset {offset} bytes, exceeding the ±{max}-byte range of this branch encoding"),
         }
     }
 }
@@ -203,6 +214,8 @@ const SUPPORTED_OPS: &[&str] = &[
     "cmp_eq", "cmp_ne", "cmp_lt", "cmp_le", "cmp_gt", "cmp_ge",
     // A1++ — host call
     "call_builtin",
+    // A1++.5 — control flow within a function
+    "label", "jmp", "jmp_if_true", "jmp_if_false",
 ];
 
 /// Syscall number used by the RV32I `ecall` for `call_builtin print_i64`.
@@ -315,15 +328,43 @@ pub fn lower_iir_to_riscv(
     Ok(words)
 }
 
+/// Kind of branch placeholder waiting to be patched once the target
+/// label's byte offset is known.
+///
+/// `B_TYPE_*` cover the conditional branches (`beq`/`bne`) emitted by
+/// `jmp_if_true` / `jmp_if_false`; the placeholder records which
+/// registers were already encoded into the opcode word but with a zero
+/// offset, plus the comparison kind so the patcher can re-emit with
+/// the right offset.  `J_TYPE_JAL` covers the unconditional `jmp` →
+/// `jal x0, offset`.
+#[derive(Debug, Clone, Copy)]
+enum BranchKind {
+    /// `beq rs1, x0, +offset` — fire branch when cond is zero (false).
+    BeqZero { rs1: u32 },
+    /// `bne rs1, x0, +offset` — fire branch when cond is non-zero (true).
+    BneZero { rs1: u32 },
+    /// `jal x0, +offset` — unconditional jump, discard return address.
+    JalDiscard,
+}
+
 /// Per-function state shared by `lower_function` and `lower_instr`.
 struct FnState<'a> {
     fn_name: &'a str,
     /// IIR var name → assigned RV32I register index (`x*`).
     env: HashMap<String, u32>,
     /// Next free index into [`TEMP_REGISTERS`].  When this exceeds the
-    /// pool length we return `OutOfRegisters` — A1++ replaces this with
+    /// pool length we return `OutOfRegisters` — A1++.5 replaces this with
     /// a stack-spilling allocator.
     next_temp: usize,
+    /// Label name → byte offset within the function body.
+    /// Filled lazily as `label "<name>"` instructions are emitted.
+    labels: HashMap<String, usize>,
+    /// Pending branch patches.  Each entry records:
+    ///   - the word index into the function body that needs patching,
+    ///   - the target label name,
+    ///   - the encoding kind (so we know which encoder to call once we
+    ///     know the resolved byte offset).
+    branches: Vec<(usize, String, BranchKind)>,
 }
 
 impl FnState<'_> {
@@ -357,6 +398,8 @@ fn lower_function(func: &IIRFunction) -> Result<Vec<u32>, IIRRiscvError> {
         fn_name: &func.name,
         env: HashMap::new(),
         next_temp: 0,
+        labels: HashMap::new(),
+        branches: Vec::new(),
     };
     // Bind parameters to a0..a7.  Validator already guarantees count <= 8.
     for (i, (pname, _)) in func.params.iter().enumerate() {
@@ -366,7 +409,60 @@ fn lower_function(func: &IIRFunction) -> Result<Vec<u32>, IIRRiscvError> {
     for instr in &func.instructions {
         lower_instr(instr, &mut state, &mut words)?;
     }
+
+    // ── Second pass: resolve branch offsets ─────────────────────────────
+    //
+    // After all instructions are emitted we know the byte offset of every
+    // label (recorded in `state.labels`).  Walk the pending patch list
+    // and replace each placeholder word with the real encoded branch.
+    //
+    // PC-relative offset = target_byte - source_byte.  RV32I branch
+    // encoders take a signed byte offset directly; range-check before
+    // re-encoding.
+    for (word_idx, label_name, kind) in &state.branches {
+        let target = state.labels.get(label_name).copied().ok_or_else(|| {
+            IIRRiscvError::UndefinedLabel {
+                function: state.fn_name.into(),
+                label: label_name.clone(),
+            }
+        })?;
+        let src_byte = (*word_idx) * 4;
+        let offset = target as i64 - src_byte as i64;
+        let new_word = match kind {
+            BranchKind::BeqZero { rs1 } => {
+                check_branch_offset(state.fn_name, label_name, offset, 4096)?;
+                encode_beq(*rs1, X0_ZERO, offset as i32)
+            }
+            BranchKind::BneZero { rs1 } => {
+                check_branch_offset(state.fn_name, label_name, offset, 4096)?;
+                encode_bne(*rs1, X0_ZERO, offset as i32)
+            }
+            BranchKind::JalDiscard => {
+                check_branch_offset(state.fn_name, label_name, offset, 1 << 20)?;
+                encode_jal(X0_ZERO, offset as i32)
+            }
+        };
+        words[*word_idx] = new_word;
+    }
+
     Ok(words)
+}
+
+fn check_branch_offset(
+    fn_name: &str,
+    label: &str,
+    offset: i64,
+    max: i64,
+) -> Result<(), IIRRiscvError> {
+    if offset < -max || offset >= max {
+        return Err(IIRRiscvError::BranchOutOfRange {
+            function: fn_name.into(),
+            label: label.into(),
+            offset,
+            max,
+        });
+    }
+    Ok(())
 }
 
 /// Emit one IIR instruction's worth of RV32I words.
@@ -514,6 +610,78 @@ fn lower_instr(
         // For `print_i64`: load the syscall number ECALL_PRINT_I64_NUM
         // into a7, ensure the value is in a0, then `ecall`.
         "call_builtin" => lower_call_builtin(instr, state, out),
+
+        // ── label "<name>": record byte offset for backpatching ─────────
+        //
+        // `label` emits zero machine words — it's purely a marker.  The
+        // current byte offset is `out.len() * 4` (each word is 4 bytes).
+        // A duplicate label name silently overwrites; that's a frontend
+        // bug we could catch with a validator pass, but for v0.3.1 we
+        // accept any name and let the latest definition win.
+        "label" => {
+            let name = match instr.srcs.first() {
+                Some(Operand::Var(s)) => s.clone(),
+                _ => return Err(IIRRiscvError::InvalidOperand {
+                    function: state.fn_name.into(),
+                    detail: "label requires srcs[0] = Operand::Var(name)".into(),
+                }),
+            };
+            state.labels.insert(name, out.len() * 4);
+            Ok(())
+        }
+
+        // ── jmp "<name>": unconditional `jal x0, +offset` ───────────────
+        //
+        // We emit a placeholder zero word and record a patch site so the
+        // second pass can compute the PC-relative offset once the label
+        // is known.
+        "jmp" => {
+            let target = match instr.srcs.first() {
+                Some(Operand::Var(s)) => s.clone(),
+                _ => return Err(IIRRiscvError::InvalidOperand {
+                    function: state.fn_name.into(),
+                    detail: "jmp requires srcs[0] = Operand::Var(target_label)".into(),
+                }),
+            };
+            state.branches.push((out.len(), target, BranchKind::JalDiscard));
+            out.push(0); // placeholder
+            Ok(())
+        }
+
+        // ── jmp_if_true / jmp_if_false ──────────────────────────────────
+        //
+        // The cond var is interpreted as a boolean (any non-zero = true).
+        // We compare against `x0`:
+        //
+        //   jmp_if_true  cond, L  →  bne cond, x0, L
+        //   jmp_if_false cond, L  →  beq cond, x0, L
+        //
+        // Operand layout: srcs = [Var(cond), Var(target_label)].
+        "jmp_if_true" | "jmp_if_false" => {
+            let cond_name = match instr.srcs.first() {
+                Some(Operand::Var(s)) => s.clone(),
+                _ => return Err(IIRRiscvError::InvalidOperand {
+                    function: state.fn_name.into(),
+                    detail: format!("{} requires srcs[0] = Operand::Var(cond)", instr.op),
+                }),
+            };
+            let target = match instr.srcs.get(1) {
+                Some(Operand::Var(s)) => s.clone(),
+                _ => return Err(IIRRiscvError::InvalidOperand {
+                    function: state.fn_name.into(),
+                    detail: format!("{} requires srcs[1] = Operand::Var(target_label)", instr.op),
+                }),
+            };
+            let rs1 = state.lookup(&cond_name)?;
+            let kind = if instr.op == "jmp_if_true" {
+                BranchKind::BneZero { rs1 }
+            } else {
+                BranchKind::BeqZero { rs1 }
+            };
+            state.branches.push((out.len(), target, kind));
+            out.push(0); // placeholder
+            Ok(())
+        }
 
         other => Err(IIRRiscvError::UnsupportedOp {
             function: state.fn_name.into(),

--- a/code/packages/rust/iir-to-riscv/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-riscv/tests/test_backend.rs
@@ -521,3 +521,119 @@ fn call_builtin_unknown_name_is_unsupported() {
         other => panic!("expected UnsupportedOp, got: {other:?}"),
     }
 }
+
+// ===========================================================================
+// 15. A1++.5 — control flow within a function
+// ===========================================================================
+//
+// `label "L"` records a byte offset; `jmp "L"` → `jal x0, +offset`;
+// `jmp_if_true cond, L` → `bne cond, x0, +offset`;
+// `jmp_if_false cond, L` → `beq cond, x0, +offset`.
+//
+// Offsets are resolved in a second pass after every label is known.
+
+#[test]
+fn jmp_around_a_dead_block_patches_jal_with_real_offset() {
+    use riscv_simulator::encoding::encode_jal;
+    // Module:
+    //   const v = 1
+    //   jmp "L_end"
+    //   const dead = 99    ; unreachable but kept to grow the gap
+    //   label "L_end"
+    //   ret v
+    let f = IIRFunction::new("f", vec![], "i32", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(1)], "i32"),
+        IIRInstr::new("jmp",   None,             vec![Operand::Var("L_end".into())], "void"),
+        IIRInstr::new("const", Some("dead".into()), vec![Operand::Int(99)], "i32"),
+        IIRInstr::new("label", None, vec![Operand::Var("L_end".into())], "void"),
+        IIRInstr::new("ret",   None, vec![Operand::Var("v".into())], "i32"),
+    ]);
+    let words = lower(&module_with(f));
+    // Expected layout:
+    //   [0] addi t0, x0, 1      ; v = 1                    @ byte 0
+    //   [1] jal  x0, +8         ; jmp to L_end             @ byte 4
+    //   [2] addi t1, x0, 99     ; dead = 99                @ byte 8
+    //   [3] (label L_end here)  ; addi a0, t0, 0  @ byte 12  ← target
+    //   [4] jalr x0, x1, 0      ; ret                      @ byte 16
+    //
+    // So jal at byte 4 should jump +8 bytes (target byte 12).
+    assert_eq!(words[1], encode_jal(X0, 8),
+        "jal at byte 4 should encode +8 offset; got 0x{:08x}", words[1]);
+}
+
+#[test]
+fn jmp_if_true_emits_bne_with_resolved_offset() {
+    use riscv_simulator::encoding::encode_bne;
+    // const cond = 1
+    // jmp_if_true cond, "L_end"
+    // const dead = 99
+    // label "L_end"
+    // ret_void
+    let f = IIRFunction::new("f", vec![], "void", vec![
+        IIRInstr::new("const", Some("cond".into()), vec![Operand::Int(1)], "i32"),
+        IIRInstr::new("jmp_if_true", None,
+            vec![Operand::Var("cond".into()), Operand::Var("L_end".into())], "i32"),
+        IIRInstr::new("const", Some("dead".into()), vec![Operand::Int(99)], "i32"),
+        IIRInstr::new("label", None, vec![Operand::Var("L_end".into())], "void"),
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ]);
+    let words = lower(&module_with(f));
+    // [0] addi t0, x0, 1     @ byte 0   (cond = 1, t0)
+    // [1] bne  t0, x0, +8    @ byte 4   ← jmp_if_true
+    // [2] addi t1, x0, 99    @ byte 8   (dead)
+    // [3] jalr x0, x1, 0     @ byte 12  ← L_end, ret
+    assert_eq!(words[1], encode_bne(T0, X0, 8),
+        "bne t0, x0, +8 expected at byte 4; got 0x{:08x}", words[1]);
+}
+
+#[test]
+fn jmp_if_false_emits_beq_with_resolved_offset() {
+    use riscv_simulator::encoding::encode_beq;
+    // Same shape as jmp_if_true but with the opposite branch.
+    let f = IIRFunction::new("f", vec![], "void", vec![
+        IIRInstr::new("const", Some("cond".into()), vec![Operand::Int(0)], "i32"),
+        IIRInstr::new("jmp_if_false", None,
+            vec![Operand::Var("cond".into()), Operand::Var("L_end".into())], "i32"),
+        IIRInstr::new("const", Some("dead".into()), vec![Operand::Int(99)], "i32"),
+        IIRInstr::new("label", None, vec![Operand::Var("L_end".into())], "void"),
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ]);
+    let words = lower(&module_with(f));
+    assert_eq!(words[1], encode_beq(T0, X0, 8),
+        "beq t0, x0, +8 expected at byte 4; got 0x{:08x}", words[1]);
+}
+
+#[test]
+fn backward_jmp_emits_negative_offset() {
+    use riscv_simulator::encoding::encode_jal;
+    // Trivial infinite loop:
+    //   label "top"
+    //   jmp "top"
+    //   ret_void   (unreachable)
+    let f = IIRFunction::new("f", vec![], "void", vec![
+        IIRInstr::new("label", None, vec![Operand::Var("top".into())], "void"),
+        IIRInstr::new("jmp", None, vec![Operand::Var("top".into())], "void"),
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ]);
+    let words = lower(&module_with(f));
+    // label "top" sits at byte 0, jal is at byte 0 (first emitted word).
+    // Wait — label emits 0 words, so jal is at word index 0 (byte 0).
+    // Target byte = 0, source byte = 0, offset = 0.
+    // That's `jal x0, +0` — encoding 0x6F.
+    assert_eq!(words[0], encode_jal(X0, 0),
+        "jal x0, +0 expected for label-at-jmp; got 0x{:08x}", words[0]);
+}
+
+#[test]
+fn undefined_label_is_rejected() {
+    let f = IIRFunction::new("f", vec![], "void", vec![
+        IIRInstr::new("jmp", None, vec![Operand::Var("nowhere".into())], "void"),
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ]);
+    let err = lower_iir_to_riscv(&module_with(f), &IIRRiscvConfig::default())
+        .expect_err("undefined label should fail");
+    match err {
+        IIRRiscvError::UndefinedLabel { label, .. } => assert_eq!(label, "nowhere"),
+        other => panic!("expected UndefinedLabel, got: {other:?}"),
+    }
+}

--- a/code/specs/iir-to-riscv.md
+++ b/code/specs/iir-to-riscv.md
@@ -53,8 +53,9 @@ IIRModule
 |---------|-------|--------|
 | v0.1.0 (A1) | crate skeleton: any module → single `ret` (`0x0000_8067`) | **merged** |
 | v0.2.0 (A1+) | const/mov/add/sub/ret + linear register allocator | **merged** |
-| **v0.3.0 (A1++ first slice — this PR)** | wide consts (`lui+addi`) + comparisons (slt/sltu + xor synth) + `ecall print_i64` | this PR |
-| v0.3.1 (A1++.5) | branches (`label`/`jmp`/`jmp_if_*` + 2-pass offsets) + calls (`jal` + ra save/restore + stack spilling) + i64 register pairs | future |
+| v0.3.0 (A1++ first slice) | wide consts (`lui+addi`) + comparisons + `ecall print_i64` | **merged** |
+| **v0.3.1 (A1++.5 control-flow slice — this PR)** | `label` / `jmp` / `jmp_if_true` / `jmp_if_false` with two-pass label resolution (beq/bne/jal) | this PR |
+| v0.3.2 (A1++.5.5) | calls (`jal` + ra save/restore + stack spilling) + i64 register pairs | future |
 | v0.4.0 (A1+++) | `lang-aot --target=riscv32` wiring | future |
 | (later) | RV32M (mul/div), RV32A (atomics), RV32F (floats), DWARF emission via aot-debug | future |
 


### PR DESCRIPTION
## Summary

- **A1++.5 control-flow slice** of [`MULTILANG-ARCHITECTURE-BACKENDS.md`](code/specs/MULTILANG-ARCHITECTURE-BACKENDS.md). Lands the control-flow piece of the A1++ bundle.
- Cross-function `call` + stack spilling stay deferred to A1++.5.5 — splitting them keeps each PR's review surface focused.
- 31 unit + 1 doctest, all green (was 26 + 1).

## Op coverage added

| IIR op | RV32I lowering |
|--------|----------------|
| `label "L"` | byte-offset marker, emits zero machine words |
| `jmp "L"` | `jal x0, +offset` (J-type, ±1 MiB range) |
| `jmp_if_true cond, "L"` | `bne cond, x0, +offset` (B-type, ±4 KiB range) |
| `jmp_if_false cond, "L"` | `beq cond, x0, +offset` (B-type, ±4 KiB range) |

## Implementation — two-pass label resolution

Single traversal of IIR, two visits of the words vector:

1. Per-instr lowering — each `label` records `labels[name] = out.len() * 4`. Each branch pushes a **placeholder zero word** and records `(word_idx, target_label, BranchKind)` in `state.branches`.
2. After all instructions emit, `lower_function` walks `state.branches`, computes `offset = target_byte - source_byte`, range-checks, re-emits via the right encoder, writes back into `words[word_idx]`.

Result: same byte layout as a real two-pass assembler with simpler per-instr code (no forward-branch logic).

## New error variants

- `UndefinedLabel` — branch to a `label` that was never defined
- `BranchOutOfRange` — target overflows the encoding range

## Test plan
- [x] `cargo test -p iir-to-riscv` — 31 + 1 doctest, all green
- [x] Forward `jmp` over a dead block → exact `jal x0, +8`
- [x] `jmp_if_true cond, L` → exact `bne t0, x0, +8`
- [x] `jmp_if_false cond, L` → exact `beq t0, x0, +8`
- [x] Backward infinite-loop `jmp` → `jal x0, +0`
- [x] Undefined label rejected with `UndefinedLabel`
- [x] /security-review passed

## Spec status row

| Version | Scope | Status |
|---------|-------|--------|
| v0.1.0 (A1) | skeleton | **merged** |
| v0.2.0 (A1+) | const/mov/add/sub/ret + allocator | **merged** |
| v0.3.0 (A1++ first slice) | wide consts + cmps + `ecall print_i64` | **merged** |
| **v0.3.1 (A1++.5 control-flow — this PR)** | `label`/`jmp`/`jmp_if_*` + 2-pass offsets | this PR |
| v0.3.2 (A1++.5.5) | calls + stack spilling + i64 pairs | future |
| v0.4.0 (A1+++) | `lang-aot --target=riscv32` wiring | future |

🤖 Generated with [Claude Code](https://claude.com/claude-code)