### PR TITLE
feat(mosaic-emit-qt): lower the Grid primitive

### DIFF
--- a/code/packages/rust/mosaic-emit-qt/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-qt/src/pipeline.rs
@@ -484,6 +484,12 @@ fn emit_qml_tree(node: &LayoutNode, depth: usize, emits: &[EmitDecl]) -> Result<
         "HostTooltip" => return emit_host_tooltip_qml(node, depth, emits),
         "HostNumberInput" => return emit_host_number_input_qml(node, depth, emits),
 
+        // UI26 §6.2 — `Grid` userland spreadsheet primitive.  Lowers
+        // to a `ColumnLayout` containing one `RowLayout` header plus
+        // one `Repeater`-driven `RowLayout` per body row.  See
+        // [`emit_grid_qml`].
+        "Grid" => return emit_grid_qml(node, depth, emits),
+
         "HostTable" => return emit_host_table_qml(node, depth, emits),
         // UI29 §3.1 — `For` meta-primitive: lower to a `Repeater` with an
         // `Item` delegate that re-exports `modelData` / `index` under the
@@ -1706,6 +1712,198 @@ fn tree_needs_controls_import(node: &LayoutNode) -> bool {
 /// |---|---|
 /// | `HostTableHead`     | RowLayout(s); descendant `Text` nodes get `font.bold: true`  |
 /// | `HostTableBody`     | RowLayout(s) per `Row` child                                 |
+/// Lower the `Grid` userland primitive (UI26 §6.2 v2 shape) to QML.
+///
+/// The Grid carries enough slots to act as a self-contained
+/// spreadsheet view; this emitter mirrors the React/SwiftUI Grid
+/// lowering at the Qt level so VisiCalc and similar apps can be
+/// generated end-to-end against `mosaic-compile --backend qt`.
+///
+/// ## Slot / emit mapping
+///
+/// | Mosaic prop      | QML usage                                          |
+/// |------------------|----------------------------------------------------|
+/// | `headers`        | Required.  `Repeater { model: <slot> }` header row.|
+/// | `rows`           | Required.  `Repeater { model: <slot> }` body rows. |
+/// | `column-widths`  | Accepted but not yet propagated (v0.2.0).          |
+/// | `selected-row`   | Optional.  Pairs with `selected-col` for highlight.|
+/// | `selected-col`   | Optional.                                          |
+/// | `onNavigate`     | Optional emit.  Each body cell's `MouseArea` fires |
+/// |                  | the signal with `(rowIdx, colIdx)`.                |
+///
+/// ## Shape
+///
+/// ```qml
+/// ColumnLayout {
+///     spacing: 0
+///     RowLayout {                                  // header row
+///         spacing: 0
+///         Repeater {
+///             model: headers
+///             Rectangle {
+///                 Layout.preferredWidth: 96
+///                 Layout.preferredHeight: 24
+///                 color: "#2D2D30"
+///                 border.color: "#3F3F46"
+///                 Text { anchors.centerIn: parent; text: modelData; color: "#9D9D9D" }
+///             }
+///         }
+///     }
+///     Repeater {                                   // body rows
+///         model: rows
+///         RowLayout {
+///             property int rowIdx: index
+///             spacing: 0
+///             Repeater {
+///                 model: modelData
+///                 Rectangle {
+///                     property int colIdx: index
+///                     property bool isSelected: rowIdx === selectedRow && colIdx === selectedCol
+///                     Layout.preferredWidth: 96
+///                     Layout.preferredHeight: 22
+///                     color: isSelected ? "#264F78" : "#1E1E1E"
+///                     border.color: isSelected ? "#007ACC" : "#3F3F46"
+///                     Text { anchors.right: parent.right; anchors.rightMargin: 4
+///                            text: modelData; color: "#CCCCCC" }
+///                     MouseArea {
+///                         anchors.fill: parent
+///                         onClicked: navigate(rowIdx, colIdx)
+///                     }
+///                 }
+///             }
+///         }
+///     }
+/// }
+/// ```
+///
+/// ## Deliberate v0.1.0 simplifications
+///
+/// - Cell width hardcoded to 96px; the `column-widths` slot is
+///   accepted but the per-column override isn't yet plumbed.
+/// - No inline edit cell — the host renders an external editor
+///   (FormulaBar) and pushes state via the `edit-*` slots.
+/// - Selection palette is hardcoded (excel-blue); the `.msl`
+///   `state selected` lowering lands in a follow-up.
+/// - `onNavigate` arity is respected: parameterless signal →
+///   `navigate()`; ≥1-arity signal → `navigate(rowIdx, colIdx)`.
+fn emit_grid_qml(
+    node: &LayoutNode,
+    depth: usize,
+    emits: &[EmitDecl],
+) -> Result<String, PipelineEmitError> {
+    let pad = "    ".repeat(depth);
+    let inner = "    ".repeat(depth + 1);
+    let inner2 = "    ".repeat(depth + 2);
+    let inner3 = "    ".repeat(depth + 3);
+    let inner4 = "    ".repeat(depth + 4);
+    let inner5 = "    ".repeat(depth + 5);
+
+    let headers_slot = find_slot_ref_prop(node, "headers").ok_or_else(|| {
+        PipelineEmitError::UnsafeSlotName("Grid missing required prop 'headers'".to_string())
+    })?;
+    let rows_slot = find_slot_ref_prop(node, "rows").ok_or_else(|| {
+        PipelineEmitError::UnsafeSlotName("Grid missing required prop 'rows'".to_string())
+    })?;
+    let headers_var = to_camel_case_first_lower(headers_slot);
+    let rows_var = to_camel_case_first_lower(rows_slot);
+    validate_safe_identifier(&headers_var).map_err(PipelineEmitError::UnsafeSlotName)?;
+    validate_safe_identifier(&rows_var).map_err(PipelineEmitError::UnsafeSlotName)?;
+
+    let selected_row_var = find_slot_ref_prop(node, "selected-row")
+        .map(to_camel_case_first_lower)
+        .filter(|s| !s.is_empty());
+    let selected_col_var = find_slot_ref_prop(node, "selected-col")
+        .map(to_camel_case_first_lower)
+        .filter(|s| !s.is_empty());
+    if let Some(v) = selected_row_var.as_deref() {
+        validate_safe_identifier(v).map_err(PipelineEmitError::UnsafeSlotName)?;
+    }
+    if let Some(v) = selected_col_var.as_deref() {
+        validate_safe_identifier(v).map_err(PipelineEmitError::UnsafeSlotName)?;
+    }
+    let selected_expr = match (&selected_row_var, &selected_col_var) {
+        (Some(r), Some(c)) => format!("rowIdx === {r} && colIdx === {c}"),
+        _ => "false".to_string(),
+    };
+
+    let on_navigate_call: Option<String> = if let Some(emit_name) = find_emit_ref_prop(node, "onNavigate") {
+        let camel = to_camel_case_first_lower(&strip_on_prefix(emit_name));
+        validate_safe_identifier(&camel).map_err(PipelineEmitError::UnsafeEmitName)?;
+        let arity = emits.iter().find(|e| e.name == *emit_name).map(|e| e.params.len()).unwrap_or(0);
+        Some(if arity == 0 {
+            format!("{camel}()")
+        } else {
+            format!("{camel}(rowIdx, colIdx)")
+        })
+    } else {
+        None
+    };
+
+    let mut out = String::new();
+    writeln!(out, "{pad}ColumnLayout {{").unwrap();
+    writeln!(out, "{inner}spacing: 0").unwrap();
+
+    // Header row.
+    writeln!(out, "{inner}RowLayout {{").unwrap();
+    writeln!(out, "{inner2}spacing: 0").unwrap();
+    writeln!(out, "{inner2}Repeater {{").unwrap();
+    writeln!(out, "{inner3}model: {headers_var}").unwrap();
+    writeln!(out, "{inner3}Rectangle {{").unwrap();
+    writeln!(out, "{inner4}Layout.preferredWidth: 96").unwrap();
+    writeln!(out, "{inner4}Layout.preferredHeight: 24").unwrap();
+    writeln!(out, "{inner4}color: \"#2D2D30\"").unwrap();
+    writeln!(out, "{inner4}border.color: \"#3F3F46\"").unwrap();
+    writeln!(out, "{inner4}border.width: 1").unwrap();
+    writeln!(out, "{inner4}Text {{").unwrap();
+    writeln!(out, "{inner5}anchors.centerIn: parent").unwrap();
+    writeln!(out, "{inner5}text: modelData").unwrap();
+    writeln!(out, "{inner5}color: \"#9D9D9D\"").unwrap();
+    writeln!(out, "{inner5}font.family: \"monospace\"").unwrap();
+    writeln!(out, "{inner4}}}").unwrap();
+    writeln!(out, "{inner3}}}").unwrap();
+    writeln!(out, "{inner2}}}").unwrap();
+    writeln!(out, "{inner}}}").unwrap();
+
+    // Body rows.
+    writeln!(out, "{inner}Repeater {{").unwrap();
+    writeln!(out, "{inner2}model: {rows_var}").unwrap();
+    writeln!(out, "{inner2}RowLayout {{").unwrap();
+    writeln!(out, "{inner3}property int rowIdx: index").unwrap();
+    writeln!(out, "{inner3}spacing: 0").unwrap();
+    writeln!(out, "{inner3}Repeater {{").unwrap();
+    writeln!(out, "{inner4}model: modelData").unwrap();
+    writeln!(out, "{inner4}Rectangle {{").unwrap();
+    writeln!(out, "{inner5}property int colIdx: index").unwrap();
+    writeln!(out, "{inner5}property bool isSelected: {selected_expr}").unwrap();
+    writeln!(out, "{inner5}Layout.preferredWidth: 96").unwrap();
+    writeln!(out, "{inner5}Layout.preferredHeight: 22").unwrap();
+    writeln!(out, "{inner5}color: isSelected ? \"#264F78\" : \"#1E1E1E\"").unwrap();
+    writeln!(out, "{inner5}border.color: isSelected ? \"#007ACC\" : \"#3F3F46\"").unwrap();
+    writeln!(out, "{inner5}border.width: 1").unwrap();
+    writeln!(out, "{inner5}Text {{").unwrap();
+    let inner6 = "    ".repeat(depth + 6);
+    writeln!(out, "{inner6}anchors.right: parent.right").unwrap();
+    writeln!(out, "{inner6}anchors.rightMargin: 4").unwrap();
+    writeln!(out, "{inner6}anchors.verticalCenter: parent.verticalCenter").unwrap();
+    writeln!(out, "{inner6}text: modelData").unwrap();
+    writeln!(out, "{inner6}color: isSelected ? \"white\" : \"#CCCCCC\"").unwrap();
+    writeln!(out, "{inner6}font.family: \"monospace\"").unwrap();
+    writeln!(out, "{inner5}}}").unwrap();
+    if let Some(call) = on_navigate_call {
+        writeln!(out, "{inner5}MouseArea {{").unwrap();
+        writeln!(out, "{inner6}anchors.fill: parent").unwrap();
+        writeln!(out, "{inner6}onClicked: {call}").unwrap();
+        writeln!(out, "{inner5}}}").unwrap();
+    }
+    writeln!(out, "{inner4}}}").unwrap();
+    writeln!(out, "{inner3}}}").unwrap();
+    writeln!(out, "{inner2}}}").unwrap();
+    writeln!(out, "{inner}}}").unwrap();
+
+    writeln!(out, "{pad}}}").unwrap();
+    Ok(out)
+}
+
 /// | `HostTableFoot`     | RowLayout(s) preceded by a divider Rectangle                 |
 /// | `HostTableColGroup` | Ignored — no QML analog. Emitted as a `// ColGroup …` comment |
 /// | (any other child)   | Walked normally (so a stray `Text` inside `HostTable` works) |
@@ -4063,6 +4261,98 @@ mod tests {
             matches!(err, PipelineEmitError::UnknownPrimitive(ref t) if t == "FlibbertyJibbet"),
             "expected UnknownPrimitive(FlibbertyJibbet), got {err:?}"
         );
+    }
+
+    // =====================================================================
+    // Grid primitive — VisiCalc-shape, exercised by the cross-backend demos.
+    // =====================================================================
+
+    #[test]
+    fn grid_with_headers_and_rows_emits_column_of_rowlayouts() {
+        let m = component(
+            "VisiCalc",
+            vec![
+                SlotDecl {
+                    name: "column-headers".into(),
+                    r#type: SlotType::List(Box::new(ListInnerType::Text)),
+                    required: true,
+                    default: None,
+                },
+                SlotDecl {
+                    name: "viewport-rows".into(),
+                    r#type: SlotType::List(Box::new(ListInnerType::List(Box::new(ListInnerType::Text)))),
+                    required: true,
+                    default: None,
+                },
+            ],
+            vec![],
+        );
+        let l = LayoutDef {
+            component_name: "VisiCalc".to_string(),
+            root: LayoutNode {
+                tag: "Grid".to_string(),
+                part_name: None,
+                props: vec![
+                    LayoutProp { name: "headers".into(), value: LayoutPropValue::SlotRef("column-headers".into()) },
+                    LayoutProp { name: "rows".into(), value: LayoutPropValue::SlotRef("viewport-rows".into()) },
+                ],
+                children: Vec::new(),
+            },
+        };
+        let r = from_pipeline(&m, &l, &empty_style("VisiCalc")).unwrap();
+        let out = r.output;
+        assert!(out.contains("ColumnLayout {"), "missing ColumnLayout in:\n{out}");
+        assert!(out.contains("Repeater {"), "missing Repeater in:\n{out}");
+        assert!(out.contains("model: columnHeaders"), "missing header model binding in:\n{out}");
+        assert!(out.contains("model: viewportRows"), "missing row model binding in:\n{out}");
+        assert!(out.contains("Layout.preferredWidth: 96"), "missing cell width in:\n{out}");
+    }
+
+    #[test]
+    fn grid_with_selection_and_on_navigate_emits_mouse_area_dispatch() {
+        let m = component(
+            "VisiCalc",
+            vec![
+                SlotDecl {
+                    name: "column-headers".into(),
+                    r#type: SlotType::List(Box::new(ListInnerType::Text)),
+                    required: true,
+                    default: None,
+                },
+                SlotDecl {
+                    name: "viewport-rows".into(),
+                    r#type: SlotType::List(Box::new(ListInnerType::List(Box::new(ListInnerType::Text)))),
+                    required: true,
+                    default: None,
+                },
+                SlotDecl { name: "selected-row".into(), r#type: SlotType::Number, required: true, default: None },
+                SlotDecl { name: "selected-col".into(), r#type: SlotType::Number, required: true, default: None },
+            ],
+            vec![emit_decl("onNavigate", vec![
+                EmitParam { name: "row".into(), r#type: EmitPayloadType::Number },
+                EmitParam { name: "col".into(), r#type: EmitPayloadType::Number },
+            ])],
+        );
+        let l = LayoutDef {
+            component_name: "VisiCalc".to_string(),
+            root: LayoutNode {
+                tag: "Grid".to_string(),
+                part_name: None,
+                props: vec![
+                    LayoutProp { name: "headers".into(), value: LayoutPropValue::SlotRef("column-headers".into()) },
+                    LayoutProp { name: "rows".into(), value: LayoutPropValue::SlotRef("viewport-rows".into()) },
+                    LayoutProp { name: "selected-row".into(), value: LayoutPropValue::SlotRef("selected-row".into()) },
+                    LayoutProp { name: "selected-col".into(), value: LayoutPropValue::SlotRef("selected-col".into()) },
+                    LayoutProp { name: "onNavigate".into(), value: LayoutPropValue::EmitRef("onNavigate".into()) },
+                ],
+                children: Vec::new(),
+            },
+        };
+        let r = from_pipeline(&m, &l, &empty_style("VisiCalc")).unwrap();
+        let out = r.output;
+        assert!(out.contains("rowIdx === selectedRow && colIdx === selectedCol"));
+        assert!(out.contains("\"#264F78\""));
+        assert!(out.contains("onClicked: navigate(rowIdx, colIdx)"));
     }
 
     // =====================================================================


### PR DESCRIPTION
## Summary

Adds first-class lowering for the UI26 §6.2 `Grid` userland primitive in the Qt/QML emitter. Mirrors the React (already shipped in main) and SwiftUI (#4813) Grid lowerings at the QML level. After this PR, `visicalc-qt`'s current hand-written grid in `main.qml` can be replaced by the generated output.

## Shape

```qml
ColumnLayout {
  RowLayout {                                  // header row
    Repeater { model: headers; Rectangle { ... Text { ... } } }
  }
  Repeater { model: rows
    RowLayout {
      property int rowIdx: index
      Repeater { model: modelData
        Rectangle {
          property int colIdx: index
          property bool isSelected: rowIdx === selectedRow && colIdx === selectedCol
          color: isSelected ? "#264F78" : "#1E1E1E"
          Text { ... text: modelData; ... }
          MouseArea { anchors.fill: parent; onClicked: navigate(rowIdx, colIdx) }
        }
      }
    }
  }
}
```

## Slot / emit mapping

| Mosaic prop | QML usage |
| --- | --- |
| `headers` | Required. Header Repeater model |
| `rows` | Required. Body Repeater model |
| `column-widths` | Accepted; per-column override deferred to v0.2.0 |
| `selected-row` | Optional. Pairs with `selected-col` for tint |
| `selected-col` | Optional |
| `onNavigate` | Optional emit. Per-cell `MouseArea.onClicked` |

`onNavigate` arity is respected (parameterless → `navigate()`; ≥1-arity → `navigate(rowIdx, colIdx)`), continuing the pattern from qt-emit-other-hosts (#4810).

## Tests

2 new tests:
- `grid_with_headers_and_rows_emits_column_of_rowlayouts`
- `grid_with_selection_and_on_navigate_emits_mouse_area_dispatch`

Total `mosaic-emit-qt` tests: **99 (97 baseline + 2 new), all green.**

## Test plan

- [x] `cargo test -p mosaic-emit-qt` green
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)