### PR TITLE
Track browser form validation descriptors

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -762,6 +762,23 @@ def check_browser_expected_lists(
             require_optional_string_list(
                 successful_path, control, "submission_values", errors
             )
+        require_optional_object_list(form_path, form, "validation_controls", errors)
+        for validation_index, control in enumerate(
+            object_list_items(form, "validation_controls")
+        ):
+            validation_path = f"{form_path}.validation_controls[{validation_index}]"
+            require_optional_nullable_string(validation_path, control, "id", errors)
+            require_string(validation_path, control, "control_type", errors)
+            require_optional_nullable_string(validation_path, control, "name", errors)
+            require_optional_nullable_string(validation_path, control, "form_owner", errors)
+            require_optional_boolean(validation_path, control, "will_validate", errors)
+            require_optional_boolean(validation_path, control, "required", errors)
+            require_optional_string_list(
+                validation_path, control, "validation_attributes", errors
+            )
+            require_optional_nullable_string(
+                validation_path, control, "validation_barred_reason", errors
+            )
         require_object_list(form_path, form, "controls", errors)
         require_optional_object_list(form_path, form, "submitters", errors)
         for control_index, control in enumerate(object_list_items(form, "controls")):

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -1616,6 +1616,7 @@ pub struct BrowserForm {
     pub selects: Vec<BrowserFormSelect>,
     pub outputs: Vec<BrowserFormOutput>,
     pub successful_controls: Vec<BrowserFormSuccessfulControl>,
+    pub validation_controls: Vec<BrowserFormValidationControl>,
     pub controls: Vec<BrowserFormControl>,
     pub submitters: Vec<BrowserFormSubmitter>,
 }
@@ -1691,6 +1692,18 @@ pub struct BrowserFormSuccessfulControl {
     pub name: String,
     pub form_owner: Option<String>,
     pub submission_values: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserFormValidationControl {
+    pub id: Option<String>,
+    pub control_type: String,
+    pub name: Option<String>,
+    pub form_owner: Option<String>,
+    pub will_validate: bool,
+    pub required: bool,
+    pub validation_attributes: Vec<String>,
+    pub validation_barred_reason: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -12746,6 +12759,7 @@ fn browser_form(
     let selects = browser_form_selects(&controls);
     let outputs = browser_form_outputs(&controls);
     let successful_controls = browser_form_successful_controls(&controls);
+    let validation_controls = browser_form_validation_controls(&controls);
     let submitters = browser_form_submitters(
         &controls,
         action.as_deref(),
@@ -12788,6 +12802,7 @@ fn browser_form(
         selects,
         outputs,
         successful_controls,
+        validation_controls,
         controls,
         submitters,
     }
@@ -13129,6 +13144,30 @@ fn browser_form_successful_controls(
                 form_owner: control.form_owner.clone(),
                 submission_values: control.submission_values.clone(),
             })
+        })
+        .collect()
+}
+
+fn browser_form_validation_controls(
+    controls: &[BrowserFormControl],
+) -> Vec<BrowserFormValidationControl> {
+    controls
+        .iter()
+        .filter(|control| {
+            control.will_validate
+                || control.required
+                || !control.validation_attributes.is_empty()
+                || control.validation_barred_reason.is_some()
+        })
+        .map(|control| BrowserFormValidationControl {
+            id: control.id.clone(),
+            control_type: control.control_type.clone(),
+            name: control.name.clone(),
+            form_owner: control.form_owner.clone(),
+            will_validate: control.will_validate,
+            required: control.required,
+            validation_attributes: control.validation_attributes.clone(),
+            validation_barred_reason: control.validation_barred_reason.clone(),
         })
         .collect()
 }

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -3,11 +3,11 @@ use coding_adventures_html_parser::{
     BrowserDatalistOption, BrowserDocument, BrowserDocumentMetadata, BrowserEmbeddedContext,
     BrowserForm, BrowserFormControl, BrowserFormDatalist, BrowserFormFieldset, BrowserFormLabel,
     BrowserFormOutput, BrowserFormSelect, BrowserFormSubmitter, BrowserFormSuccessfulControl,
-    BrowserHeading, BrowserHttpEquivHint, BrowserImage, BrowserImageSource,
-    BrowserInteractiveElement, BrowserLink, BrowserMedia, BrowserMeta, BrowserMetadataDirective,
-    BrowserRefresh, BrowserResource, BrowserResourceHint, BrowserScript, BrowserSelectOption,
-    BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet, BrowserTable,
-    BrowserTemplate, BrowserThemeColor,
+    BrowserFormValidationControl, BrowserHeading, BrowserHttpEquivHint, BrowserImage,
+    BrowserImageSource, BrowserInteractiveElement, BrowserLink, BrowserMedia, BrowserMeta,
+    BrowserMetadataDirective, BrowserRefresh, BrowserResource, BrowserResourceHint, BrowserScript,
+    BrowserSelectOption, BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet,
+    BrowserTable, BrowserTemplate, BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -727,6 +727,8 @@ struct ExpectedForm {
     outputs: Vec<ExpectedFormOutput>,
     #[serde(default)]
     successful_controls: Vec<ExpectedFormSuccessfulControl>,
+    #[serde(default)]
+    validation_controls: Vec<ExpectedFormValidationControl>,
     controls: Vec<ExpectedFormControl>,
     #[serde(default)]
     submitters: Vec<ExpectedFormSubmitter>,
@@ -840,6 +842,25 @@ struct ExpectedFormSuccessfulControl {
     form_owner: Option<String>,
     #[serde(default)]
     submission_values: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedFormValidationControl {
+    #[serde(default)]
+    id: Option<String>,
+    control_type: String,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    form_owner: Option<String>,
+    #[serde(default)]
+    will_validate: bool,
+    #[serde(default)]
+    required: bool,
+    #[serde(default)]
+    validation_attributes: Vec<String>,
+    #[serde(default)]
+    validation_barred_reason: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1153,6 +1174,75 @@ fn browser_form_validation_descriptor_metadata_tracks_constraint_attributes_and_
         actual.forms, expected.forms,
         "form controls should preserve validation attributes and barred validation reasons",
     );
+}
+
+#[test]
+fn browser_form_validation_control_descriptors_track_candidates_and_barred_controls() {
+    let document = parse_browser_document(
+        "<form id=signup>\
+         <input id=email name=email type=email required minlength=3 maxlength=80>\
+         <input id=age name=age type=number min=18 max=120 step=1>\
+         <textarea id=bio name=bio readonly maxlength=200>About me</textarea>\
+         <input id=token type=hidden name=token value=abc>\
+         <fieldset disabled><legend>Legacy</legend><input id=legacy name=legacy required></fieldset>\
+         <output id=preview name=preview for=\"email age\">Preview</output>\
+         <input id=go type=image name=go src=go.png alt=Go>\
+         </form>\
+         <input id=external form=signup name=outside required>",
+    )
+    .expect("form validation descriptor fixture should parse");
+
+    let form = document
+        .forms
+        .first()
+        .expect("signup form should be summarized");
+    let descriptors = &form.validation_controls;
+    let ids: Vec<&str> = descriptors
+        .iter()
+        .filter_map(|control| control.id.as_deref())
+        .collect();
+    assert_eq!(
+        ids,
+        vec!["email", "age", "bio", "token", "legacy", "preview", "go", "external"]
+    );
+
+    assert!(descriptors[0].will_validate);
+    assert!(descriptors[0].required);
+    assert_eq!(
+        descriptors[0].validation_attributes,
+        vec!["required", "minlength", "maxlength"]
+    );
+    assert!(descriptors[1].will_validate);
+    assert_eq!(
+        descriptors[1].validation_attributes,
+        vec!["min", "max", "step"]
+    );
+    assert!(!descriptors[2].will_validate);
+    assert_eq!(
+        descriptors[2].validation_barred_reason.as_deref(),
+        Some("readonly")
+    );
+    assert_eq!(
+        descriptors[3].validation_barred_reason.as_deref(),
+        Some("input-type-hidden")
+    );
+    assert!(!descriptors[4].will_validate);
+    assert!(descriptors[4].required);
+    assert_eq!(
+        descriptors[4].validation_barred_reason.as_deref(),
+        Some("disabled")
+    );
+    assert_eq!(
+        descriptors[5].validation_barred_reason.as_deref(),
+        Some("output")
+    );
+    assert_eq!(
+        descriptors[6].validation_barred_reason.as_deref(),
+        Some("input-type-image")
+    );
+    assert_eq!(descriptors[7].form_owner.as_deref(), Some("signup"));
+    assert!(descriptors[7].will_validate);
+    assert_eq!(descriptors[7].validation_attributes, vec!["required"]);
 }
 
 #[test]
@@ -2221,6 +2311,11 @@ impl ExpectedForm {
                 .into_iter()
                 .map(ExpectedFormSuccessfulControl::into_browser_form_successful_control)
                 .collect(),
+            validation_controls: self
+                .validation_controls
+                .into_iter()
+                .map(ExpectedFormValidationControl::into_browser_form_validation_control)
+                .collect(),
             controls: self
                 .controls
                 .into_iter()
@@ -2309,6 +2404,21 @@ impl ExpectedFormSuccessfulControl {
             name: self.name,
             form_owner: self.form_owner,
             submission_values: self.submission_values,
+        }
+    }
+}
+
+impl ExpectedFormValidationControl {
+    fn into_browser_form_validation_control(self) -> BrowserFormValidationControl {
+        BrowserFormValidationControl {
+            id: self.id,
+            control_type: self.control_type,
+            name: self.name,
+            form_owner: self.form_owner,
+            will_validate: self.will_validate,
+            required: self.required,
+            validation_attributes: self.validation_attributes,
+            validation_barred_reason: self.validation_barred_reason,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -84,6 +84,15 @@
               { "control_type": "select", "name": "section", "submission_values": ["manuals"] },
               { "control_type": "textarea", "name": "notes", "submission_values": ["Line one Line two"] }
             ],
+            "validation_controls": [
+              { "control_type": "text", "name": "q", "will_validate": true },
+              { "control_type": "hidden", "name": "page", "validation_barred_reason": "input-type-hidden" },
+              { "control_type": "checkbox", "name": "in_stock", "will_validate": true },
+              { "control_type": "text", "name": "disabled", "validation_barred_reason": "disabled" },
+              { "control_type": "select", "name": "section", "will_validate": true },
+              { "control_type": "textarea", "name": "notes", "will_validate": true },
+              { "control_type": "submit", "name": "go", "will_validate": true }
+            ],
             "controls": [
               { "control_type": "text", "name": "q", "value": "rust html", "successful": true, "submission_values": ["rust html"], "disabled": false, "will_validate": true, "checked": false, "text": "", "options": [] },
               { "control_type": "hidden", "name": "page", "value": "1", "successful": true, "submission_values": ["1"], "disabled": false, "validation_barred_reason": "input-type-hidden", "checked": false, "text": "", "options": [] },
@@ -225,6 +234,18 @@
               { "id": "kind", "control_type": "select", "name": "kind", "submission_values": ["books"] },
               { "id": "upload", "control_type": "file", "name": "upload", "submission_values": [] },
               { "id": "external", "control_type": "text", "name": "outside", "form_owner": "search", "submission_values": [""] }
+            ],
+            "validation_controls": [
+              { "id": "q", "control_type": "text", "name": "q", "will_validate": true, "required": true, "validation_attributes": ["required", "pattern", "minlength", "maxlength"] },
+              { "id": "count", "control_type": "number", "name": "count", "will_validate": true, "required": true, "validation_attributes": ["required", "min", "max", "step"] },
+              { "id": "notes", "control_type": "textarea", "name": "notes", "validation_attributes": ["readonly", "maxlength"], "validation_barred_reason": "readonly" },
+              { "id": "fast", "control_type": "checkbox", "name": "fast", "validation_barred_reason": "disabled" },
+              { "id": "kind", "control_type": "select", "name": "kind", "will_validate": true },
+              { "id": "upload", "control_type": "file", "name": "upload", "will_validate": true },
+              { "id": "go", "control_type": "submit", "will_validate": true },
+              { "id": "imageGo", "control_type": "image", "name": "image-go", "validation_barred_reason": "input-type-image" },
+              { "id": "total", "control_type": "output", "name": "total", "validation_barred_reason": "output" },
+              { "id": "external", "control_type": "text", "name": "outside", "form_owner": "search", "will_validate": true }
             ],
             "controls": [
               { "id": "q", "control_type": "text", "name": "q", "labels": ["Query"], "accessible_name": "Query", "accessible_description": "Query", "placeholder": "Search terms", "autocomplete": "section-primary shipping search", "autocomplete_tokens": ["section-primary", "shipping", "search"], "autocapitalize": "words", "enterkeyhint": "search", "dirname": "q.dir", "spellcheck": "false", "autocorrect": "off", "inputmode": "search", "pattern": "[A-Za-z ]+", "minlength": "2", "maxlength": "80", "size": "40", "list": "query-suggestions", "datalist_options": ["Rust", "HTML", "Browser APIs"], "value": null, "successful": true, "submission_values": [""], "autofocus": true, "disabled": false, "required": true, "will_validate": true, "validation_attributes": ["required", "pattern", "minlength", "maxlength"], "checked": false, "text": "", "options": [] },


### PR DESCRIPTION
## Summary
- add form-level `validation_controls` descriptors for constraint candidates, required controls, validation attributes, and barred-validation reasons
- cover readonly, disabled fieldset ancestry, hidden/image/output barred controls, and external form-owned validation candidates
- extend browser-readiness fixture schema and fixtures with validation descriptor metadata

## Tests
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py`
- `cargo test -p coding-adventures-html-parser browser_form_validation_control_descriptors_track_candidates_and_barred_controls`
- `cargo test -p coding-adventures-html-parser browser_form_`
- `cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts`
- `cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`