### PR TITLE
feat(ml_framework_core): forward op dispatch — 15 Function subclasses (Ruby pilot PR #6/8)

### DIFF
--- a/code/packages/ruby/ml_framework_core/CHANGELOG.md
+++ b/code/packages/ruby/ml_framework_core/CHANGELOG.md
@@ -2,6 +2,129 @@
 
 ## Unreleased
 
+### Added — v0.3.0: forward op dispatch (15 Function subclasses)
+
+PR #6 of 8 in the Ruby pilot.  Adds the 15 differentiable operations on
+top of the v0.2 autograd engine.  Every op is a `Function` subclass with
+a `forward` method; the autograd graph builds automatically when any
+input has `requires_grad`.  Backward implementations land in PR #7.
+
+#### The 15 ops
+
+| Op       | Class      | Rust dispatch?     | matrix-ir kind                   |
+|----------|------------|--------------------|----------------------------------|
+| Add      | `AddOp`    | yes (≥ 10k cells)  | `Add (lhs/rhs/output)`           |
+| Sub      | `SubOp`    | yes                | `Sub`                            |
+| Mul      | `MulOp`    | yes                | `Mul`                            |
+| Div      | `DivOp`    | yes                | `Div`                            |
+| Neg      | `NegOp`    | yes                | `Neg (input/output)`             |
+| Abs      | `AbsOp`    | yes                | `Abs`                            |
+| Tanh     | `TanhOp`   | yes                | `Tanh`                           |
+| MatMul   | `MatMulOp` | yes (2-D only)     | `MatMul (a/b/output)`            |
+| Sum      | `SumOp`    | yes (reduce-all)   | `ReduceSum (axes/keep_dims)`     |
+| Mean     | `MeanOp`   | yes                | `ReduceMean`                     |
+| Pow      | `PowOp`    | pure Ruby          | —  (Rust Pow takes 2 tensors)    |
+| ReLU     | `ReLUOp`   | pure Ruby          | —  (Max + zero-tensor constant)  |
+| Sigmoid  | `SigmoidOp`| pure Ruby          | —  (4-op multi-graph)            |
+| GELU     | `GELUOp`   | pure Ruby          | —  (large multi-op graph)        |
+| Softmax  | `SoftmaxOp`| pure Ruby          | —  (multi-op graph)              |
+
+The "pure Ruby" five have working Rust paths in the Python reference;
+left in pure Ruby for v0.3.0 to keep this PR focused.  Follow-ups can
+lift them over individually.
+
+#### Dispatch threshold
+
+`Ops::DISPATCH_THRESHOLD = 10_000` cells.  Below it, every op uses
+pure Ruby — fast at small sizes, avoids the JSON-build + hex-encode
++ FFI overhead.  Above it, the eligible ops dispatch into the Rust
+executor via `MatrixRustRuby.run_graph_on_cpu` (matches the Python
+reference's `_ELEMENTWISE_RUST_THRESHOLD`).
+
+#### Lazy require for matrix_rust_ruby
+
+`coding_adventures/matrix_rust_ruby` is `require`d LAZILY inside
+`Ops.run_envelope` — only when we actually need to dispatch to Rust.
+This keeps small-tensor / pure-Ruby workflows runnable even when the
+matrix_rust_ruby gem's native ext isn't built (e.g. on CI machines
+without a Rust toolchain, or during early dev).
+
+#### Hex packing helpers
+
+```ruby
+Ops.pack_f32_hex([1.0, 2.5])              # → "0000803f00002040"
+Ops.unpack_f32_hex("0000803f", 1)         # → [1.0]
+```
+
+Uses Ruby's `pack("e*")` (little-endian f32) + `unpack1("H*")` —
+matches the Python reference's `struct.pack("<{n}f", ...)` byte-for-byte
+so envelopes built here are bit-compatible with those built in Python.
+
+#### Tensor extensions
+
+```ruby
+# Operator overloads now route through Function.apply
+a + b   a - b   a * b   a / b   a**2   -a
+
+# Scalar broadcasting (small-tensor only for v0.3.0)
+a + 5   a * 5.0   ...
+
+# Named op methods
+a.matmul(b)
+a.relu  a.sigmoid  a.tanh  a.gelu  a.softmax
+a.sum   a.mean
+a.abs
+```
+
+The original v0.1 element-wise overloads are REPLACED by autograd-aware
+versions; numeric results are unchanged (Tensor#== is value-based), but
+each call now builds a graph node if any input has `requires_grad`.
+
+#### Architecture choices
+
+- **Function.apply always, threshold in forward**: every op goes through
+  `Function.apply` (so the autograd graph builds uniformly); each
+  individual `forward` chooses Rust vs. Ruby internally based on the
+  threshold.  Simpler than two-tier dispatch.
+- **Pure-Ruby `_binary_elementwise` / `_unary_elementwise` helpers** on
+  the MLFrameworkCore module: shared dispatch shape for the 4 binary
+  + 3 unary ops, so each op subclass is a 3-line definition.
+- **Envelope shapes mirror Python `_rust_backend.py` byte-for-byte**:
+  same `"kind"` strings, same tensor/op/inputs/outputs JSON layout.
+  Cross-language wire compatibility is the contract.
+
+#### Tests added (47 minitests, 90 assertions, all passing)
+
+- `HexHelpersTest` (4): pack/unpack round-trip + known-value spot checks
+- `ForwardSmallTest` (20): every op's small-tensor (pure-Ruby) path —
+  Add/Sub/Mul/Div/Neg/Abs/Pow/MatMul/ReLU/Sigmoid/Tanh/GELU/Softmax/Sum/Mean
+  with numerical correctness assertions + edge cases (sigmoid at 0,
+  tanh approaches 1, softmax sums to 1, softmax numerical stability
+  with 1000-magnitude inputs, GELU at 1 ≈ 0.8413, matmul argument
+  validation)
+- `AutogradWiringTest` (5): every op produces a tensor with the right
+  `grad_fn` class when input has `requires_grad`; no grad_fn when no
+  input requires grad
+- `OperatorOverloadsTest` (5): `+ - * / ** -` route through their Op
+  classes; scalar broadcasting; unsupported operand raises
+- `TensorNamedOpMethodsTest` (9): `t.relu`, `t.sigmoid`, etc. each
+  dispatch correctly
+- `DispatchPathBranchingTest` (2): threshold constant + small tensor
+  doesn't trigger MatrixRustRuby require
+
+Existing tests:
+- `test/tensor_test.rb` — 63/63 pass (no regressions)
+- `test/autograd_test.rb` — 18/18 pass (no regressions)
+
+#### What's next
+
+- PR #7: backward dispatch — implement `backward(output_grad)` on each
+  of the 15 Function subclasses using the analytical gradient formulas
+  from `code/packages/python/ml-framework-core/src/ml_framework_core/autograd.py`.
+  End-to-end test: train a 2-layer MLP on a tiny synthetic dataset for
+  N steps; assert loss decreases monotonically.
+- PR #8: benchmark script + RubyGems publishing polish.
+
 ### Added — v0.2.0: autograd engine (Function.apply + Tensor#backward)
 
 PR #5 of 8 in the Ruby pilot.  Adds reverse-mode automatic differentiation

--- a/code/packages/ruby/ml_framework_core/lib/coding_adventures/ml_framework_core.rb
+++ b/code/packages/ruby/ml_framework_core/lib/coding_adventures/ml_framework_core.rb
@@ -18,6 +18,7 @@
 require_relative "ml_framework_core/version"
 require_relative "ml_framework_core/tensor"
 require_relative "ml_framework_core/autograd"
+require_relative "ml_framework_core/ops"
 
 # Short alias for callers who don't want to type the full namespace.
 # Mirrors PyTorch's `import torch as t` convention.

--- a/code/packages/ruby/ml_framework_core/lib/coding_adventures/ml_framework_core/ops.rb
+++ b/code/packages/ruby/ml_framework_core/lib/coding_adventures/ml_framework_core/ops.rb
@@ -1,0 +1,557 @@
+# frozen_string_literal: true
+
+# ops.rb — the 15 differentiable operations of ml_framework_core
+# ====================================================================
+#
+# This is where Tensors get math.  Every op is a `Function` subclass
+# (defined in autograd.rb) with a `forward` method that:
+#
+#   - If the input is below a threshold (10k cells), uses pure Ruby —
+#     fast enough at that size, avoids the JSON+hex+FFI overhead.
+#   - If above the threshold, builds a matrix-ir-json envelope and
+#     dispatches through `MatrixRustRuby.run_graph_on_cpu` to the Rust
+#     `matrix-cpu` executor.
+#
+# The envelope shapes here MIRROR the Python reference at
+# `code/packages/python/ml-framework-core/src/ml_framework_core/_rust_backend.py`
+# byte-for-byte.  If you change anything here, also update there — the
+# wire format is the cross-language contract.
+#
+# # backward() implementations come in PR #7
+#
+# This PR ships forward-only.  Each subclass below has a forward but no
+# backward override; calling `.backward` on a tensor produced by these
+# ops will hit `Function#backward`'s NotImplementedError.  PR #7 fills
+# them in using the analytical gradient formulas from autograd.py.
+#
+# # Op coverage in v0.3.0
+#
+#   ╔═════════════╤══════════════════════╤═══════════════════════════╗
+#   ║ Op          │ Rust dispatch        │ matrix-ir-json kind       ║
+#   ╟─────────────┼──────────────────────┼───────────────────────────╢
+#   ║ Add         │ yes (Rust)           │ Add (lhs/rhs/output)      ║
+#   ║ Sub         │ yes                  │ Sub                       ║
+#   ║ Mul         │ yes                  │ Mul                       ║
+#   ║ Div         │ yes                  │ Div                       ║
+#   ║ Neg         │ yes                  │ Neg (input/output)        ║
+#   ║ Abs         │ yes                  │ Abs                       ║
+#   ║ Tanh        │ yes                  │ Tanh                      ║
+#   ║ MatMul      │ yes (2-D only)       │ MatMul (a/b/output)       ║
+#   ║ Sum         │ yes (reduce-all)     │ ReduceSum (axes/keepdims) ║
+#   ║ Mean        │ yes                  │ ReduceMean                ║
+#   ║ Pow         │ pure Ruby            │ — (Rust Pow takes tensor) ║
+#   ║ ReLU        │ pure Ruby            │ — (could use Max + const) ║
+#   ║ Sigmoid     │ pure Ruby            │ — (multi-op graph)        ║
+#   ║ GELU        │ pure Ruby            │ — (multi-op graph)        ║
+#   ║ Softmax     │ pure Ruby            │ — (multi-op graph)        ║
+#   ╚═════════════╧══════════════════════╧═══════════════════════════╝
+#
+# The "pure Ruby" five all have working Rust paths in the Python
+# reference; we left them in pure Ruby for v0.3.0 to keep this PR
+# focused.  Future PRs can lift them over one by one.
+
+require "json"
+require_relative "tensor"
+require_relative "autograd"
+
+# NOTE: `coding_adventures/matrix_rust_ruby` is required LAZILY inside
+# `Ops.run_envelope` (only when we actually need to dispatch to Rust).
+# This keeps small-tensor / pure-Ruby workflows runnable even when the
+# matrix_rust_ruby gem's native extension isn't built — e.g. on CI
+# machines without a Rust toolchain, or during early dev iteration.
+
+module CodingAdventures
+  module MLFrameworkCore
+    # ========================================================================
+    # Module-level helpers: hex packing, threshold, envelope dispatcher.
+    # ========================================================================
+    module Ops
+      # Tensors with `numel` ≥ this dispatch to Rust; smaller use pure Ruby.
+      # 10_000 cells is the rough break-even from the Python benchmark
+      # (`scripts/benchmark_mx10.py`) — below it, the JSON + hex + FFI
+      # overhead dominates; above it, matrix-cpu's f32 SIMD wins big.
+      DISPATCH_THRESHOLD = 10_000
+
+      module_function
+
+      # @return [Integer] the dispatch threshold (exposed so tests can
+      #   intentionally cross it from both sides).
+      def dispatch_threshold
+        DISPATCH_THRESHOLD
+      end
+
+      # Pack an Array<Float> into a hex string of little-endian f32 bytes.
+      # Ruby's `pack("e*")` is `e` = little-endian single-precision (f32);
+      # `unpack1("H*")` converts the bytes to a lowercase hex string.
+      def pack_f32_hex(arr)
+        arr.pack("e*").unpack1("H*")
+      end
+
+      # Inverse of `pack_f32_hex`.  Returns an Array<Float> of length numel.
+      # We pass `numel` explicitly because String#unpack returns extra
+      # elements if the hex has trailing zero bytes (it doesn't here, but
+      # being explicit is cheap insurance).
+      def unpack_f32_hex(hex, numel)
+        [hex].pack("H*").unpack("e#{numel}")
+      end
+
+      # Drive the Rust executor: JSON-serialize, call into the gem, parse
+      # the JSON response, and decode `outputs[0]` back to an Array<Float>.
+      #
+      # @param envelope [Hash] the matrix-ir-json envelope as a Ruby Hash.
+      # @param output_numel [Integer] expected number of f32 cells in the
+      #   single output.
+      # @return [Array<Float>] decoded output data.
+      def run_envelope(envelope, output_numel)
+        # Lazy require — see header comment.  Defers the cost of loading
+        # the matrix_rust_ruby native extension until the first dispatch.
+        require "coding_adventures/matrix_rust_ruby" unless defined?(::MatrixRustRuby)
+        env_json = JSON.generate(envelope)
+        result_json = ::MatrixRustRuby.run_graph_on_cpu(env_json)
+        result = JSON.parse(result_json)
+        out_hex = result.fetch("outputs").fetch(0)
+        floats = unpack_f32_hex(out_hex, output_numel)
+        expected_bytes = output_numel * 4
+        # Hex string is 2 chars per byte; if we got the wrong length back,
+        # the executor is misbehaving — fail loudly.
+        unless out_hex.length == expected_bytes * 2
+          raise RuntimeError,
+                "matrix_cpu returned #{out_hex.length / 2} bytes, expected #{expected_bytes}"
+        end
+        floats
+      end
+
+      # Build the matrix-ir-json envelope for a binary elementwise op
+      # (Add/Sub/Mul/Div).  Mirrors `_rust_backend._elementwise_binary_via_rust`.
+      def binary_elementwise_envelope(kind, a, b)
+        shape = a.shape
+        {
+          "graph" => {
+            "matrix_ir_version" => 1,
+            "tensors" => [
+              { "id" => 0, "dtype" => "f32", "shape" => shape },
+              { "id" => 1, "dtype" => "f32", "shape" => shape },
+              { "id" => 2, "dtype" => "f32", "shape" => shape },
+            ],
+            "inputs" => [0, 1],
+            "outputs" => [2],
+            "ops" => [{ "kind" => kind, "lhs" => 0, "rhs" => 1, "output" => 2 }],
+            "constants" => [],
+          },
+          "inputs" => [pack_f32_hex(a.to_a), pack_f32_hex(b.to_a)],
+        }
+      end
+
+      # Build the matrix-ir-json envelope for a unary elementwise op
+      # (Neg/Abs/Tanh).  Mirrors `_rust_backend._elementwise_unary_via_rust`.
+      def unary_elementwise_envelope(kind, a)
+        shape = a.shape
+        {
+          "graph" => {
+            "matrix_ir_version" => 1,
+            "tensors" => [
+              { "id" => 0, "dtype" => "f32", "shape" => shape },
+              { "id" => 1, "dtype" => "f32", "shape" => shape },
+            ],
+            "inputs" => [0],
+            "outputs" => [1],
+            "ops" => [{ "kind" => kind, "input" => 0, "output" => 1 }],
+            "constants" => [],
+          },
+          "inputs" => [pack_f32_hex(a.to_a)],
+        }
+      end
+
+      # Envelope for MatMul of two 2-D tensors.  Mirrors
+      # `_rust_backend.matmul_via_rust`.
+      def matmul_envelope(a, b)
+        m, k = a.shape
+        _, n = b.shape
+        {
+          "graph" => {
+            "matrix_ir_version" => 1,
+            "tensors" => [
+              { "id" => 0, "dtype" => "f32", "shape" => [m, k] },
+              { "id" => 1, "dtype" => "f32", "shape" => [k, n] },
+              { "id" => 2, "dtype" => "f32", "shape" => [m, n] },
+            ],
+            "inputs" => [0, 1],
+            "outputs" => [2],
+            "ops" => [{ "kind" => "MatMul", "a" => 0, "b" => 1, "output" => 2 }],
+            "constants" => [],
+          },
+          "inputs" => [pack_f32_hex(a.to_a), pack_f32_hex(b.to_a)],
+        }
+      end
+
+      # Envelope for ReduceSum / ReduceMean over ALL axes (collapse to scalar).
+      # Mirrors `_rust_backend._reduce_all_via_rust`.
+      def reduce_all_envelope(kind, a)
+        shape = a.shape
+        axes = (0...shape.length).to_a
+        {
+          "graph" => {
+            "matrix_ir_version" => 1,
+            "tensors" => [
+              { "id" => 0, "dtype" => "f32", "shape" => shape },
+              { "id" => 1, "dtype" => "f32", "shape" => [] },
+            ],
+            "inputs" => [0],
+            "outputs" => [1],
+            "ops" => [
+              {
+                "kind" => kind,
+                "input" => 0,
+                "axes" => axes,
+                "keep_dims" => false,
+                "output" => 1,
+              },
+            ],
+            "constants" => [],
+          },
+          "inputs" => [pack_f32_hex(a.to_a)],
+        }
+      end
+    end
+
+    # ========================================================================
+    # The 15 differentiable ops, each a Function subclass.
+    #
+    # Pattern: every `forward` checks the Ops.dispatch_threshold and either
+    # builds an envelope + runs via Rust, or computes element-wise in Ruby.
+    # The Function base class's `apply` (from autograd.rb) handles
+    # grad_fn wiring; here we just provide the forward math.
+    # ========================================================================
+
+    # --- Helper used by binary ops to share dispatch logic ---
+    def self._binary_elementwise(kind, a, b, ruby_op)
+      unless a.shape == b.shape
+        raise ArgumentError,
+              "shape mismatch for #{kind}: #{a.shape.inspect} vs #{b.shape.inspect}"
+      end
+
+      if a.numel >= Ops.dispatch_threshold
+        envelope = Ops.binary_elementwise_envelope(kind, a, b)
+        floats = Ops.run_envelope(envelope, a.numel)
+        Tensor.new(floats, shape: a.shape)
+      else
+        # Pure-Ruby fallback.  Uses Tensor's own operator overloads which
+        # are themselves element-wise pure Ruby — but we go through
+        # to_a.zip directly to avoid creating extra intermediate Tensors
+        # that would themselves try to dispatch through Function.apply.
+        a_data = a.to_a
+        b_data = b.to_a
+        out = Array.new(a.numel)
+        i = 0
+        while i < a.numel
+          out[i] = ruby_op.call(a_data[i], b_data[i])
+          i += 1
+        end
+        Tensor.new(out, shape: a.shape)
+      end
+    end
+
+    def self._unary_elementwise(kind, a, ruby_op)
+      if a.numel >= Ops.dispatch_threshold
+        envelope = Ops.unary_elementwise_envelope(kind, a)
+        floats = Ops.run_envelope(envelope, a.numel)
+        Tensor.new(floats, shape: a.shape)
+      else
+        Tensor.new(a.to_a.map { |v| ruby_op.call(v) }, shape: a.shape)
+      end
+    end
+
+    # ────────── Binary elementwise: Add / Sub / Mul / Div ──────────
+
+    class AddOp < Function
+      def forward(a, b)
+        MLFrameworkCore._binary_elementwise("Add", a, b, ->(x, y) { x + y })
+      end
+    end
+
+    class SubOp < Function
+      def forward(a, b)
+        MLFrameworkCore._binary_elementwise("Sub", a, b, ->(x, y) { x - y })
+      end
+    end
+
+    class MulOp < Function
+      def forward(a, b)
+        MLFrameworkCore._binary_elementwise("Mul", a, b, ->(x, y) { x * y })
+      end
+    end
+
+    class DivOp < Function
+      def forward(a, b)
+        MLFrameworkCore._binary_elementwise("Div", a, b, ->(x, y) { x / y })
+      end
+    end
+
+    # ────────── Unary elementwise (with Rust dispatch): Neg / Abs / Tanh ──────────
+
+    class NegOp < Function
+      def forward(a)
+        MLFrameworkCore._unary_elementwise("Neg", a, ->(v) { -v })
+      end
+    end
+
+    class AbsOp < Function
+      def forward(a)
+        MLFrameworkCore._unary_elementwise("Abs", a, ->(v) { v.abs })
+      end
+    end
+
+    class TanhOp < Function
+      def forward(a)
+        MLFrameworkCore._unary_elementwise("Tanh", a, ->(v) { Math.tanh(v) })
+      end
+    end
+
+    # ────────── Pow: scalar exponent, pure Ruby for v0.3.0 ──────────
+    #
+    # The matrix-cpu Pow op takes two TENSOR inputs.  Routing a
+    # scalar-exponent Pow through Rust would require broadcasting the
+    # exponent to a full tensor — net-loss below threshold, marginal
+    # above.  Stays pure Ruby for v0.3.0; can lift later if profiling
+    # shows it matters.
+    class PowOp < Function
+      def forward(a, exponent)
+        e = exponent.is_a?(Numeric) ? exponent.to_f : exponent.to_a[0]
+        Tensor.new(a.to_a.map { |v| v**e }, shape: a.shape)
+      end
+    end
+
+    # ────────── MatMul (2-D only in v0.3.0) ──────────
+
+    class MatMulOp < Function
+      def forward(a, b)
+        unless a.ndim == 2 && b.ndim == 2
+          raise ArgumentError,
+                "matmul requires 2-D tensors, got #{a.ndim}-D and #{b.ndim}-D"
+        end
+        m, k1 = a.shape
+        k2, n = b.shape
+        unless k1 == k2
+          raise ArgumentError,
+                "matmul shape mismatch: #{a.shape.inspect} @ #{b.shape.inspect}"
+        end
+
+        if a.numel >= Ops.dispatch_threshold || b.numel >= Ops.dispatch_threshold
+          envelope = Ops.matmul_envelope(a, b)
+          floats = Ops.run_envelope(envelope, m * n)
+          Tensor.new(floats, shape: [m, n])
+        else
+          # Pure-Ruby triple-loop matmul.  O(m*k*n) — fine at small sizes.
+          a_data = a.to_a
+          b_data = b.to_a
+          out = Array.new(m * n, 0.0)
+          (0...m).each do |i|
+            (0...n).each do |j|
+              acc = 0.0
+              (0...k1).each do |kk|
+                acc += a_data[i * k1 + kk] * b_data[kk * n + j]
+              end
+              out[i * n + j] = acc
+            end
+          end
+          Tensor.new(out, shape: [m, n])
+        end
+      end
+    end
+
+    # ────────── ReLU / Sigmoid / GELU / Softmax — pure Ruby for v0.3.0 ──────────
+
+    class ReLUOp < Function
+      def forward(a)
+        Tensor.new(a.to_a.map { |v| v.positive? ? v : 0.0 }, shape: a.shape)
+      end
+    end
+
+    class SigmoidOp < Function
+      def forward(a)
+        Tensor.new(a.to_a.map { |v| 1.0 / (1.0 + Math.exp(-v)) }, shape: a.shape)
+      end
+    end
+
+    class GELUOp < Function
+      # GELU(x) = 0.5 * x * (1 + tanh(sqrt(2/π) * (x + 0.044715 * x³)))
+      # — the "tanh approximation" formulation matching PyTorch's default
+      # and the Python reference.
+      def forward(a)
+        c = Math.sqrt(2.0 / Math::PI)
+        Tensor.new(
+          a.to_a.map { |x| 0.5 * x * (1.0 + Math.tanh(c * (x + 0.044715 * x * x * x))) },
+          shape: a.shape,
+        )
+      end
+    end
+
+    class SoftmaxOp < Function
+      # Softmax over the LAST axis (axis = -1).  Numerically stable: subtract
+      # the max before exp() so values never overflow exp's range.  Matches
+      # the Python reference's softmax_via_python_for_small_tensors path.
+      def forward(a)
+        flat = a.to_a
+        shape = a.shape
+        ndim = shape.length
+        last_axis_size = ndim.zero? ? 1 : shape[-1]
+        outer = a.numel / last_axis_size
+
+        out = Array.new(a.numel)
+        outer.times do |o|
+          row_start = o * last_axis_size
+          # row max for numerical stability
+          row_max = -Float::INFINITY
+          last_axis_size.times do |k|
+            v = flat[row_start + k]
+            row_max = v if v > row_max
+          end
+          # exp(x - max) and accumulate the sum
+          sum = 0.0
+          tmp = Array.new(last_axis_size)
+          last_axis_size.times do |k|
+            e = Math.exp(flat[row_start + k] - row_max)
+            tmp[k] = e
+            sum += e
+          end
+          # normalise
+          last_axis_size.times do |k|
+            out[row_start + k] = tmp[k] / sum
+          end
+        end
+        Tensor.new(out, shape: a.shape)
+      end
+    end
+
+    # ────────── Reductions: Sum / Mean (reduce-all) ──────────
+    #
+    # For v0.3.0 we support the reduce-all case only (matches Python
+    # reference's MX10 Phase 3).  Per-axis reductions deferred to a
+    # follow-up.  Output shape is (1,) — same contract as the Python
+    # SumFunction / MeanFunction for dim=None.
+
+    class SumOp < Function
+      def forward(a)
+        if a.numel >= Ops.dispatch_threshold
+          envelope = Ops.reduce_all_envelope("ReduceSum", a)
+          floats = Ops.run_envelope(envelope, 1)
+          Tensor.new(floats, shape: [1])
+        else
+          Tensor.new([a.to_a.sum], shape: [1])
+        end
+      end
+    end
+
+    class MeanOp < Function
+      def forward(a)
+        if a.numel >= Ops.dispatch_threshold
+          envelope = Ops.reduce_all_envelope("ReduceMean", a)
+          floats = Ops.run_envelope(envelope, 1)
+          Tensor.new(floats, shape: [1])
+        else
+          n = a.numel.to_f
+          Tensor.new([a.to_a.sum / n], shape: [1])
+        end
+      end
+    end
+
+    # ========================================================================
+    # Wire ops up to Tensor: operator overloads + named methods.
+    #
+    # We REOPEN Tensor to add these — the existing element-wise overloads
+    # from tensor.rb stay in place as the pure-Ruby fallback; the new ones
+    # go through Function.apply so the autograd graph builds and large
+    # tensors dispatch through Rust.
+    #
+    # Naming note: we keep the existing `+ - * / **` overloads operating
+    # element-wise (their original v0.1 behaviour, unchanged).  For
+    # gradient-tracked or large-tensor cases users should call the named
+    # methods (`a.relu`, `a.matmul(b)`, etc.) explicitly, OR set
+    # `a.requires_grad = true` so the overloads route through Function.apply
+    # automatically.
+    # ========================================================================
+    class Tensor
+      # Define the autograd-aware operator overloads.  These shadow the
+      # original v0.1 ones; the original pure-Ruby element-wise logic is
+      # still reachable via `_binary_op_inline` (the private method).  When
+      # autograd is wired up (i.e. when this file is required), the
+      # overloads go through Function.apply so grad_fn wiring happens.
+      def +(other)
+        AddOp.apply(self, _coerce_tensor(other))
+      end
+
+      def -(other)
+        SubOp.apply(self, _coerce_tensor(other))
+      end
+
+      def *(other)
+        MulOp.apply(self, _coerce_tensor(other))
+      end
+
+      def /(other)
+        DivOp.apply(self, _coerce_tensor(other))
+      end
+
+      def **(other)
+        PowOp.apply(self, other)
+      end
+
+      def -@
+        NegOp.apply(self)
+      end
+
+      def abs
+        AbsOp.apply(self)
+      end
+
+      def matmul(other)
+        MatMulOp.apply(self, other)
+      end
+
+      def relu
+        ReLUOp.apply(self)
+      end
+
+      def sigmoid
+        SigmoidOp.apply(self)
+      end
+
+      def tanh
+        TanhOp.apply(self)
+      end
+
+      def gelu
+        GELUOp.apply(self)
+      end
+
+      def softmax
+        SoftmaxOp.apply(self)
+      end
+
+      def sum
+        SumOp.apply(self)
+      end
+
+      def mean
+        MeanOp.apply(self)
+      end
+
+      private
+
+      # When a binary op receives a scalar (e.g. `t + 5`), broadcast it
+      # to a tensor of the same shape so the elementwise path works
+      # uniformly.  Materialising a full broadcast tensor is wasteful for
+      # large tensors but for v0.3.0 it keeps the autograd story simple
+      # — scalar broadcasting in matrix-cpu lands in a later PR.
+      def _coerce_tensor(other)
+        return other if other.is_a?(Tensor)
+
+        if other.is_a?(Numeric)
+          Tensor.full(shape, other.to_f)
+        else
+          raise TypeError, "cannot combine Tensor with #{other.class}"
+        end
+      end
+    end
+  end
+end

--- a/code/packages/ruby/ml_framework_core/lib/coding_adventures/ml_framework_core/version.rb
+++ b/code/packages/ruby/ml_framework_core/lib/coding_adventures/ml_framework_core/version.rb
@@ -2,6 +2,6 @@
 
 module CodingAdventures
   module MLFrameworkCore
-    VERSION = "0.2.0"
+    VERSION = "0.3.0"
   end
 end

--- a/code/packages/ruby/ml_framework_core/required_capabilities.json
+++ b/code/packages/ruby/ml_framework_core/required_capabilities.json
@@ -2,6 +2,13 @@
   "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
   "version": 1,
   "package": "ruby/ml_framework_core",
-  "capabilities": [],
-  "justification": "Pure-Ruby Tensor library (v0.1). No FFI, no network, no filesystem, no process spawning. Future PRs (#6: forward op dispatch) will add an `ffi/call` capability for the matrix_rust_ruby native ext once large-tensor ops dispatch into Rust; v0.1 has no outward-facing surface beyond the in-process Ruby API."
+  "capabilities": [
+    {
+      "category": "ffi",
+      "action": "call",
+      "target": "MatrixRustRuby.run_graph_on_cpu (via coding_adventures_matrix_rust_ruby gem)",
+      "justification": "Forward dispatch of large-tensor (numel >= 10_000) ops routes through the matrix_rust_ruby gem's native extension, which delegates to c-bridge's pure-Rust matrix-cpu envelope runner. Small tensors stay in pure Ruby. The require is lazy (only fired on first dispatch) so pure-Ruby workflows don't load the native ext."
+    }
+  ],
+  "justification": "Mixed pure-Ruby / FFI-dispatch library. The single FFI surface is one call to MatrixRustRuby.run_graph_on_cpu with a JSON envelope string. No network, no filesystem, no process spawning. Pure-Ruby fallback covers every op below the threshold and several ops always."
 }

--- a/code/packages/ruby/ml_framework_core/test/ops_test.rb
+++ b/code/packages/ruby/ml_framework_core/test/ops_test.rb
@@ -1,0 +1,354 @@
+# frozen_string_literal: true
+
+# ops_test.rb — coverage for the 15 differentiable ops added in PR #6.
+# ======================================================================
+#
+# Test sections:
+#   - HexHelpersTest — pack_f32_hex / unpack_f32_hex round-trip
+#   - ForwardSmallTest — all 15 ops, small tensors (pure-Ruby path)
+#   - AutogradWiringTest — every op produces a tensor with grad_fn
+#     when input has requires_grad
+#   - OperatorOverloadsTest — `+ - * / ** -` now route through Function.apply
+#   - DispatchPathBranchingTest — verifies the threshold gate (we don't
+#     actually invoke Rust here, just confirm the small-tensor path)
+#
+# We DON'T exercise the Rust dispatch path in this test file because it
+# requires the matrix_rust_ruby gem's native ext to be built — that's
+# integration territory.  The Python reference has a separate
+# `test_rust_backend_parity.py` for that comparison.
+#
+# Gradient correctness (backward()) is PR #7's responsibility; this file
+# only checks that `forward` produces correct output values and that
+# `grad_fn` is wired up so the graph EXISTS for PR #7 to traverse.
+
+require "minitest/autorun"
+require "coding_adventures/ml_framework_core"
+
+T   = CodingAdventures::MLFrameworkCore::Tensor   unless defined?(T)
+Ops = CodingAdventures::MLFrameworkCore::Ops      unless defined?(Ops)
+
+# Op constant shortcuts.
+M    = CodingAdventures::MLFrameworkCore
+AddO = M::AddOp
+SubO = M::SubOp
+MulO = M::MulOp
+DivO = M::DivOp
+NegO = M::NegOp
+AbsO = M::AbsOp
+PowO = M::PowOp
+MMo  = M::MatMulOp
+ReLU = M::ReLUOp
+Sig  = M::SigmoidOp
+Tnh  = M::TanhOp
+Gel  = M::GELUOp
+Sfx  = M::SoftmaxOp
+SmO  = M::SumOp
+MnO  = M::MeanOp
+
+# Float comparison helper — f32 dispatch chops precision somewhere
+# around 1e-7, so use a generous epsilon for transcendentals.
+def assert_arrays_close(expected, actual, epsilon: 1e-6, msg: nil)
+  assert_equal expected.length, actual.length, "length mismatch: #{msg}"
+  expected.each_with_index do |e, i|
+    a = actual[i]
+    delta = (e - a).abs
+    assert delta < epsilon, "#{msg} [#{i}]: expected #{e}, got #{a} (delta #{delta} > #{epsilon})"
+  end
+end
+
+class HexHelpersTest < Minitest::Test
+  def test_pack_then_unpack_round_trip
+    arr = [1.5, 2.5, -3.25, 0.0, 1.0]
+    hex = Ops.pack_f32_hex(arr)
+    back = Ops.unpack_f32_hex(hex, arr.length)
+    assert_arrays_close arr, back, msg: "round-trip"
+  end
+
+  def test_pack_emits_4_hex_chars_per_byte_per_cell
+    # Single f32 = 4 bytes = 8 hex chars.
+    hex = Ops.pack_f32_hex([1.0])
+    assert_equal 8, hex.length, "expected 8 hex chars (4 bytes × 2), got #{hex.inspect}"
+  end
+
+  def test_pack_known_value
+    # 1.0 in little-endian f32 is 00 00 80 3f.
+    assert_equal "0000803f", Ops.pack_f32_hex([1.0])
+  end
+
+  def test_unpack_known_hex
+    arr = Ops.unpack_f32_hex("0000803f", 1)
+    assert_equal [1.0], arr
+  end
+end
+
+class ForwardSmallTest < Minitest::Test
+  def test_add
+    a = T.new([1.0, 2.0, 3.0])
+    b = T.new([10.0, 20.0, 30.0])
+    assert_equal [11.0, 22.0, 33.0], AddO.apply(a, b).to_a
+  end
+
+  def test_sub
+    a = T.new([10.0, 20.0])
+    b = T.new([1.0, 2.0])
+    assert_equal [9.0, 18.0], SubO.apply(a, b).to_a
+  end
+
+  def test_mul
+    a = T.new([2.0, 3.0])
+    b = T.new([4.0, 5.0])
+    assert_equal [8.0, 15.0], MulO.apply(a, b).to_a
+  end
+
+  def test_div
+    a = T.new([10.0, 20.0])
+    b = T.new([2.0, 4.0])
+    assert_equal [5.0, 5.0], DivO.apply(a, b).to_a
+  end
+
+  def test_neg
+    a = T.new([1.0, -2.0, 3.0])
+    assert_equal [-1.0, 2.0, -3.0], NegO.apply(a).to_a
+  end
+
+  def test_abs
+    a = T.new([-1.5, 2.5, -3.5])
+    assert_equal [1.5, 2.5, 3.5], AbsO.apply(a).to_a
+  end
+
+  def test_pow_scalar_exponent
+    a = T.new([2.0, 3.0, 4.0])
+    assert_equal [4.0, 9.0, 16.0], PowO.apply(a, 2).to_a
+  end
+
+  def test_matmul_small_2x2
+    a = T.new([[1, 2], [3, 4]])
+    b = T.new([[5, 6], [7, 8]])
+    # [1*5+2*7, 1*6+2*8] = [19, 22]
+    # [3*5+4*7, 3*6+4*8] = [43, 50]
+    out = MMo.apply(a, b)
+    assert_equal [2, 2], out.shape
+    assert_equal [19.0, 22.0, 43.0, 50.0], out.to_a
+  end
+
+  def test_matmul_rejects_non_2d
+    assert_raises(ArgumentError) { MMo.apply(T.new([1, 2, 3]), T.new([[1, 2], [3, 4]])) }
+  end
+
+  def test_matmul_rejects_inner_dim_mismatch
+    assert_raises(ArgumentError) { MMo.apply(T.zeros(2, 3), T.zeros(4, 5)) }
+  end
+
+  def test_relu
+    a = T.new([-1.0, 0.0, 1.0, -2.5, 3.5])
+    assert_equal [0.0, 0.0, 1.0, 0.0, 3.5], ReLU.apply(a).to_a
+  end
+
+  def test_sigmoid_at_zero_is_half
+    out = Sig.apply(T.new([0.0])).to_a
+    assert_in_delta 0.5, out[0], 1e-12
+  end
+
+  def test_sigmoid_monotonic
+    out = Sig.apply(T.new([-2.0, -1.0, 0.0, 1.0, 2.0])).to_a
+    out.each_cons(2) { |a, b| assert b >= a, "sigmoid must be monotonic" }
+  end
+
+  def test_tanh_at_zero_is_zero
+    assert_in_delta 0.0, Tnh.apply(T.new([0.0])).to_a[0], 1e-12
+  end
+
+  def test_tanh_approaches_one_for_large_positive
+    assert_in_delta 1.0, Tnh.apply(T.new([10.0])).to_a[0], 1e-6
+  end
+
+  def test_gelu_at_zero_is_zero
+    assert_in_delta 0.0, Gel.apply(T.new([0.0])).to_a[0], 1e-12
+  end
+
+  def test_gelu_at_one
+    # GELU(1) ≈ 0.8413 (tanh-approx form)
+    out = Gel.apply(T.new([1.0])).to_a[0]
+    assert_in_delta 0.8413, out, 1e-3
+  end
+
+  def test_softmax_sums_to_one
+    out = Sfx.apply(T.new([1.0, 2.0, 3.0, 4.0])).to_a
+    assert_in_delta 1.0, out.sum, 1e-6
+  end
+
+  def test_softmax_largest_input_largest_output
+    out = Sfx.apply(T.new([1.0, 2.0, 3.0, 4.0])).to_a
+    assert_equal out.max, out[3]
+    assert_equal out.min, out[0]
+  end
+
+  def test_softmax_numerical_stability_large_inputs
+    # Without the max-subtraction trick, exp(1000) overflows to Infinity.
+    # Our impl subtracts the max first, so this must NOT raise or NaN.
+    out = Sfx.apply(T.new([1000.0, 1001.0, 1002.0])).to_a
+    out.each { |v| assert v.finite?, "softmax of large inputs gave non-finite: #{v}" }
+    assert_in_delta 1.0, out.sum, 1e-6
+  end
+
+  def test_sum_returns_scalar_shape_1
+    out = SmO.apply(T.new([1.0, 2.0, 3.0, 4.0]))
+    assert_equal [1], out.shape
+    assert_equal [10.0], out.to_a
+  end
+
+  def test_mean_returns_scalar_shape_1
+    out = MnO.apply(T.new([1.0, 2.0, 3.0, 4.0]))
+    assert_equal [1], out.shape
+    assert_equal [2.5], out.to_a
+  end
+end
+
+class AutogradWiringTest < Minitest::Test
+  # For each op: input with requires_grad → output has grad_fn of the
+  # right class.  Just verifies the wiring; gradient values are PR #7.
+
+  def test_add_wires_grad_fn
+    x = T.new([1.0, 2.0]); x.requires_grad = true
+    y = T.new([3.0, 4.0]); y.requires_grad = true
+    z = AddO.apply(x, y)
+    assert z.requires_grad
+    assert_kind_of AddO, z.grad_fn
+    assert_equal [x, y], z.grad_fn.parents
+  end
+
+  def test_unary_ops_wire_grad_fn
+    x = T.new([1.0, 2.0]); x.requires_grad = true
+    [NegO, AbsO, ReLU, Sig, Tnh, Gel, Sfx].each do |op|
+      y = op.apply(x)
+      assert y.requires_grad, "#{op}.apply output should require_grad"
+      assert_kind_of op, y.grad_fn, "#{op}.apply output should have #{op} grad_fn"
+    end
+  end
+
+  def test_matmul_wires_grad_fn
+    a = T.zeros(2, 3); a.requires_grad = true
+    b = T.zeros(3, 2)
+    out = MMo.apply(a, b)
+    assert out.requires_grad
+    assert_kind_of MMo, out.grad_fn
+  end
+
+  def test_reductions_wire_grad_fn
+    x = T.new([1.0, 2.0, 3.0]); x.requires_grad = true
+    assert_kind_of SmO, SmO.apply(x).grad_fn
+    assert_kind_of MnO, MnO.apply(x).grad_fn
+  end
+
+  def test_no_grad_fn_when_no_input_requires_grad
+    z = AddO.apply(T.new([1.0]), T.new([2.0]))
+    refute z.requires_grad
+    assert_nil z.grad_fn
+  end
+end
+
+class OperatorOverloadsTest < Minitest::Test
+  # The original v0.1 overloads used inline element-wise math; the new
+  # ones in ops.rb shadow them and dispatch through Function.apply.
+  # Numeric values are unchanged (Tensor#== is value-based) but they now
+  # build an autograd graph.
+
+  def test_plus_routes_through_add_op
+    x = T.new([1.0, 2.0]); x.requires_grad = true
+    y = T.new([3.0, 4.0])
+    z = x + y
+    assert_equal [4.0, 6.0], z.to_a
+    assert_kind_of AddO, z.grad_fn
+  end
+
+  def test_unary_minus_routes_through_neg_op
+    x = T.new([1.0, -2.0]); x.requires_grad = true
+    y = -x
+    assert_equal [-1.0, 2.0], y.to_a
+    assert_kind_of NegO, y.grad_fn
+  end
+
+  def test_scalar_broadcast_via_coercion
+    # `t + 5` should broadcast 5 into a same-shape tensor before Add.
+    x = T.new([1.0, 2.0, 3.0])
+    y = x + 5
+    assert_equal [6.0, 7.0, 8.0], y.to_a
+  end
+
+  def test_pow_with_scalar
+    x = T.new([2.0, 3.0])
+    y = x**3
+    assert_equal [8.0, 27.0], y.to_a
+  end
+
+  def test_unsupported_operand_raises
+    assert_raises(TypeError) { T.new([1.0]) + "not a number" }
+  end
+end
+
+class TensorNamedOpMethodsTest < Minitest::Test
+  def test_relu_method_dispatches_to_relu_op
+    x = T.new([-1.0, 0.0, 1.0]); x.requires_grad = true
+    y = x.relu
+    assert_equal [0.0, 0.0, 1.0], y.to_a
+    assert_kind_of ReLU, y.grad_fn
+  end
+
+  def test_sigmoid_method
+    out = T.new([0.0]).sigmoid.to_a[0]
+    assert_in_delta 0.5, out, 1e-12
+  end
+
+  def test_tanh_method
+    assert_in_delta 0.0, T.new([0.0]).tanh.to_a[0], 1e-12
+  end
+
+  def test_gelu_method
+    assert_in_delta 0.0, T.new([0.0]).gelu.to_a[0], 1e-12
+  end
+
+  def test_softmax_method
+    out = T.new([1.0, 1.0, 1.0]).softmax.to_a
+    assert_arrays_close [1.0 / 3, 1.0 / 3, 1.0 / 3], out, epsilon: 1e-6
+  end
+
+  def test_sum_method
+    assert_equal [6.0], T.new([1.0, 2.0, 3.0]).sum.to_a
+  end
+
+  def test_mean_method
+    assert_equal [2.0], T.new([1.0, 2.0, 3.0]).mean.to_a
+  end
+
+  def test_matmul_method
+    a = T.new([[1, 2], [3, 4]])
+    b = T.new([[1, 0], [0, 1]])
+    assert_equal a.to_a, a.matmul(b).to_a
+  end
+
+  def test_abs_method
+    assert_equal [1.0, 2.0, 3.0], T.new([-1.0, 2.0, -3.0]).abs.to_a
+  end
+end
+
+class DispatchPathBranchingTest < Minitest::Test
+  def test_dispatch_threshold_constant
+    # Smoke check that the threshold module method returns a sensible value.
+    assert_kind_of Integer, Ops.dispatch_threshold
+    assert Ops.dispatch_threshold >= 1
+    assert_equal 10_000, Ops.dispatch_threshold
+  end
+
+  def test_small_tensor_uses_ruby_fallback
+    # If small-tensor path tried to dispatch through Rust, this would
+    # require the matrix_rust_ruby native ext.  Since we KNOW we're below
+    # threshold, no MatrixRustRuby require should fire.  Easiest proof:
+    # the operation completes without ::MatrixRustRuby being defined.
+    refute defined?(::MatrixRustRuby), "MatrixRustRuby should not be loaded yet"
+    # Run a small Add — must stay pure Ruby.
+    result = AddO.apply(T.new([1.0, 2.0]), T.new([3.0, 4.0]))
+    assert_equal [4.0, 6.0], result.to_a
+    # Still not loaded.
+    refute defined?(::MatrixRustRuby), "small Add must not have loaded MatrixRustRuby"
+  end
+end


### PR DESCRIPTION
## Summary

- 15 new `Function` subclasses (Add, Sub, Mul, Div, Neg, Abs, Pow, MatMul, ReLU, Sigmoid, Tanh, GELU, Softmax, Sum, Mean).
- Tensors with `numel >= 10_000` dispatch through `MatrixRustRuby.run_graph_on_cpu` (eligible ops); smaller tensors and unsupported ops use pure-Ruby fallback.
- Tensor reopened with autograd-aware operator overloads (`+ - * / ** -@`) and named op methods (`matmul`, `relu`, `sigmoid`, etc.).
- 47 new tests (90 assertions); 128 tests total across the gem, all passing.

## Architecture

- **Function.apply always, threshold inside forward**: every op routes through `Function.apply` (autograd wiring uniform); each forward picks Rust vs Ruby based on `numel`.
- **Envelope shapes mirror Python `_rust_backend.py` byte-for-byte** — cross-language wire compatibility preserved.
- **Lazy require for `matrix_rust_ruby`**: only fires on first Rust dispatch — pure-Ruby workflows don't load the native ext.

## Op dispatch matrix

| Op       | Rust dispatch?     |
|----------|--------------------|
| Add/Sub/Mul/Div/Neg/Abs/Tanh/MatMul/Sum/Mean | yes (≥10k cells) |
| Pow/ReLU/Sigmoid/GELU/Softmax | pure Ruby (deferred to follow-up) |

The "pure Ruby" five have working Rust paths in the Python reference; deferred from v0.3.0 to keep this PR focused.

## Test plan

- [x] `ruby -c` on every .rb file: Syntax OK
- [x] `test/tensor_test.rb`: 63/63 (no regressions)
- [x] `test/autograd_test.rb`: 18/18 (no regressions)
- [x] `test/ops_test.rb`: 47/47 (new)
- [x] Security review: passed (no JSON injection, no hex injection, no unsafe deserialization)
- [ ] CI: build (ubuntu/macos/windows) — pending
- [ ] CI: CodeQL ruby Analyze — pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)