### PR TITLE
board-vm: plan ejected firmware boot

### DIFF
--- a/code/packages/rust/board-vm-uno-r4-firmware/README.md
+++ b/code/packages/rust/board-vm-uno-r4-firmware/README.md
@@ -60,6 +60,11 @@ generated constants. Host-side tests compare that firmware summary against the
 target-independent `board-vm-eject` artifact summary, so the board-specific view
 cannot drift from the Rust-owned eject contract.
 
+The ejected boot-plan helper validates the embedded artifact and returns the
+checked summary together with the board startup action, so firmware entrypoints
+do not need to interpret raw boot-policy constants separately from artifact
+metadata validation.
+
 The ejected artifact stays board-agnostic; this firmware binary is the Uno R4
 backend that decides how to validate and execute it.
 

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/lib.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/lib.rs
@@ -114,6 +114,12 @@ pub enum EjectedBootAction {
     Run,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EjectedBootPlan {
+    pub action: EjectedBootAction,
+    pub summary: EjectedFirmwareProgramSummary,
+}
+
 impl From<ModuleError> for FirmwareSmokeError {
     fn from(value: ModuleError) -> Self {
         Self::Module(value)
@@ -169,8 +175,17 @@ pub fn validate_ejected_blink_program(board_max_stack: u8) -> Result<(), Firmwar
 pub fn ejected_boot_action(
     program: EjectedFirmwareProgram<'_>,
 ) -> Result<EjectedBootAction, FirmwareSmokeError> {
+    Ok(ejected_boot_plan(program)?.action)
+}
+
+pub fn ejected_boot_plan(
+    program: EjectedFirmwareProgram<'_>,
+) -> Result<EjectedBootPlan, FirmwareSmokeError> {
     parse_checked_ejected_program(program)?;
-    boot_action_for_policy(program.boot_policy)
+    Ok(EjectedBootPlan {
+        action: boot_action_for_policy(program.boot_policy)?,
+        summary: program.summary(),
+    })
 }
 
 pub fn run_ejected_boot_program_once<H, const MAX_STACK: usize, const MAX_HANDLES: usize>(
@@ -464,6 +479,28 @@ mod tests {
         assert_eq!(
             ejected_boot_action(EjectedFirmwareProgram::blink()).unwrap(),
             EjectedBootAction::Run
+        );
+    }
+
+    #[test]
+    fn ejected_blink_boot_plan_surfaces_checked_summary_and_action() {
+        assert_eq!(
+            ejected_boot_plan(EjectedFirmwareProgram::blink()).unwrap(),
+            EjectedBootPlan {
+                action: EjectedBootAction::Run,
+                summary: EjectedFirmwareProgram::blink().summary(),
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_ejected_boot_plan_for_crc_mismatch() {
+        let mut program = EjectedFirmwareProgram::blink();
+        program.module_crc32 ^= 1;
+
+        assert_eq!(
+            ejected_boot_plan(program).unwrap_err(),
+            FirmwareSmokeError::ArtifactCrcMismatch
         );
     }
 


### PR DESCRIPTION
## Summary
- add an `EjectedBootPlan` that returns the validated ejected artifact summary together with the firmware startup action
- route `ejected_boot_action()` through the boot-plan helper so the raw action path uses the same artifact validation
- document the boot-plan surface for Uno R4 ejected firmware entrypoints

## Validation
- cargo fmt -p board-vm-uno-r4-firmware
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-ejected-boot-plan cargo test -p board-vm-uno-r4-firmware
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-ejected-boot-plan cargo test -p board-vm-protocol -p board-vm-ir -p board-vm-host -p board-vm-device -p board-vm-loopback -p board-vm-client -p board-vm-eject -p board-vm-uno-r4-firmware -p board-vm-cli
- git diff --check
- git diff --cached --check