### PR TITLE
feat(ml-framework-core-ts): pure-TypeScript Tensor (JS/TS pilot PR #1/5)

### DIFF
--- a/code/packages/typescript/ml-framework-core/BUILD
+++ b/code/packages/typescript/ml-framework-core/BUILD
@@ -1,0 +1,1 @@
+npm install --silent && npm run build && npm test

--- a/code/packages/typescript/ml-framework-core/BUILD_windows
+++ b/code/packages/typescript/ml-framework-core/BUILD_windows
@@ -1,0 +1,1 @@
+npm install --silent && npm run build && npm test

--- a/code/packages/typescript/ml-framework-core/CHANGELOG.md
+++ b/code/packages/typescript/ml-framework-core/CHANGELOG.md
@@ -1,0 +1,102 @@
+# Changelog
+
+## Unreleased
+
+### Added — v0.1.0: pure-TypeScript Tensor class
+
+First release.  Ships the bottom layer of the TypeScript ML framework
+stack: a PyTorch-shaped `Tensor` class implemented entirely in
+TypeScript.  No Rust calls, no native addons.  Layered design — PRs
+#2–#5 will add the autograd engine, forward + backward op dispatch,
+end-to-end MLP test, and benchmark + RubyGems-style publishing polish.
+
+#### Public API
+
+```ts
+import { Tensor } from "@coding-adventures/ml-framework-core";
+```
+
+- **Construction**: `new Tensor(data, { shape?, dtype? })`
+- **Factories**: `zeros`, `ones`, `full`, `eye` (square or rectangular),
+  `arange` (1/2/3-arg, supports negative step, rejects NaN/Infinity),
+  `randn` (deterministic with `seed:`, via Box-Muller + seeded LCG),
+  `fromArray`
+- **Shape ops**: `reshape`, `transpose` (2-D only in v0.1), `flatten`,
+  `squeeze` (all-1 or specific axis), `unsqueeze` (negative axes OK)
+- **Element-wise math methods**: `add`, `sub`, `mul`, `div`, `pow`, `neg`
+  — tensor⊗tensor (same shape) and tensor⊗scalar.  TypeScript has no
+  operator overloading; chain methods (`x.add(y).mul(2)`) instead.
+- **Conversions**: `toArray` (flat `number[]`), `toNested`
+  (shape-respecting nested array)
+- **Introspection**: `shape`, `dtype`, `ndim`, `numel`, `equals`,
+  `equalsClose`, `toString`
+
+#### Architecture choices
+
+- **`Float32Array` storage** instead of `number[]`:
+  - Matches matrix-cpu's f32 dtype byte-for-byte — no lossy round-trip
+    at the future FFI dispatch boundary
+  - ~2-3× faster for tight inner loops (V8 specializes Float32Array
+    aggressively)
+  - Row-major contiguous layout matches matrix-cpu's expectation
+- **No operator overloading**: TypeScript inherits JavaScript's lack
+  of it.  Method-chaining (`x.add(y).relu()`) is unambiguous and reads
+  naturally; matches TensorFlow.js convention.
+- **Same-shape only for binary ops**: no NumPy-style broadcasting in
+  v0.1.  Adding it now would couple Tensor to the shape-broadcasting
+  algorithm; pulled in when ops dispatch lands.
+- **Box-Muller `randn`**: textbook two-line algorithm; avoids pulling
+  in a distribution library.  Seeded variant uses a tiny LCG with
+  Numerical Recipes constants (not crypto-secure; documented).
+- **Arange rejects non-finite bounds**: `Infinity` would loop forever
+  building the result array; `NaN` would silently return empty.  Both
+  raise `RangeError`.
+
+#### File layout
+
+```
+ml-framework-core/
+├── package.json                        (ESM, TS, vitest)
+├── tsconfig.json                       (target ES2022, module ESNext)
+├── vitest.config.ts                    (80% coverage thresholds)
+├── src/
+│   ├── index.ts                        (entry point, re-exports)
+│   ├── version.ts                      ("0.1.0")
+│   └── tensor.ts                       (the Tensor class + helpers)
+├── tests/
+│   └── tensor.test.ts                  (~50 vitest cases, 7 describe blocks)
+├── BUILD / BUILD_windows               (npm install + npm test)
+├── required_capabilities.json          (empty — no FFI/net/fs)
+├── README.md
+└── CHANGELOG.md
+```
+
+#### Test coverage (~50 vitest cases)
+
+- **Construction** (8): flat/nested/scalar/deep-nested/ragged-rejection/
+  explicit-shape validation/dtype rejection/non-number elements
+- **Factories** (16): every factory + arange edge cases (zero step,
+  negative step, non-finite bounds) + randn determinism + Box-Muller
+  mean sanity check on 1000 samples
+- **Shape ops** (12): reshape (mismatch rejection, round-trip),
+  flatten, transpose (default, perm, double-identity, invalid perm,
+  higher-rank not-implemented), squeeze (default, axis, negative,
+  non-unit rejection), unsqueeze (positive, negative, round-trip)
+- **Element-wise math** (8): every method + scalar broadcast + shape
+  mismatch + type rejection
+- **Equality + toString** (4): shape-aware equals, equalsClose with
+  epsilon, toString formatting, toString truncation
+- **Round-trip** (3): toNested 2-D and 3-D, reshape preserves toArray
+- **Helpers** (5): inferShape edge cases, flattenToFloat32 validation
+- **Version** (1): VERSION constant well-formed
+
+#### What's next
+
+- PR #2: `autograd.ts` — `Function` base class, `apply`, topological
+  sort, `Tensor#backward`.  Mirrors the Ruby pilot's PR #5 structure.
+- PR #3: `ops.ts` — 15 Function subclasses (Add, Sub, Mul, Div, Neg,
+  Abs, Pow, MatMul, ReLU, Sigmoid, Tanh, GELU, Softmax, Sum, Mean).
+  Each dispatches large tensors through `@coding-adventures/matrix-rust-napi`'s
+  `runGraphOnCpu`.
+- PR #4: backward dispatch + end-to-end MLP training test.
+- PR #5: benchmark script + v1.0.0 polish.

--- a/code/packages/typescript/ml-framework-core/README.md
+++ b/code/packages/typescript/ml-framework-core/README.md
@@ -1,0 +1,116 @@
+# `@coding-adventures/ml-framework-core`
+
+Idiomatic TypeScript Tensor + autograd on top of the Rust matrix-cpu
+execution engine.  v0.1.0 ships the Tensor layer in pure TypeScript;
+autograd, op dispatch through Rust, and an end-to-end MLP land in
+PRs #2–#5.
+
+## Install
+
+```bash
+npm install @coding-adventures/ml-framework-core
+```
+
+(Not yet published; in-repo path-resolution works today via the workspace.)
+
+## Quick start (v0.1.0)
+
+```ts
+import { Tensor } from "@coding-adventures/ml-framework-core";
+
+// Construction
+const a = new Tensor([[1, 2, 3], [4, 5, 6]]);  // shape inferred → [2, 3]
+const b = new Tensor([1, 2, 3], { shape: [3] });
+
+// Factories
+Tensor.zeros(2, 3);
+Tensor.ones(3);
+Tensor.full([2, 2], 7.5);
+Tensor.eye(3);                  // 3×3 identity
+Tensor.eye(2, 3);               // rectangular
+Tensor.arange(5);               // 0, 1, 2, 3, 4
+Tensor.arange(0, 10, 2);        // 0, 2, 4, 6, 8
+Tensor.randn([3, 4], 42);       // standard-normal with seed
+Tensor.fromArray([[1, 2], [3, 4]]);
+
+// Shape ops
+a.reshape([3, 2]);
+a.transpose();                  // 2-D only in v0.1
+a.flatten();
+a.squeeze();
+a.unsqueeze(0);
+
+// Element-wise math (TypeScript has no operator overloading;
+// chain methods instead — PyTorch-from-JS convention)
+a.add(b)   a.sub(b)   a.mul(b)   a.div(b)
+a.pow(2)   a.neg()
+a.add(5)                        // scalar broadcasts
+
+// Introspection
+a.shape;        // → [2, 3]
+a.dtype;        // → "f32"
+a.ndim;         // → 2
+a.numel;        // → 6
+a.toArray();    // flat number[]
+a.toNested();   // nested array matching shape
+a.equals(b);    // structural element-wise equality
+a.equalsClose(b, 1e-6);
+```
+
+## What's intentionally NOT in v0.1.0
+
+| Feature                | Lands in | Why deferred                              |
+|------------------------|----------|-------------------------------------------|
+| Autograd (`backward`)  | PR #2    | Needs its own focused PR                  |
+| Rust dispatch          | PR #3    | Needs autograd graph first                |
+| Broadcasting           | PR #3    | Couples Tensor to shape algebra           |
+| Indexing/slicing       | post-#5  | 50+ lines of arg-shape handling           |
+| Reductions (sum/mean)  | PR #3    | These become Function subclasses          |
+| Higher-rank transpose  | post-#5  | Generic strided index math not needed yet |
+
+## Storage model
+
+- `data` is a `Float32Array`.
+- `shape` is `readonly number[]`.
+- `dtype` is `"f32"`.
+
+Using `Float32Array` instead of `number[]`:
+
+- **No lossy conversion at the dispatch boundary** — the bytes we'd send
+  to matrix-cpu are already f32 in memory.  No round-trip through f64.
+- **Roughly 2-3× faster** for tight inner loops (V8 specializes the
+  contiguous-Float32 path).
+- **Row-major contiguous layout** — matches matrix-cpu's expectation.
+
+## Architecture (will be filled out by PRs #2–#5)
+
+```
+@coding-adventures/ml-framework-core   ← this package (v0.1.0)
+       ↓ (PR #2 adds autograd)
+       ↓ (PR #3 adds Rust dispatch above 10k cells)
+@coding-adventures/matrix-rust-napi    ← TS wrapper (v0.4.0, exists)
+       ↓
+matrix-rust-napi (Rust cdylib)         ← N-API addon (v0.3.0, exists)
+       ↓
+node-bridge (Rust workspace crate)     ← zero-dep N-API wrapper (v0.1.0, exists)
+       ↓
+matrix-ir-json → matrix-ir → matrix-runtime → matrix-cpu
+```
+
+The bottom three layers already exist — this package is the top of the
+TS stack we're building.
+
+## Testing
+
+```bash
+npm install
+npm test
+```
+
+The v0.1.0 suite runs ~50 vitest cases covering construction,
+factories, shape ops, element-wise math, equality, and round-trip
+properties.
+
+## License
+
+MIT.

--- a/code/packages/typescript/ml-framework-core/package-lock.json
+++ b/code/packages/typescript/ml-framework-core/package-lock.json
@@ -1,0 +1,2311 @@
+{
+  "name": "@coding-adventures/ml-framework-core",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/ml-framework-core",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.61.0.tgz",
+      "integrity": "sha512-dnxczajOqt0gesZlN5pGQ1s1imQVrsmCw5G2Ci4oM+0WvNz3pyRnlWrT7McoZIb8VlFwCawdmbWRmxRn7HI+VQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.61.0.tgz",
+      "integrity": "sha512-Bp3JpGP00Vu3f238ivRrjf7z3xSzVPXqCmaJYA9t2c+c8vKYvOzmXF7LkkeUalTEGd6cZcSWe+PFIP3Vy48fRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.61.0.tgz",
+      "integrity": "sha512-zaYIpr670mUmmZ1tVzUFplbQbG7h3Gugx3L5FoqhsC2m/YnLlR1a7zVLmXNPy+iY1tFPEbNG+HHBXZGyId0G5w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.61.0.tgz",
+      "integrity": "sha512-+P49fvkv2dSoeevUW+lgZ/I2JHSsJCK1Lyjj7Cu6E4UHG4tS9XIefzIjo5qhgELjAclnen1rLzK2PMKJdo+Dyg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.61.0.tgz",
+      "integrity": "sha512-l3FAAOyKJXH2ea6KNFN+MMgC/rnE94YGLXs2ehYqDcCoHt1DpvgWX75BhUJxN38XojP7Ul+4H8PRn7EdyqSDrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.61.0.tgz",
+      "integrity": "sha512-VokPN3TSctKj65cyCNPaUh4vMFA8awxOot/0sp+4J7ZlNRKQEhXhawqPwajoi8H5ZFt61i0ugZJuTKXBjGJ17Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.61.0.tgz",
+      "integrity": "sha512-DxH0P3wxm+Yzs/p3zrk9dw1rURu8p0Nv5+MRK/L7OtnLNg5rLZraSBFZ8iUXOd9f2BlhJyEpIZUH/emjq4UJ4g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.61.0.tgz",
+      "integrity": "sha512-T6ZvMNe84kAz6TBWHC7hGAoEtzP1LWYw/AqayGWEF6uISt3Abk/st06LqRD9THd7Xz3NxzurUpzAuEAUbZf+nw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.61.0.tgz",
+      "integrity": "sha512-q/4hzvQkDs8b4jIBab1pnLiiM0ayTZsN2amBFPDzuyZxjEd4wDwx0UJFYM3cOZzSf5Kw8fnWSprJzIBMkcR44Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.61.0.tgz",
+      "integrity": "sha512-vvYWX3akdEAY6km+9wAqFDnk6pQsbJKVnj7xawcvs/+fdlYBGp+U+Qq/lLfpIxYIZvZLHMAKD9HLdacSx/r3dw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.61.0.tgz",
+      "integrity": "sha512-DePa5cqOxDP/Zp0VOXpeWaGew5iIv5DXp9NYbzkX5PFQyWVX9184WCTh3hvr/7lhXo8ZVlbFLkz8+o/q1dU6gA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.61.0.tgz",
+      "integrity": "sha512-LV8aWMB8UChglMCEzs7RkN0GsH29RJaLLqwm9fCIjlqwxQTiWAqNcc7wjBkH31hV0PU/yVxGYvrYsgfea2qw6g==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.61.0.tgz",
+      "integrity": "sha512-QoNSnwQtaeNu5grdBbsL0tt1uyl5EnS8DA8Mr3nluMXbhdQNyhN+G4tBax7VCdxLKj8YJ0/4OO9Ho84jMnJtKA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.61.0.tgz",
+      "integrity": "sha512-/zZp5MKapIIApE8trN8qLGNSiRN9TUoaUZ1cmVu4XnVdd5LQLOXTtyi+vtfUbNnT3iyjzpPqYeKXmvJ+gJGYWw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.61.0.tgz",
+      "integrity": "sha512-RbrzcD3aJ1k3UbtMRRBNwojdVVyXjuVAFTfn/xPa6EEl6GE9Sm/akPgFTb9aAC9pMKGJ6CtWxaGrqWcabH+ySg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.61.0.tgz",
+      "integrity": "sha512-ZF+onDsBso8PJf1XaG9lB+O9RnBpKGnY6OrzC4CSHrtC1jb6jWLTKK4bRqdoCXHd22gyr2hiYmEAm8Wns/BOCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.61.0.tgz",
+      "integrity": "sha512-Atk0aSIk5Zx2Wuh9dgRQgLP0Koc8hOeYpbWryMXyk8G8/HmPkwPPkMqIIDhrXHHYqfUzSJA/I7IWSBv8xSmRBA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.61.0.tgz",
+      "integrity": "sha512-0uMOcf3eZ5K+K4cYHkdxShFMPlPXCOdfDFEFn9dNYAEEd2cVvmOfH7zFgRVoDgmtQ1m9k5q7qfrHzyMAubKYUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.61.0.tgz",
+      "integrity": "sha512-mvFtE4A/t/7hRJ7X8Ozmu8FsIkAUat2nzl12pgU337BRmq87AQUJztwHz2Zv5/tjo9/C95E66CK03SI/ToEDJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.61.0.tgz",
+      "integrity": "sha512-z9b9+aTxvt8n2rNltMPvyaUfB8NJ+CVyOrGK/MdIKHx7B+lXmZpm/XbRsU7Rpf3fRqJ2uS6mBJiJveCtq8LHDg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.61.0.tgz",
+      "integrity": "sha512-jXaXFqKMehsOc+g8R6oo33RRC6w07G9jDBxAE5eAKX7mOcCbZloYIPNhfG9Wl+P9O9IWHFO4OJgPi1Ml2qkt7w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.61.0.tgz",
+      "integrity": "sha512-OXNWVFocS2IA4+QplhTZZ2a+8hPZR7T8KuozsNmJKK8y7cp83StHvGksfHzPG3wczWTczyWHVQuqeiTUbjiyBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.61.0.tgz",
+      "integrity": "sha512-AlAbNtBO637LxSldqV43z0FfXoGfl2TW1DgAg/bs7aQswFbDewz2SJm3BUhiGfbOVtW571xbc9p+REdxhyN/Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.61.0.tgz",
+      "integrity": "sha512-QRSrQXyJ1M4tjNXdR0/G/IgV6lzfQQJYBjlWIEYkY2Xs86DRl/iEpQ4blMDjJxSl7n19eDKKXMg0AmuBVYy8pQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.61.0.tgz",
+      "integrity": "sha512-tkuFxhvKO/HlGd0VsINF6vHSYH8AF8W0TcNxKDK6JZmrehngFj78pToc8iemtnvwilDjs2G/qSzYFhe9U8q+fw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.6.tgz",
+      "integrity": "sha512-LsAdmUapA0qSN306d8+zOyawM0hFm2m2Hg9IwVNIKBm+qJV8cijiq2c+gxKZcB1HCfIWAy+0qEZDCUQA58A1cw==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.6",
+        "vitest": "3.2.6"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "3.2.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "3.2.6",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.61.0.tgz",
+      "integrity": "sha512-T9mWdbWfQtp0B5lv/HX+wrhYsmXRlcWnXXmJbXqKJhlRaoS6KMhq0gpyzW4UJfclcxrEdLnTgjT2NjruLONu0g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.61.0",
+        "@rollup/rollup-android-arm64": "4.61.0",
+        "@rollup/rollup-darwin-arm64": "4.61.0",
+        "@rollup/rollup-darwin-x64": "4.61.0",
+        "@rollup/rollup-freebsd-arm64": "4.61.0",
+        "@rollup/rollup-freebsd-x64": "4.61.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.61.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.61.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.61.0",
+        "@rollup/rollup-linux-arm64-musl": "4.61.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.61.0",
+        "@rollup/rollup-linux-loong64-musl": "4.61.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.61.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.61.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.61.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.61.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.61.0",
+        "@rollup/rollup-linux-x64-gnu": "4.61.0",
+        "@rollup/rollup-linux-x64-musl": "4.61.0",
+        "@rollup/rollup-openbsd-x64": "4.61.0",
+        "@rollup/rollup-openharmony-arm64": "4.61.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.61.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.61.0",
+        "@rollup/rollup-win32-x64-gnu": "4.61.0",
+        "@rollup/rollup-win32-x64-msvc": "4.61.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true
+    },
+    "node_modules/vite": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.6",
+        "@vitest/mocker": "3.2.6",
+        "@vitest/pretty-format": "^3.2.6",
+        "@vitest/runner": "3.2.6",
+        "@vitest/snapshot": "3.2.6",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.6",
+        "@vitest/ui": "3.2.6",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/packages/typescript/ml-framework-core/package.json
+++ b/code/packages/typescript/ml-framework-core/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@coding-adventures/ml-framework-core",
+  "version": "0.1.0",
+  "description": "Idiomatic TypeScript Tensor + autograd on top of the Rust matrix-cpu engine.  v0.1.0 ships the Tensor layer (factories, shape ops, named element-wise methods); autograd + 15 op dispatch + end-to-end MLP land in PRs #2–#5.",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "files": [
+    "src",
+    "README.md",
+    "CHANGELOG.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "homepage": "https://github.com/adhithyan15/coding-adventures/tree/main/code/packages/typescript/ml-framework-core",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/adhithyan15/coding-adventures.git"
+  },
+  "bugs": {
+    "url": "https://github.com/adhithyan15/coding-adventures/issues"
+  },
+  "keywords": [
+    "tensor",
+    "autograd",
+    "ml",
+    "neural-network",
+    "pytorch",
+    "matrix-cpu"
+  ],
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0",
+    "@vitest/coverage-v8": "^3.0.0",
+    "@types/node": "^20.0.0"
+  }
+}

--- a/code/packages/typescript/ml-framework-core/required_capabilities.json
+++ b/code/packages/typescript/ml-framework-core/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "typescript/ml-framework-core",
+  "capabilities": [],
+  "justification": "Pure-TypeScript Tensor library (v0.1.0). No FFI, no network, no filesystem, no process spawning. PR #3 will add an FFI dispatch capability for the @coding-adventures/matrix-rust-napi addon once large-tensor ops route through Rust; v0.1.0 has no outward-facing surface beyond the in-process TypeScript API."
+}

--- a/code/packages/typescript/ml-framework-core/src/index.ts
+++ b/code/packages/typescript/ml-framework-core/src/index.ts
@@ -1,0 +1,42 @@
+/**
+ * # `@coding-adventures/ml-framework-core`
+ *
+ * Idiomatic TypeScript Tensor + autograd built on the Rust matrix-cpu
+ * engine.  v0.1.0 ships the bottom layer: a pure-TypeScript `Tensor`
+ * class.  Future PRs add autograd (PR #2), forward op dispatch through
+ * the workspace's `@coding-adventures/matrix-rust-napi` package (PR #3),
+ * backward + end-to-end MLP test (PR #4), and v1.0.0 polish (PR #5).
+ *
+ * ## Usage
+ *
+ * ```ts
+ * import { Tensor } from "@coding-adventures/ml-framework-core";
+ *
+ * const t = Tensor.zeros(2, 3);
+ * console.log(t.shape);       // → [2, 3]
+ * const t2 = t.add(1.0);      // element-wise + 1
+ * console.log(t2.toArray());  // → [1, 1, 1, 1, 1, 1]
+ * ```
+ *
+ * ## Layered architecture
+ *
+ * ```
+ * @coding-adventures/ml-framework-core   ← this package (v0.1.0)
+ *     ↓
+ * @coding-adventures/matrix-rust-napi    ← TS wrapper for the Rust addon (v0.4.0)
+ *     ↓
+ * matrix-rust-napi (Rust cdylib)          ← exposes runGraphOnCpu via N-API (v0.3.0)
+ *     ↓
+ * node-bridge (Rust workspace crate)      ← zero-dep N-API wrapper (v0.1.0)
+ *     ↓
+ * matrix-ir-json → matrix-ir → matrix-runtime → matrix-cpu
+ * ```
+ *
+ * v0.1.0 doesn't touch the Rust dispatch yet — every method here is pure
+ * TypeScript.  The dispatch wiring lands in PR #3 once the autograd
+ * machinery (PR #2) is in place.
+ */
+
+export { Tensor, inferShape, flattenToFloat32 } from "./tensor.js";
+export type { Dtype, Shape, TensorOptions } from "./tensor.js";
+export { VERSION } from "./version.js";

--- a/code/packages/typescript/ml-framework-core/src/tensor.ts
+++ b/code/packages/typescript/ml-framework-core/src/tensor.ts
@@ -1,0 +1,555 @@
+/**
+ * # Tensor — N-dimensional Float32Array with shape
+ *
+ * The TypeScript Tensor.  Same role as PyTorch's `torch.Tensor` and the
+ * Ruby `Tensor`: hold a flat array of f32 values plus a shape, and
+ * provide all the factory + reshape + math methods on top.
+ *
+ * ## Storage model
+ *
+ * - `data`  — `Float32Array` (native typed array; matches the matrix-cpu
+ *             f32 dtype byte-for-byte, no conversion at dispatch).
+ * - `shape` — readonly `number[]` of positive integers; empty array for
+ *             a 0-d scalar.
+ * - `dtype` — always `"f32"` in v0.1.
+ *
+ * ### Why `Float32Array`, not `number[]`?
+ *
+ * - **Type accuracy.**  JS's `number` is f64; storing f32 values in a
+ *   `number[]` would round-trip them through f64 on every read.  A
+ *   `Float32Array` view stores the bits we'd send to matrix-cpu, so
+ *   there's never a lossy conversion at the FFI boundary.
+ * - **Performance.**  Native typed arrays are roughly 2-3× faster than
+ *   `number[]` for the kind of tight inner loops Tensor ops require
+ *   (V8 specializes hard on the contiguous-Float32 case).
+ * - **Memory layout.**  Already row-major and contiguous — matches
+ *   matrix-cpu's expectation without a copy.
+ *
+ * ## No operator overloading
+ *
+ * TypeScript inherits JavaScript's lack of operator overloading.  Instead
+ * of `a + b`, we use `a.add(b)`.  This is the same convention as TensorFlow.js
+ * and NumPy-from-JS libraries.  It's noisier but unambiguous, and chains
+ * read naturally: `x.matmul(w).relu().add(bias)`.
+ *
+ * ## What's NOT here (deferred)
+ *
+ * - Broadcasting: same shape only for v0.1.
+ * - Indexing slices (`t[1, 2]` or `t.slice(...)`).
+ * - Autograd-prep slots (`requiresGrad`, `grad`, `gradFn`) — added in PR #2.
+ * - The 15 differentiable ops with `.add()`, `.relu()`, etc. — added in PR #3
+ *   on top of the autograd `Function.apply` machinery from PR #2.  v0.1's
+ *   `.add()` family below are pure-Ruby fallback math without autograd.
+ */
+
+export type Dtype = "f32";
+
+export type Shape = readonly number[];
+
+// ---------------------------------------------------------------------------
+// Helper functions — public so the test suite can exercise them directly.
+// ---------------------------------------------------------------------------
+
+/**
+ * Walk a possibly-nested array and infer its shape.  Validates that every
+ * sub-array at the same depth has the same length (rectangular nesting).
+ *
+ * @throws TypeError if the structure is ragged
+ */
+export function inferShape(data: unknown): number[] {
+  if (!Array.isArray(data)) return [];
+  if (data.length === 0) return [0];
+
+  const shape: number[] = [];
+  let probe: unknown = data;
+  while (Array.isArray(probe)) {
+    shape.push(probe.length);
+    probe = probe[0];
+  }
+
+  // Validate rectangularity at every depth.
+  validateRectangular(data, shape, 0);
+
+  return shape;
+}
+
+function validateRectangular(node: unknown, shape: number[], depth: number): void {
+  if (depth >= shape.length) return;
+
+  if (!Array.isArray(node) || node.length !== shape[depth]) {
+    throw new TypeError(
+      `ragged nested array: expected length ${shape[depth]} at depth ${depth}, got ${
+        Array.isArray(node) ? node.length : typeof node
+      }`,
+    );
+  }
+
+  for (const child of node) {
+    validateRectangular(child, shape, depth + 1);
+  }
+}
+
+/**
+ * Flatten arbitrarily-nested arrays into a single Float32Array.  Validates
+ * the result length matches the expected `numel` (product of shape).
+ */
+export function flattenToFloat32(data: unknown, expected: number): Float32Array {
+  const flat: number[] = [];
+  flatten(data, flat);
+  if (flat.length !== expected) {
+    throw new RangeError(
+      `data length ${flat.length} does not match expected numel ${expected}`,
+    );
+  }
+  return Float32Array.from(flat);
+}
+
+function flatten(node: unknown, out: number[]): void {
+  if (Array.isArray(node)) {
+    for (const child of node) flatten(child, out);
+  } else if (typeof node === "number") {
+    out.push(node);
+  } else {
+    throw new TypeError(`tensor data must be numbers; got ${typeof node}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The Tensor class itself.
+// ---------------------------------------------------------------------------
+
+export interface TensorOptions {
+  shape?: Shape;
+  dtype?: Dtype;
+}
+
+export class Tensor {
+  /** Flat row-major data, length = numel. */
+  public readonly data: Float32Array;
+
+  /** Shape array — never mutated after construction. */
+  public readonly shape: readonly number[];
+
+  /** Element dtype.  Always "f32" in v0.1. */
+  public readonly dtype: Dtype;
+
+  /**
+   * Construct a Tensor from either a flat array (with explicit shape) or a
+   * nested array (shape is inferred from nesting).
+   */
+  constructor(data: unknown, options: TensorOptions = {}) {
+    const dtype = options.dtype ?? "f32";
+    if (dtype !== "f32") {
+      throw new TypeError(`dtype ${dtype} not supported; v0.1 supports "f32" only`);
+    }
+
+    if (options.shape !== undefined) {
+      // Explicit shape — caller must already have flat (or single-level
+      // nested) data of the matching numel.  Validate carefully.
+      const shape = options.shape.map((n) => Math.trunc(n));
+      const expected = shape.reduce((a, b) => a * b, 1);
+      this.data = flattenToFloat32(data, expected);
+      this.shape = shape;
+    } else {
+      // Infer from nesting.
+      const inferred = inferShape(data);
+      const expected = inferred.reduce((a, b) => a * b, 1);
+      this.data =
+        inferred.length === 0 && typeof data === "number"
+          ? Float32Array.from([data])
+          : flattenToFloat32(data, expected);
+      this.shape = inferred.length === 0 ? [1] : inferred;
+    }
+
+    this.dtype = "f32";
+  }
+
+  // -------------------------------------------------------------------------
+  // Introspection
+  // -------------------------------------------------------------------------
+
+  /** Number of dimensions (rank). */
+  get ndim(): number {
+    return this.shape.length;
+  }
+
+  /** Total number of elements. */
+  get numel(): number {
+    return this.shape.reduce((a, b) => a * b, 1);
+  }
+
+  /** Flat copy of the data as a `number[]` for callers that want plain JS. */
+  toArray(): number[] {
+    return Array.from(this.data);
+  }
+
+  /**
+   * Recursively un-flatten the data into a nested array matching `shape`.
+   * Round-trip: `new Tensor(t.toNested()).equals(t) === true`.
+   */
+  toNested(): number | number[] | number[][] | unknown {
+    if (this.shape.length === 0) return this.data[0];
+    return unflatten(Array.from(this.data), this.shape, 0, 0).value;
+  }
+
+  /**
+   * Element-wise equality.  Two tensors are equal iff their shapes match
+   * and every element matches.  Strict equality on numbers — for f32
+   * tensors where rounding may have happened, use `equalsClose`.
+   */
+  equals(other: Tensor): boolean {
+    if (!shapesEqual(this.shape, other.shape)) return false;
+    if (this.data.length !== other.data.length) return false;
+    for (let i = 0; i < this.data.length; i++) {
+      if (this.data[i] !== other.data[i]) return false;
+    }
+    return true;
+  }
+
+  /**
+   * Element-wise approximate equality.  Useful for testing operations
+   * involving transcendental functions where f32 precision causes
+   * sub-1e-6 differences.
+   */
+  equalsClose(other: Tensor, epsilon = 1e-6): boolean {
+    if (!shapesEqual(this.shape, other.shape)) return false;
+    if (this.data.length !== other.data.length) return false;
+    for (let i = 0; i < this.data.length; i++) {
+      if (Math.abs(this.data[i]! - other.data[i]!) > epsilon) return false;
+    }
+    return true;
+  }
+
+  /** Compact display useful in REPL output. */
+  toString(): string {
+    const preview = Array.from(this.data.slice(0, 6))
+      .map((v) => (Number.isInteger(v) ? v.toFixed(0) : v.toFixed(4)))
+      .join(", ");
+    const suffix = this.data.length > 6 ? ", …" : "";
+    return `Tensor<shape=[${this.shape.join(", ")}] dtype=${this.dtype}>[${preview}${suffix}]`;
+  }
+
+  // -------------------------------------------------------------------------
+  // Shape operations
+  // -------------------------------------------------------------------------
+
+  /** Return a new Tensor with the data viewed under the new shape. */
+  reshape(newShape: number[]): Tensor {
+    const numel = newShape.reduce((a, b) => a * b, 1);
+    if (numel !== this.numel) {
+      throw new RangeError(
+        `reshape: new shape [${newShape.join(", ")}] has numel ${numel} but tensor has ${this.numel}`,
+      );
+    }
+    return new Tensor(Array.from(this.data), { shape: newShape });
+  }
+
+  /** Flatten to 1-D. */
+  flatten(): Tensor {
+    return new Tensor(Array.from(this.data), { shape: [this.numel] });
+  }
+
+  /**
+   * Transpose.  2-D only in v0.1 (higher-rank perm transpose needs generic
+   * strided index math; deferred to a later PR when there's actual demand).
+   */
+  transpose(...perm: number[]): Tensor {
+    if (perm.length === 0) {
+      if (this.ndim !== 2) {
+        throw new RangeError(
+          `transpose() with no args is only defined for 2-D tensors (got shape [${this.shape.join(", ")}])`,
+        );
+      }
+      perm = [1, 0];
+    } else if (perm.length !== this.ndim) {
+      throw new RangeError(`transpose perm length ${perm.length} != ndim ${this.ndim}`);
+    }
+
+    // Validate perm is a permutation of [0..ndim).
+    const sorted = [...perm].sort((a, b) => a - b);
+    for (let i = 0; i < sorted.length; i++) {
+      if (sorted[i] !== i) {
+        throw new RangeError(`transpose perm [${perm.join(", ")}] is not a permutation of [0..${this.ndim})`);
+      }
+    }
+
+    if (this.ndim !== 2) {
+      throw new Error(`transpose on rank-${this.ndim} tensors not yet implemented (v0.1: 2-D only)`);
+    }
+
+    const [rows, cols] = this.shape as [number, number];
+    const out = new Float32Array(rows * cols);
+    for (let r = 0; r < rows; r++) {
+      for (let c = 0; c < cols; c++) {
+        out[c * rows + r] = this.data[r * cols + c]!;
+      }
+    }
+    return new Tensor(Array.from(out), { shape: [cols, rows] });
+  }
+
+  /** Drop size-1 dimensions.  With no axis, drops all of them. */
+  squeeze(axis?: number): Tensor {
+    let newShape: number[];
+    if (axis === undefined) {
+      newShape = this.shape.filter((d) => d !== 1);
+    } else {
+      let normalized = axis;
+      if (normalized < 0) normalized += this.ndim;
+      if (normalized < 0 || normalized >= this.ndim) {
+        throw new RangeError(`squeeze axis ${axis} out of range [-${this.ndim}, ${this.ndim})`);
+      }
+      if (this.shape[normalized] !== 1) {
+        throw new RangeError(`cannot squeeze axis ${normalized} of size ${this.shape[normalized]}`);
+      }
+      newShape = this.shape.slice();
+      newShape.splice(normalized, 1);
+    }
+    return new Tensor(Array.from(this.data), { shape: newShape });
+  }
+
+  /** Insert a size-1 dimension at the given axis. */
+  unsqueeze(axis: number): Tensor {
+    let normalized = axis;
+    if (normalized < 0) normalized += this.ndim + 1;
+    if (normalized < 0 || normalized > this.ndim) {
+      throw new RangeError(`unsqueeze axis ${axis} out of range [-${this.ndim + 1}, ${this.ndim + 1}]`);
+    }
+    const newShape = this.shape.slice();
+    newShape.splice(normalized, 0, 1);
+    return new Tensor(Array.from(this.data), { shape: newShape });
+  }
+
+  // -------------------------------------------------------------------------
+  // Element-wise math methods (pure TypeScript — no autograd, no dispatch)
+  //
+  // PR #3 will replace these with Function-subclass-routed versions that
+  // build autograd graphs and dispatch large tensors to Rust.  For v0.1
+  // they're plain in-place math.
+  // -------------------------------------------------------------------------
+
+  add(other: Tensor | number): Tensor {
+    return this.binaryOp(other, (a, b) => a + b);
+  }
+
+  sub(other: Tensor | number): Tensor {
+    return this.binaryOp(other, (a, b) => a - b);
+  }
+
+  mul(other: Tensor | number): Tensor {
+    return this.binaryOp(other, (a, b) => a * b);
+  }
+
+  div(other: Tensor | number): Tensor {
+    return this.binaryOp(other, (a, b) => a / b);
+  }
+
+  pow(exponent: number): Tensor {
+    const out = new Float32Array(this.numel);
+    for (let i = 0; i < this.numel; i++) {
+      out[i] = Math.pow(this.data[i]!, exponent);
+    }
+    return new Tensor(Array.from(out), { shape: this.shape.slice() });
+  }
+
+  neg(): Tensor {
+    const out = new Float32Array(this.numel);
+    for (let i = 0; i < this.numel; i++) {
+      out[i] = -this.data[i]!;
+    }
+    return new Tensor(Array.from(out), { shape: this.shape.slice() });
+  }
+
+  private binaryOp(other: Tensor | number, fn: (a: number, b: number) => number): Tensor {
+    if (other instanceof Tensor) {
+      if (!shapesEqual(this.shape, other.shape)) {
+        throw new RangeError(
+          `shape mismatch: [${this.shape.join(", ")}] vs [${other.shape.join(", ")}] (broadcasting not in v0.1)`,
+        );
+      }
+      const out = new Float32Array(this.numel);
+      for (let i = 0; i < this.numel; i++) {
+        out[i] = fn(this.data[i]!, other.data[i]!);
+      }
+      return new Tensor(Array.from(out), { shape: this.shape.slice() });
+    } else if (typeof other === "number") {
+      const out = new Float32Array(this.numel);
+      for (let i = 0; i < this.numel; i++) {
+        out[i] = fn(this.data[i]!, other);
+      }
+      return new Tensor(Array.from(out), { shape: this.shape.slice() });
+    } else {
+      throw new TypeError(`cannot combine Tensor with ${typeof other}`);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Static factories (the entries from PyTorch's `torch.*` namespace).
+  // -------------------------------------------------------------------------
+
+  static zeros(...shape: number[]): Tensor {
+    const flat = shape.flat();
+    const numel = flat.reduce((a, b) => a * b, 1);
+    return new Tensor(new Array(numel).fill(0), { shape: flat });
+  }
+
+  static ones(...shape: number[]): Tensor {
+    const flat = shape.flat();
+    const numel = flat.reduce((a, b) => a * b, 1);
+    return new Tensor(new Array(numel).fill(1), { shape: flat });
+  }
+
+  /** Tensor filled with `value`.  Shape is the first arg (an array). */
+  static full(shape: number[], value: number): Tensor {
+    const numel = shape.reduce((a, b) => a * b, 1);
+    return new Tensor(new Array(numel).fill(value), { shape: shape.slice() });
+  }
+
+  /** Square or rectangular identity-like tensor — 1s on the diagonal. */
+  static eye(n: number, m?: number): Tensor {
+    const cols = m ?? n;
+    const data = new Array(n * cols).fill(0);
+    const diag = Math.min(n, cols);
+    for (let i = 0; i < diag; i++) {
+      data[i * cols + i] = 1;
+    }
+    return new Tensor(data, { shape: [n, cols] });
+  }
+
+  /**
+   * 1-D range tensor.  Signatures:
+   *
+   * - `arange(stop)`
+   * - `arange(start, stop)`
+   * - `arange(start, stop, step)`
+   *
+   * Stop is EXCLUSIVE (NumPy / Python convention).  Step can be negative.
+   * Rejects non-finite bounds — `Number.POSITIVE_INFINITY` would loop
+   * forever building the result array.
+   */
+  static arange(start: number, stop?: number, step?: number): Tensor {
+    let s: number, e: number, k: number;
+    if (stop === undefined) {
+      s = 0;
+      e = start;
+      k = 1;
+    } else if (step === undefined) {
+      s = start;
+      e = stop;
+      k = 1;
+    } else {
+      s = start;
+      e = stop;
+      k = step;
+    }
+
+    if (k === 0) throw new RangeError("arange step cannot be zero");
+    if (!Number.isFinite(s) || !Number.isFinite(e) || !Number.isFinite(k)) {
+      throw new RangeError(`arange bounds must be finite, got start=${s} stop=${e} step=${k}`);
+    }
+
+    const data: number[] = [];
+    let x = s;
+    if (k > 0) {
+      while (x < e) {
+        data.push(x);
+        x += k;
+      }
+    } else {
+      while (x > e) {
+        data.push(x);
+        x += k;
+      }
+    }
+    return new Tensor(data, { shape: [data.length] });
+  }
+
+  /** Sugar for `new Tensor(nested)`. */
+  static fromArray(nested: unknown): Tensor {
+    return new Tensor(nested);
+  }
+
+  /**
+   * Standard-normal samples via Box-Muller.  Optional seed — when provided,
+   * the output is deterministic (useful for testing and reproducible
+   * benchmarks).
+   *
+   * Box-Muller is the textbook two-line algorithm for turning two uniforms
+   * into two normals — avoids pulling in a distribution library.
+   */
+  static randn(shape: number[], seed?: number): Tensor {
+    const numel = shape.reduce((a, b) => a * b, 1);
+    const random = seed !== undefined ? makeSeededRandom(seed) : Math.random;
+    const data = new Array(numel);
+    let i = 0;
+    while (i < numel) {
+      let u1 = random();
+      if (u1 === 0) u1 = Number.MIN_VALUE; // ln(0) is -∞; nudge into the domain.
+      const u2 = random();
+      const mag = Math.sqrt(-2 * Math.log(u1));
+      data[i] = mag * Math.cos(2 * Math.PI * u2);
+      if (i + 1 < numel) {
+        data[i + 1] = mag * Math.sin(2 * Math.PI * u2);
+      }
+      i += 2;
+    }
+    return new Tensor(data, { shape: shape.slice() });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function shapesEqual(a: Shape, b: Shape): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+/**
+ * Recursively un-flatten a flat array back into nested form.  Helper used
+ * by `Tensor.toNested()`.  Returns a value-and-cursor so the recursion
+ * can resume where the previous call left off.
+ */
+function unflatten(
+  flat: number[],
+  shape: readonly number[],
+  start: number,
+  depth: number,
+): { value: unknown; next: number } {
+  if (depth >= shape.length) {
+    return { value: flat[start], next: start + 1 };
+  }
+  if (depth === shape.length - 1) {
+    const len = shape[depth]!;
+    return { value: flat.slice(start, start + len), next: start + len };
+  }
+  const len = shape[depth]!;
+  const result: unknown[] = [];
+  let cursor = start;
+  for (let i = 0; i < len; i++) {
+    const sub = unflatten(flat, shape, cursor, depth + 1);
+    result.push(sub.value);
+    cursor = sub.next;
+  }
+  return { value: result, next: cursor };
+}
+
+/**
+ * Tiny seeded RNG (LCG — xorshift would be only marginally better and the
+ * LCG implementation fits in two lines).  Returns a function with the same
+ * 0..1 contract as `Math.random()` so callers can swap freely.
+ *
+ * Constants from Numerical Recipes' "quick and dirty" LCG.  Not
+ * cryptographically secure — this is for reproducible weight initialization,
+ * not for crypto material.
+ */
+function makeSeededRandom(seed: number): () => number {
+  let state = (Math.trunc(seed) >>> 0) || 1;
+  return () => {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    return state / 0x100000000;
+  };
+}

--- a/code/packages/typescript/ml-framework-core/src/version.ts
+++ b/code/packages/typescript/ml-framework-core/src/version.ts
@@ -1,0 +1,7 @@
+/**
+ * Single source of truth for the package version.
+ *
+ * Kept in sync with package.json's `version` field by hand — there's no
+ * build step that injects it.  When bumping, update both files.
+ */
+export const VERSION = "0.1.0" as const;

--- a/code/packages/typescript/ml-framework-core/tests/tensor.test.ts
+++ b/code/packages/typescript/ml-framework-core/tests/tensor.test.ts
@@ -1,0 +1,354 @@
+/**
+ * tensor.test.ts — vitest coverage for the v0.1 Tensor class.
+ *
+ * Mirrors `code/packages/ruby/ml_framework_core/test/tensor_test.rb` but
+ * adapted to TypeScript / Vitest idiom (`describe` + `it` blocks rather
+ * than minitest's class-per-section convention).
+ *
+ * Sections:
+ *  - Construction (flat, nested, scalar, explicit shape, ragged rejection,
+ *    dtype rejection)
+ *  - Factories (zeros / ones / full / eye / arange / randn / fromArray)
+ *  - Shape ops (reshape / transpose / flatten / squeeze / unsqueeze)
+ *  - Element-wise math (add / sub / mul / div / pow / neg, scalar broadcast,
+ *    shape-mismatch + type rejection)
+ *  - Equality + inspect
+ *  - Round-trip properties
+ *  - Version constant
+ */
+
+import { describe, it, expect } from "vitest";
+import { Tensor, inferShape, flattenToFloat32, VERSION } from "../src/index.js";
+
+describe("Tensor — construction", () => {
+  it("constructs from a flat array with explicit shape", () => {
+    const t = new Tensor([1, 2, 3, 4], { shape: [2, 2] });
+    expect(t.shape).toEqual([2, 2]);
+    expect(t.numel).toBe(4);
+    expect(t.ndim).toBe(2);
+    expect(t.dtype).toBe("f32");
+    expect(t.toArray()).toEqual([1, 2, 3, 4]);
+  });
+
+  it("constructs from nested array and infers shape", () => {
+    const t = new Tensor([[1, 2, 3], [4, 5, 6]]);
+    expect(t.shape).toEqual([2, 3]);
+    expect(t.toArray()).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+
+  it("constructs from deeply-nested array", () => {
+    const t = new Tensor([[[1, 2], [3, 4]], [[5, 6], [7, 8]]]);
+    expect(t.shape).toEqual([2, 2, 2]);
+    expect(t.numel).toBe(8);
+  });
+
+  it("constructs from a scalar with explicit shape", () => {
+    const t = new Tensor(7, { shape: [1] });
+    expect(t.shape).toEqual([1]);
+    expect(t.toArray()).toEqual([7]);
+  });
+
+  it("throws on ragged nested arrays", () => {
+    expect(() => new Tensor([[1, 2], [3]])).toThrow(TypeError);
+  });
+
+  it("throws on data length mismatch with explicit shape", () => {
+    expect(() => new Tensor([1, 2, 3], { shape: [2, 2] })).toThrow(RangeError);
+  });
+
+  it("throws on unsupported dtype", () => {
+    expect(() => new Tensor([1, 2, 3], { dtype: "f64" as never })).toThrow(TypeError);
+  });
+
+  it("throws when nested data contains non-numbers", () => {
+    expect(() => new Tensor([[1, 2], [3, "oops"]] as never)).toThrow(TypeError);
+  });
+});
+
+describe("Tensor — factories", () => {
+  it("zeros() returns all-zero tensor of the requested shape", () => {
+    const t = Tensor.zeros(2, 3);
+    expect(t.shape).toEqual([2, 3]);
+    expect(t.toArray()).toEqual([0, 0, 0, 0, 0, 0]);
+  });
+
+  it("ones() returns all-one tensor", () => {
+    const t = Tensor.ones(3);
+    expect(t.shape).toEqual([3]);
+    expect(t.toArray()).toEqual([1, 1, 1]);
+  });
+
+  it("full([shape], value) fills uniformly", () => {
+    const t = Tensor.full([2, 2], 7.5);
+    expect(t.shape).toEqual([2, 2]);
+    expect(t.toArray()).toEqual([7.5, 7.5, 7.5, 7.5]);
+  });
+
+  it("eye(n) returns the n×n identity matrix", () => {
+    const t = Tensor.eye(3);
+    expect(t.shape).toEqual([3, 3]);
+    expect(t.toArray()).toEqual([1, 0, 0, 0, 1, 0, 0, 0, 1]);
+  });
+
+  it("eye(n, m) returns a rectangular diagonal-ones matrix", () => {
+    const t = Tensor.eye(2, 3);
+    expect(t.shape).toEqual([2, 3]);
+    expect(t.toArray()).toEqual([1, 0, 0, 0, 1, 0]);
+  });
+
+  it("arange(stop) returns [0, stop)", () => {
+    expect(Tensor.arange(5).toArray()).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it("arange(start, stop) returns [start, stop)", () => {
+    expect(Tensor.arange(2, 5).toArray()).toEqual([2, 3, 4]);
+  });
+
+  it("arange with positive step", () => {
+    expect(Tensor.arange(0, 10, 2).toArray()).toEqual([0, 2, 4, 6, 8]);
+  });
+
+  it("arange with negative step", () => {
+    expect(Tensor.arange(5, 0, -1).toArray()).toEqual([5, 4, 3, 2, 1]);
+  });
+
+  it("arange rejects zero step", () => {
+    expect(() => Tensor.arange(0, 5, 0)).toThrow(RangeError);
+  });
+
+  it("arange rejects non-finite bounds", () => {
+    expect(() => Tensor.arange(0, Number.POSITIVE_INFINITY)).toThrow(RangeError);
+    expect(() => Tensor.arange(0, Number.NaN)).toThrow(RangeError);
+    expect(() => Tensor.arange(Number.NEGATIVE_INFINITY, 0, -1)).toThrow(RangeError);
+  });
+
+  it("fromArray() is equivalent to the constructor", () => {
+    const a = Tensor.fromArray([[1, 2], [3, 4]]);
+    const b = new Tensor([[1, 2], [3, 4]]);
+    expect(a.equals(b)).toBe(true);
+  });
+
+  it("randn(shape) respects the requested shape", () => {
+    const t = Tensor.randn([3, 4], 42);
+    expect(t.shape).toEqual([3, 4]);
+    expect(t.numel).toBe(12);
+    // Values aren't all the same (extremely unlikely with N(0,1) samples).
+    const unique = new Set(t.toArray());
+    expect(unique.size).toBeGreaterThan(1);
+  });
+
+  it("randn(seed) is deterministic for the same seed", () => {
+    const a = Tensor.randn([5], 123);
+    const b = Tensor.randn([5], 123);
+    expect(a.toArray()).toEqual(b.toArray());
+  });
+
+  it("randn(no seed) is non-deterministic", () => {
+    const a = Tensor.randn([5]);
+    const b = Tensor.randn([5]);
+    expect(a.toArray()).not.toEqual(b.toArray());
+  });
+
+  it("randn mean is roughly zero (sanity check on Box-Muller)", () => {
+    // 1000 samples — |mean| should be well under 0.2 for N(0, 1).
+    const t = Tensor.randn([1000], 7);
+    const arr = t.toArray();
+    const mean = arr.reduce((a, b) => a + b, 0) / arr.length;
+    expect(Math.abs(mean)).toBeLessThan(0.2);
+  });
+});
+
+describe("Tensor — shape ops", () => {
+  it("reshape preserves data", () => {
+    const t = Tensor.arange(6).reshape([2, 3]);
+    expect(t.shape).toEqual([2, 3]);
+    expect(t.toArray()).toEqual([0, 1, 2, 3, 4, 5]);
+  });
+
+  it("reshape with mismatched numel throws", () => {
+    expect(() => Tensor.arange(6).reshape([2, 4])).toThrow(RangeError);
+  });
+
+  it("reshape round-trips through new shape", () => {
+    const t = Tensor.arange(12);
+    expect(t.equals(t.reshape([3, 4]).reshape([12]))).toBe(true);
+  });
+
+  it("flatten produces a 1-D tensor", () => {
+    const t = new Tensor([[1, 2], [3, 4]]).flatten();
+    expect(t.shape).toEqual([4]);
+    expect(t.toArray()).toEqual([1, 2, 3, 4]);
+  });
+
+  it("transpose 2-D default swaps the two dims", () => {
+    const t = new Tensor([[1, 2, 3], [4, 5, 6]]).transpose();
+    expect(t.shape).toEqual([3, 2]);
+    expect(t.toArray()).toEqual([1, 4, 2, 5, 3, 6]);
+  });
+
+  it("transpose with explicit perm", () => {
+    const t = new Tensor([[1, 2], [3, 4]]).transpose(1, 0);
+    expect(t.toArray()).toEqual([1, 3, 2, 4]);
+  });
+
+  it("transpose twice is the identity", () => {
+    const t = new Tensor([[1, 2, 3], [4, 5, 6]]);
+    expect(t.equals(t.transpose().transpose())).toBe(true);
+  });
+
+  it("transpose rejects invalid perm", () => {
+    const t = new Tensor([[1, 2], [3, 4]]);
+    expect(() => t.transpose(0, 0)).toThrow(RangeError);
+    expect(() => t.transpose(0, 1, 2)).toThrow(RangeError);
+  });
+
+  it("transpose on higher-rank tensors is not yet implemented", () => {
+    const t = Tensor.zeros(2, 2, 2);
+    expect(() => t.transpose(2, 1, 0)).toThrow();
+  });
+
+  it("squeeze with no arg drops all size-1 dims", () => {
+    const t = Tensor.zeros(1, 3, 1, 2);
+    expect(t.squeeze().shape).toEqual([3, 2]);
+  });
+
+  it("squeeze with explicit axis drops only that axis", () => {
+    const t = Tensor.zeros(1, 3, 1);
+    expect(t.squeeze(0).shape).toEqual([3, 1]);
+    expect(t.squeeze(2).shape).toEqual([1, 3]);
+  });
+
+  it("squeeze with negative axis", () => {
+    const t = Tensor.zeros(3, 1);
+    expect(t.squeeze(-1).shape).toEqual([3]);
+  });
+
+  it("squeeze of non-unit axis throws", () => {
+    expect(() => Tensor.zeros(3, 2).squeeze(0)).toThrow(RangeError);
+  });
+
+  it("unsqueeze inserts size-1 axis", () => {
+    const t = Tensor.zeros(3);
+    expect(t.unsqueeze(0).shape).toEqual([1, 3]);
+    expect(t.unsqueeze(1).shape).toEqual([3, 1]);
+    expect(t.unsqueeze(-1).shape).toEqual([3, 1]);
+  });
+
+  it("unsqueeze then squeeze round-trips", () => {
+    const t = Tensor.arange(6).reshape([2, 3]);
+    expect(t.equals(t.unsqueeze(0).squeeze(0))).toBe(true);
+  });
+});
+
+describe("Tensor — element-wise math", () => {
+  it("add tensors", () => {
+    const a = new Tensor([1, 2, 3]);
+    const b = new Tensor([10, 20, 30]);
+    expect(a.add(b).toArray()).toEqual([11, 22, 33]);
+  });
+
+  it("add scalar broadcasts", () => {
+    expect(new Tensor([1, 2, 3]).add(10).toArray()).toEqual([11, 12, 13]);
+  });
+
+  it("sub", () => {
+    expect(new Tensor([5, 7, 9]).sub(new Tensor([1, 2, 3])).toArray()).toEqual([4, 5, 6]);
+  });
+
+  it("mul", () => {
+    expect(new Tensor([2, 3, 4]).mul(new Tensor([5, 6, 7])).toArray()).toEqual([10, 18, 28]);
+  });
+
+  it("div", () => {
+    expect(new Tensor([10, 20, 30]).div(new Tensor([2, 4, 5])).toArray()).toEqual([5, 5, 6]);
+  });
+
+  it("pow with scalar exponent", () => {
+    expect(new Tensor([2, 3, 4]).pow(2).toArray()).toEqual([4, 9, 16]);
+  });
+
+  it("neg flips signs", () => {
+    expect(new Tensor([1, -2, 3]).neg().toArray()).toEqual([-1, 2, -3]);
+  });
+
+  it("shape mismatch throws RangeError", () => {
+    expect(() => Tensor.zeros(2, 3).add(Tensor.zeros(3, 2))).toThrow(RangeError);
+  });
+
+  it("unsupported operand throws TypeError", () => {
+    expect(() => Tensor.zeros(2).add("not a number" as never)).toThrow(TypeError);
+  });
+});
+
+describe("Tensor — equality and toString", () => {
+  it("equals compares shape and data", () => {
+    expect(new Tensor([1, 2, 3]).equals(new Tensor([1, 2, 3]))).toBe(true);
+    expect(new Tensor([1, 2, 3]).equals(new Tensor([1, 2, 4]))).toBe(false);
+    expect(new Tensor([1, 2, 3]).equals(new Tensor([1, 2, 3], { shape: [3, 1] }))).toBe(false);
+  });
+
+  it("equalsClose handles f32-precision noise", () => {
+    const a = new Tensor([1.0, 2.0]);
+    const b = new Tensor([1.0 + 1e-7, 2.0 - 1e-7]);
+    expect(a.equals(b)).toBe(false);
+    expect(a.equalsClose(b, 1e-6)).toBe(true);
+  });
+
+  it("toString includes shape and dtype", () => {
+    const s = Tensor.zeros(2, 3).toString();
+    expect(s).toContain("shape=[2, 3]");
+    expect(s).toContain("dtype=f32");
+  });
+
+  it("toString truncates long data", () => {
+    const s = Tensor.arange(100).toString();
+    expect(s).toContain("…");
+  });
+});
+
+describe("Tensor — round-trip properties", () => {
+  it("toNested round-trips 2-D", () => {
+    const original = [[1, 2, 3], [4, 5, 6]];
+    expect(new Tensor(original).toNested()).toEqual(original);
+  });
+
+  it("toNested round-trips 3-D", () => {
+    const original = [[[1, 2], [3, 4]], [[5, 6], [7, 8]]];
+    expect(new Tensor(original).toNested()).toEqual(original);
+  });
+
+  it("reshape preserves toArray", () => {
+    const t = Tensor.arange(12);
+    expect(t.toArray()).toEqual(t.reshape([3, 4]).toArray());
+  });
+});
+
+describe("Tensor — helper functions", () => {
+  it("inferShape returns [] for non-arrays", () => {
+    expect(inferShape(5)).toEqual([]);
+    expect(inferShape(null)).toEqual([]);
+  });
+
+  it("inferShape returns [0] for empty arrays", () => {
+    expect(inferShape([])).toEqual([0]);
+  });
+
+  it("inferShape handles 3-D nesting", () => {
+    expect(inferShape([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])).toEqual([2, 2, 2]);
+  });
+
+  it("flattenToFloat32 enforces expected length", () => {
+    expect(() => flattenToFloat32([1, 2, 3], 4)).toThrow(RangeError);
+  });
+
+  it("flattenToFloat32 handles nested input", () => {
+    expect(Array.from(flattenToFloat32([[1, 2], [3, 4]], 4))).toEqual([1, 2, 3, 4]);
+  });
+});
+
+describe("Version", () => {
+  it("VERSION is defined and well-formed", () => {
+    expect(typeof VERSION).toBe("string");
+    expect(VERSION).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+});

--- a/code/packages/typescript/ml-framework-core/tsconfig.json
+++ b/code/packages/typescript/ml-framework-core/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "strict": true,
+    "noUncheckedIndexedAccess": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/code/packages/typescript/ml-framework-core/vitest.config.ts
+++ b/code/packages/typescript/ml-framework-core/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config";
+
+// Vitest config for ml-framework-core.
+//
+// v0.1.0 (Tensor) is pure TypeScript — no native addons, no async work,
+// nothing that benefits from cross-file parallelism but also nothing that
+// breaks under it.  Keep the defaults for simplicity; future PRs that
+// dispatch into the Rust matrix-rust-napi addon will need fileParallelism
+// disabled (the .node file loads once globally) but PR #1 doesn't.
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      thresholds: { lines: 80, functions: 80, branches: 80, statements: 80 },
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- New TypeScript package `@coding-adventures/ml-framework-core` (v0.1.0) shipping the bottom layer of the TS ML framework stack: a PyTorch-shaped `Tensor` class.
- No native addons, no Rust calls, no FFI — intentionally minimal for v0.1.0. Layered design: PRs #2–#5 add autograd, op dispatch, backward, benchmarks.
- 61 vitest tests, all passing.

## Architecture

```
@coding-adventures/ml-framework-core (THIS PR)
  Tensor + factories + shape ops + element-wise math
  ↓ PRs #2-#5 layer on autograd, ops, backward, benchmark
@coding-adventures/matrix-rust-napi (TS wrapper, v0.4.0, exists)
  ↓
matrix-rust-napi (Rust cdylib, v0.3.0, exists)
  ↓
node-bridge (Rust workspace crate, v0.1.0, exists)
  ↓
matrix-ir-json → matrix-ir → matrix-runtime → matrix-cpu
```

JS/TS pilot is **5 PRs** (not 8 like Ruby) because the bottom three layers already exist in the workspace.

## Public API (v0.1.0)

```ts
import { Tensor } from "@coding-adventures/ml-framework-core";

Tensor.zeros(2, 3); Tensor.ones(3); Tensor.eye(3); Tensor.arange(0, 10, 2);
Tensor.randn([3, 4], 42); Tensor.fromArray([[1, 2], [3, 4]]);

t.reshape([3, 2]); t.transpose(); t.flatten(); t.squeeze(); t.unsqueeze(0);
a.add(b); a.sub(b); a.mul(b); a.div(b); a.pow(2); a.neg();
a.add(5);  // scalar broadcasts
```

## TS-specific decisions

- **`Float32Array` storage**: matches matrix-cpu f32 byte-for-byte; ~2-3× faster than `number[]`
- **No operator overloading**: method-chaining (`x.add(y).relu()`) is the PyTorch-from-JS convention
- **ESM-first**: `\"type\": \"module\"` in package.json, matches existing matrix-rust-napi TS pattern
- **Vitest** for tests (matches existing TS package setup)
- **`Tensor.arange` rejects non-finite bounds** (Infinity would loop forever, NaN silently returns empty)

## Test plan

- [x] `npx tsc --noEmit`: 0 errors
- [x] `npx vitest run`: 61/61 passing
- [x] Security review passed (no FFI, no prototype pollution, no regex DoS, lockfile review clean)
- [ ] CI: build (ubuntu/macos/windows) `npm install && npm test` — pending
- [ ] CI: CodeQL javascript Analyze — pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)