### PR TITLE
A2++: iir-to-intel8008 multi-register const + mov + ret-value staging

### DIFF
--- a/code/packages/rust/iir-to-intel8008/CHANGELOG.md
+++ b/code/packages/rust/iir-to-intel8008/CHANGELOG.md
@@ -3,6 +3,63 @@
 All notable changes to this crate are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.3.0] — 2026-06-02 (A2++ — multi-register `const` + `mov` + ret-value staging)
+
+### Added — linear register allocator over A/B/C/D/E/H/L
+
+Extends v0.2.0's accumulator-only `const` to a real allocator that
+hands out the 8008's seven general-purpose registers in order:
+`A, B, C, D, E, H, L`.  `A` comes first so the trivial `const v; ret v`
+case stays at the 3-byte shape (`MVI A, n; HLT`) without an extra
+`MOV A, X` round-trip.
+
+| IIR op | Intel 8008 lowering |
+|--------|---------------------|
+| `const dest, Int(n)` | `MVI dest_reg, n` (`(rrr << 3) \| 0x06` + immediate byte) |
+| `mov dest, src` | `MOV dest_reg, src_reg` (family `01 ddd sss`) |
+| `ret <var>` | stage `var` into `A` via `MOV A, var_reg` if needed, then `HLT` |
+| `ret_void` | `HLT` |
+
+Register encoding: `A=7`, `B=0`, `C=1`, `D=2`, `E=3`, `H=4`, `L=5`,
+`M=6` (memory pseudo-register, not allocated).  Pool: `[A, B, C, D,
+E, H, L]`.
+
+### New encoder helpers
+
+* `encode_mvi(rrr: u8) -> u8` — `(rrr << 3) \| 0x06` for the
+  immediate-load family.
+* `encode_mov(ddd: u8, sss: u8) -> u8` — `0x40 \| (ddd << 3) \| sss`
+  for the MOV family.
+
+Both `debug_assert!` their inputs fit in 3 bits.
+
+### New error variants
+
+* `IIRIntel8008Error::UndefinedVariable` — `mov` or `ret` referenced
+  a name that was never bound.
+* `IIRIntel8008Error::OutOfRegisters` — 8th local exhausted the pool.
+  Stack spilling lands in A2++.5 or later.
+
+### Tests added (17 total, was 12)
+
+* `two_consts_use_a_then_b_then_mov_a_b_before_hlt` — pinned exact
+  6-byte sequence `MVI A,1; MVI B,2; MOV A,B; HLT` (`0x3E 0x01 0x06
+  0x02 0x78 0x76`).
+* `ret_of_first_const_omits_the_redundant_mov` — regression for the
+  v0.2.0 3-byte trivial-case shape (A-first allocator preserves it).
+* `mov_lowers_to_canonical_mov_ddd_sss` — `MOV B, A = 0x47`,
+  `MOV A, B = 0x78`.
+* `allocator_exhaustion_yields_out_of_registers` — 8 consts → fails
+  on `v7` with `OutOfRegisters`.
+* `undefined_variable_in_mov_is_rejected`.
+
+### What is NOT in v0.3.0 (deferred to A2++.5)
+
+* ALU on the accumulator (`ADD`/`SUB`/`CMP`/etc., family `10 ooo
+  sss`).
+* Real `RET` (`0x3F`) via `CALL` (`0x44` + 14-bit address) and the
+  internal return stack.
+
 ## [0.2.0] — 2026-06-02 (A2+ — `const` → MVI A; `ret`/`ret_void` → HLT)
 
 ### Added — first real instruction lowering

--- a/code/packages/rust/iir-to-intel8008/Cargo.toml
+++ b/code/packages/rust/iir-to-intel8008/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iir-to-intel8008"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
-description = "IIR → Intel 8008 machine code backend (Oct's native target) — lowers IIRModule to a Vec<u8> of 8-bit Intel 8008 opcodes.  v0.2.0 (A2+): adds `const` → MVI A, n (3E nn) for the accumulator and treats `ret`/`ret_void` as HLT; multi-register MOV and real RET via CALL/stack land in A2++."
+description = "IIR → Intel 8008 machine code backend (Oct's native target) — lowers IIRModule to a Vec<u8> of 8-bit Intel 8008 opcodes.  v0.3.0 (A2++): adds a linear register allocator over A/B/C/D/E/H/L, multi-register `const` → MVI rrr,n, `mov dest,src` → MOV ddd,sss (family 01 ddd sss), and ret-value staging into A.  ALU + real RET via CALL/stack land in A2++.5."
 
 [lib]
 name = "iir_to_intel8008"

--- a/code/packages/rust/iir-to-intel8008/src/lib.rs
+++ b/code/packages/rust/iir-to-intel8008/src/lib.rs
@@ -79,6 +79,7 @@
 //! ```
 
 use interpreter_ir::{IIRModule, Operand};
+use std::collections::HashMap;
 use std::fmt;
 
 // ===========================================================================
@@ -103,6 +104,52 @@ pub const HLT: u8 = 0x76;
 /// `rrr = 111 = A`).  Two-byte instruction: this opcode plus the literal
 /// immediate byte.
 pub const MVI_A: u8 = 0x3E;
+
+// ===========================================================================
+// Intel 8008 register encoding
+// ===========================================================================
+//
+// The 8008's 3-bit register field uses these codes:
+//
+//   A = 7   (111)  accumulator
+//   B = 0   (000)
+//   C = 1   (001)
+//   D = 2   (010)
+//   E = 3   (011)
+//   H = 4   (100)
+//   L = 5   (101)
+//   M = 6   (110)  memory pseudo-register (not allocated to)
+//
+// MVI rrr, n   = 00 rrr 110             = `(rrr << 3) | 0x06`  + imm byte
+// MOV ddd, sss = 01 ddd sss             = `(ddd << 3) | sss | 0x40`
+//
+// The MVI/MOV opcode generators below assert their inputs fit in 3 bits
+// — anything outside [0, 7] would corrupt the surrounding bit-fields.
+
+/// Linear-allocator pool ordered to keep the trivial `const v; ret v`
+/// case at one MVI byte: A is handed out first, so `ret v` finds the
+/// value already in A and skips the redundant `MOV A, X` round-trip.
+const REGISTER_POOL: [u8; 7] = [7, 0, 1, 2, 3, 4, 5]; // A, B, C, D, E, H, L
+
+/// The accumulator register (`A = 0b111 = 7`).  `ret <var>` moves the
+/// return value into A before halting; `ret_void` doesn't touch it.
+const REG_A: u8 = 7;
+
+/// Encode an `MVI rrr, imm8` first byte.
+///
+/// `rrr` must be in `[0, 7]` (any of the 7 GP registers + the M
+/// pseudo-register; in practice we only ever pass GP-register indices).
+fn encode_mvi(rrr: u8) -> u8 {
+    debug_assert!(rrr <= 7, "register index out of 3-bit range: {rrr}");
+    (rrr << 3) | 0x06
+}
+
+/// Encode a `MOV ddd, sss` opcode (single byte, family `01 ddd sss`).
+fn encode_mov(ddd: u8, sss: u8) -> u8 {
+    debug_assert!(ddd <= 7, "ddd out of 3-bit range: {ddd}");
+    debug_assert!(sss <= 7, "sss out of 3-bit range: {sss}");
+    0x40 | (ddd << 3) | sss
+}
 
 // ===========================================================================
 // IIRIntel8008Config
@@ -152,6 +199,13 @@ pub enum IIRIntel8008Error {
     UnsupportedType { function: String, type_hint: String },
     /// An operand has an unexpected shape.
     InvalidOperand { function: String, detail: String },
+    /// A variable name was used (via `mov` or `ret`) before it was bound
+    /// by `const` or `mov`.
+    UndefinedVariable { function: String, name: String },
+    /// The function tried to bind more locals than the 8008's 7
+    /// general-purpose registers (A/B/C/D/E/H/L) can hold.  Stack
+    /// spilling lands in a future increment (A2++.5 or later).
+    OutOfRegisters { function: String, name: String },
 }
 
 impl fmt::Display for IIRIntel8008Error {
@@ -168,6 +222,12 @@ impl fmt::Display for IIRIntel8008Error {
             }
             Self::InvalidOperand { function, detail } => {
                 write!(f, "invalid operand in function {function:?}: {detail}")
+            }
+            Self::UndefinedVariable { function, name } => {
+                write!(f, "undefined variable {name:?} in function {function:?}")
+            }
+            Self::OutOfRegisters { function, name } => {
+                write!(f, "out of 8008 registers (A/B/C/D/E/H/L) while binding {name:?} in function {function:?}; stack spilling not yet supported")
             }
         }
     }
@@ -204,12 +264,13 @@ pub fn validate_for_intel8008(_module: &IIRModule) -> Vec<String> {
 /// enough to load into the simulator, step once, and confirm
 /// [`Simulator::halted`] returns `true`.  Real lowering arrives in
 /// v0.2.0+ (A2+).
-/// Supported instruction opcodes in v0.2.0 (A2+).
+/// Supported instruction opcodes in v0.3.0 (A2++).
 ///
-/// `const` lowers to `MVI A, n` (3E + immediate byte).  `ret`/`ret_void`
-/// lowers to `HLT` — proper RET via CALL/stack lands in A2++.  Anything
-/// else is `UnsupportedOp`.
-const SUPPORTED_OPS: &[&str] = &["const", "ret", "ret_void"];
+/// `const` lowers to `MVI rrr, n` with `rrr` allocated from the
+/// `REGISTER_POOL`.  `mov` lowers to `MOV ddd, sss`.  `ret` moves the
+/// value into `A` (if not already there) and emits `HLT`; `ret_void`
+/// just emits `HLT`.  Anything else is `UnsupportedOp`.
+const SUPPORTED_OPS: &[&str] = &["const", "mov", "ret", "ret_void"];
 
 pub fn lower_iir_to_intel8008(
     module: &IIRModule,
@@ -228,6 +289,15 @@ pub fn lower_iir_to_intel8008(
 
     let mut bytes = Vec::new();
     for f in &module.functions {
+        // ── Per-function allocator state ──────────────────────────────
+        //
+        // IIR var name → its assigned 3-bit register index.  Sequentially
+        // hands out registers from REGISTER_POOL starting with A — this
+        // keeps the trivial `const v; ret v` case at the same 3-byte
+        // shape as v0.2.0 (no redundant `MOV A, X` round-trip).
+        let mut env: HashMap<String, u8> = HashMap::new();
+        let mut next_reg: usize = 0;
+
         for instr in &f.instructions {
             if !SUPPORTED_OPS.contains(&instr.op.as_str()) {
                 return Err(IIRIntel8008Error::UnsupportedOp {
@@ -236,62 +306,141 @@ pub fn lower_iir_to_intel8008(
                 });
             }
             match instr.op.as_str() {
-                // ── const: lower to MVI A, n ─────────────────────────────
-                //
-                // v0.2.0 treats every `const` as a load into the
-                // accumulator.  Multi-register allocation (B/C/D/E/H/L)
-                // lands in A2++ alongside MOV.  For values outside the
-                // 8-bit unsigned range (0..255) we return InvalidOperand —
-                // the 8008 has no wide-immediate idiom comparable to
-                // RV32's `lui`.
+                // ── const dest, Int(n) → MVI dest_reg, n ────────────────
                 "const" => {
-                    let n = match instr.srcs.first() {
-                        Some(Operand::Int(n)) => *n,
-                        Some(Operand::Bool(b)) => if *b { 1 } else { 0 },
-                        _ => return Err(IIRIntel8008Error::InvalidOperand {
-                            function: f.name.clone(),
-                            detail: "const srcs[0] must be Int or Bool".into(),
-                        }),
-                    };
-                    // Accept i8 ([-128,127]) interpreted as two's-complement
-                    // u8 OR u8 ([0,255]) — both fit in the immediate byte.
-                    let byte: u8 = if (0..=255).contains(&n) {
-                        n as u8
-                    } else if (-128..0).contains(&n) {
-                        (n as i8) as u8 // two's-complement reinterpretation
-                    } else {
-                        return Err(IIRIntel8008Error::InvalidOperand {
-                            function: f.name.clone(),
-                            detail: format!(
-                                "const {n} exceeds 8-bit byte range \
-                                 ([-128, 255]); 8008 has no wide-immediate \
-                                 idiom — split into multiple MVIs in A2++"
-                            ),
-                        });
-                    };
-                    bytes.push(MVI_A);
+                    let dest = require_dest(instr, "const", &f.name)?;
+                    let byte = encode_immediate_byte(instr.srcs.first(), &f.name)?;
+                    let rrr = alloc_register(&mut next_reg, dest, &mut env, &f.name)?;
+                    bytes.push(encode_mvi(rrr));
                     bytes.push(byte);
                 }
-                // ── ret / ret_void: lower to HLT for now ─────────────────
+
+                // ── mov dest, src → MOV ddd, sss ────────────────────────
                 //
-                // Intel 8008's real RET (`0x3F`) requires the CPU to have
-                // a non-empty internal return stack — that means proper
-                // CALL semantics, which arrive in A2++.  Until then, HLT
-                // gives the simulator a clean stop point.
-                "ret" | "ret_void" => {
+                // If the source and dest happen to be the same register
+                // (unlikely under SSA but possible if upstream re-binds a
+                // name), we emit no byte — the move is a no-op.
+                "mov" => {
+                    let dest = require_dest(instr, "mov", &f.name)?;
+                    let src_name = match instr.srcs.first() {
+                        Some(Operand::Var(s)) => s.clone(),
+                        _ => return Err(IIRIntel8008Error::InvalidOperand {
+                            function: f.name.clone(),
+                            detail: "mov srcs[0] must be Var".into(),
+                        }),
+                    };
+                    let sss = lookup_register(&env, &src_name, &f.name)?;
+                    let ddd = alloc_register(&mut next_reg, dest, &mut env, &f.name)?;
+                    if ddd != sss {
+                        bytes.push(encode_mov(ddd, sss));
+                    }
+                }
+
+                // ── ret <var>: stage value in A, then HLT ───────────────
+                //
+                // If `var`'s register is already A, the MOV is omitted.
+                // Real RET via CALL/stack lands in A2++.5 — until then,
+                // HLT is the universal stopping primitive.
+                "ret" => {
+                    let src_name = match instr.srcs.first() {
+                        Some(Operand::Var(s)) => s.clone(),
+                        _ => return Err(IIRIntel8008Error::InvalidOperand {
+                            function: f.name.clone(),
+                            detail: "ret srcs[0] must be Var".into(),
+                        }),
+                    };
+                    let sss = lookup_register(&env, &src_name, &f.name)?;
+                    if sss != REG_A {
+                        bytes.push(encode_mov(REG_A, sss));
+                    }
                     bytes.push(HLT);
                 }
+
+                // ── ret_void: just HLT ──────────────────────────────────
+                "ret_void" => {
+                    bytes.push(HLT);
+                }
+
                 _ => unreachable!("SUPPORTED_OPS guard above prevents this"),
             }
         }
     }
 
-    // If the module had functions but no instructions emitted anything
-    // (empty bodies), still produce HLT so the .bin is non-empty and the
-    // simulator has a stopping point.
     if bytes.is_empty() {
         bytes.push(HLT);
     }
 
     Ok(bytes)
+}
+
+// ---------------------------------------------------------------------------
+// Per-instruction helpers
+// ---------------------------------------------------------------------------
+
+fn require_dest<'a>(
+    instr: &'a interpreter_ir::IIRInstr,
+    op: &str,
+    fn_name: &str,
+) -> Result<&'a str, IIRIntel8008Error> {
+    instr.dest.as_deref().ok_or_else(|| IIRIntel8008Error::InvalidOperand {
+        function: fn_name.to_string(),
+        detail: format!("{op} requires a dest"),
+    })
+}
+
+fn encode_immediate_byte(
+    op: Option<&Operand>,
+    fn_name: &str,
+) -> Result<u8, IIRIntel8008Error> {
+    let n = match op {
+        Some(Operand::Int(n)) => *n,
+        Some(Operand::Bool(b)) => if *b { 1 } else { 0 },
+        _ => return Err(IIRIntel8008Error::InvalidOperand {
+            function: fn_name.to_string(),
+            detail: "const srcs[0] must be Int or Bool".into(),
+        }),
+    };
+    if (0..=255).contains(&n) {
+        Ok(n as u8)
+    } else if (-128..0).contains(&n) {
+        Ok((n as i8) as u8)
+    } else {
+        Err(IIRIntel8008Error::InvalidOperand {
+            function: fn_name.to_string(),
+            detail: format!(
+                "const {n} exceeds 8-bit byte range ([-128, 255]); 8008 \
+                 has no wide-immediate idiom — split into multiple MVIs \
+                 in A2++"
+            ),
+        })
+    }
+}
+
+fn alloc_register(
+    next_reg: &mut usize,
+    dest: &str,
+    env: &mut HashMap<String, u8>,
+    fn_name: &str,
+) -> Result<u8, IIRIntel8008Error> {
+    if *next_reg >= REGISTER_POOL.len() {
+        return Err(IIRIntel8008Error::OutOfRegisters {
+            function: fn_name.to_string(),
+            name: dest.to_string(),
+        });
+    }
+    let rrr = REGISTER_POOL[*next_reg];
+    *next_reg += 1;
+    env.insert(dest.to_string(), rrr);
+    Ok(rrr)
+}
+
+fn lookup_register(
+    env: &HashMap<String, u8>,
+    name: &str,
+    fn_name: &str,
+) -> Result<u8, IIRIntel8008Error> {
+    env.get(name).copied().ok_or_else(|| IIRIntel8008Error::UndefinedVariable {
+        function: fn_name.to_string(),
+        name: name.to_string(),
+    })
 }

--- a/code/packages/rust/iir-to-intel8008/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-intel8008/tests/test_backend.rs
@@ -187,12 +187,123 @@ fn unsupported_op_is_rejected_with_function_name() {
         IIRInstr::new("ret_void", None, vec![], "void"),
     ]);
     let err = lower_iir_to_intel8008(&module_with(f), &IIRIntel8008Config::default())
-        .expect_err("`add` should be UnsupportedOp in A2+");
+        .expect_err("`add` should be UnsupportedOp in A2++");
     match err {
         IIRIntel8008Error::UnsupportedOp { function, op } => {
             assert_eq!(function, "boom");
             assert_eq!(op, "add");
         }
         other => panic!("expected UnsupportedOp, got: {other:?}"),
+    }
+}
+
+// ===========================================================================
+// 6. A2++ — multi-register allocator (A → B → C → D → E → H → L)
+// ===========================================================================
+//
+// `const` rounds out a register from REGISTER_POOL.  A is handed out
+// first so the trivial `const v; ret v` case keeps its 3-byte shape
+// (no redundant MOV A, X round-trip).  Subsequent consts spill into
+// B, C, D, E, H, L in order.
+
+#[test]
+fn two_consts_use_a_then_b_then_mov_a_b_before_hlt() {
+    // const v=1; const w=2; ret w
+    //   MVI A, 1   (0x3E 0x01)
+    //   MVI B, 2   (0x06 0x02)
+    //   MOV A, B   (01 111 000 = 0x78)  ← stage w into A
+    //   HLT        (0x76)
+    let f = IIRFunction::new("f", vec![], "u8", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(1)], "u8"),
+        IIRInstr::new("const", Some("w".into()), vec![Operand::Int(2)], "u8"),
+        IIRInstr::new("ret",   None,             vec![Operand::Var("w".into())], "u8"),
+    ]);
+    let bytes = lower_iir_to_intel8008(&module_with(f), &IIRIntel8008Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![
+        MVI_A, 0x01,    // const v → A
+        0x06,  0x02,    // const w → B (MVI B = 0x06)
+        0x78,           // MOV A, B (01 111 000 — stage w into A for ret)
+        HLT,
+    ], "expected MVI A,1 + MVI B,2 + MOV A,B + HLT; got: {bytes:02x?}");
+}
+
+#[test]
+fn ret_of_first_const_omits_the_redundant_mov() {
+    // Regression for the A2+ pinned 3-byte shape: when the value being
+    // returned is already in A, no `MOV A, X` is emitted.
+    let f = IIRFunction::new("f", vec![], "u8", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(42)], "u8"),
+        IIRInstr::new("ret",   None,             vec![Operand::Var("v".into())], "u8"),
+    ]);
+    let bytes = lower_iir_to_intel8008(&module_with(f), &IIRIntel8008Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![MVI_A, 0x2A, HLT],
+        "A-first allocator should keep the trivial case at 3 bytes; got: {bytes:02x?}");
+}
+
+#[test]
+fn mov_lowers_to_canonical_mov_ddd_sss() {
+    // const v=7; mov w=v; ret w
+    // v is in A (allocated first). w is in B (next pool slot).
+    //   MVI A, 7    0x3E 0x07
+    //   MOV B, A    01 000 111 = 0x47
+    //   MOV A, B    0x78  ← stage w back into A for ret
+    //   HLT         0x76
+    let f = IIRFunction::new("f", vec![], "u8", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(7)], "u8"),
+        IIRInstr::new("mov",   Some("w".into()), vec![Operand::Var("v".into())], "u8"),
+        IIRInstr::new("ret",   None,             vec![Operand::Var("w".into())], "u8"),
+    ]);
+    let bytes = lower_iir_to_intel8008(&module_with(f), &IIRIntel8008Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![
+        MVI_A, 0x07,    // const v=7 → A
+        0x47,           // MOV B, A (01 000 111)
+        0x78,           // MOV A, B (01 111 000) — stage w into A for ret
+        HLT,
+    ], "expected MVI A,7 + MOV B,A + MOV A,B + HLT; got: {bytes:02x?}");
+}
+
+#[test]
+fn allocator_exhaustion_yields_out_of_registers() {
+    // 7 const + 1 const → exhausts the 7-slot pool [A,B,C,D,E,H,L].
+    let mut body = Vec::new();
+    for i in 0..8 {
+        body.push(IIRInstr::new(
+            "const",
+            Some(format!("v{i}")),
+            vec![Operand::Int(i as i64)],
+            "u8",
+        ));
+    }
+    body.push(IIRInstr::new("ret_void", None, vec![], "void"));
+    let f = IIRFunction::new("greedy", vec![], "void", body);
+
+    let err = lower_iir_to_intel8008(&module_with(f), &IIRIntel8008Config::default())
+        .expect_err("8 consts should exhaust the 7-register pool");
+    match err {
+        IIRIntel8008Error::OutOfRegisters { function, name } => {
+            assert_eq!(function, "greedy");
+            assert_eq!(name, "v7", "should fail on the 8th local");
+        }
+        other => panic!("expected OutOfRegisters, got: {other:?}"),
+    }
+}
+
+#[test]
+fn undefined_variable_in_mov_is_rejected() {
+    let f = IIRFunction::new("f", vec![], "void", vec![
+        IIRInstr::new("mov", Some("w".into()),
+            vec![Operand::Var("ghost".into())], "u8"),
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ]);
+    let err = lower_iir_to_intel8008(&module_with(f), &IIRIntel8008Config::default())
+        .expect_err("mov from undefined var should fail");
+    match err {
+        IIRIntel8008Error::UndefinedVariable { name, .. } => {
+            assert_eq!(name, "ghost");
+        }
+        other => panic!("expected UndefinedVariable, got: {other:?}"),
     }
 }

--- a/code/specs/iir-to-intel8008.md
+++ b/code/specs/iir-to-intel8008.md
@@ -54,8 +54,9 @@ IIRModule
 | Version | Scope | Status |
 |---------|-------|--------|
 | v0.1.0 (A2) | crate skeleton: any module → single `HLT` (`0x76`) | **merged** |
-| **v0.2.0 (A2+ — this PR)** | `const` → `MVI A, n` + `ret`/`ret_void` → `HLT` (accumulator-only first slice) | this PR |
-| v0.3.0 (A2++) | Multi-register allocation (B/C/D/E/H/L) + `MOV r1, r2` + ALU on the accumulator + real `RET` via `CALL`/stack | future |
+| v0.2.0 (A2+) | `const` → `MVI A, n` + `ret`/`ret_void` → `HLT` (accumulator-only first slice) | **merged** |
+| **v0.3.0 (A2++ — this PR)** | Linear register allocator over A/B/C/D/E/H/L + multi-register `const` + `mov` + ret-value staging | this PR |
+| v0.3.1 (A2++.5) | ALU on the accumulator (`ADD`/`SUB`/`CMP`/etc.) + real `RET` (`0x3F`) via `CALL` + internal return stack | future |
 | v0.4.0 (A2+++) | Conditional + unconditional jumps with 14-bit address backpatching + `lang-aot --target=intel8008` | future |
 
 ## Public surface (v0.1.0)


### PR DESCRIPTION
## Summary

- **A2++** of [`MULTILANG-ARCHITECTURE-BACKENDS.md`](code/specs/MULTILANG-ARCHITECTURE-BACKENDS.md). Extends v0.2.0 (accumulator-only) to v0.3.0 with a real linear allocator over the 8008's seven general-purpose registers.
- 17 unit + 1 doctest (was 12 + 1), all green.

## Allocator design

Pool: `[A, B, C, D, E, H, L]` (3-bit encoding indices `[7, 0, 1, 2, 3, 4, 5]`).

**Why A-first**: the trivial `const v; ret v` stays at 3 bytes (`MVI A,n; HLT`) — the return value is already in A, so no redundant `MOV A, X`. Subsequent consts spill into B, C, D, E, H, L.

## Op coverage

| IIR op | Intel 8008 lowering |
|--------|---------------------|
| `const dest, Int(n)` | `MVI dest_reg, n` (`(rrr << 3) \| 0x06` + immediate byte) |
| `mov dest, src` | `MOV dest_reg, src_reg` (family `01 ddd sss`, `0x40 \| (ddd << 3) \| sss`) |
| `ret <var>` | optional `MOV A, var_reg` (skip if already A) + `HLT` |
| `ret_void` | `HLT` |

## New encoder helpers

```rust
fn encode_mvi(rrr: u8) -> u8;   // debug_assert!(rrr <= 7)
fn encode_mov(ddd: u8, sss: u8) -> u8;  // both <= 7
```

## New errors

- `UndefinedVariable` — `mov`/`ret` references unbound name
- `OutOfRegisters` — 8th local exhausts the 7-register pool

## Test plan
- [x] `cargo test -p iir-to-intel8008` — 17 + 1 doctest, all green
- [x] `two_consts_use_a_then_b_then_mov_a_b_before_hlt` — exact 6-byte sequence `0x3E 0x01 0x06 0x02 0x78 0x76`
- [x] Confirms `MOV A, B = 0x78` (family `01 ddd sss`), NOT `0xF8` (which would be group 11)
- [x] `ret_of_first_const_omits_the_redundant_mov` — A-first regression test
- [x] `mov_lowers_to_canonical_mov_ddd_sss` — `MOV B, A = 0x47`, `MOV A, B = 0x78`
- [x] `allocator_exhaustion_yields_out_of_registers` — 8 consts → `OutOfRegisters` on `v7`
- [x] `undefined_variable_in_mov_is_rejected`
- [x] /security-review passed

## Spec status row

| Version | Scope | Status |
|---------|-------|--------|
| v0.1.0 (A2) | skeleton | merged |
| v0.2.0 (A2+) | const A + HLT | merged |
| **v0.3.0 (A2++ — this PR)** | multi-register const + mov + ret staging | this PR |
| v0.3.1 (A2++.5) | ALU on accumulator + real RET via CALL/stack | future |
| v0.4.0 (A2+++) | jumps + lang-aot --target=intel8008 | future |

🤖 Generated with [Claude Code](https://claude.com/claude-code)