### PR TITLE
feat(mosaic-emit-flutter): lower the Grid primitive

### DIFF
--- a/code/packages/rust/mosaic-emit-flutter/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-flutter/src/pipeline.rs
@@ -534,6 +534,12 @@ fn emit_widget_tree(
     if node.tag == "HostTable" {
         return emit_host_table(node, indent, part_styles, component);
     }
+    // UI26 §6.2 — Grid userland primitive.  See [`emit_grid_flutter`]
+    // for the slot/emit mapping; produces a Column-of-Rows layout
+    // via List `.map(...)` calls.
+    if node.tag == "Grid" {
+        return emit_grid_flutter(node, indent, component);
+    }
     // UI29-4 kernel — three new primitives. `HostLink` lowers to an
     // `InkWell` wrapping a `Text` (with a `url_launcher` TODO comment
     // since Flutter has no built-in URL-launch capability without an
@@ -1426,6 +1432,131 @@ fn emit_host_dialog(_node: &LayoutNode,
 /// | unknown keyword        | (no wrap — drops silently per the allow-list security gate)        |
 ///
 /// The allow-list (`ltr` / `rtl` / `auto`) is the security gate: an
+/// Lower the `Grid` userland primitive (UI26 §6.2 v2 shape) to Flutter.
+///
+/// Mirrors the React, SwiftUI, Qt, and Compose Grid lowerings.
+///
+/// ## Slot / emit mapping
+///
+/// | Mosaic prop      | Flutter usage                                       |
+/// |------------------|-----------------------------------------------------|
+/// | `headers`        | Required.  `List<String>` header row.               |
+/// | `rows`           | Required.  `List<List<String>>` body rows.          |
+/// | `column-widths`  | Accepted; per-column override deferred to v0.2.0.   |
+/// | `selected-row`   | Optional.  Pairs with `selected-col` for tint.      |
+/// | `selected-col`   | Optional.                                           |
+/// | `onNavigate`     | Optional emit.  Each cell's `GestureDetector`       |
+/// |                  | dispatches it.                                      |
+///
+/// ## Shape
+///
+/// ```dart
+/// Column(children: [
+///   Row(children: [
+///     for (final h in headers)
+///       Container(width: 96, height: 24, child: Text(h)),
+///   ]),
+///   for (int r = 0; r < rows.length; r++)
+///     Row(children: [
+///       for (int c = 0; c < rows[r].length; c++)
+///         GestureDetector(
+///           onTap: () => dispatch(<C>EventNavigate(row: r, col: c)),
+///           child: Container(
+///             width: 96, height: 22,
+///             color: (r == selectedRow && c == selectedCol)
+///                   ? const Color(0xFF264F78) : const Color(0xFF1E1E1E),
+///             child: Text(rows[r][c]),
+///           ),
+///         ),
+///     ]),
+/// ])
+/// ```
+fn emit_grid_flutter(
+    node: &LayoutNode,
+    indent: usize,
+    component: &str,
+) -> Result<String, PipelineEmitError> {
+    let pad = " ".repeat(indent);
+    let inner = " ".repeat(indent + 2);
+    let inner2 = " ".repeat(indent + 4);
+    let inner3 = " ".repeat(indent + 6);
+    let inner4 = " ".repeat(indent + 8);
+
+    let headers_slot = find_slot_ref_prop(node, "headers").ok_or_else(|| {
+        PipelineEmitError::UnsafeSlotName("Grid missing required prop 'headers'".to_string())
+    })?;
+    let rows_slot = find_slot_ref_prop(node, "rows").ok_or_else(|| {
+        PipelineEmitError::UnsafeSlotName("Grid missing required prop 'rows'".to_string())
+    })?;
+    let headers_var = to_camel_case_first_lower(headers_slot);
+    let rows_var = to_camel_case_first_lower(rows_slot);
+    validate_slot_or_field_name(&headers_var)?;
+    validate_slot_or_field_name(&rows_var)?;
+
+    let selected_row_var = find_slot_ref_prop(node, "selected-row").map(to_camel_case_first_lower);
+    let selected_col_var = find_slot_ref_prop(node, "selected-col").map(to_camel_case_first_lower);
+    if let Some(v) = selected_row_var.as_deref() {
+        validate_slot_or_field_name(v)?;
+    }
+    if let Some(v) = selected_col_var.as_deref() {
+        validate_slot_or_field_name(v)?;
+    }
+    let selected_expr = match (&selected_row_var, &selected_col_var) {
+        (Some(r), Some(c)) => format!("r == {r} && c == {c}"),
+        _ => "false".to_string(),
+    };
+
+    let on_navigate_call: Option<String> = if let Some(emit_name) = find_emit_ref_prop(node, "onNavigate") {
+        let case = pascalize(&strip_on_prefix(emit_name));
+        validate_emit_name(&case)?;
+        Some(format!(
+            "dispatch({component}Event{case}(row: r, col: c))"
+        ))
+    } else {
+        None
+    };
+
+    let cell_gesture_open = if on_navigate_call.is_some() {
+        format!("{inner3}GestureDetector(\n{inner4}onTap: () => {},\n{inner4}child: ", on_navigate_call.unwrap())
+    } else {
+        format!("{inner3}")
+    };
+    let cell_gesture_close = if on_navigate_call_was_set(node) { format!("\n{inner3})") } else { String::new() };
+
+    let mut out = String::new();
+    writeln!(out, "{pad}Column(children: [").unwrap();
+
+    // Header row.
+    writeln!(out, "{inner}Row(children: [").unwrap();
+    writeln!(out, "{inner2}for (final h in {headers_var})").unwrap();
+    writeln!(out, "{inner3}Container(width: 96, height: 24, color: const Color(0xFF2D2D30), child: Text(h)),").unwrap();
+    writeln!(out, "{inner}]),").unwrap();
+
+    // Body rows.
+    writeln!(out, "{inner}for (int r = 0; r < {rows_var}.length; r++)").unwrap();
+    writeln!(out, "{inner2}Row(children: [").unwrap();
+    writeln!(out, "{inner3}for (int c = 0; c < {rows_var}[r].length; c++)").unwrap();
+    writeln!(out, "{cell_gesture_open}Container(").unwrap();
+    let body_pad = " ".repeat(indent + 10);
+    writeln!(out, "{body_pad}width: 96,").unwrap();
+    writeln!(out, "{body_pad}height: 22,").unwrap();
+    writeln!(
+        out,
+        "{body_pad}color: ({selected_expr}) ? const Color(0xFF264F78) : const Color(0xFF1E1E1E),"
+    )
+    .unwrap();
+    writeln!(out, "{body_pad}child: Text({rows_var}[r][c]),").unwrap();
+    writeln!(out, "{inner3}){cell_gesture_close},").unwrap();
+    writeln!(out, "{inner2}]),").unwrap();
+
+    writeln!(out, "{pad}])").unwrap();
+    Ok(out)
+}
+
+fn on_navigate_call_was_set(node: &LayoutNode) -> bool {
+    find_emit_ref_prop(node, "onNavigate").is_some()
+}
+
 /// attacker-controlled keyword can't sneak a `child: pwn()` payload
 /// into the generated source because it never reaches the format
 /// string. Slot refs go through `is_safe_dart_identifier` so they
@@ -2138,7 +2269,7 @@ fn _layout_prop_kindcheck(_: LayoutProp) {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mosmodel_compiler::EmitParam;
+    use mosmodel_compiler::{EmitParam, ListInnerType};
 
     fn empty_style(name: &str) -> StyleDef {
         StyleDef {
@@ -2468,6 +2599,82 @@ mod tests {
             !out.contains("/* TODO"),
             "regenerated output should not contain TODO placeholders:\n{out}"
         );
+    }
+
+    // ----- Grid primitive -----------------------------------------------
+
+    #[test]
+    fn grid_with_headers_and_rows_emits_column_of_rows() {
+        let m = component(
+            "VisiCalc",
+            vec![
+                slot("column-headers", SlotType::List(Box::new(ListInnerType::Text)), true),
+                slot(
+                    "viewport-rows",
+                    SlotType::List(Box::new(ListInnerType::List(Box::new(ListInnerType::Text)))),
+                    true,
+                ),
+            ],
+            vec![],
+        );
+        let l = layout(
+            "VisiCalc",
+            node_with(
+                "Grid",
+                vec![
+                    LayoutProp { name: "headers".into(), value: LayoutPropValue::SlotRef("column-headers".into()) },
+                    LayoutProp { name: "rows".into(), value: LayoutPropValue::SlotRef("viewport-rows".into()) },
+                ],
+                vec![],
+            ),
+        );
+        let r = from_pipeline(&m, &l, &empty_style("VisiCalc")).unwrap();
+        let out = r.output;
+        assert!(out.contains("Column(children: ["), "missing Column root in:\n{out}");
+        assert!(out.contains("for (final h in columnHeaders)"), "missing headers loop in:\n{out}");
+        assert!(out.contains("for (int r = 0; r < viewportRows.length"), "missing body row loop in:\n{out}");
+        assert!(out.contains("for (int c = 0; c < viewportRows[r].length"), "missing body cell loop in:\n{out}");
+    }
+
+    #[test]
+    fn grid_with_on_navigate_emit_dispatches_per_cell() {
+        let m = component(
+            "VisiCalc",
+            vec![
+                slot("column-headers", SlotType::List(Box::new(ListInnerType::Text)), true),
+                slot(
+                    "viewport-rows",
+                    SlotType::List(Box::new(ListInnerType::List(Box::new(ListInnerType::Text)))),
+                    true,
+                ),
+            ],
+            vec![emit(
+                "onNavigate",
+                vec![
+                    EmitParam { name: "row".into(), r#type: EmitPayloadType::Number },
+                    EmitParam { name: "col".into(), r#type: EmitPayloadType::Number },
+                ],
+            )],
+        );
+        let l = layout(
+            "VisiCalc",
+            node_with(
+                "Grid",
+                vec![
+                    LayoutProp { name: "headers".into(), value: LayoutPropValue::SlotRef("column-headers".into()) },
+                    LayoutProp { name: "rows".into(), value: LayoutPropValue::SlotRef("viewport-rows".into()) },
+                    LayoutProp { name: "onNavigate".into(), value: LayoutPropValue::EmitRef("onNavigate".into()) },
+                ],
+                vec![],
+            ),
+        );
+        let r = from_pipeline(&m, &l, &empty_style("VisiCalc")).unwrap();
+        let out = r.output;
+        assert!(
+            out.contains("dispatch(VisiCalcEventNavigate(row: r, col: c))"),
+            "expected real dispatch call, got:\n{out}"
+        );
+        assert!(out.contains("GestureDetector"), "expected per-cell GestureDetector in:\n{out}");
     }
 
     // ----- HostCheckbox + HostRadio scaffolds --------------------------


### PR DESCRIPTION
## Summary

Adds first-class lowering for the UI26 §6.2 `Grid` userland primitive in the Flutter emitter. **Final** cycle of the cross-backend Grid sweep started in #4813 (SwiftUI), #4815 (Qt), and #4817 (Compose). Now every backend in the autonomous loop's roadmap that supports Grid emits it through `mosaic-compile`; no demo needs to hand-write a grid view anymore.

## Shape

```dart
Column(children: [
  Row(children: [
    for (final h in headers)
      Container(width: 96, height: 24, color: Color(0xFF2D2D30), child: Text(h)),
  ]),
  for (int r = 0; r < rows.length; r++)
    Row(children: [
      for (int c = 0; c < rows[r].length; c++)
        GestureDetector(
          onTap: () => dispatch(<C>EventNavigate(row: r, col: c)),
          child: Container(
            width: 96, height: 22,
            color: (r == selectedRow && c == selectedCol)
                  ? Color(0xFF264F78) : Color(0xFF1E1E1E),
            child: Text(rows[r][c]),
          ),
        ),
    ]),
])
```

## Slot / emit mapping

| Mosaic prop | Flutter usage |
| --- | --- |
| `headers` | Required. `List<String>` header row |
| `rows` | Required. `List<List<String>>` body rows |
| `column-widths` | Accepted; per-column override deferred to v0.2.0 |
| `selected-row` | Optional. Pairs with `selected-col` for tint |
| `selected-col` | Optional |
| `onNavigate` | Optional emit. Per-cell `GestureDetector.onTap` |

## Tests

2 new tests:
- `grid_with_headers_and_rows_emits_column_of_rows`
- `grid_with_on_navigate_emit_dispatches_per_cell`

Total `mosaic-emit-flutter` tests: **60 (58 baseline + 2 new), all green.**

## End of loop

This is the **last roadmap item.** Once this PR merges, all backends' Grid primitives + signal-arity sweep + cross-platform demos are done. The cron driver will detect "all merged" on its next fire and self-delete.

## Test plan

- [x] `cargo test -p mosaic-emit-flutter` green
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)