### PR TITLE
test(closure-pass-treeshake): retention test — function-called (CLOC13.C.1 follow-up)

### DIFF
--- a/code/packages/rust/closure-pass-treeshake/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-treeshake/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to the `coding-adventures-closure-pass-treeshake` crate will be documented in this file.
 
+## [0.3.1] - 2026-06-02
+
+### Added — retention test (paired with CLOC13.0.2 activation)
+
+A single new test: `apply_step_keeps_function_when_called`. Fixture: `function f() {} f();`. Now that PR #4825 (CLOC13.0.2 nested scopes) is on main, the analyzer walks reference sites both at the top level AND inside function bodies under nested Function scopes. The `f()` callee Identifier emits a Reference resolving to the function binding, so `use_count[f] = 1` and the apply step's dead-shape scan correctly skips `f`.
+
+This test was intentionally deferred from CLOC13.C.1 (PR #4803) because at that time:
+- The analyzer body (CLOC13.0 / PR #4787) populated bindings but not references.
+- Reference activation (CLOC13.0.1 / PR #4800) was about to land but #4803 was forked from earlier main.
+- Including the retention test in #4803 would have made it fail pre-#4800 and pass post-#4800 — fragile across PR sequencing.
+
+Bundling it now as a tiny follow-up keeps the test surface complete without coupling to a mid-flight rebase.
+
+No code changes to the pass body — just test coverage. No version bump beyond the patch level (`0.3.0` → `0.3.1`).
+
 ## [0.3.0] - 2026-06-02
 
 ### Added (CLOC13.C.1 — the apply step, `changed` unpinned)

--- a/code/packages/rust/closure-pass-treeshake/Cargo.toml
+++ b/code/packages/rust/closure-pass-treeshake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-treeshake"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Tree-shaking pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Removes module exports and imports that aren't reachable from the program's entry points, eliminating whole-module dead weight that intra-module DCE can't see."
 

--- a/code/packages/rust/closure-pass-treeshake/src/lib.rs
+++ b/code/packages/rust/closure-pass-treeshake/src/lib.rs
@@ -587,4 +587,53 @@ mod tests {
         assert!(!out.changed);
         assert_eq!(out.program.body, prog.body);
     }
+
+    #[test]
+    fn apply_step_keeps_function_when_called() {
+        // `function f() {} f();` — the function is referenced by
+        // the top-level `f()` call site, so it must NOT be dropped.
+        //
+        // This is the retention test that was intentionally
+        // deferred from CLOC13.C.1 (PR #4803). At the time, the
+        // analyzer (CLOC13.0.1 / PR #4800) only collected
+        // references inside top-level ExpressionStatements; the
+        // `f()` call WAS in such a statement, so the reference
+        // would have been emitted with `from_scope = GLOBAL` —
+        // but the lookup would have correctly resolved `f` to
+        // the function binding either way.
+        //
+        // With CLOC13.0.2 (PR #4825) on main, the analyzer now
+        // walks function bodies under nested Function scopes too,
+        // and reference resolution walks the parent chain. This
+        // test exercises the simpler top-level-callee case, and
+        // pins the retention contract: use_count[f] == 1 ⇒
+        // treeshake skips ⇒ program unchanged ⇒ changed == false.
+        use coding_adventures_javascript_ast::{
+            CallExpression, Expression, ExpressionStatement, Identifier, Statement,
+        };
+        let call_f = ProgramItem::Statement(Statement::expression_statement(
+            ExpressionStatement {
+                cv: None,
+                expression: Expression::CallExpression(CallExpression {
+                    cv: None,
+                    callee: Box::new(Expression::Identifier(Identifier {
+                        cv: None,
+                        name: "f".to_string(),
+                    })),
+                    arguments: Vec::new(),
+                }),
+            },
+        ));
+        let prog = program_with(vec![fn_decl("f"), call_f]);
+        let out = run_pass(prog.clone());
+        assert!(!out.changed, "f is referenced by the call site");
+        assert_eq!(out.program.body.len(), 2);
+        // The function declaration survives at index 0.
+        match &out.program.body[0] {
+            ProgramItem::Declaration(Declaration::FunctionDeclaration(fd)) => {
+                assert_eq!(fd.id.name, "f");
+            }
+            _ => panic!("expected the function declaration to survive at index 0"),
+        }
+    }
 }


### PR DESCRIPTION
## Summary
Adds the **retention test** that was intentionally deferred from CLOC13.C.1 (PR #4803). Fixture: `function f() {} f();`. Asserts the function survives because it's referenced by the call site.

## Why it was deferred
At the time of #4803 the analyzer had bindings (CLOC13.0 / #4787) but no references walker (CLOC13.0.1 / #4800 was about to ship). Including the retention test in #4803 would have flipped behaviour mid-sequence — pre-#4800 it would have failed, post-#4800 it would have passed. Documented in lessons.md as the broken-canary-window pattern.

## Why it works now
With #4825 (CLOC13.0.2 nested scopes) on main, the analyzer walks references both at the top level AND inside function-body scopes. The `f()` callee Identifier emits a Reference resolving to the function binding via parent-chain lookup, so `use_count[f] = 1` and the apply step's dead-shape scan correctly skips `f`.

## Diff scope
- 49 lines added in `#[cfg(test)] mod tests` block — single new test.
- CHANGELOG entry under `[0.3.1]`.
- Cargo.toml: `0.3.0` → `0.3.1` (patch-level, no behaviour change).

## Test plan
- [x] `cargo test -p coding-adventures-closure-pass-treeshake` — 16/16 pass (15 prior + 1 retention).
- [x] Security review (Agent): PASS. Test-only diff fully contained in `#[cfg(test)]` block; no production code touched, no module boundary moved.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)