### PR TITLE
feat(ml-framework-core-ts): autograd engine — Function.apply + Tensor#backward (JS/TS pilot PR #2/5)

### DIFF
--- a/code/packages/typescript/ml-framework-core/CHANGELOG.md
+++ b/code/packages/typescript/ml-framework-core/CHANGELOG.md
@@ -2,6 +2,109 @@
 
 ## Unreleased
 
+### Added — v0.2.0: autograd engine (Function.apply + Tensor#backward)
+
+PR #2 of 5 in the JS/TS pilot.  Adds reverse-mode automatic
+differentiation on top of v0.1's Tensor class.  All math still pure
+TypeScript; PR #3 layers on the 15 concrete Function subclasses that
+route large ops through Rust via `@coding-adventures/matrix-rust-napi`.
+
+#### New module: `src/autograd.ts`
+
+```ts
+import { Function, Identity, Tensor } from "@coding-adventures/ml-framework-core";
+
+// Base class for every differentiable op:
+abstract class Function {
+  parents: Tensor[];                          // input Tensors (filtered)
+  savedForBackward: Record<string, unknown>;  // subclass scratch
+  static apply<T extends Function>(...inputs: unknown[]): Tensor;
+  abstract forward(...inputs: unknown[]): Tensor;
+  abstract backward(outputGrad: Tensor): (Tensor | null)[];
+}
+
+// Built-in subclass for testing the machinery:
+class Identity extends Function { ... }
+
+// Tensor gets four new things (added in tensor.ts):
+class Tensor {
+  requiresGrad: boolean;       // default false; user-mutable
+  grad: Tensor | null;         // populated by backward()
+  gradFn: Function | null;     // set by Function.apply()
+  backward(grad?: Tensor): void;
+  static onesLike(t): Tensor;
+  static zerosLike(t): Tensor;
+}
+```
+
+#### How it works (same algorithm as Ruby pilot + Python reference)
+
+`Function.apply(...inputs)`:
+  1. Instantiate the Function (so it can hold state for backward).
+  2. Filter `inputs` to Tensors and stash as `parents`.  Non-Tensor args
+     (e.g. Pow's scalar exponent) flow through to `forward` but don't
+     appear in the autograd graph.
+  3. Call `forward(...inputs)`.
+  4. If any Tensor input has `requiresGrad`, mark the output the same
+     way and set `output.gradFn = fn` so backwardImpl can find us.
+
+`Tensor#backward(grad?)`:
+  1. Default `grad` to `onesLike(this)`.
+  2. DFS post-order to build the topological list upstream via gradFn.
+  3. Walk topo list REVERSE: for each non-leaf, call gradFn.backward,
+     distribute per-input grads into a `Map<Tensor, Tensor>` keyed on
+     object identity (JS Maps use reference equality for object keys —
+     perfect for our shared-parent case).
+  4. For each leaf with requiresGrad, accumulate the gradient into
+     `.grad`.  Supports repeated backward() without zero_grad.
+
+O(V + E) where V is operations, E is tensor edges.
+
+#### Architecture choices
+
+- **Free `backwardImpl` function, not Tensor method**: keeps tensor.ts
+  focused on storage; the autograd walker lives in autograd.ts.
+  `Tensor#backward(grad?)` is a 1-line delegate.
+- **`Map<Tensor, Tensor>` for gradMap**: JS Map uses reference equality
+  for object keys.  Same Tensor reaching via multiple paths (e.g.
+  `Add(x, x)`) collapses to one Map entry — gradients accumulate
+  correctly.
+- **`Set<Tensor>` for visited**: same reference-equality property.
+- **`gradFn` typed `any`**: would otherwise create a tensor.ts ↔
+  autograd.ts circular type dependency.  TypeScript handles cycles at
+  runtime fine, but the type system needs help.  Documented in code.
+- **Static `Function.apply` with `this: new () => T` constraint**:
+  preserves the concrete subclass type so `MyOp.apply(...)` returns
+  `Tensor` without losing `gradFn`'s `MyOp` type.
+
+#### Tests added (18 vitest cases, all passing)
+
+- `Function.apply — wiring` (5): requiresGrad propagation, no gradFn
+  when no input requires grad, apply returns NEW Tensor, abstract
+  method errors propagate
+- `Tensor#backward — sanity` (3): non-grad tensor throws, mismatched
+  grad shape throws, returns void
+- `Tensor#backward — end-to-end` (6): identity backward writes ones,
+  explicit seed, backward twice accumulates, chain of identities,
+  shared parent accumulates, leaf without requiresGrad is skipped
+- `Function — introspection` (2): toString shows class + parent count,
+  default state on fresh instance
+- `Tensor — onesLike / zerosLike` (2)
+
+Existing 61 Tensor tests continue to pass — no regressions.
+
+Total: 79 tests, all passing.
+
+#### What's next
+
+- PR #3: `ops.ts` — 15 Function subclasses (Add/Sub/Mul/Div/Neg/Abs/
+  Pow/MatMul/ReLU/Sigmoid/Tanh/GELU/Softmax/Sum/Mean).  Each `forward`
+  builds a matrix-ir-json envelope matching the Python `_rust_backend.py`
+  shapes and dispatches large tensors through
+  `@coding-adventures/matrix-rust-napi.runGraphOnCpu`.
+- PR #4: backward dispatch + end-to-end MLP training test.
+- PR #5: benchmark + v1.0.0 polish.
+
 ### Added — v0.1.0: pure-TypeScript Tensor class
 
 First release.  Ships the bottom layer of the TypeScript ML framework

--- a/code/packages/typescript/ml-framework-core/package.json
+++ b/code/packages/typescript/ml-framework-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/ml-framework-core",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Idiomatic TypeScript Tensor + autograd on top of the Rust matrix-cpu engine.  v0.1.0 ships the Tensor layer (factories, shape ops, named element-wise methods); autograd + 15 op dispatch + end-to-end MLP land in PRs #2–#5.",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/ml-framework-core/src/autograd.ts
+++ b/code/packages/typescript/ml-framework-core/src/autograd.ts
@@ -1,0 +1,222 @@
+/**
+ * # autograd.ts — reverse-mode automatic differentiation for Tensor
+ *
+ * Adds two pieces of machinery on top of v0.1's Tensor:
+ *
+ *   1. The `Function` base class.  Every differentiable op (Add, MatMul,
+ *      ReLU, ...) is a `Function` subclass that defines `forward` and
+ *      `backward`.  PR #3 implements the ~15 specific subclasses; here we
+ *      provide the base class and one `Identity` subclass for testing.
+ *
+ *   2. The `backwardImpl` function — a free standalone function that
+ *      implements topological sort + reverse walk on the autograd graph.
+ *      `Tensor#backward` (defined in tensor.ts) delegates to it.
+ *
+ * ## Why backward() is a free function, not a method
+ *
+ * The walker needs to read every Tensor's `gradFn` and write its `grad`.
+ * If it lived inside `Tensor`, we'd have either (a) a circular dependency
+ * between tensor.ts and autograd.ts, or (b) a giant tensor.ts that owns
+ * both storage and graph logic.  Splitting into a free function in
+ * autograd.ts keeps the modules small and lets Tensor stay focused on
+ * "I am a Float32Array with a shape."
+ *
+ * The `tensor.ts` file does have a thin `Tensor#backward(grad?)` method
+ * but it's a one-liner that imports and calls `backwardImpl`.
+ *
+ * ## Algorithm (same as Ruby pilot + Python reference)
+ *
+ *   1. If `grad` is undefined, default to ones-like (PyTorch convention;
+ *      strictly only valid for scalar outputs but we allow any shape).
+ *   2. DFS post-order to build the topological list upstream through the
+ *      `gradFn` chain.
+ *   3. Walk topo list in REVERSE.  For each non-leaf, call
+ *      `gradFn.backward(nodeGrad)` to get per-input grads, accumulate
+ *      them into a per-parent `gradMap` keyed on object identity (via a
+ *      JS `Map`, which uses reference equality for object keys).
+ *   4. For each leaf with `requiresGrad`, copy/accumulate the gradient
+ *      into the public `.grad` slot.  Supports repeated `backward()`
+ *      without zero_grad (PyTorch convention).
+ *
+ * O(V + E) where V is operations, E is tensor edges.
+ */
+
+import { Tensor } from "./tensor.js";
+
+// ---------------------------------------------------------------------------
+// Function base class — extend for every differentiable op.
+// ---------------------------------------------------------------------------
+
+export abstract class Function {
+  /**
+   * The tensor inputs that produced the output.  `backward()` returns
+   * gradients in the same order.  Set by `apply()`; subclasses should
+   * not touch.
+   */
+  public parents: Tensor[] = [];
+
+  /**
+   * Free-form storage for whatever the subclass wants to cache in
+   * `forward()` for use in `backward()` — typically the input tensors,
+   * the output, or shape metadata.  Symbol-keyed `Map`-like Record so
+   * keys are namespaced per-instance.
+   */
+  public savedForBackward: Record<string, unknown> = {};
+
+  /**
+   * The canonical entry point for invoking an op.
+   *
+   *   1. Instantiate the Function (so it can hold state for backward).
+   *   2. Filter `inputs` to Tensors and stash them as `parents`.  Non-Tensor
+   *      args (e.g. Pow's scalar exponent) pass through to `forward` but
+   *      don't appear in the autograd graph — they don't have gradients.
+   *   3. Run `forward(...inputs)`.
+   *   4. If any Tensor input has `requiresGrad`, mark the output the same
+   *      way and wire `output.gradFn = fn` so `backwardImpl` can walk us.
+   *
+   * The static method signature uses a generic `T extends Function` so
+   * subclasses don't lose their concrete type when calling `MyOp.apply(...)`.
+   */
+  static apply<T extends Function>(
+    this: new () => T,
+    ...inputs: unknown[]
+  ): Tensor {
+    const fn = new this();
+
+    fn.parents = inputs.filter((i): i is Tensor => i instanceof Tensor);
+
+    const output = fn.forward(...inputs);
+
+    const needsGrad = inputs.some((i) => i instanceof Tensor && i.requiresGrad);
+    if (needsGrad) {
+      output.requiresGrad = true;
+      output.gradFn = fn;
+    }
+    return output;
+  }
+
+  /** Subclasses override.  Compute the forward result. */
+  abstract forward(...inputs: unknown[]): Tensor;
+
+  /**
+   * Subclasses override.  Given the gradient of the loss w.r.t. this
+   * Function's output, return one gradient per `parents[i]` (in the same
+   * order).  Use `null` in a slot for any parent that doesn't need a
+   * gradient (rare).
+   */
+  abstract backward(outputGrad: Tensor): (Tensor | null)[];
+
+  /** Friendly default for inspect / console.log output. */
+  toString(): string {
+    return `<${this.constructor.name} parents=${this.parents.length}>`;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Identity — the simplest possible Function subclass.
+//
+// forward(x)  → fresh Tensor with the same data as x
+// backward(g) → [g]   (gradient passes through unchanged)
+//
+// Used by the autograd test suite to exercise the apply() / backward()
+// machinery without depending on op-specific math.  The real ops land
+// in PR #3 (ops.ts).
+// ---------------------------------------------------------------------------
+
+export class Identity extends Function {
+  forward(...inputs: unknown[]): Tensor {
+    const x = inputs[0];
+    if (!(x instanceof Tensor)) {
+      throw new TypeError("Identity.forward expects a Tensor argument");
+    }
+    // Return a NEW Tensor so object identity (`y === x`) is false even
+    // though `y.equals(x)` is true.  Constructors copy, so this works.
+    return new Tensor(Array.from(x.data), { shape: x.shape.slice() });
+  }
+
+  backward(outputGrad: Tensor): (Tensor | null)[] {
+    // d/dx(x) = 1; gradient passes through unchanged.
+    return [outputGrad];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// backwardImpl — the actual reverse-mode autodiff walker.
+//
+// Called from `Tensor#backward(grad?)` in tensor.ts.  Lives here so the
+// algorithm code (which is the meat of autograd) sits next to the
+// Function base class.
+// ---------------------------------------------------------------------------
+
+export function backwardImpl(start: Tensor, grad?: Tensor): void {
+  if (!start.requiresGrad) {
+    throw new Error("backward() called on a tensor that doesn't require grad");
+  }
+
+  const seed = grad ?? Tensor.onesLike(start);
+  if (!shapesMatch(seed.shape, start.shape)) {
+    throw new RangeError(
+      `backward grad shape [${seed.shape.join(", ")}] != tensor shape [${start.shape.join(", ")}]`,
+    );
+  }
+
+  // Topological order: each tensor appears AFTER its parents.  Walking in
+  // reverse processes children before parents.
+  const topoOrder: Tensor[] = [];
+  const visited = new Set<Tensor>();   // identity-based, perfect for our needs
+  function buildTopo(t: Tensor): void {
+    if (visited.has(t)) return;
+    visited.add(t);
+    if (t.gradFn) {
+      for (const p of t.gradFn.parents) buildTopo(p);
+    }
+    topoOrder.push(t);
+  }
+  buildTopo(start);
+
+  // gradMap: Tensor → accumulated gradient.  Map uses reference equality
+  // for object keys, which is exactly what we need — the same Tensor
+  // reaching multiple paths (e.g. `Add(x, x)`) collapses to one entry.
+  const gradMap = new Map<Tensor, Tensor>();
+  gradMap.set(start, seed);
+
+  for (let i = topoOrder.length - 1; i >= 0; i--) {
+    const node = topoOrder[i]!;
+    const nodeGrad = gradMap.get(node);
+    if (!nodeGrad) continue;
+
+    if (!node.gradFn) {
+      // Leaf — store/accumulate into the public grad slot.
+      if (!node.requiresGrad) continue;
+
+      if (!node.grad) {
+        // First time seeing this leaf — copy the accumulated grad.
+        node.grad = new Tensor(Array.from(nodeGrad.data), { shape: nodeGrad.shape.slice() });
+      } else {
+        // Accumulate: supports repeated backward() without zero_grad
+        // (caller is expected to zero between steps when training).
+        node.grad = node.grad.add(nodeGrad);
+      }
+      continue;
+    }
+
+    // Non-leaf — ask the Function for per-input grads, distribute them.
+    const inputGrads = node.gradFn.backward(nodeGrad);
+    for (let j = 0; j < node.gradFn.parents.length; j++) {
+      const parent = node.gradFn.parents[j]!;
+      const inputGrad = inputGrads[j];
+      if (!inputGrad) continue;
+
+      const existing = gradMap.get(parent);
+      gradMap.set(parent, existing ? existing.add(inputGrad) : inputGrad);
+    }
+  }
+}
+
+function shapesMatch(a: readonly number[], b: readonly number[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}

--- a/code/packages/typescript/ml-framework-core/src/index.ts
+++ b/code/packages/typescript/ml-framework-core/src/index.ts
@@ -39,4 +39,5 @@
 
 export { Tensor, inferShape, flattenToFloat32 } from "./tensor.js";
 export type { Dtype, Shape, TensorOptions } from "./tensor.js";
+export { Function, Identity, backwardImpl } from "./autograd.js";
 export { VERSION } from "./version.js";

--- a/code/packages/typescript/ml-framework-core/src/tensor.ts
+++ b/code/packages/typescript/ml-framework-core/src/tensor.ts
@@ -42,6 +42,8 @@
  *   `.add()` family below are pure-Ruby fallback math without autograd.
  */
 
+import { backwardImpl } from "./autograd.js";
+
 export type Dtype = "f32";
 
 export type Shape = readonly number[];
@@ -132,6 +134,33 @@ export class Tensor {
 
   /** Element dtype.  Always "f32" in v0.1. */
   public readonly dtype: Dtype;
+
+  /**
+   * Whether ops that consume this tensor should build an autograd graph.
+   * Mutable (PyTorch convention): set via `t.requiresGrad = true` on
+   * leaf tensors that should track gradients.
+   */
+  public requiresGrad: boolean = false;
+
+  /**
+   * Accumulated gradient after `backward()` runs.  `null` until then.
+   * For non-leaf tensors, this stays `null` — only leaves with
+   * `requiresGrad = true` accumulate here.
+   */
+  public grad: Tensor | null = null;
+
+  /**
+   * The `Function` instance that produced this tensor.  `null` for
+   * leaves (tensors constructed directly, not via `Function.apply`).
+   * Typed as `unknown` to break the tensor.ts ↔ autograd.ts cycle —
+   * the actual type is `Function` from autograd.ts.  Callers should
+   * cast.  (We use a thin getter elsewhere when we really need the
+   * concrete type.)
+   *
+   * The walker in `autograd.ts` is the only place this is read.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public gradFn: any = null;
 
   /**
    * Construct a Tensor from either a flat array (with explicit shape) or a
@@ -359,6 +388,36 @@ export class Tensor {
     return new Tensor(Array.from(out), { shape: this.shape.slice() });
   }
 
+  /**
+   * Kick off reverse-mode autodiff from this tensor.  Mutates the public
+   * `.grad` slot of every leaf that participated in producing this tensor.
+   *
+   * `grad` defaults to `ones_like(this)` (PyTorch convention; strictly
+   * only correct for scalar outputs, but we accept any shape).  Repeated
+   * `backward()` calls accumulate into `.grad` — caller is expected to
+   * zero between training steps.
+   *
+   * Lives here as a thin one-line delegate to `backwardImpl` in
+   * autograd.ts.  The split keeps tensor.ts focused on storage.
+   */
+  backward(grad?: Tensor): void {
+    // Lazy import to break the tensor.ts ↔ autograd.ts module cycle.
+    // The import resolves on first call; subsequent calls hit the
+    // module cache.  Note: top-level `import { backwardImpl }` would
+    // work in TS too, but a lazy require keeps the cycle disciplined.
+    //
+    // We use dynamic-import-style require via createRequire because the
+    // package is ESM (`"type": "module"`) — but actually a static
+    // ESM import works fine here because `Tensor` is only USED (not
+    // structurally referenced) inside backwardImpl.  Static import:
+    /* eslint-disable @typescript-eslint/no-var-requires */
+    // Note: Tested both static and lazy import; static is fine because
+    // the cycle is shaped (autograd imports Tensor → tensor imports
+    // backwardImpl) and resolved before either runs.
+    // eslint-enable
+    backwardImpl(this, grad);
+  }
+
   private binaryOp(other: Tensor | number, fn: (a: number, b: number) => number): Tensor {
     if (other instanceof Tensor) {
       if (!shapesEqual(this.shape, other.shape)) {
@@ -466,6 +525,16 @@ export class Tensor {
   /** Sugar for `new Tensor(nested)`. */
   static fromArray(nested: unknown): Tensor {
     return new Tensor(nested);
+  }
+
+  /** Ones tensor with the same shape as `other`. */
+  static onesLike(other: Tensor): Tensor {
+    return Tensor.ones(...other.shape.slice());
+  }
+
+  /** Zeros tensor with the same shape as `other`. */
+  static zerosLike(other: Tensor): Tensor {
+    return Tensor.zeros(...other.shape.slice());
   }
 
   /**

--- a/code/packages/typescript/ml-framework-core/src/version.ts
+++ b/code/packages/typescript/ml-framework-core/src/version.ts
@@ -4,4 +4,4 @@
  * Kept in sync with package.json's `version` field by hand — there's no
  * build step that injects it.  When bumping, update both files.
  */
-export const VERSION = "0.1.0" as const;
+export const VERSION = "0.2.0" as const;

--- a/code/packages/typescript/ml-framework-core/tests/autograd.test.ts
+++ b/code/packages/typescript/ml-framework-core/tests/autograd.test.ts
@@ -1,0 +1,196 @@
+/**
+ * autograd.test.ts — exercises Function.apply + Tensor#backward.
+ *
+ * Mirrors `code/packages/ruby/ml_framework_core/test/autograd_test.rb`
+ * adapted to vitest idiom.  Uses only the `Identity` Function subclass
+ * so the tests don't depend on op-specific math — PR #3 adds the real
+ * ops and their own parity/gradient tests.
+ *
+ * Sections:
+ *  - apply() wiring: requiresGrad propagation, grad_fn attachment
+ *  - Tensor#backward sanity: must require requiresGrad, must accept seed
+ *  - End-to-end: backward populates leaf .grad
+ *  - Accumulation: repeated backward sums grads
+ *  - Chain: multi-step graphs propagate
+ *  - Shared parent: `x → Id → a, x → Id → b` accumulates
+ *  - Function introspection
+ *  - onesLike / zerosLike factories
+ */
+
+import { describe, it, expect } from "vitest";
+import { Tensor, Function, Identity } from "../src/index.js";
+
+describe("Function.apply — wiring", () => {
+  it("propagates requiresGrad through Identity", () => {
+    const x = new Tensor([1, 2, 3]);
+    x.requiresGrad = true;
+    const y = Identity.apply(x);
+
+    expect(y.requiresGrad).toBe(true);
+    expect(y.gradFn).toBeInstanceOf(Identity);
+    expect(y.gradFn.parents).toEqual([x]);
+  });
+
+  it("does not attach gradFn when no input requires grad", () => {
+    const x = new Tensor([1, 2, 3]);
+    const y = Identity.apply(x);
+    expect(y.requiresGrad).toBe(false);
+    expect(y.gradFn).toBeNull();
+  });
+
+  it("apply() returns a NEW tensor (object identity, not value equality)", () => {
+    const x = new Tensor([1, 2]);
+    x.requiresGrad = true;
+    const y = Identity.apply(x);
+    expect(y).not.toBe(x);
+    expect(y.equals(x)).toBe(true);
+  });
+
+  it("subclass without forward throws on apply", () => {
+    class BadFn extends Function {
+      forward(): Tensor {
+        throw new Error("not implemented");
+      }
+      backward(): (Tensor | null)[] {
+        throw new Error("not implemented");
+      }
+    }
+    expect(() => BadFn.apply(new Tensor([1]))).toThrow();
+  });
+
+  it("subclass without backward throws on tensor.backward()", () => {
+    class NoBack extends Function {
+      forward(...inputs: unknown[]): Tensor {
+        const x = inputs[0] as Tensor;
+        return new Tensor(Array.from(x.data), { shape: x.shape.slice() });
+      }
+      backward(): (Tensor | null)[] {
+        throw new Error("subclass must implement backward");
+      }
+    }
+    const x = new Tensor([1]);
+    x.requiresGrad = true;
+    const y = NoBack.apply(x);
+    expect(() => y.backward()).toThrow();
+  });
+});
+
+describe("Tensor#backward — sanity", () => {
+  it("throws when called on a non-grad tensor", () => {
+    const x = new Tensor([1, 2, 3]);
+    expect(x.requiresGrad).toBe(false);
+    expect(() => x.backward()).toThrow();
+  });
+
+  it("throws when seed grad shape doesn't match", () => {
+    const x = new Tensor([1, 2]);
+    x.requiresGrad = true;
+    const y = Identity.apply(x);
+    expect(() => y.backward(Tensor.ones(3))).toThrow(RangeError);
+  });
+
+  it("returns undefined (void)", () => {
+    const x = new Tensor([1, 2]);
+    x.requiresGrad = true;
+    const y = Identity.apply(x);
+    expect(y.backward()).toBeUndefined();
+  });
+});
+
+describe("Tensor#backward — end-to-end", () => {
+  it("identity backward writes ones to leaf .grad", () => {
+    const x = new Tensor([1, 2, 3]);
+    x.requiresGrad = true;
+    const y = Identity.apply(x);
+    y.backward();
+    // d(identity(x))/dx == 1; with seed = ones, x.grad = ones.
+    expect(x.grad).not.toBeNull();
+    expect(x.grad!.toArray()).toEqual([1, 1, 1]);
+  });
+
+  it("identity backward with explicit seed grad", () => {
+    const x = new Tensor([1, 2]);
+    x.requiresGrad = true;
+    const y = Identity.apply(x);
+    y.backward(Tensor.full([2], 5));
+    // Identity's local derivative is 1; seed = [5, 5] passes through.
+    expect(x.grad!.toArray()).toEqual([5, 5]);
+  });
+
+  it("backward twice accumulates into leaf grad", () => {
+    const x = new Tensor([1, 2]);
+    x.requiresGrad = true;
+    const y = Identity.apply(x);
+    y.backward();
+    y.backward();
+    // PyTorch convention: repeated backward sums into .grad.
+    expect(x.grad!.toArray()).toEqual([2, 2]);
+  });
+
+  it("chain of identities propagates", () => {
+    const x = new Tensor([1, 2, 3]);
+    x.requiresGrad = true;
+    const y = Identity.apply(Identity.apply(Identity.apply(x)));
+    y.backward();
+    // Chain rule with all-identity is still all-ones.
+    expect(x.grad!.toArray()).toEqual([1, 1, 1]);
+  });
+
+  it("shared parent accumulates from both paths", () => {
+    // Build:  x ─┬─ Id ─→ a
+    //            └─ Id ─→ b
+    // Run backward on each independently; the SAME leaf x.grad accumulates.
+    const x = new Tensor([1, 2]);
+    x.requiresGrad = true;
+    const a = Identity.apply(x);
+    const b = Identity.apply(x);
+    a.backward();
+    b.backward();
+    expect(x.grad!.toArray()).toEqual([2, 2]);
+  });
+
+  it("leaf without requiresGrad is skipped", () => {
+    const x = new Tensor([1, 2]); // no requiresGrad
+    const y = new Tensor([1, 2]);
+    y.requiresGrad = true;
+    const z1 = Identity.apply(x);
+    expect(z1.requiresGrad).toBe(false);
+    expect(x.grad).toBeNull();
+
+    const w = Identity.apply(y);
+    w.backward();
+    expect(y.grad!.toArray()).toEqual([1, 1]);
+  });
+});
+
+describe("Function — introspection", () => {
+  it("toString shows class name and parent count", () => {
+    const x = new Tensor([1]);
+    x.requiresGrad = true;
+    const y = Identity.apply(x);
+    expect(y.gradFn.toString()).toContain("Identity");
+    expect(y.gradFn.toString()).toContain("parents=1");
+  });
+
+  it("default state on freshly-constructed Function", () => {
+    const fn = new Identity();
+    expect(fn.parents).toEqual([]);
+    expect(fn.savedForBackward).toEqual({});
+  });
+});
+
+describe("Tensor — onesLike / zerosLike", () => {
+  it("onesLike", () => {
+    const x = Tensor.zeros(2, 3);
+    const o = Tensor.onesLike(x);
+    expect(o.shape).toEqual(x.shape);
+    expect(o.toArray()).toEqual([1, 1, 1, 1, 1, 1]);
+  });
+
+  it("zerosLike", () => {
+    const x = Tensor.ones(4);
+    const z = Tensor.zerosLike(x);
+    expect(z.shape).toEqual(x.shape);
+    expect(z.toArray()).toEqual([0, 0, 0, 0]);
+  });
+});


### PR DESCRIPTION
## Summary

- New `Function` abstract class with `apply<T>()` classmethod that wires up the autograd graph (sets `output.gradFn` + `requiresGrad`)
- `Identity` Function subclass for testing the machinery without bringing in op-specific math
- `Tensor#backward(grad?)` — DFS topological sort + reverse walk; accumulates gradients into leaf `.grad` slots; supports repeated backward
- `Tensor.onesLike` / `Tensor.zerosLike` factories
- 18 new vitest cases, 79 total across the package, all passing

## How it works

`Function.apply<T>(...inputs)`: filter to Tensors → forward → wire `gradFn` if any input requires grad.

`Tensor#backward(grad?)`:
1. Default grad to `onesLike(this)`
2. DFS post-order to build topological list upstream
3. Walk REVERSE; for each non-leaf call `gradFn.backward`, distribute via `Map<Tensor, Tensor>` (JS Maps use reference equality on object keys — perfect for shared parents)
4. Accumulate into leaf `.grad`

O(V + E). Mirrors the Ruby pilot's algorithm.

## Architecture choices

- **Free `backwardImpl` function**, not Tensor method — keeps tensor.ts focused on storage
- **`Map<Tensor, Tensor>` for gradMap** — JS reference equality solves shared-parent accumulation for free
- **`gradFn: any`** — breaks the tensor.ts ↔ autograd.ts circular type dep; runtime is fine via live ESM bindings
- **`static apply<T extends Function>(this: new () => T, ...)`** — preserves the concrete subclass type

## Test plan

- [x] `npx tsc --noEmit`: 0 errors
- [x] `npx vitest run`: 79/79 passing
- [x] Security review passed (1 INFO note on recursion depth — non-blocking)
- [ ] CI: build (ubuntu/macos/windows) — pending
- [ ] CI: CodeQL js-ts Analyze — pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)