### PR TITLE
[codex] board-vm: validate ejected boot plans

### DIFF
--- a/code/packages/rust/board-vm-uno-r4-firmware/README.md
+++ b/code/packages/rust/board-vm-uno-r4-firmware/README.md
@@ -63,7 +63,9 @@ cannot drift from the Rust-owned eject contract.
 The ejected boot-plan helper validates the embedded artifact and returns the
 checked summary together with the board startup action, so firmware entrypoints
 do not need to interpret raw boot-policy constants separately from artifact
-metadata validation.
+metadata validation. The stricter validated boot-plan path also checks the
+artifact against the board capability set and maximum stack before startup code
+acts on that plan.
 
 The ejected artifact stays board-agnostic; this firmware binary is the Uno R4
 backend that decides how to validate and execute it.

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/lib.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/lib.rs
@@ -159,9 +159,20 @@ pub fn validate_ejected_program(
     capabilities: CapabilitySet,
     board_max_stack: u8,
 ) -> Result<(), FirmwareSmokeError> {
+    validate_ejected_boot_plan(program, capabilities, board_max_stack).map(|_| ())
+}
+
+pub fn validate_ejected_boot_plan(
+    program: EjectedFirmwareProgram<'_>,
+    capabilities: CapabilitySet,
+    board_max_stack: u8,
+) -> Result<EjectedBootPlan, FirmwareSmokeError> {
     let module = parse_checked_ejected_program(program)?;
     validate(&module, capabilities, board_max_stack)?;
-    Ok(())
+    Ok(EjectedBootPlan {
+        action: boot_action_for_policy(program.boot_policy)?,
+        summary: program.summary(),
+    })
 }
 
 pub fn validate_ejected_blink_program(board_max_stack: u8) -> Result<(), FirmwareSmokeError> {
@@ -490,6 +501,44 @@ mod tests {
                 action: EjectedBootAction::Run,
                 summary: EjectedFirmwareProgram::blink().summary(),
             }
+        );
+    }
+
+    #[test]
+    fn validated_ejected_blink_boot_plan_checks_board_contract() {
+        assert_eq!(
+            validate_ejected_boot_plan(
+                EjectedFirmwareProgram::blink(),
+                CapabilitySet::blink_mvp(),
+                16
+            )
+            .unwrap(),
+            EjectedBootPlan {
+                action: EjectedBootAction::Run,
+                summary: EjectedFirmwareProgram::blink().summary(),
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_validated_ejected_boot_plan_without_required_capability() {
+        assert_eq!(
+            validate_ejected_boot_plan(EjectedFirmwareProgram::blink(), CapabilitySet::empty(), 16)
+                .unwrap_err(),
+            FirmwareSmokeError::Validate(ValidateError::UnsupportedCapability(CAP_GPIO_OPEN))
+        );
+    }
+
+    #[test]
+    fn rejects_validated_ejected_boot_plan_when_board_stack_is_too_small() {
+        assert_eq!(
+            validate_ejected_boot_plan(
+                EjectedFirmwareProgram::blink(),
+                CapabilitySet::blink_mvp(),
+                3
+            )
+            .unwrap_err(),
+            FirmwareSmokeError::Validate(ValidateError::DeclaredStackTooLarge)
         );
     }
 


### PR DESCRIPTION
## Summary
- add a board-aware ejected boot-plan validator for Uno R4 firmware artifacts
- route validate_ejected_program through the stricter boot-plan path
- cover valid, missing-capability, and too-small-stack boot-plan validation cases
- document that the strict plan checks board capabilities and stack limits before startup acts on it

## Validation
- cargo fmt -p board-vm-uno-r4-firmware
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-ejected-boot-plan-validation cargo test -p board-vm-uno-r4-firmware
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-ejected-boot-plan-validation cargo test -p board-vm-protocol -p board-vm-ir -p board-vm-host -p board-vm-device -p board-vm-loopback -p board-vm-client -p board-vm-eject -p board-vm-uno-r4-firmware -p board-vm-cli
- git diff --check
- git diff --cached --check