### PR TITLE
Track browser form button descriptors

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -779,6 +779,32 @@ def check_browser_expected_lists(
             require_optional_nullable_string(
                 validation_path, control, "validation_barred_reason", errors
             )
+        require_optional_object_list(form_path, form, "buttons", errors)
+        for button_index, button in enumerate(object_list_items(form, "buttons")):
+            button_path = f"{form_path}.buttons[{button_index}]"
+            require_optional_nullable_string(button_path, button, "id", errors)
+            require_string(button_path, button, "control_type", errors)
+            for field in (
+                "name",
+                "form_owner",
+                "accessible_name",
+                "action",
+                "resolved_action",
+                "enctype",
+                "target",
+                "effective_target",
+                "value",
+                "src",
+                "resolved_src",
+                "alt",
+                "width",
+                "height",
+            ):
+                require_optional_nullable_string(button_path, button, field, errors)
+            for field in ("disabled", "autofocus", "submitter", "novalidate"):
+                require_optional_boolean(button_path, button, field, errors)
+            require_string(button_path, button, "method", errors)
+            require_string(button_path, button, "text", errors)
         require_object_list(form_path, form, "controls", errors)
         require_optional_object_list(form_path, form, "submitters", errors)
         for control_index, control in enumerate(object_list_items(form, "controls")):

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -1617,6 +1617,7 @@ pub struct BrowserForm {
     pub outputs: Vec<BrowserFormOutput>,
     pub successful_controls: Vec<BrowserFormSuccessfulControl>,
     pub validation_controls: Vec<BrowserFormValidationControl>,
+    pub buttons: Vec<BrowserFormButton>,
     pub controls: Vec<BrowserFormControl>,
     pub submitters: Vec<BrowserFormSubmitter>,
 }
@@ -1704,6 +1705,32 @@ pub struct BrowserFormValidationControl {
     pub required: bool,
     pub validation_attributes: Vec<String>,
     pub validation_barred_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserFormButton {
+    pub id: Option<String>,
+    pub control_type: String,
+    pub name: Option<String>,
+    pub form_owner: Option<String>,
+    pub accessible_name: Option<String>,
+    pub disabled: bool,
+    pub autofocus: bool,
+    pub submitter: bool,
+    pub action: Option<String>,
+    pub resolved_action: Option<String>,
+    pub method: String,
+    pub enctype: Option<String>,
+    pub target: Option<String>,
+    pub effective_target: Option<String>,
+    pub novalidate: bool,
+    pub value: Option<String>,
+    pub text: String,
+    pub src: Option<String>,
+    pub resolved_src: Option<String>,
+    pub alt: Option<String>,
+    pub width: Option<String>,
+    pub height: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -12760,6 +12787,16 @@ fn browser_form(
     let outputs = browser_form_outputs(&controls);
     let successful_controls = browser_form_successful_controls(&controls);
     let validation_controls = browser_form_validation_controls(&controls);
+    let buttons = browser_form_buttons(
+        &controls,
+        action.as_deref(),
+        resolved_action.as_deref(),
+        &method,
+        enctype.as_deref(),
+        target.as_deref(),
+        base_target,
+        novalidate,
+    );
     let submitters = browser_form_submitters(
         &controls,
         action.as_deref(),
@@ -12803,6 +12840,7 @@ fn browser_form(
         outputs,
         successful_controls,
         validation_controls,
+        buttons,
         controls,
         submitters,
     }
@@ -13170,6 +13208,98 @@ fn browser_form_validation_controls(
             validation_barred_reason: control.validation_barred_reason.clone(),
         })
         .collect()
+}
+
+fn browser_form_buttons(
+    controls: &[BrowserFormControl],
+    action: Option<&str>,
+    resolved_action: Option<&str>,
+    method: &str,
+    enctype: Option<&str>,
+    target: Option<&str>,
+    base_target: Option<&str>,
+    novalidate: bool,
+) -> Vec<BrowserFormButton> {
+    controls
+        .iter()
+        .filter(|control| is_browser_form_button(control))
+        .map(|control| {
+            let submitter = is_browser_form_submitter(control);
+            BrowserFormButton {
+                id: control.id.clone(),
+                control_type: control.control_type.clone(),
+                name: control.name.clone(),
+                form_owner: control.form_owner.clone(),
+                accessible_name: control
+                    .accessible_name
+                    .clone()
+                    .or_else(|| control.alt.clone()),
+                disabled: control.disabled,
+                autofocus: control.autofocus,
+                submitter,
+                action: if submitter {
+                    control
+                        .form_action
+                        .clone()
+                        .or_else(|| action.map(ToOwned::to_owned))
+                } else {
+                    control.form_action.clone()
+                },
+                resolved_action: if submitter {
+                    control
+                        .resolved_form_action
+                        .clone()
+                        .or_else(|| resolved_action.map(ToOwned::to_owned))
+                } else {
+                    control.resolved_form_action.clone()
+                },
+                method: control
+                    .form_method
+                    .clone()
+                    .unwrap_or_else(|| method.to_string()),
+                enctype: if submitter {
+                    control
+                        .form_enctype
+                        .clone()
+                        .or_else(|| enctype.map(ToOwned::to_owned))
+                } else {
+                    control.form_enctype.clone()
+                },
+                target: if submitter {
+                    control
+                        .form_target
+                        .clone()
+                        .or_else(|| target.map(ToOwned::to_owned))
+                } else {
+                    control.form_target.clone()
+                },
+                effective_target: if submitter {
+                    control
+                        .form_target
+                        .clone()
+                        .or_else(|| target.map(ToOwned::to_owned))
+                        .or_else(|| base_target.map(ToOwned::to_owned))
+                } else {
+                    control.form_target.clone()
+                },
+                novalidate: submitter && (novalidate || control.form_novalidate),
+                value: control.value.clone(),
+                text: control.text.clone(),
+                src: control.src.clone(),
+                resolved_src: control.resolved_src.clone(),
+                alt: control.alt.clone(),
+                width: control.width.clone(),
+                height: control.height.clone(),
+            }
+        })
+        .collect()
+}
+
+fn is_browser_form_button(control: &BrowserFormControl) -> bool {
+    matches!(
+        control.control_type.as_str(),
+        "button" | "image" | "reset" | "submit"
+    )
 }
 
 fn is_browser_form_submitter(control: &BrowserFormControl) -> bool {

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -1,13 +1,13 @@
 use coding_adventures_html_parser::{
     parse_browser_document, BrowserAnchor, BrowserComponentHydrationTarget, BrowserDataAttribute,
     BrowserDatalistOption, BrowserDocument, BrowserDocumentMetadata, BrowserEmbeddedContext,
-    BrowserForm, BrowserFormControl, BrowserFormDatalist, BrowserFormFieldset, BrowserFormLabel,
-    BrowserFormOutput, BrowserFormSelect, BrowserFormSubmitter, BrowserFormSuccessfulControl,
-    BrowserFormValidationControl, BrowserHeading, BrowserHttpEquivHint, BrowserImage,
-    BrowserImageSource, BrowserInteractiveElement, BrowserLink, BrowserMedia, BrowserMeta,
-    BrowserMetadataDirective, BrowserRefresh, BrowserResource, BrowserResourceHint, BrowserScript,
-    BrowserSelectOption, BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet,
-    BrowserTable, BrowserTemplate, BrowserThemeColor,
+    BrowserForm, BrowserFormButton, BrowserFormControl, BrowserFormDatalist, BrowserFormFieldset,
+    BrowserFormLabel, BrowserFormOutput, BrowserFormSelect, BrowserFormSubmitter,
+    BrowserFormSuccessfulControl, BrowserFormValidationControl, BrowserHeading,
+    BrowserHttpEquivHint, BrowserImage, BrowserImageSource, BrowserInteractiveElement, BrowserLink,
+    BrowserMedia, BrowserMeta, BrowserMetadataDirective, BrowserRefresh, BrowserResource,
+    BrowserResourceHint, BrowserScript, BrowserSelectOption, BrowserStructuredItem,
+    BrowserStructuredProperty, BrowserStylesheet, BrowserTable, BrowserTemplate, BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -729,6 +729,8 @@ struct ExpectedForm {
     successful_controls: Vec<ExpectedFormSuccessfulControl>,
     #[serde(default)]
     validation_controls: Vec<ExpectedFormValidationControl>,
+    #[serde(default)]
+    buttons: Vec<ExpectedFormButton>,
     controls: Vec<ExpectedFormControl>,
     #[serde(default)]
     submitters: Vec<ExpectedFormSubmitter>,
@@ -1016,6 +1018,51 @@ struct ExpectedFormSubmitter {
     novalidate: bool,
     #[serde(default)]
     value: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedFormButton {
+    #[serde(default)]
+    id: Option<String>,
+    control_type: String,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    form_owner: Option<String>,
+    #[serde(default)]
+    accessible_name: Option<String>,
+    #[serde(default)]
+    disabled: bool,
+    #[serde(default)]
+    autofocus: bool,
+    #[serde(default)]
+    submitter: bool,
+    #[serde(default)]
+    action: Option<String>,
+    #[serde(default)]
+    resolved_action: Option<String>,
+    method: String,
+    #[serde(default)]
+    enctype: Option<String>,
+    #[serde(default)]
+    target: Option<String>,
+    #[serde(default)]
+    effective_target: Option<String>,
+    #[serde(default)]
+    novalidate: bool,
+    #[serde(default)]
+    value: Option<String>,
+    text: String,
+    #[serde(default)]
+    src: Option<String>,
+    #[serde(default)]
+    resolved_src: Option<String>,
+    #[serde(default)]
+    alt: Option<String>,
+    #[serde(default)]
+    width: Option<String>,
+    #[serde(default)]
+    height: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1356,6 +1403,94 @@ fn browser_form_successful_control_descriptor_metadata_tracks_submission_entries
         form.successful_controls[5].submission_values,
         vec!["external"]
     );
+}
+
+#[test]
+fn browser_form_button_descriptor_metadata_tracks_submitters_and_button_controls() {
+    let document = parse_browser_document(
+        "<base href=\"https://example.test/forms/index.html\" target=_base>\
+         <form id=actions action=submit method=post target=_form novalidate>\
+         <button id=save name=save value=s type=submit formaction=save formenctype=text/plain \
+             formmethod=get formtarget=_save formnovalidate autofocus>Save</button>\
+         <button id=reset type=reset name=reset value=r>Reset</button>\
+         <input id=plain type=button name=plain value=Plain>\
+         <input id=image type=image name=img src=go.png alt=Image width=20 height=10>\
+         <button id=disabled name=disabled disabled>Disabled</button>\
+         </form>\
+         <button id=external form=actions type=submit name=outside formtarget=_outside>Outside</button>",
+    )
+    .expect("form button descriptor fixture should parse");
+
+    let form = document
+        .forms
+        .first()
+        .expect("actions form should be summarized");
+    let ids: Vec<&str> = form
+        .buttons
+        .iter()
+        .filter_map(|button| button.id.as_deref())
+        .collect();
+    assert_eq!(
+        ids,
+        vec!["save", "reset", "plain", "image", "disabled", "external"]
+    );
+
+    let save = &form.buttons[0];
+    assert!(save.submitter);
+    assert!(save.autofocus);
+    assert_eq!(save.accessible_name.as_deref(), Some("Save"));
+    assert_eq!(save.action.as_deref(), Some("save"));
+    assert_eq!(
+        save.resolved_action.as_deref(),
+        Some("https://example.test/forms/save")
+    );
+    assert_eq!(save.method, "get");
+    assert_eq!(save.enctype.as_deref(), Some("text/plain"));
+    assert_eq!(save.target.as_deref(), Some("_save"));
+    assert_eq!(save.effective_target.as_deref(), Some("_save"));
+    assert!(save.novalidate);
+    assert_eq!(save.value.as_deref(), Some("s"));
+    assert_eq!(save.text, "Save");
+
+    let reset = &form.buttons[1];
+    assert_eq!(reset.control_type, "reset");
+    assert!(!reset.submitter);
+    assert_eq!(reset.method, "post");
+    assert_eq!(reset.text, "Reset");
+
+    let plain = &form.buttons[2];
+    assert_eq!(plain.control_type, "button");
+    assert!(!plain.submitter);
+    assert_eq!(plain.value.as_deref(), Some("Plain"));
+    assert!(plain.text.is_empty());
+
+    let image = &form.buttons[3];
+    assert_eq!(image.control_type, "image");
+    assert!(image.submitter);
+    assert_eq!(image.accessible_name.as_deref(), Some("Image"));
+    assert_eq!(
+        image.resolved_action.as_deref(),
+        Some("https://example.test/forms/submit")
+    );
+    assert_eq!(image.effective_target.as_deref(), Some("_form"));
+    assert_eq!(image.src.as_deref(), Some("go.png"));
+    assert_eq!(
+        image.resolved_src.as_deref(),
+        Some("https://example.test/forms/go.png")
+    );
+    assert_eq!(image.width.as_deref(), Some("20"));
+    assert_eq!(image.height.as_deref(), Some("10"));
+
+    let disabled = &form.buttons[4];
+    assert!(disabled.disabled);
+    assert!(!disabled.submitter);
+    assert!(!disabled.novalidate);
+
+    let external = &form.buttons[5];
+    assert_eq!(external.form_owner.as_deref(), Some("actions"));
+    assert!(external.submitter);
+    assert_eq!(external.effective_target.as_deref(), Some("_outside"));
+    assert_eq!(external.text, "Outside");
 }
 
 #[test]
@@ -2316,6 +2451,11 @@ impl ExpectedForm {
                 .into_iter()
                 .map(ExpectedFormValidationControl::into_browser_form_validation_control)
                 .collect(),
+            buttons: self
+                .buttons
+                .into_iter()
+                .map(ExpectedFormButton::into_browser_form_button)
+                .collect(),
             controls: self
                 .controls
                 .into_iter()
@@ -2545,6 +2685,35 @@ impl ExpectedFormSubmitter {
             effective_target: self.effective_target,
             novalidate: self.novalidate,
             value: self.value,
+        }
+    }
+}
+
+impl ExpectedFormButton {
+    fn into_browser_form_button(self) -> BrowserFormButton {
+        BrowserFormButton {
+            id: self.id,
+            control_type: self.control_type,
+            name: self.name,
+            form_owner: self.form_owner,
+            accessible_name: self.accessible_name,
+            disabled: self.disabled,
+            autofocus: self.autofocus,
+            submitter: self.submitter,
+            action: self.action,
+            resolved_action: self.resolved_action,
+            method: self.method,
+            enctype: self.enctype,
+            target: self.target,
+            effective_target: self.effective_target,
+            novalidate: self.novalidate,
+            value: self.value,
+            text: self.text,
+            src: self.src,
+            resolved_src: self.resolved_src,
+            alt: self.alt,
+            width: self.width,
+            height: self.height,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -93,6 +93,9 @@
               { "control_type": "textarea", "name": "notes", "will_validate": true },
               { "control_type": "submit", "name": "go", "will_validate": true }
             ],
+            "buttons": [
+              { "control_type": "submit", "name": "go", "accessible_name": "Search", "submitter": true, "action": "/search", "method": "post", "enctype": "multipart/form-data", "target": "results", "effective_target": "results", "text": "Search" }
+            ],
             "controls": [
               { "control_type": "text", "name": "q", "value": "rust html", "successful": true, "submission_values": ["rust html"], "disabled": false, "will_validate": true, "checked": false, "text": "", "options": [] },
               { "control_type": "hidden", "name": "page", "value": "1", "successful": true, "submission_values": ["1"], "disabled": false, "validation_barred_reason": "input-type-hidden", "checked": false, "text": "", "options": [] },
@@ -246,6 +249,10 @@
               { "id": "imageGo", "control_type": "image", "name": "image-go", "validation_barred_reason": "input-type-image" },
               { "id": "total", "control_type": "output", "name": "total", "validation_barred_reason": "output" },
               { "id": "external", "control_type": "text", "name": "outside", "form_owner": "search", "will_validate": true }
+            ],
+            "buttons": [
+              { "id": "go", "control_type": "submit", "accessible_name": "Run search", "submitter": true, "action": "run.html", "resolved_action": "https://example.test/search/run.html", "method": "post", "enctype": "application/x-www-form-urlencoded", "target": "results", "effective_target": "results", "novalidate": true, "text": "Go" },
+              { "id": "imageGo", "control_type": "image", "name": "image-go", "accessible_name": "Search image", "submitter": true, "action": "find.html", "resolved_action": "https://example.test/search/find.html", "method": "post", "effective_target": "_search", "novalidate": true, "text": "", "src": "buttons/search.png", "resolved_src": "https://example.test/search/buttons/search.png", "alt": "Search image", "width": "32", "height": "16" }
             ],
             "controls": [
               { "id": "q", "control_type": "text", "name": "q", "labels": ["Query"], "accessible_name": "Query", "accessible_description": "Query", "placeholder": "Search terms", "autocomplete": "section-primary shipping search", "autocomplete_tokens": ["section-primary", "shipping", "search"], "autocapitalize": "words", "enterkeyhint": "search", "dirname": "q.dir", "spellcheck": "false", "autocorrect": "off", "inputmode": "search", "pattern": "[A-Za-z ]+", "minlength": "2", "maxlength": "80", "size": "40", "list": "query-suggestions", "datalist_options": ["Rust", "HTML", "Browser APIs"], "value": null, "successful": true, "submission_values": [""], "autofocus": true, "disabled": false, "required": true, "will_validate": true, "validation_attributes": ["required", "pattern", "minlength", "maxlength"], "checked": false, "text": "", "options": [] },


### PR DESCRIPTION
## Summary
- add form-level `buttons` descriptors for submit, image, reset, and plain button controls
- preserve submitter override metadata, effective targets, image button media fields, disabled/autofocus state, and external form ownership
- extend browser-readiness fixture schema and fixtures with button descriptor metadata

## Tests
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py`
- `cargo test -p coding-adventures-html-parser browser_form_button_descriptor_metadata_tracks_submitters_and_button_controls`
- `cargo test -p coding-adventures-html-parser browser_form_`
- `cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts`
- `cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`