### PR TITLE
A2+: iir-to-intel8008 const → MVI A + ret/ret_void → HLT

### DIFF
--- a/code/packages/rust/iir-to-intel8008/CHANGELOG.md
+++ b/code/packages/rust/iir-to-intel8008/CHANGELOG.md
@@ -3,6 +3,56 @@
 All notable changes to this crate are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.2.0] — 2026-06-02 (A2+ — `const` → MVI A; `ret`/`ret_void` → HLT)
+
+### Added — first real instruction lowering
+
+Extends v0.1.0's HLT-only skeleton with three IIR ops:
+
+| IIR op | Intel 8008 lowering |
+|--------|---------------------|
+| `const dest, Int(n)` | `MVI A, n` (`0x3E` + immediate byte) |
+| `ret <var>` | `HLT` (real RET lands in A2++) |
+| `ret_void` | `HLT` |
+
+The accumulator-only first slice: every `const` goes into `A`.  Multi-
+register allocation (B/C/D/E/H/L) lands in A2++ alongside `MOV r1, r2`
+(family `11 ddd sss`) and ALU on the accumulator.
+
+#### Why `ret` → `HLT` for now
+
+Intel 8008's real `RET` (`0x3F`) requires the CPU to have a non-empty
+internal return stack — which means proper `CALL` semantics first.
+A2++ adds the `CALL/RET` stack discipline; until then, `HLT` gives the
+simulator a clean stopping point for trivial test programs.
+
+#### New constant in the public surface
+
+* `pub const MVI_A: u8 = 0x3E;` — Intel 8008 `MVI A, imm8` first byte
+  (bit pattern `00 111 110`, immediate-load family `00 rrr 110` with
+  `rrr = 111 = A`).
+
+#### Immediate byte range
+
+`const` accepts integers in `[-128, 255]`:
+* `[0, 255]` cast straight to `u8`.
+* `[-128, -1]` reinterpreted as two's-complement (`-1 → 0xFF`).
+* Anything outside → `InvalidOperand` with a precise message naming
+  the 8-bit limit.  The 8008 has no wide-immediate idiom comparable
+  to RV32I's `lui` — A2++ will split wider values into multiple
+  `MVI` sequences across multiple registers.
+
+#### Tests added (12 total, was 6)
+
+* `const_42_then_ret_lowers_to_mvi_a_42_then_hlt` — pinned exact
+  3-byte sequence `0x3E 0x2A 0x76`.
+* `mvi_a_constant_pinned_to_0x3e`
+* `const_negative_uses_twos_complement_byte` (`-1 → 0xFF`)
+* `const_out_of_byte_range_is_rejected` (`1000` overflows)
+* `ret_void_alone_emits_just_hlt`
+* `unsupported_op_is_rejected_with_function_name` (`add` rejected
+  with function name preserved in the error)
+
 ## [0.1.0] — 2026-06-02 (A2 — crate skeleton)
 
 ### Added — `HLT`-only emission

--- a/code/packages/rust/iir-to-intel8008/Cargo.toml
+++ b/code/packages/rust/iir-to-intel8008/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iir-to-intel8008"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
-description = "IIR → Intel 8008 machine code backend (Oct's native target) — lowers IIRModule to a Vec<u8> of 8-bit Intel 8008 opcodes.  v0.1.0 (A2): crate skeleton emitting a single HLT (0x76); instruction lowering deferred to v0.2.0+."
+description = "IIR → Intel 8008 machine code backend (Oct's native target) — lowers IIRModule to a Vec<u8> of 8-bit Intel 8008 opcodes.  v0.2.0 (A2+): adds `const` → MVI A, n (3E nn) for the accumulator and treats `ret`/`ret_void` as HLT; multi-register MOV and real RET via CALL/stack land in A2++."
 
 [lib]
 name = "iir_to_intel8008"

--- a/code/packages/rust/iir-to-intel8008/src/lib.rs
+++ b/code/packages/rust/iir-to-intel8008/src/lib.rs
@@ -78,11 +78,11 @@
 //!       • burn to a 1702 EPROM (Oct's intended deployment path)
 //! ```
 
-use interpreter_ir::IIRModule;
+use interpreter_ir::{IIRModule, Operand};
 use std::fmt;
 
 // ===========================================================================
-// Intel 8008 opcode constants used by v0.1.0
+// Intel 8008 opcode constants
 // ===========================================================================
 //
 // The 8008's instruction encoding is irregular by modern standards: the
@@ -92,13 +92,17 @@ use std::fmt;
 // register-register MOV family but encodes "MOV M,M" — semantically a
 // self-move on the memory-pointer pseudo-register — which the silicon
 // implements as a halt.
-//
-// Bit pattern of HLT: `01 110 110` = `0x76`.  The simulator's
-// `Simulator::halted()` accessor flips true after this byte is
-// executed.
 
 /// Intel 8008 `HLT` opcode — `0x76`.  Halts the CPU.
 pub const HLT: u8 = 0x76;
+
+/// Intel 8008 `MVI A, imm8` first byte — `0x3E`.  Loads the next byte
+/// into the accumulator register.
+///
+/// Bit pattern: `00 111 110` (immediate-load family `00 rrr 110`, where
+/// `rrr = 111 = A`).  Two-byte instruction: this opcode plus the literal
+/// immediate byte.
+pub const MVI_A: u8 = 0x3E;
 
 // ===========================================================================
 // IIRIntel8008Config
@@ -200,6 +204,13 @@ pub fn validate_for_intel8008(_module: &IIRModule) -> Vec<String> {
 /// enough to load into the simulator, step once, and confirm
 /// [`Simulator::halted`] returns `true`.  Real lowering arrives in
 /// v0.2.0+ (A2+).
+/// Supported instruction opcodes in v0.2.0 (A2+).
+///
+/// `const` lowers to `MVI A, n` (3E + immediate byte).  `ret`/`ret_void`
+/// lowers to `HLT` — proper RET via CALL/stack lands in A2++.  Anything
+/// else is `UnsupportedOp`.
+const SUPPORTED_OPS: &[&str] = &["const", "ret", "ret_void"];
+
 pub fn lower_iir_to_intel8008(
     module: &IIRModule,
     _cfg: &IIRIntel8008Config,
@@ -208,9 +219,79 @@ pub fn lower_iir_to_intel8008(
     if !errors.is_empty() {
         return Err(IIRIntel8008Error::ValidationFailed(errors));
     }
-    // Single emitted byte: HLT.  Wrapped through the named constant so a
-    // future revision of the simulator's opcode table that changes the
-    // halt encoding flows through automatically — we'd update `HLT` once
-    // and every backend re-emits the right byte.
-    Ok(vec![HLT])
+
+    // Trivial empty-module contract — preserves v0.1.0 callable behaviour
+    // for the canonical "fn main() {}" minimal case.
+    if module.functions.is_empty() {
+        return Ok(vec![HLT]);
+    }
+
+    let mut bytes = Vec::new();
+    for f in &module.functions {
+        for instr in &f.instructions {
+            if !SUPPORTED_OPS.contains(&instr.op.as_str()) {
+                return Err(IIRIntel8008Error::UnsupportedOp {
+                    function: f.name.clone(),
+                    op: instr.op.clone(),
+                });
+            }
+            match instr.op.as_str() {
+                // ── const: lower to MVI A, n ─────────────────────────────
+                //
+                // v0.2.0 treats every `const` as a load into the
+                // accumulator.  Multi-register allocation (B/C/D/E/H/L)
+                // lands in A2++ alongside MOV.  For values outside the
+                // 8-bit unsigned range (0..255) we return InvalidOperand —
+                // the 8008 has no wide-immediate idiom comparable to
+                // RV32's `lui`.
+                "const" => {
+                    let n = match instr.srcs.first() {
+                        Some(Operand::Int(n)) => *n,
+                        Some(Operand::Bool(b)) => if *b { 1 } else { 0 },
+                        _ => return Err(IIRIntel8008Error::InvalidOperand {
+                            function: f.name.clone(),
+                            detail: "const srcs[0] must be Int or Bool".into(),
+                        }),
+                    };
+                    // Accept i8 ([-128,127]) interpreted as two's-complement
+                    // u8 OR u8 ([0,255]) — both fit in the immediate byte.
+                    let byte: u8 = if (0..=255).contains(&n) {
+                        n as u8
+                    } else if (-128..0).contains(&n) {
+                        (n as i8) as u8 // two's-complement reinterpretation
+                    } else {
+                        return Err(IIRIntel8008Error::InvalidOperand {
+                            function: f.name.clone(),
+                            detail: format!(
+                                "const {n} exceeds 8-bit byte range \
+                                 ([-128, 255]); 8008 has no wide-immediate \
+                                 idiom — split into multiple MVIs in A2++"
+                            ),
+                        });
+                    };
+                    bytes.push(MVI_A);
+                    bytes.push(byte);
+                }
+                // ── ret / ret_void: lower to HLT for now ─────────────────
+                //
+                // Intel 8008's real RET (`0x3F`) requires the CPU to have
+                // a non-empty internal return stack — that means proper
+                // CALL semantics, which arrive in A2++.  Until then, HLT
+                // gives the simulator a clean stop point.
+                "ret" | "ret_void" => {
+                    bytes.push(HLT);
+                }
+                _ => unreachable!("SUPPORTED_OPS guard above prevents this"),
+            }
+        }
+    }
+
+    // If the module had functions but no instructions emitted anything
+    // (empty bodies), still produce HLT so the .bin is non-empty and the
+    // simulator has a stopping point.
+    if bytes.is_empty() {
+        bytes.push(HLT);
+    }
+
+    Ok(bytes)
 }

--- a/code/packages/rust/iir-to-intel8008/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-intel8008/tests/test_backend.rs
@@ -3,11 +3,23 @@
 //! Smoke-level — confirms the validator stub, the emitter shape, and
 //! the exact encoded `HLT` byte (`0x76`).
 
-use interpreter_ir::IIRModule;
+use interpreter_ir::{IIRFunction, IIRInstr, IIRModule, Operand};
 use iir_to_intel8008::{
     lower_iir_to_intel8008, validate_for_intel8008,
-    IIRIntel8008Config, IIRIntel8008Error, HLT,
+    IIRIntel8008Config, IIRIntel8008Error, HLT, MVI_A,
 };
+
+fn module_with(f: IIRFunction) -> IIRModule {
+    let entry = f.name.clone();
+    IIRModule {
+        name: "test".into(),
+        functions: vec![f],
+        entry_point: Some(entry),
+        language: "test".into(),
+        exports: vec![],
+        imports: vec![],
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -95,4 +107,92 @@ fn errors_display_without_panic() {
     let _ = format!("{}", IIRIntel8008Error::InvalidOperand {
         function: "f".into(), detail: "bad".into(),
     });
+}
+
+// ===========================================================================
+// 5. A2+ — `const` lowers to `MVI A, n` (0x3E + immediate byte)
+// ===========================================================================
+//
+// The accumulator-only first slice: every `const` goes into A; multi-
+// register allocation (B/C/D/E/H/L) lands in A2++.  `ret`/`ret_void`
+// emits `HLT` until A2++ wires up the 8008's CALL/RET stack.
+
+#[test]
+fn const_42_then_ret_lowers_to_mvi_a_42_then_hlt() {
+    let f = IIRFunction::new("answer", vec![], "u8", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(42)], "u8"),
+        IIRInstr::new("ret",   None,             vec![Operand::Var("v".into())], "u8"),
+    ]);
+    let bytes = lower_iir_to_intel8008(&module_with(f), &IIRIntel8008Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![MVI_A, 42, HLT],
+        "expected MVI A,42 (0x3E 0x2A) + HLT (0x76); got: {bytes:02x?}");
+}
+
+#[test]
+fn mvi_a_constant_pinned_to_0x3e() {
+    // Sanity: the MVI_A constant matches the canonical Intel 8008
+    // documented encoding (0x3E).
+    assert_eq!(MVI_A, 0x3E,
+        "MVI A immediate-load opcode should be 0x3E (bit pattern 00 111 110)");
+}
+
+#[test]
+fn const_negative_uses_twos_complement_byte() {
+    // -1 → 0xFF via two's-complement reinterpretation.
+    let f = IIRFunction::new("f", vec![], "i8", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(-1)], "i8"),
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ]);
+    let bytes = lower_iir_to_intel8008(&module_with(f), &IIRIntel8008Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![MVI_A, 0xFF, HLT],
+        "expected MVI A,0xFF + HLT for `const -1`; got: {bytes:02x?}");
+}
+
+#[test]
+fn const_out_of_byte_range_is_rejected() {
+    let f = IIRFunction::new("f", vec![], "i16", vec![
+        // 1000 fits in i16 but not in a single 8008 immediate byte.
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(1000)], "i16"),
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ]);
+    let err = lower_iir_to_intel8008(&module_with(f), &IIRIntel8008Config::default())
+        .expect_err("1000 should overflow the 8-bit immediate");
+    match err {
+        IIRIntel8008Error::InvalidOperand { detail, .. } => {
+            assert!(detail.contains("8-bit"),
+                "expected message naming the 8-bit limit; got: {detail}");
+        }
+        other => panic!("expected InvalidOperand, got: {other:?}"),
+    }
+}
+
+#[test]
+fn ret_void_alone_emits_just_hlt() {
+    let f = IIRFunction::new("main", vec![], "void", vec![
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ]);
+    let bytes = lower_iir_to_intel8008(&module_with(f), &IIRIntel8008Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![HLT],
+        "ret_void-only function should emit just HLT; got: {bytes:02x?}");
+}
+
+#[test]
+fn unsupported_op_is_rejected_with_function_name() {
+    let f = IIRFunction::new("boom", vec![], "void", vec![
+        IIRInstr::new("add", Some("v".into()),
+            vec![Operand::Int(1), Operand::Int(2)], "u8"),
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ]);
+    let err = lower_iir_to_intel8008(&module_with(f), &IIRIntel8008Config::default())
+        .expect_err("`add` should be UnsupportedOp in A2+");
+    match err {
+        IIRIntel8008Error::UnsupportedOp { function, op } => {
+            assert_eq!(function, "boom");
+            assert_eq!(op, "add");
+        }
+        other => panic!("expected UnsupportedOp, got: {other:?}"),
+    }
 }

--- a/code/specs/iir-to-intel8008.md
+++ b/code/specs/iir-to-intel8008.md
@@ -53,10 +53,10 @@ IIRModule
 
 | Version | Scope | Status |
 |---------|-------|--------|
-| **v0.1.0 (A2 — this PR)** | crate skeleton: any module → single `HLT` (`0x76`) | this PR |
-| v0.2.0 (A2+) | MVI (immediate load) + MOV (register-register) + arithmetic on the accumulator | future |
-| v0.3.0 (A2++) | Conditional + unconditional jumps, calls, stack frame; 14-bit address backpatching | future |
-| v0.4.0 (A2+++) | `lang-aot --target=intel8008` wiring | future |
+| v0.1.0 (A2) | crate skeleton: any module → single `HLT` (`0x76`) | **merged** |
+| **v0.2.0 (A2+ — this PR)** | `const` → `MVI A, n` + `ret`/`ret_void` → `HLT` (accumulator-only first slice) | this PR |
+| v0.3.0 (A2++) | Multi-register allocation (B/C/D/E/H/L) + `MOV r1, r2` + ALU on the accumulator + real `RET` via `CALL`/stack | future |
+| v0.4.0 (A2+++) | Conditional + unconditional jumps with 14-bit address backpatching + `lang-aot --target=intel8008` | future |
 
 ## Public surface (v0.1.0)
 


### PR DESCRIPTION
## Summary

- **A2+** of [`MULTILANG-ARCHITECTURE-BACKENDS.md`](code/specs/MULTILANG-ARCHITECTURE-BACKENDS.md). Extends v0.1.0 (HLT-only skeleton) to v0.2.0 — first real Intel 8008 instruction lowering.
- 12 unit + 1 doctest (was 6 + 1), all green.

## Op coverage added

| IIR op | Intel 8008 lowering |
|--------|---------------------|
| `const dest, Int(n)` | `MVI A, n` (`0x3E` + immediate byte) |
| `ret <var>` | `HLT` |
| `ret_void` | `HLT` |

## Accumulator-only first slice

Every `const` goes into `A`. Multi-register allocation (B/C/D/E/H/L) + `MOV r1, r2` + ALU + real `RET` via `CALL`/stack land in A2++.

## Why `ret` → `HLT` for now

Intel 8008's real `RET` (`0x3F`) requires the CPU's internal return stack to be non-empty — which means proper `CALL` semantics first. A2++ adds the `CALL/RET` stack discipline; until then, `HLT` gives the simulator a clean stop point.

## Immediate byte range (`const`)

`const` accepts integers in `[-128, 255]`:

- `[0, 255]` cast straight to `u8`
- `[-128, -1]` reinterpreted as two's-complement (`-1 → 0xFF`)
- Outside → `InvalidOperand` naming the 8-bit limit. The 8008 has no wide-immediate idiom comparable to RV32I's `lui`; A2++ will split wider values into multi-MVI sequences.

## New public constant

```rust
pub const MVI_A: u8 = 0x3E;  // bit pattern 00 111 110
```

## Test plan
- [x] `cargo test -p iir-to-intel8008` — 12 + 1 doctest, all green
- [x] `const_42_then_ret_lowers_to_mvi_a_42_then_hlt` — pinned exact 3-byte sequence `0x3E 0x2A 0x76`
- [x] `mvi_a_constant_pinned_to_0x3e`
- [x] `const_negative_uses_twos_complement_byte` (`-1 → 0xFF`)
- [x] `const_out_of_byte_range_is_rejected` (`1000` overflows)
- [x] `ret_void_alone_emits_just_hlt`
- [x] `unsupported_op_is_rejected_with_function_name`
- [x] /security-review passed

## Spec status row

| Version | Scope | Status |
|---------|-------|--------|
| v0.1.0 (A2) | skeleton | merged |
| **v0.2.0 (A2+ — this PR)** | const → MVI A; ret/ret_void → HLT | this PR |
| v0.3.0 (A2++) | multi-register MOV + ALU + real RET via CALL/stack | future |
| v0.4.0 (A2+++) | jumps + lang-aot --target=intel8008 wiring | future |

🤖 Generated with [Claude Code](https://claude.com/claude-code)