### PR TITLE
A2: iir-to-intel8008 crate skeleton (Oct's native target)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -655,6 +655,7 @@ members = [
     "iir-to-wasm",
     "iir-to-llvm",
     "iir-to-riscv",
+    "iir-to-intel8008",
     "aot-debug",
     "twig-to-beam",
     "twig-to-wasm",

--- a/code/packages/rust/iir-to-intel8008/BUILD
+++ b/code/packages/rust/iir-to-intel8008/BUILD
@@ -1,0 +1,1 @@
+cargo test -p iir-to-intel8008

--- a/code/packages/rust/iir-to-intel8008/CHANGELOG.md
+++ b/code/packages/rust/iir-to-intel8008/CHANGELOG.md
@@ -1,0 +1,75 @@
+# Changelog — iir-to-intel8008
+
+All notable changes to this crate are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [0.1.0] — 2026-06-02 (A2 — crate skeleton)
+
+### Added — `HLT`-only emission
+
+First release.  Implements item A2 of the
+[multi-language architecture backends plan][plan]: a crate skeleton
+that lowers any IIR module to a single Intel 8008 `HLT` instruction
+(opcode `0x76`).
+
+#### Public surface
+
+```rust
+pub struct IIRIntel8008Config { pub module_name: String }
+impl IIRIntel8008Config {
+    pub fn new(module_name: impl Into<String>) -> Self;
+}
+
+pub enum IIRIntel8008Error {
+    ValidationFailed(Vec<String>),
+    UnsupportedOp     { function: String, op: String },
+    UnsupportedType   { function: String, type_hint: String },
+    InvalidOperand    { function: String, detail: String },
+}
+
+pub fn validate_for_intel8008(module: &IIRModule) -> Vec<String>;
+pub fn lower_iir_to_intel8008(
+    module: &IIRModule,
+    cfg: &IIRIntel8008Config,
+) -> Result<Vec<u8>, IIRIntel8008Error>;
+
+pub const HLT: u8 = 0x76;
+```
+
+#### Why an Intel 8008 backend?
+
+The 8008 (1972) is the first commercial 8-bit microprocessor and is
+**Oct's native target** — Oct programs are written specifically to
+round-trip through 8008 silicon (or the in-tree `intel8008-simulator`).
+A2 establishes the second architecture backend alongside RV32I (A1) and
+lays the groundwork for A4 (Intel 4004), which shares the historical-
+microprocessor backend shape.
+
+#### Why `Vec<u8>` output, not textual asm?
+
+* **Round-trips with `intel8008-simulator`** — `Simulator::run` takes
+  raw `&[u8]` instruction streams directly.
+* **Deterministic test surface** — `assert_eq!(bytes, vec![0x76])` is
+  unambiguous; 8008 mnemonics have Intel-spec vs MCS-8 historical
+  divergence.
+* **Trivial output size** — 8008 instructions are 1, 2, or 3 bytes;
+  textual round-trip contributes nothing.
+
+#### What is NOT in v0.1.0
+
+* **No instruction lowering.**  Function bodies in the input
+  `IIRModule` are ignored.  v0.2.0 (A2+) lowers MVI / MOV / basic
+  arithmetic.
+* **No `lang-aot --target=intel8008`.**  Deferred to v0.4.0 (A2+++).
+* **No external assembler / linker integration.**
+
+#### Tests added (6 total)
+
+* `validate_returns_empty_for_empty_module`
+* `lower_emits_exactly_one_byte`
+* `lower_emits_the_canonical_hlt_byte` (exact `0x76`)
+* `default_config_has_nonempty_module_name`
+* `new_sets_module_name`
+* `errors_display_without_panic`
+
+[plan]: ../../../specs/MULTILANG-ARCHITECTURE-BACKENDS.md

--- a/code/packages/rust/iir-to-intel8008/Cargo.toml
+++ b/code/packages/rust/iir-to-intel8008/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "iir-to-intel8008"
+version = "0.1.0"
+edition = "2021"
+description = "IIR → Intel 8008 machine code backend (Oct's native target) — lowers IIRModule to a Vec<u8> of 8-bit Intel 8008 opcodes.  v0.1.0 (A2): crate skeleton emitting a single HLT (0x76); instruction lowering deferred to v0.2.0+."
+
+[lib]
+name = "iir_to_intel8008"
+path = "src/lib.rs"
+
+[dependencies]
+interpreter-ir = { path = "../interpreter-ir" }
+# Pulled in for the simulator's symbolic mnemonic comments / opcode
+# constants — we mirror its naming so downstream consumers can decode
+# our output by feeding it back into the simulator.
+coding-adventures-intel8008-simulator = { path = "../intel8008-simulator" }
+
+[[test]]
+name = "test_backend"
+path = "tests/test_backend.rs"

--- a/code/packages/rust/iir-to-intel8008/README.md
+++ b/code/packages/rust/iir-to-intel8008/README.md
@@ -1,0 +1,75 @@
+# iir-to-intel8008
+
+IIR → Intel 8008 machine code backend. Emits `Vec<u8>` of encoded
+8-bit Intel 8008 opcodes — Oct's native target.
+
+**Status: v0.1.0 (A2 skeleton).** Any module lowers to a single `HLT`
+(`0x76`). Real instruction lowering arrives in A2+ / A2++.
+
+## Why an Intel 8008 backend?
+
+The Intel 8008 (1972) is the first commercial 8-bit microprocessor. In
+this codebase it's **Oct's native target** — Oct programs are written
+specifically to round-trip through the 8008.
+
+| Backend | Target |
+|---------|--------|
+| iir-to-wasm | WebAssembly 1.0 (software) |
+| iir-to-jvm-class-file | JVM bytecode (software) |
+| iir-to-cil-bytecode | CLR CIL (software) |
+| iir-to-beam | Erlang BEAM (software) |
+| iir-to-llvm | LLVM IR (textual → AOT) |
+| iir-to-riscv | RV32I machine code (hardware) |
+| **iir-to-intel8008 (this)** | **Intel 8008 machine code (Oct's native target)** |
+
+## Why `Vec<u8>` (not textual `.asm`)?
+
+- **Round-trips with `intel8008-simulator`** — its `Simulator::run`
+  consumes raw `&[u8]` instruction streams directly.
+- **Deterministic test surface** — `assert_eq!(bytes, vec![0x76])`.
+- **Trivial output size** — Intel 8008 instructions are 1, 2, or 3
+  bytes; emitting bytes skips the textual round-trip.
+
+## Quick start
+
+```rust
+use interpreter_ir::IIRModule;
+use iir_to_intel8008::{validate_for_intel8008, lower_iir_to_intel8008, IIRIntel8008Config};
+
+let module = IIRModule {
+    name: "demo".into(),
+    functions: vec![],
+    entry_point: None,
+    language: "demo".into(),
+    exports: vec![],
+    imports: vec![],
+};
+
+assert!(validate_for_intel8008(&module).is_empty());
+
+let bytes = lower_iir_to_intel8008(&module, &IIRIntel8008Config::default())
+    .expect("lowering should succeed");
+// 0x76 == Intel 8008 HLT.
+assert_eq!(bytes, vec![0x76]);
+```
+
+## Roadmap
+
+| Version | Scope |
+|---------|-------|
+| v0.1.0 (A2)  | Crate skeleton: any module → single `HLT`. *(this release)* |
+| v0.2.0 (A2+) | MVI (immediate load) + MOV (register-register) + arithmetic |
+| v0.3.0 (A2++)| Conditional + unconditional jumps, calls, stack frame |
+| v0.4.0 (A2+++)| `lang-aot --target=intel8008` wiring |
+
+See [`code/specs/MULTILANG-ARCHITECTURE-BACKENDS.md`](../../../specs/MULTILANG-ARCHITECTURE-BACKENDS.md)
+§A2 for the full plan.
+
+## Tests
+
+```sh
+cargo test -p iir-to-intel8008
+```
+
+6 tests at v0.1.0 covering the validator stub, the exact `HLT`
+encoding, config defaults, and error display.

--- a/code/packages/rust/iir-to-intel8008/src/lib.rs
+++ b/code/packages/rust/iir-to-intel8008/src/lib.rs
@@ -1,0 +1,216 @@
+//! # iir-to-intel8008 — IIR → Intel 8008 machine code backend (v0.1.0 skeleton).
+//!
+//! Lowers an [`interpreter_ir::IIRModule`] to a `Vec<u8>` of encoded
+//! 8-bit Intel 8008 opcodes, suitable to drop into the in-tree
+//! [`intel8008-simulator`] or to write out as a flat `.bin` for an
+//! external emulator.
+//!
+//! ## Why an Intel 8008 backend?
+//!
+//! The Intel 8008 (1972) is the first commercial 8-bit microprocessor.
+//! In this codebase it's **Oct's native target** — the Oct front-end
+//! produces IIR specifically intended to round-trip through an 8008.
+//!
+//! Adding the 8008 as a backend gives us:
+//!
+//! 1. **Historical fidelity.**  Oct programs can run on the actual ISA
+//!    they were designed for.
+//! 2. **A second architecture backend** alongside RISC-V (A1).  The two
+//!    architectures sit at opposite ends of the design space: RV32I is
+//!    a clean modern load-store RISC; the 8008 is an irregular
+//!    accumulator-based CISC with 8-bit registers and 14-bit
+//!    addressing.  Each exposes a different set of constraints in the
+//!    backend interface.
+//! 3. **A foundation for A4 (Intel 4004)** — the 4004 is even more
+//!    constrained, but shares much of the historical-microprocessor
+//!    backend shape that A2 establishes.
+//!
+//! ## Scope of v0.1.0 (A2)
+//!
+//! This release is a **skeleton**: any IIR module lowers to a single
+//! `HLT` instruction (opcode `0x76`).  No instruction selection yet;
+//! that arrives in A2+ (basic arithmetic / MOV / register allocation)
+//! and beyond.
+//!
+//! ## Why `Vec<u8>` output, not textual asm?
+//!
+//! - **Round-trips with `intel8008-simulator`** — its
+//!   [`Simulator::run`] method consumes raw `&[u8]` instruction streams.
+//! - **Deterministic test surface** — `assert_eq!(bytes, vec![0x76])`
+//!   is unambiguous; assembler syntax for the 8008 has Intel-mnemonics
+//!   vs MCS-8 historical-mnemonics divergence.
+//! - **Trivial output size** — Intel 8008 instructions are 1, 2, or 3
+//!   bytes; emitting bytes directly skips a textual-assembly round-trip
+//!   that contributes nothing.
+//!
+//! ## Quick start
+//!
+//! ```
+//! use interpreter_ir::IIRModule;
+//! use iir_to_intel8008::{validate_for_intel8008, lower_iir_to_intel8008, IIRIntel8008Config};
+//!
+//! let module = IIRModule {
+//!     name: "demo".into(),
+//!     functions: vec![],
+//!     entry_point: None,
+//!     language: "demo".into(),
+//!     exports: vec![],
+//!     imports: vec![],
+//! };
+//!
+//! assert!(validate_for_intel8008(&module).is_empty());
+//!
+//! let bytes = lower_iir_to_intel8008(&module, &IIRIntel8008Config::default())
+//!     .expect("lowering should succeed");
+//! // 0x76 == Intel 8008 HLT.
+//! assert_eq!(bytes, vec![0x76]);
+//! ```
+//!
+//! ## Pipeline position
+//!
+//! ```text
+//! IIRModule
+//!   → validate_for_intel8008()    pre-flight, returns Vec<String>
+//!   → lower_iir_to_intel8008()    returns Vec<u8> of 8008 opcodes
+//!   → (optional)
+//!       • intel8008_simulator::Simulator::run for in-process testing
+//!       • write to .bin + external emulator
+//!       • burn to a 1702 EPROM (Oct's intended deployment path)
+//! ```
+
+use interpreter_ir::IIRModule;
+use std::fmt;
+
+// ===========================================================================
+// Intel 8008 opcode constants used by v0.1.0
+// ===========================================================================
+//
+// The 8008's instruction encoding is irregular by modern standards: the
+// top 2 bits group instructions into four families (immediate-byte ops,
+// register-register MOV, ALU on register, and condition/jump/call), and
+// the lower 6 bits select within the family.  HLT lives in the
+// register-register MOV family but encodes "MOV M,M" — semantically a
+// self-move on the memory-pointer pseudo-register — which the silicon
+// implements as a halt.
+//
+// Bit pattern of HLT: `01 110 110` = `0x76`.  The simulator's
+// `Simulator::halted()` accessor flips true after this byte is
+// executed.
+
+/// Intel 8008 `HLT` opcode — `0x76`.  Halts the CPU.
+pub const HLT: u8 = 0x76;
+
+// ===========================================================================
+// IIRIntel8008Config
+// ===========================================================================
+
+/// Configuration for the IIR → Intel 8008 lowering pass.
+///
+/// Currently only the module name is configurable, reserved for future
+/// symbol-table / ROM-image emission.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IIRIntel8008Config {
+    /// Module name — reserved for future symbol-table / `.bin` header use.
+    pub module_name: String,
+}
+
+impl IIRIntel8008Config {
+    /// Build a config with a custom module name.
+    pub fn new(module_name: impl Into<String>) -> Self {
+        Self {
+            module_name: module_name.into(),
+        }
+    }
+}
+
+impl Default for IIRIntel8008Config {
+    fn default() -> Self {
+        Self {
+            module_name: "iir_module".into(),
+        }
+    }
+}
+
+// ===========================================================================
+// IIRIntel8008Error
+// ===========================================================================
+
+/// Errors that can occur during IIR → Intel 8008 lowering.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IIRIntel8008Error {
+    /// The module failed pre-flight validation.
+    ValidationFailed(Vec<String>),
+    /// An IIR opcode not yet supported by this backend.  v0.1.0 doesn't
+    /// lower any instructions, so a non-empty function body would
+    /// surface this in a future version.
+    UnsupportedOp { function: String, op: String },
+    /// A type hint that does not map to any Intel 8008 representation.
+    UnsupportedType { function: String, type_hint: String },
+    /// An operand has an unexpected shape.
+    InvalidOperand { function: String, detail: String },
+}
+
+impl fmt::Display for IIRIntel8008Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ValidationFailed(errs) => {
+                write!(f, "validation failed:\n  {}", errs.join("\n  "))
+            }
+            Self::UnsupportedOp { function, op } => {
+                write!(f, "unsupported op in function {function:?}: {op}")
+            }
+            Self::UnsupportedType { function, type_hint } => {
+                write!(f, "unsupported type in function {function:?}: {type_hint}")
+            }
+            Self::InvalidOperand { function, detail } => {
+                write!(f, "invalid operand in function {function:?}: {detail}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for IIRIntel8008Error {}
+
+// ===========================================================================
+// validate_for_intel8008
+// ===========================================================================
+
+/// Pre-flight validation for IIR → Intel 8008 lowering.
+///
+/// **v0.1.0 stub**: always returns an empty `Vec` — there are no
+/// validation rules yet because no instructions are lowered.  Future
+/// versions will add rules as opcodes come online (see
+/// `MULTILANG-ARCHITECTURE-BACKENDS.md` §A2).
+///
+/// Mirrors the shape of the other IIR backends'
+/// `validate_for_{wasm,jvm,clr,beam,llvm,riscv}` so callers can switch
+/// backends without changing their pre-flight logic.
+pub fn validate_for_intel8008(_module: &IIRModule) -> Vec<String> {
+    Vec::new()
+}
+
+// ===========================================================================
+// lower_iir_to_intel8008
+// ===========================================================================
+
+/// Lower an [`IIRModule`] to a `Vec<u8>` of Intel 8008 opcode bytes.
+///
+/// **v0.1.0 scope**: emits a single `HLT` regardless of the input.
+/// This is the smallest "valid Intel 8008 program" we can produce —
+/// enough to load into the simulator, step once, and confirm
+/// [`Simulator::halted`] returns `true`.  Real lowering arrives in
+/// v0.2.0+ (A2+).
+pub fn lower_iir_to_intel8008(
+    module: &IIRModule,
+    _cfg: &IIRIntel8008Config,
+) -> Result<Vec<u8>, IIRIntel8008Error> {
+    let errors = validate_for_intel8008(module);
+    if !errors.is_empty() {
+        return Err(IIRIntel8008Error::ValidationFailed(errors));
+    }
+    // Single emitted byte: HLT.  Wrapped through the named constant so a
+    // future revision of the simulator's opcode table that changes the
+    // halt encoding flows through automatically — we'd update `HLT` once
+    // and every backend re-emits the right byte.
+    Ok(vec![HLT])
+}

--- a/code/packages/rust/iir-to-intel8008/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-intel8008/tests/test_backend.rs
@@ -1,0 +1,98 @@
+//! Integration tests for `iir-to-intel8008` v0.1.0 (A2 skeleton).
+//!
+//! Smoke-level — confirms the validator stub, the emitter shape, and
+//! the exact encoded `HLT` byte (`0x76`).
+
+use interpreter_ir::IIRModule;
+use iir_to_intel8008::{
+    lower_iir_to_intel8008, validate_for_intel8008,
+    IIRIntel8008Config, IIRIntel8008Error, HLT,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn empty_module() -> IIRModule {
+    IIRModule {
+        name: "demo".into(),
+        functions: vec![],
+        entry_point: None,
+        language: "test".into(),
+        exports: vec![],
+        imports: vec![],
+    }
+}
+
+// ===========================================================================
+// 1. Validator stub
+// ===========================================================================
+
+#[test]
+fn validate_returns_empty_for_empty_module() {
+    assert!(validate_for_intel8008(&empty_module()).is_empty());
+}
+
+// ===========================================================================
+// 2. Lowering shape and the exact `HLT` encoding
+// ===========================================================================
+
+#[test]
+fn lower_emits_exactly_one_byte() {
+    let bytes = lower_iir_to_intel8008(&empty_module(), &IIRIntel8008Config::default())
+        .expect("lowering");
+    assert_eq!(bytes.len(), 1,
+        "v0.1.0 must emit exactly one byte; got: {bytes:?}");
+}
+
+/// The emitted byte is `0x76` — the canonical Intel 8008 `HLT`
+/// (`MOV M,M` semantics, halt as a side effect in silicon).
+///
+/// Bit layout: `01 110 110` = `0x76`.  Volume I of the Intel 8008 User's
+/// Manual lists this in the MOV r1,r2 family but the simulator's
+/// `halted()` accessor flips true when this byte executes.  Pinning the
+/// exact constant guards against any future change in the simulator's
+/// opcode table.
+#[test]
+fn lower_emits_the_canonical_hlt_byte() {
+    let bytes = lower_iir_to_intel8008(&empty_module(), &IIRIntel8008Config::default())
+        .expect("lowering");
+    assert_eq!(bytes[0], 0x76,
+        "expected canonical HLT encoding 0x76; got 0x{:02x}", bytes[0]);
+    assert_eq!(bytes[0], HLT,
+        "the emitted byte should equal the exported HLT constant");
+}
+
+// ===========================================================================
+// 3. Config defaults
+// ===========================================================================
+
+#[test]
+fn default_config_has_nonempty_module_name() {
+    let cfg = IIRIntel8008Config::default();
+    assert!(!cfg.module_name.is_empty());
+}
+
+#[test]
+fn new_sets_module_name() {
+    let cfg = IIRIntel8008Config::new("custom");
+    assert_eq!(cfg.module_name, "custom");
+}
+
+// ===========================================================================
+// 4. Error display
+// ===========================================================================
+
+#[test]
+fn errors_display_without_panic() {
+    let _ = format!("{}", IIRIntel8008Error::ValidationFailed(vec!["x".into()]));
+    let _ = format!("{}", IIRIntel8008Error::UnsupportedOp {
+        function: "f".into(), op: "weird".into(),
+    });
+    let _ = format!("{}", IIRIntel8008Error::UnsupportedType {
+        function: "f".into(), type_hint: "weird".into(),
+    });
+    let _ = format!("{}", IIRIntel8008Error::InvalidOperand {
+        function: "f".into(), detail: "bad".into(),
+    });
+}

--- a/code/specs/iir-to-intel8008.md
+++ b/code/specs/iir-to-intel8008.md
@@ -1,0 +1,115 @@
+# iir-to-intel8008 — IIR → Intel 8008 machine code backend
+
+**Status:** v0.1.0 — skeleton (A2)
+**Plan:** [`MULTILANG-ARCHITECTURE-BACKENDS.md`](MULTILANG-ARCHITECTURE-BACKENDS.md) §A2
+**Related:** [`iir-to-riscv`][rv], [`intel8008-simulator`][sim]
+
+[rv]: ../packages/rust/iir-to-riscv/
+[sim]: ../packages/rust/intel8008-simulator/
+
+## Why a new crate?
+
+The Intel 8008 (1972) is the first commercial 8-bit microprocessor. In
+this codebase it's **Oct's native target** — Oct programs are written
+to round-trip through 8008 silicon (or the in-tree
+[`intel8008-simulator`][sim]).
+
+Adding the 8008 as a backend gives us:
+
+1. **Historical fidelity for Oct.** Oct can finally run on the actual
+   ISA it was designed for.
+2. **A second architecture backend** alongside RV32I (A1).  The two sit
+   at opposite ends of the design space: RV32I is a clean modern
+   load-store RISC; the 8008 is an irregular accumulator-based CISC
+   with 8-bit registers and 14-bit addressing.  Each exposes a
+   different set of constraints in the backend interface.
+3. **A foundation for A4 (Intel 4004)**, which shares much of the
+   historical-microprocessor backend shape.
+
+## Why `Vec<u8>` output, not textual asm?
+
+* **Round-trips with `intel8008-simulator`** — its `Simulator::run`
+  method consumes raw `&[u8]` instruction streams directly.
+* **Deterministic test surface** — `assert_eq!(bytes, vec![0x76])` is
+  unambiguous; 8008 mnemonics have Intel-spec vs MCS-8 historical
+  divergence.
+* **Trivial output size** — 8008 instructions are 1, 2, or 3 bytes;
+  emitting them as bytes skips a textual-assembly round-trip that
+  contributes nothing.
+
+## Pipeline
+
+```text
+IIRModule
+  → validate_for_intel8008()      pre-flight, returns Vec<String>
+  → lower_iir_to_intel8008()      returns Vec<u8> of 8008 opcodes
+  → (optional)
+      • intel8008-simulator: Simulator::run for in-process testing
+      • write to .bin + external emulator
+      • burn to a 1702 EPROM (Oct's intended deployment path)
+```
+
+## Scope by version
+
+| Version | Scope | Status |
+|---------|-------|--------|
+| **v0.1.0 (A2 — this PR)** | crate skeleton: any module → single `HLT` (`0x76`) | this PR |
+| v0.2.0 (A2+) | MVI (immediate load) + MOV (register-register) + arithmetic on the accumulator | future |
+| v0.3.0 (A2++) | Conditional + unconditional jumps, calls, stack frame; 14-bit address backpatching | future |
+| v0.4.0 (A2+++) | `lang-aot --target=intel8008` wiring | future |
+
+## Public surface (v0.1.0)
+
+```rust
+pub struct IIRIntel8008Config { pub module_name: String }
+impl IIRIntel8008Config {
+    pub fn new(module_name: impl Into<String>) -> Self;
+}
+
+pub enum IIRIntel8008Error {
+    ValidationFailed(Vec<String>),
+    UnsupportedOp     { function: String, op: String },
+    UnsupportedType   { function: String, type_hint: String },
+    InvalidOperand    { function: String, detail: String },
+}
+
+pub fn validate_for_intel8008(module: &IIRModule) -> Vec<String>;
+pub fn lower_iir_to_intel8008(
+    module: &IIRModule,
+    cfg: &IIRIntel8008Config,
+) -> Result<Vec<u8>, IIRIntel8008Error>;
+
+pub const HLT: u8 = 0x76;
+```
+
+## The `HLT` encoding (v0.1.0 acceptance criterion)
+
+The 8008's instruction encoding is irregular by modern standards: the
+top 2 bits group instructions into four families, and the lower 6 bits
+select within the family.  `HLT` lives in the register-register `MOV`
+family but encodes "MOV M,M" — semantically a self-move on the
+memory-pointer pseudo-register — which the silicon implements as a
+halt.
+
+Bit pattern: `01 110 110` = **`0x76`**.  The simulator's
+`Simulator::halted()` accessor flips true after this byte executes.
+
+v0.1.0's `lower_emits_the_canonical_hlt_byte` test pins this exactly
+so any future revision of the simulator's opcode table that breaks the
+encoding will surface immediately.
+
+## Non-goals (v0.1.0)
+
+* No instruction lowering — deferred to A2+.
+* No `lang-aot --target=intel8008` wiring — deferred to A2+++.
+* No external assembler / linker integration.  Output is raw bytes;
+  downstream loaders are the caller's responsibility.
+
+## Tests (v0.1.0)
+
+* `validate_returns_empty_for_empty_module` — stub validator behaves.
+* `lower_emits_exactly_one_byte` — output shape.
+* `lower_emits_the_canonical_hlt_byte` — exact `0x76`.
+* `default_config_has_nonempty_module_name` — config invariant.
+* `new_sets_module_name` — builder contract.
+* `errors_display_without_panic` — error formatting smoke.


### PR DESCRIPTION
## Summary

- **A2** of [`MULTILANG-ARCHITECTURE-BACKENDS.md`](code/specs/MULTILANG-ARCHITECTURE-BACKENDS.md) — second architecture backend (after RISC-V).
- Lands a new `iir-to-intel8008` crate (v0.1.0). Any IIR module lowers to a single Intel 8008 `HLT` (`0x76`).
- Output is `Vec<u8>` — raw 8-bit opcodes, round-tripable with the in-tree `intel8008-simulator`.
- New spec [`code/specs/iir-to-intel8008.md`](code/specs/iir-to-intel8008.md).

## Where this fits

| Backend | Target |
|---------|--------|
| iir-to-wasm | WebAssembly 1.0 (software) |
| iir-to-jvm-class-file | JVM bytecode (software) |
| iir-to-cil-bytecode | CLR CIL (software) |
| iir-to-beam | Erlang BEAM (software) |
| iir-to-llvm | LLVM IR (textual → AOT) |
| iir-to-riscv | RV32I machine code (hardware) |
| **iir-to-intel8008 (this)** | **Intel 8008 machine code (Oct's native target)** |

## Why an Intel 8008 backend?

The Intel 8008 (1972) is the first commercial 8-bit microprocessor. In this codebase it's **Oct's native target** — Oct programs are written specifically to round-trip through 8008 silicon or the in-tree `intel8008-simulator`. A2 establishes the second architecture backend alongside RV32I (A1) and lays groundwork for A4 (Intel 4004), which shares the historical-microprocessor backend shape.

## Why `Vec<u8>` (not textual `.asm`)?

- **Round-trips with `intel8008-simulator`** — `Simulator::run` consumes `&[u8]`.
- **Deterministic test surface** — `assert_eq!(bytes, vec![0x76])`.
- **8008 instructions are 1–3 bytes** — textual round-trip contributes nothing.

## The `HLT` encoding (acceptance criterion)

| Field | Value |
|-------|-------|
| bit pattern | `01 110 110` |
| hex | `0x76` |
| family | register-register MOV (`MOV M,M` — silicon implements as halt) |

Pinned exactly so any future revision of the simulator's opcode table that breaks the encoding surfaces immediately.

## Public surface (v0.1.0)
```rust
pub struct IIRIntel8008Config { pub module_name: String }
impl IIRIntel8008Config { pub fn new(...) -> Self }

pub enum IIRIntel8008Error { ValidationFailed, UnsupportedOp, UnsupportedType, InvalidOperand }

pub fn validate_for_intel8008(&IIRModule) -> Vec<String>;
pub fn lower_iir_to_intel8008(&IIRModule, &IIRIntel8008Config) -> Result<Vec<u8>, IIRIntel8008Error>;
pub const HLT: u8 = 0x76;
```

## Test plan
- [x] `cargo test -p iir-to-intel8008` — 6 unit + 1 doctest, all green
- [x] Pinned exact `HLT` encoding (`0x76`)
- [x] /security-review passed

## Roadmap from here
| Item | Scope |
|------|-------|
| A2+ | MVI + MOV + arithmetic on the accumulator |
| A2++ | Conditional + unconditional jumps, calls, stack frame; 14-bit address backpatching |
| A2+++ | `lang-aot --target=intel8008` wiring |
| A3-A5 | other architecture backends (ARMv7, Intel 4004, GE-225) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)