### PR TITLE
feat(ml_framework_core): v1.0.0 — benchmark + RubyGems polish (Ruby pilot PR #8/8) 🎉

### DIFF
--- a/code/packages/ruby/ml_framework_core/CHANGELOG.md
+++ b/code/packages/ruby/ml_framework_core/CHANGELOG.md
@@ -2,6 +2,88 @@
 
 ## Unreleased
 
+### Added — v1.0.0: complete Ruby ML framework on the Rust matrix-cpu engine
+
+PR #8 of 8 (FINAL) in the Ruby pilot.  v1.0.0 marks the completion of
+the multi-PR plan: a PyTorch-shaped Ruby ML framework with all 15 ops
+(forward + backward), autograd engine, end-to-end MLP training, and a
+benchmark script for performance characterization.
+
+#### What v1.0.0 means
+
+The complete stack works:
+
+```ruby
+require "coding_adventures/ml_framework_core"
+T = CodingAdventures::MLFrameworkCore::Tensor
+
+# Build a model
+w1 = T.new([[0.5, -0.3]]); w1.requires_grad = true
+w2 = T.new([[0.4], [0.7]]); w2.requires_grad = true
+
+# Train (loss drops 91% in 30 SGD steps on the test suite's synthetic data)
+30.times do
+  pred = x.matmul(w1).relu.matmul(w2)
+  loss = ((pred - target) * (pred - target)).mean
+  loss.backward
+  w1 = sgd_step(w1, lr: 0.01)
+  w2 = sgd_step(w2, lr: 0.01)
+end
+```
+
+All math is pure Ruby for tensors under 10k cells.  At 10k+ cells the
+ops auto-dispatch through the matrix_rust_ruby gem to the Rust
+matrix-cpu executor (SIMD-accelerated f32).  No Rust toolchain is
+required to use the gem at small/medium sizes.
+
+#### New in v1.0.0
+
+- **`scripts/benchmark.rb`** — performance characterization.  Runs
+  forward + backward on a 2-layer MLP at batch sizes 100, 1000, 5000,
+  10_000, 50_000 and prints a markdown table of median timings.
+  Gracefully handles the case where matrix_rust_ruby isn't built
+  (skips Rust-only rows with a clear "Rust needed" label).
+
+- **Gemspec polish**:
+  - Tightened description to highlight what's in the box (15 ops, autograd, dispatch)
+  - Added `homepage_uri`, `changelog_uri`, `bug_tracker_uri` to metadata
+
+- **README polish**: Quick-start section with the end-to-end MLP
+  example moved to the top; benchmark section with example output.
+
+#### Layered architecture (now complete)
+
+```
+ml_framework_core (THIS GEM, v1.0.0)
+  Tensor + autograd + 15 differentiable ops (forward + backward)
+  ↓ dispatch large tensors through ↓
+matrix_rust_ruby gem (v0.1)
+  Ruby wrapper around matrix_rust_ruby_native
+  ↓
+matrix_rust_ruby_native (Rust cdylib, v0.1)
+  Defines MatrixRustRuby.run_graph_on_cpu
+  ↓
+c-bridge (Rust workspace crate, v0.1)
+  Pure-Rust run_graph_on_cpu_via_json_envelope
+  ↓
+matrix-ir-json → matrix-ir → matrix-runtime → matrix-cpu
+```
+
+#### Test coverage (unchanged from v0.4.0 — all still passing)
+
+- `test/tensor_test.rb`            63 runs, 94 assertions
+- `test/autograd_test.rb`          18 runs, 31 assertions
+- `test/ops_test.rb`               65 runs, 122 assertions
+- `test/end_to_end_training_test`  2 runs, 4 assertions
+- Total: 148 tests, 251 assertions, 0 failures
+
+#### What's next (for the project, not the gem)
+
+The user will pick the next language pilot — Lua, JS/TS, Go, or Swift.
+The architecture pattern established by the Ruby pilot transfers
+directly: per-language Rust cdylib bridge → per-language low-level
+binding → per-language idiomatic ml_framework_core.
+
 ### Added — v0.4.0: backward dispatch + end-to-end MLP training test
 
 PR #7 of 8 in the Ruby pilot.  Adds `backward(output_grad)` to all 15

--- a/code/packages/ruby/ml_framework_core/README.md
+++ b/code/packages/ruby/ml_framework_core/README.md
@@ -1,118 +1,122 @@
-# ml_framework_core — idiomatic Ruby Tensor + autograd
+# ml_framework_core — Ruby ML framework on the Rust matrix-cpu engine
 
-A small, PyTorch-shaped Ruby ML library that runs the heavy stuff on the
-Rust `matrix-cpu` engine and falls back to pure Ruby for small or
-debugging workloads.
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Ruby](https://img.shields.io/badge/Ruby-%3E%3D%202.6.0-red)](https://www.ruby-lang.org/)
+[![Tests](https://img.shields.io/badge/tests-148%20passing-brightgreen)]()
+
+A small, PyTorch-shaped Ruby ML library.  All 15 differentiable ops, full
+autograd, end-to-end MLP training — all in idiomatic Ruby.  Tensors
+under 10k cells stay in pure Ruby; tensors above auto-dispatch through
+the `matrix_rust_ruby` gem to the Rust `matrix-cpu` executor for
+SIMD-accelerated f32 math.
+
+## Quick start
 
 ```ruby
 require "coding_adventures/ml_framework_core"
-include CodingAdventures::MLFrameworkCore       # or use MLFrameworkCore alias
-
-x = Tensor.new([[1, 2, 3], [4, 5, 6]])
-y = Tensor.eye(3)
-
-x.matmul(y) == x                # forthcoming (PR #6)
-(x + 1.0).to_nested_a           # works today
-```
-
-## Where this v0.1 sits in the multi-language stack
-
-```text
-┌─────────────────────────────────────────────────────────────────┐
-│  ml_framework_core (this gem)        ← v0.1 = Tensor only       │
-│    Tensor + factories + shape ops + operator overloads          │
-│    PR #5: autograd engine                                       │
-│    PR #6: forward op dispatch via matrix_rust_ruby              │
-│    PR #7: backward dispatch + end-to-end MLP test               │
-│    PR #8: benchmark + RubyGems publishing polish                │
-│    ↓                                                             │
-│  matrix_rust_ruby (Ruby gem)               ← PR #3 (merged)     │
-│    MatrixRustRuby.run_graph_on_cpu(envelope)                    │
-│    ↓                                                             │
-│  matrix_rust_ruby_native (Rust cdylib)     ← PR #2 (merged)     │
-│    ↓                                                             │
-│  c-bridge (Rust workspace crate)           ← PR #1 (merged)     │
-│    ↓                                                             │
-│  matrix-cpu execution engine                                    │
-└─────────────────────────────────────────────────────────────────┘
-```
-
-## What v0.1 ships
-
-This PR (#4 of 8 in the Ruby pilot) is intentionally pure Ruby — no
-native ext, no Rust calls.  That keeps it small, reviewable, and
-independently testable.
-
-### `Tensor` class
-
-```ruby
 T = CodingAdventures::MLFrameworkCore::Tensor
 
-# Construction
-T.new([1, 2, 3])                        # 1-D from flat
-T.new([[1, 2], [3, 4]])                 # 2-D from nested (shape inferred)
-T.new([1, 2, 3, 4], shape: [2, 2])      # flat + explicit shape
+# A 2-layer MLP, no bias: 1 input → 2 hidden ReLU → 1 output
+w1 = T.new([[0.5, -0.3]]); w1.requires_grad = true
+w2 = T.new([[0.4], [0.7]]); w2.requires_grad = true
 
-# Factories
-T.zeros(2, 3)
-T.ones(3)
-T.full([2, 2], 7.5)
-T.eye(3)                                # 3x3 identity
-T.eye(2, 3)                             # rectangular
-T.arange(5)                             # 0, 1, 2, 3, 4
-T.arange(2, 10, 2)                      # 2, 4, 6, 8
-T.randn(3, 4, seed: 42)                 # standard-normal via Box-Muller
-T.from_array([[1, 2], [3, 4]])          # alias for new(nested)
+# Synthetic data: regress y = 2x + 3 over 4 samples
+x      = T.new([[0.0], [1.0], [2.0], [3.0]])
+target = T.new([[3.0], [5.0], [7.0], [9.0]])
 
-# Shape ops
-t.reshape(3, 4)
-t.transpose                             # 2-D only in v0.1
-t.flatten
-t.squeeze(axis = nil)
-t.unsqueeze(axis)
+def sgd_step(p, lr)
+  new_data = p.to_a.each_with_index.map { |v, i| v - lr * p.grad.to_a[i] }
+  T.new(new_data, shape: p.shape).tap { |t| t.requires_grad = true }
+end
 
-# Operator overloads — element-wise, same shape only in v0.1
-a + b   a - b   a * b   a / b   a**2   -a
-a + 5   a - 5   a * 5   a / 5   a**2          # scalar broadcasts
+30.times do
+  pred = x.matmul(w1).relu.matmul(w2)
+  loss = ((pred - target) * (pred - target)).mean
+  loss.backward
+  w1 = sgd_step(w1, 0.01)
+  w2 = sgd_step(w2, 0.01)
+end
 
-# Conversions + introspection
-t.shape          # => [2, 3]
-t.dtype          # => :f32
-t.ndim           # => 2
-t.numel          # => 6
-t.to_a           # flat Array<Float>
-t.to_nested_a    # nested Array matching shape
-
-# Autograd-prep slots (PR #5 wires them up; here they're just storage)
-t.requires_grad        # => false by default
-t.requires_grad = true
-t.grad                 # => nil until backward() runs
-t.grad_fn              # => nil for leaf tensors
+# Loss drops 91% (36.5 → 3.2) in 30 SGD steps.
 ```
 
-## What's intentionally NOT in v0.1
+That whole snippet runs in pure Ruby today (no native ext required).
+The test suite exercises this exact training loop in
+`test/end_to_end_training_test.rb`.
 
-| Feature           | Lands in | Why deferred                         |
-|-------------------|----------|--------------------------------------|
-| Broadcasting      | PR #6    | Couples Tensor to shape algebra      |
-| Indexing/slicing  | post-#8  | 50+ lines of arg-shape handling      |
-| `sum` / `mean`    | PR #6    | These will be Function subclasses    |
-| Autograd `apply`  | PR #5    | Needs its own focused PR             |
-| Rust dispatch     | PR #6    | Needs autograd graph first           |
-| Higher-rank `transpose` | post-#8 | Strided index math not needed yet |
+## What's in the box
 
-## Storage model
+### `Tensor` (lib/.../tensor.rb)
 
-- `@data` is a flat `Array<Float>` (Ruby Floats are f64).
-- `@shape` is an `Array<Integer>`.
-- `@dtype` is `:f32` (matches matrix-cpu; in-memory f64 just happens to be
-  Ruby's only float primitive).
+```ruby
+# Construction
+T.new(nested_or_flat, shape: nil, dtype: :f32, requires_grad: false)
 
-The lossy f64→f32 conversion only happens at the Rust dispatch boundary
-(PR #6), where we pack each f64 into 4 bytes of little-endian f32 before
-hex-encoding for the JSON envelope.
+# Factories
+T.zeros(2, 3)   T.ones(3)    T.full([2, 2], 7.5)
+T.eye(3)        T.eye(2, 3)
+T.arange(5)     T.arange(0, 10, 2)    T.arange(5, 0, -1)
+T.randn(3, 4, seed: 42)
+T.from_array([[1, 2], [3, 4]])
+T.ones_like(t)  T.zeros_like(t)
 
-## Running the test suite
+# Shape ops
+t.reshape(3, 4)   t.transpose   t.flatten   t.squeeze   t.unsqueeze(0)
+
+# Operators (autograd-aware)
+a + b   a - b   a * b   a / b   a**2   -a
+a + 5   a * 2.0                                 # scalar broadcasts
+
+# Named ops
+a.matmul(b)
+a.relu   a.sigmoid   a.tanh   a.gelu   a.softmax
+a.sum    a.mean      a.abs
+
+# Introspection
+shape  dtype  ndim  numel  ==  eql?  hash  inspect  to_a  to_nested_a
+requires_grad  grad  grad_fn
+```
+
+### Autograd (lib/.../autograd.rb)
+
+```ruby
+# Function base class (subclass to define new ops)
+class MyOp < CodingAdventures::MLFrameworkCore::Function
+  def forward(x)
+    @saved_for_backward[:x] = x       # stash what backward needs
+    # ... return a Tensor ...
+  end
+
+  def backward(grad)
+    x = @saved_for_backward[:x]
+    # ... return Array<Tensor, nil> ...
+  end
+end
+
+# Tensor#backward — reverse-mode autodiff
+loss.backward
+loss.backward(custom_grad_tensor)     # explicit seed gradient
+```
+
+### Ops (lib/.../ops.rb)
+
+| Op       | Rust dispatch?     | Notes                                    |
+|----------|--------------------|------------------------------------------|
+| Add/Sub  | ≥10k cells         | Elementwise                              |
+| Mul/Div  | ≥10k cells         | Elementwise                              |
+| Neg/Abs  | ≥10k cells         | Elementwise                              |
+| Tanh     | ≥10k cells         | Elementwise activation                   |
+| MatMul   | ≥10k cells         | 2-D only in v1.0                         |
+| Sum/Mean | ≥10k cells         | Reduce-all (output shape `(1,)`)         |
+| Pow      | pure Ruby          | Scalar exponent                          |
+| ReLU     | pure Ruby          | Routes through Max+const in follow-up    |
+| Sigmoid  | pure Ruby          | Multi-op graph in follow-up              |
+| GELU     | pure Ruby          | Multi-op graph in follow-up              |
+| Softmax  | pure Ruby          | Multi-op graph; numerically stable       |
+
+## Installation
+
+### From source (workspace)
 
 ```bash
 cd code/packages/ruby/ml_framework_core
@@ -120,14 +124,81 @@ bundle install
 bundle exec rake test
 ```
 
-The suite has ~50 tests covering:
+### From RubyGems (planned)
 
-- Construction (flat, nested, scalar, explicit shape, ragged-rejection)
-- Every factory (zeros, ones, full, eye, arange, randn, from_array)
-- Every shape op (reshape, transpose, flatten, squeeze, unsqueeze)
-- Every operator overload (+, -, *, /, **, unary -, scalar broadcast)
-- Equality, hash, inspect
-- Round-trip properties (`reshape(t.shape) == t`,
-  `unsqueeze(0).squeeze(0) == t`, `transpose.transpose == t`,
-  `to_nested_a → new → to_nested_a` is identity)
-- Version constant + `MLFrameworkCore` short-alias
+```bash
+gem install coding_adventures_ml_framework_core
+```
+
+The gem itself is pure Ruby.  To enable Rust dispatch above the
+10k-cell threshold, also install `coding_adventures_matrix_rust_ruby`
+(which builds a native ext via `cargo`).
+
+## Benchmark
+
+```bash
+cd code/packages/ruby/ml_framework_core
+ruby -Ilib scripts/benchmark.rb
+```
+
+Example output (Apple M-series, Ruby 2.6, pure-Ruby fallback only):
+
+```
+| batch  | forward (ms) | backward (ms) | total (ms) | dispatch       |
+|--------|--------------|---------------|------------|----------------|
+|    100 |         0.15 |          0.23 |       0.38 | Ruby (no Rust) |
+|   1000 |         1.23 |          2.20 |       3.44 | Ruby (no Rust) |
+|   5000 |    (skipped) |     (skipped) |  (skipped) | Rust needed    |
+|  10000 |    (skipped) |     (skipped) |  (skipped) | Rust needed    |
+|  50000 |    (skipped) |     (skipped) |  (skipped) | Rust needed    |
+```
+
+Build the matrix_rust_ruby native ext (`cd ../matrix_rust_ruby &&
+bundle exec rake compile`) to see the Rust-dispatch numbers.
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  ml_framework_core (THIS GEM, v1.0.0)                            │
+│    Tensor + autograd + 15 differentiable ops                     │
+│    ↓ dispatch large tensors through ↓                            │
+│  matrix_rust_ruby (Ruby gem)                                     │
+│    MatrixRustRuby.run_graph_on_cpu(envelope_json)                │
+│    ↓                                                              │
+│  matrix_rust_ruby_native (Rust cdylib)                           │
+│    ↓                                                              │
+│  c-bridge (Rust workspace crate)                                 │
+│    pure-Rust run_graph_on_cpu_via_json_envelope                  │
+│    ↓                                                              │
+│  matrix-ir-json → matrix-ir → matrix-runtime → matrix-cpu        │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+This stack — c-bridge → matrix_rust_ruby_native → matrix_rust_ruby →
+ml_framework_core — is the **Ruby pilot** for a multi-language plan.
+The same shape will be replicated for Lua, JS/TS, Go, and Swift in
+future pilots: each language gets its own `<lang>-bridge` workspace
+crate, then its own low-level binding, then its own idiomatic
+ml_framework_core.
+
+## Tests
+
+148 tests, 251 assertions across 4 files:
+
+```bash
+ruby -Ilib -Itest test/tensor_test.rb               #  63 tests
+ruby -Ilib -Itest test/autograd_test.rb             #  18 tests
+ruby -Ilib -Itest test/ops_test.rb                  #  65 tests
+ruby -Ilib -Itest test/end_to_end_training_test.rb  #   2 tests
+```
+
+Or all at once:
+
+```bash
+bundle exec rake test
+```
+
+## License
+
+MIT.  See LICENSE in the repository root.

--- a/code/packages/ruby/ml_framework_core/coding_adventures_ml_framework_core.gemspec
+++ b/code/packages/ruby/ml_framework_core/coding_adventures_ml_framework_core.gemspec
@@ -20,11 +20,13 @@ Gem::Specification.new do |spec|
   spec.name          = "coding_adventures_ml_framework_core"
   spec.version       = CodingAdventures::MLFrameworkCore::VERSION
   spec.authors       = ["Adhithya Rajasekaran"]
-  spec.summary       = "Idiomatic Ruby Tensor and autograd on top of the Rust matrix-cpu engine"
-  spec.description   = "Pure-Ruby Tensor class with factories (zeros/ones/eye/arange/randn/...), " \
-                       "shape ops (reshape/transpose/flatten/squeeze/unsqueeze), and operator " \
-                       "overloads (+/-/*///**/-). v0.1 is pure Ruby. Future versions dispatch " \
-                       "large ops through matrix_rust_ruby to the Rust matrix-cpu engine."
+  spec.summary       = "Complete PyTorch-shaped Ruby ML framework on the Rust matrix-cpu engine"
+  spec.description   = "Tensor + autograd + 15 differentiable ops (Add/Sub/Mul/Div/Neg/Abs/Pow/" \
+                       "MatMul/ReLU/Sigmoid/Tanh/GELU/Softmax/Sum/Mean) with full forward and " \
+                       "backward. Small tensors use a pure-Ruby fast path; tensors of 10k+ cells " \
+                       "auto-dispatch through the matrix_rust_ruby gem to the Rust matrix-cpu " \
+                       "executor for SIMD-accelerated f32 math. End-to-end MLP training verified " \
+                       "by the test suite; see scripts/benchmark.rb for performance characterization."
   spec.homepage      = "https://github.com/adhithyan15/coding-adventures"
   spec.license       = "MIT"
   spec.required_ruby_version = ">= 2.6.0"
@@ -38,6 +40,9 @@ Gem::Specification.new do |spec|
 
   spec.metadata = {
     "source_code_uri" => "https://github.com/adhithyan15/coding-adventures",
+    "homepage_uri"    => "https://github.com/adhithyan15/coding-adventures/tree/main/code/packages/ruby/ml_framework_core",
+    "changelog_uri"   => "https://github.com/adhithyan15/coding-adventures/blob/main/code/packages/ruby/ml_framework_core/CHANGELOG.md",
+    "bug_tracker_uri" => "https://github.com/adhithyan15/coding-adventures/issues",
     "rubygems_mfa_required" => "true"
   }
 

--- a/code/packages/ruby/ml_framework_core/lib/coding_adventures/ml_framework_core/version.rb
+++ b/code/packages/ruby/ml_framework_core/lib/coding_adventures/ml_framework_core/version.rb
@@ -2,6 +2,6 @@
 
 module CodingAdventures
   module MLFrameworkCore
-    VERSION = "0.4.0"
+    VERSION = "1.0.0"
   end
 end

--- a/code/packages/ruby/ml_framework_core/scripts/benchmark.rb
+++ b/code/packages/ruby/ml_framework_core/scripts/benchmark.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+# scripts/benchmark.rb — performance characterization for ml_framework_core
+# ===========================================================================
+#
+# Runs the same 2-layer MLP from test/end_to_end_training_test.rb at
+# increasing batch sizes and prints a markdown table of forward +
+# backward timings.
+#
+# Two intended uses:
+#
+#   1. **Find the Ruby-vs-Rust crossover** — at small batch sizes the
+#      pure-Ruby fallback wins because the JSON+hex+FFI dispatch
+#      overhead dominates.  As batches grow, Rust's f32 SIMD pulls
+#      ahead.  The table makes the crossover visible at a glance.
+#
+#   2. **Spot regressions** — re-run after any change to ops.rb /
+#      autograd.rb and compare with prior runs.  A 2-3x slowdown
+#      anywhere should be investigated.
+#
+# Usage:
+#
+#   cd code/packages/ruby/ml_framework_core
+#   ruby -Ilib scripts/benchmark.rb
+#
+# No CLI arguments.  No file output.  Stdout-only.
+
+require "coding_adventures/ml_framework_core"
+
+T = CodingAdventures::MLFrameworkCore::Tensor
+
+# Configurable batch sizes.  Picked to bracket the 10_000-cell dispatch
+# threshold from both sides:
+#   100   →  100 cells   →  pure Ruby
+#   1000  → 1000 cells   →  pure Ruby
+#   5000  → 5000 cells   →  pure Ruby (still below 10k)
+#   10000 → 10000 cells  →  AT the threshold
+#   50000 → 50000 cells  →  WAY above the threshold (Rust dispatch)
+BATCH_SIZES = [100, 1000, 5000, 10_000, 50_000].freeze
+WARMUP_RUNS = 2
+TIMED_RUNS  = 5
+
+# Lazy-detect whether the Rust dispatch path is available.  If the
+# `matrix_rust_ruby` gem's native extension isn't built, the lazy
+# require inside Ops.run_envelope will raise LoadError — we surface
+# that as a header note rather than crashing.
+def rust_available?
+  require "coding_adventures/matrix_rust_ruby"
+  true
+rescue LoadError
+  false
+end
+
+# A single forward + backward pass at the given batch size.
+# Returns [forward_seconds, backward_seconds].
+def time_step(batch_size)
+  # Build inputs: x is (batch, 1), target is (batch, 1).  The data
+  # values themselves don't matter — we're measuring time, not loss.
+  x_data = Array.new(batch_size) { |i| [i.to_f / batch_size] }
+  y_data = Array.new(batch_size) { |i| [2.0 * (i.to_f / batch_size) + 3.0] }
+  x = T.new(x_data)
+  target = T.new(y_data)
+
+  # 1-hidden-unit MLP — minimal layer count to focus on per-cell cost
+  # rather than per-op orchestration overhead.
+  w1 = T.new([[0.5, -0.3]]); w1.requires_grad = true
+  w2 = T.new([[0.4], [0.7]]); w2.requires_grad = true
+
+  # --- forward ---
+  fwd_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  pred = x.matmul(w1).relu.matmul(w2)
+  diff = pred - target
+  loss = (diff * diff).mean
+  fwd_end = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+  # --- backward ---
+  bwd_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  loss.backward
+  bwd_end = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+  [fwd_end - fwd_start, bwd_end - bwd_start]
+end
+
+# Pick the dispatch label for a given batch size.  Heuristic: any
+# tensor that crosses the threshold somewhere in the forward graph
+# (matmul, relu, sub, mul, mean) will exercise the Rust path.  The
+# (batch × hidden) intermediate of `x.matmul(w1).relu` is batch * 2,
+# so 5000 batch → 10000-cell intermediate → Rust kicks in.  Crude
+# but useful enough as a column label.
+def dispatch_label(batch_size, rust_available)
+  return "Ruby (no Rust)" unless rust_available
+  return "Ruby"           if batch_size < 5_000
+  "Rust"
+end
+
+def run_benchmark
+  rust_ok = rust_available?
+
+  puts "# ml_framework_core benchmark"
+  puts
+  puts "Forward + backward pass on a 2-layer MLP (1 input → 2 hidden ReLU → 1 output)"
+  puts "at increasing batch sizes.  Each timing is the median of #{TIMED_RUNS} runs"
+  puts "after #{WARMUP_RUNS} warmup runs."
+  puts
+  puts "- Ruby version:    #{RUBY_VERSION} (#{RUBY_PLATFORM})"
+  puts "- matrix_rust_ruby: #{rust_ok ? "available" : "NOT BUILT — Ruby fallback only"}"
+  puts
+  puts "| batch  | forward (ms) | backward (ms) | total (ms) | dispatch       |"
+  puts "|--------|--------------|---------------|------------|----------------|"
+
+  results = []
+  BATCH_SIZES.each do |batch_size|
+    # If matrix_rust_ruby isn't available AND this batch would trigger
+    # a Rust dispatch (intermediate matmul shape ≥ 10k cells), skip
+    # the row rather than crashing with LoadError.  The dispatch is
+    # triggered when batch * hidden_dim ≥ DISPATCH_THRESHOLD; here
+    # hidden_dim = 2, so batch ≥ 5000 will route through Rust.
+    if !rust_ok && batch_size >= 5_000
+      printf("| %6d | %12s | %13s | %10s | %-14s |\n",
+             batch_size, "(skipped)", "(skipped)", "(skipped)", "Rust needed")
+      results << [batch_size, nil, nil, nil, "Rust needed"]
+      next
+    end
+
+    # Warmup runs to let any lazy requires (matrix_rust_ruby) load and
+    # to give Ruby's GC a chance to settle.
+    WARMUP_RUNS.times { time_step(batch_size) }
+
+    # Timed runs.  We collect all and take the median for stability —
+    # the mean is dominated by the worst-case outliers from GC pauses.
+    samples = Array.new(TIMED_RUNS) { time_step(batch_size) }
+    fwd_ms = samples.map { |f, _| f * 1000.0 }.sort[TIMED_RUNS / 2]
+    bwd_ms = samples.map { |_, b| b * 1000.0 }.sort[TIMED_RUNS / 2]
+    total_ms = fwd_ms + bwd_ms
+    dispatch = dispatch_label(batch_size, rust_ok)
+
+    printf("| %6d | %12.2f | %13.2f | %10.2f | %-14s |\n",
+           batch_size, fwd_ms, bwd_ms, total_ms, dispatch)
+    results << [batch_size, fwd_ms, bwd_ms, total_ms, dispatch]
+  end
+
+  puts
+  puts "## Notes"
+  puts
+  if rust_ok
+    # Find the smallest batch where Rust dispatch kicked in.
+    rust_threshold = results.find { |_, _, _, _, d| d == "Rust" }&.first
+    if rust_threshold
+      puts "- Rust dispatch crossed in around batch=#{rust_threshold} cells per intermediate."
+      puts "  Below that, the pure-Ruby element-wise loop is faster than the"
+      puts "  JSON+hex+FFI envelope round-trip."
+    else
+      puts "- All batches stayed in the pure-Ruby path."
+    end
+  else
+    puts "- All timings reflect the pure-Ruby fallback path."
+    puts "  Build the matrix_rust_ruby native ext (`cd ../matrix_rust_ruby && bundle exec rake compile`)"
+    puts "  to compare against Rust dispatch."
+  end
+  puts
+  puts "## Reproducing"
+  puts
+  puts "    cd code/packages/ruby/ml_framework_core"
+  puts "    ruby -Ilib scripts/benchmark.rb"
+end
+
+run_benchmark


### PR DESCRIPTION
## Summary — THE FINAL RUBY PILOT PR

v1.0.0 marks the **completion** of the 8-PR Ruby pilot for the multi-language ML framework plan. With this PR merged:

- 15 differentiable ops with full forward + backward (Add, Sub, Mul, Div, Neg, Abs, Pow, MatMul, ReLU, Sigmoid, Tanh, GELU, Softmax, Sum, Mean)
- Pure-Ruby autograd engine (Function.apply + Tensor#backward via topological sort + reverse walk)
- Automatic Rust dispatch above 10k cells through `matrix_rust_ruby` → `c-bridge` → `matrix-cpu`
- End-to-end MLP training verified (loss drops 91% in 30 SGD steps)
- 148 tests passing across 4 files

## What's new in v1.0.0

- **`scripts/benchmark.rb`**: forward + backward MLP timing at batch sizes 100/1000/5000/10k/50k. Markdown table output. Gracefully handles missing native ext.
- **Gemspec polish**: tightened description, added `homepage_uri`/`changelog_uri`/`bug_tracker_uri` metadata
- **README polish**: Quick-start section at top, Benchmark section with example output, test coverage section
- **Version**: 0.4.0 → 1.0.0

## The 8 Ruby pilot PRs

| #  | Title                                  | Status |
|----|----------------------------------------|--------|
| 1  | c-bridge                               | merged |
| 2  | matrix-rust-ruby-native                | merged |
| 3  | matrix_rust_ruby gem                   | merged |
| 4  | ml_framework_core Tensor               | merged |
| 5  | ml_framework_core autograd             | merged |
| 6  | ml_framework_core forward ops          | merged |
| 7  | ml_framework_core backward + MLP test  | merged |
| 8  | v1.0.0 — benchmark + polish (THIS PR)  | open   |

## Test plan

- [x] `ruby -c` on every .rb file
- [x] `Gem::Specification.load`: OK (v1.0.0)
- [x] All 4 test files pass (no regressions; 148 tests, 251 assertions)
- [x] `scripts/benchmark.rb` runs end-to-end locally (skips ≥5k rows since Rust ext isn't built locally)
- [x] Security review: passed
- [ ] CI: build (ubuntu/macos/windows) — pending
- [ ] CI: CodeQL ruby Analyze — pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)