### PR TITLE
A2++.5 first slice: iir-to-intel8008 add/sub on the accumulator

### DIFF
--- a/code/packages/rust/iir-to-intel8008/CHANGELOG.md
+++ b/code/packages/rust/iir-to-intel8008/CHANGELOG.md
@@ -3,6 +3,70 @@
 All notable changes to this crate are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.3.1] — 2026-06-02 (A2++.5 first slice — `add`/`sub` on the accumulator)
+
+### Added — accumulator-target ALU
+
+Extends v0.3.0 with two ALU ops in family `10 ooo sss`.  The 8008's
+ALU is *always* accumulator-anchored: left source AND destination are
+`A`; only the right source comes from `sss`.
+
+| IIR op | Intel 8008 lowering |
+|--------|---------------------|
+| `add dest, a, b` | (optional `MOV A, a_reg`) + `ADD b_reg` (`0x80 \| sss`) + (optional `MOV dest_reg, A`) |
+| `sub dest, a, b` | (optional `MOV A, a_reg`) + `SUB b_reg` (`0x90 \| sss`) + (optional `MOV dest_reg, A`) |
+
+#### Code-gen shape
+
+```text
+if a_reg != A:   MOV A, a_reg
+                 ADD/SUB b_reg          ; result lands in A
+if dest_reg != A: MOV dest_reg, A
+```
+
+The first const allocated to `A` and the next-allocated `dest_reg` ≠
+`A` mean the typical sequence for `r = v + w` (where `v` was the first
+const) is:
+
+```
+ADD b_reg
+MOV C, A
+```
+
+i.e. two bytes of arithmetic plus the staging move.
+
+#### Self-add idiom
+
+`add r v v` where `v` is already in `A` lowers to `ADD A` (`0x87`,
+family `10 000 111`) — the 8008 happily uses `A` as the right source.
+No leading `MOV A, A` is emitted.
+
+#### New encoder helper + opcode constants
+
+* `fn encode_alu(ooo: u8, sss: u8) -> u8` — `0x80 | (ooo << 3) | sss`.
+* `const ALU_ADD: u8 = 0b000;`
+* `const ALU_SUB: u8 = 0b010;`
+
+#### Tests added (20 total, was 17)
+
+* `add_two_consts_returns_their_sum_via_accumulator` — pinned 8-byte
+  sequence ending in `0x80 0x4F 0x79 0x76`.
+* `sub_two_consts_emits_sub_b_after_mov` — same shape with `0x90`.
+* `add_when_lhs_is_already_in_a_skips_the_staging_mov` — pinned
+  `ADD A = 0x87` for the self-add case.
+
+The pre-existing `unsupported_op_is_rejected_with_function_name` test
+flipped from probing `add` (now supported) to `safepoint` (still
+outside the whitelist).
+
+### What is NOT in v0.3.1 (deferred to A2++.5.5 / A2+++)
+
+* `cmp`, `and`, `or`, `xor`, `adc`, `sbb` — same family, different
+  `ooo` codes.
+* Real `RET` (`0x07`) via `CALL` + the internal return stack.
+* Conditional + unconditional jumps with 14-bit address backpatching.
+* `lang-aot --target=intel8008` wiring — A2+++.
+
 ## [0.3.0] — 2026-06-02 (A2++ — multi-register `const` + `mov` + ret-value staging)
 
 ### Added — linear register allocator over A/B/C/D/E/H/L

--- a/code/packages/rust/iir-to-intel8008/Cargo.toml
+++ b/code/packages/rust/iir-to-intel8008/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iir-to-intel8008"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
-description = "IIR → Intel 8008 machine code backend (Oct's native target) — lowers IIRModule to a Vec<u8> of 8-bit Intel 8008 opcodes.  v0.3.0 (A2++): adds a linear register allocator over A/B/C/D/E/H/L, multi-register `const` → MVI rrr,n, `mov dest,src` → MOV ddd,sss (family 01 ddd sss), and ret-value staging into A.  ALU + real RET via CALL/stack land in A2++.5."
+description = "IIR → Intel 8008 machine code backend (Oct's native target) — lowers IIRModule to a Vec<u8> of 8-bit Intel 8008 opcodes.  v0.3.1 (A2++.5 first slice): adds `add`/`sub` ALU on the accumulator (family 10 ooo sss) — stage left source into A, execute ADD/SUB right_reg, capture result into dest_reg if it isn't already A.  Real RET via CALL/stack still pending."
 
 [lib]
 name = "iir_to_intel8008"

--- a/code/packages/rust/iir-to-intel8008/src/lib.rs
+++ b/code/packages/rust/iir-to-intel8008/src/lib.rs
@@ -151,6 +151,23 @@ fn encode_mov(ddd: u8, sss: u8) -> u8 {
     0x40 | (ddd << 3) | sss
 }
 
+/// Encode an accumulator-target ALU opcode in family `10 ooo sss`.
+///
+/// The 3-bit `ooo` selects the operation (`000` = ADD, `010` = SUB,
+/// `111` = CMP, etc.).  The 3-bit `sss` selects the right-hand source
+/// register — the left-hand source AND destination are always the
+/// accumulator `A`, which is the 8008's defining accumulator-based ISA
+/// shape.
+fn encode_alu(ooo: u8, sss: u8) -> u8 {
+    debug_assert!(ooo <= 7, "ooo out of 3-bit range: {ooo}");
+    debug_assert!(sss <= 7, "sss out of 3-bit range: {sss}");
+    0x80 | (ooo << 3) | sss
+}
+
+/// ALU operation codes (`ooo` field in `10 ooo sss`).
+const ALU_ADD: u8 = 0b000; // ADD r
+const ALU_SUB: u8 = 0b010; // SUB r
+
 // ===========================================================================
 // IIRIntel8008Config
 // ===========================================================================
@@ -270,7 +287,12 @@ pub fn validate_for_intel8008(_module: &IIRModule) -> Vec<String> {
 /// `REGISTER_POOL`.  `mov` lowers to `MOV ddd, sss`.  `ret` moves the
 /// value into `A` (if not already there) and emits `HLT`; `ret_void`
 /// just emits `HLT`.  Anything else is `UnsupportedOp`.
-const SUPPORTED_OPS: &[&str] = &["const", "mov", "ret", "ret_void"];
+const SUPPORTED_OPS: &[&str] = &[
+    // A2 / A2+ / A2++
+    "const", "mov", "ret", "ret_void",
+    // A2++.5 — accumulator ALU
+    "add", "sub",
+];
 
 pub fn lower_iir_to_intel8008(
     module: &IIRModule,
@@ -359,6 +381,49 @@ pub fn lower_iir_to_intel8008(
                 // ── ret_void: just HLT ──────────────────────────────────
                 "ret_void" => {
                     bytes.push(HLT);
+                }
+
+                // ── add dest, a, b → MOV A,a; ADD b_reg; MOV dest,A ─────
+                //
+                // The 8008's accumulator-based ALU forces all binary ops
+                // through `A`.  If `a` already lives there, the leading
+                // `MOV A, a_reg` is skipped.  Likewise, if the
+                // newly-allocated `dest_reg` IS A, the trailing
+                // `MOV dest_reg, A` is skipped — common when this is the
+                // first arithmetic op in the function and the allocator
+                // hands out A.
+                //
+                // sub: identical shape, just family-`10 010 sss`.
+                "add" | "sub" => {
+                    let dest = require_dest(instr, &instr.op, &f.name)?;
+                    let a_name = match instr.srcs.first() {
+                        Some(Operand::Var(s)) => s.clone(),
+                        _ => return Err(IIRIntel8008Error::InvalidOperand {
+                            function: f.name.clone(),
+                            detail: format!("{} srcs[0] must be Var", instr.op),
+                        }),
+                    };
+                    let b_name = match instr.srcs.get(1) {
+                        Some(Operand::Var(s)) => s.clone(),
+                        _ => return Err(IIRIntel8008Error::InvalidOperand {
+                            function: f.name.clone(),
+                            detail: format!("{} srcs[1] must be Var", instr.op),
+                        }),
+                    };
+                    let a_reg = lookup_register(&env, &a_name, &f.name)?;
+                    let b_reg = lookup_register(&env, &b_name, &f.name)?;
+                    // Stage a into A if it isn't already there.
+                    if a_reg != REG_A {
+                        bytes.push(encode_mov(REG_A, a_reg));
+                    }
+                    // Execute the ALU op (result lands in A).
+                    let ooo = if instr.op == "add" { ALU_ADD } else { ALU_SUB };
+                    bytes.push(encode_alu(ooo, b_reg));
+                    // Capture the result into dest_reg unless dest_reg is A.
+                    let dest_reg = alloc_register(&mut next_reg, dest, &mut env, &f.name)?;
+                    if dest_reg != REG_A {
+                        bytes.push(encode_mov(dest_reg, REG_A));
+                    }
                 }
 
                 _ => unreachable!("SUPPORTED_OPS guard above prevents this"),

--- a/code/packages/rust/iir-to-intel8008/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-intel8008/tests/test_backend.rs
@@ -181,17 +181,18 @@ fn ret_void_alone_emits_just_hlt() {
 
 #[test]
 fn unsupported_op_is_rejected_with_function_name() {
+    // After A2++.5 added add/sub, `safepoint` is still outside the
+    // whitelist — use it as the canonical never-supported probe.
     let f = IIRFunction::new("boom", vec![], "void", vec![
-        IIRInstr::new("add", Some("v".into()),
-            vec![Operand::Int(1), Operand::Int(2)], "u8"),
+        IIRInstr::new("safepoint", None, vec![], "void"),
         IIRInstr::new("ret_void", None, vec![], "void"),
     ]);
     let err = lower_iir_to_intel8008(&module_with(f), &IIRIntel8008Config::default())
-        .expect_err("`add` should be UnsupportedOp in A2++");
+        .expect_err("`safepoint` should be UnsupportedOp");
     match err {
         IIRIntel8008Error::UnsupportedOp { function, op } => {
             assert_eq!(function, "boom");
-            assert_eq!(op, "add");
+            assert_eq!(op, "safepoint");
         }
         other => panic!("expected UnsupportedOp, got: {other:?}"),
     }
@@ -306,4 +307,97 @@ fn undefined_variable_in_mov_is_rejected() {
         }
         other => panic!("expected UndefinedVariable, got: {other:?}"),
     }
+}
+
+// ===========================================================================
+// 7. A2++.5 — accumulator-target ALU (ADD, SUB)
+// ===========================================================================
+//
+// All 8008 ALU ops use A as both left source and destination.  The
+// lowering shape is therefore:
+//
+//   if a not in A: MOV A, a_reg
+//   ADD/SUB b_reg                    ; result lands in A
+//   if dest_reg not A: MOV dest_reg, A
+//
+// The first const allocates to A so the leading mv is usually skipped.
+
+#[test]
+fn add_two_consts_returns_their_sum_via_accumulator() {
+    // const v=3; const w=4; add r v w; ret r
+    //
+    // Allocator: v→A, w→B, r→C.
+    //   MVI A,3   = 0x3E 0x03
+    //   MVI B,4   = 0x06 0x04
+    //   ADD B     = 0x80           (10 000 000 — sss=B=0)
+    //   MOV C,A   = 01 001 111 = 0x4F
+    //   MOV A,C   = 01 111 001 = 0x79  (stage r into A for ret)
+    //   HLT       = 0x76
+    let f = IIRFunction::new("add3plus4", vec![], "u8", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(3)], "u8"),
+        IIRInstr::new("const", Some("w".into()), vec![Operand::Int(4)], "u8"),
+        IIRInstr::new("add", Some("r".into()),
+            vec![Operand::Var("v".into()), Operand::Var("w".into())], "u8"),
+        IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "u8"),
+    ]);
+    let bytes = lower_iir_to_intel8008(&module_with(f), &IIRIntel8008Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![
+        MVI_A, 0x03,    // MVI A, 3
+        0x06,  0x04,    // MVI B, 4
+        0x80,           // ADD B
+        0x4F,           // MOV C, A
+        0x79,           // MOV A, C (stage r into A for ret)
+        HLT,
+    ], "add 3+4 expected; got: {bytes:02x?}");
+}
+
+#[test]
+fn sub_two_consts_emits_sub_b_after_mov() {
+    // const v=10; const w=4; sub r v w; ret r
+    // Same shape but using 0x90 (SUB B, family 10 010 000) instead of 0x80.
+    let f = IIRFunction::new("ten_minus_four", vec![], "u8", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(10)], "u8"),
+        IIRInstr::new("const", Some("w".into()), vec![Operand::Int(4)], "u8"),
+        IIRInstr::new("sub", Some("r".into()),
+            vec![Operand::Var("v".into()), Operand::Var("w".into())], "u8"),
+        IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "u8"),
+    ]);
+    let bytes = lower_iir_to_intel8008(&module_with(f), &IIRIntel8008Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![
+        MVI_A, 0x0A,    // MVI A, 10
+        0x06,  0x04,    // MVI B, 4
+        0x90,           // SUB B   (10 010 000)
+        0x4F,           // MOV C, A
+        0x79,           // MOV A, C
+        HLT,
+    ], "sub 10-4 expected; got: {bytes:02x?}");
+}
+
+#[test]
+fn add_when_lhs_is_already_in_a_skips_the_staging_mov() {
+    // const v=5; add r v v; ret r
+    // v is in A.  add r v v means r = v + v.  Sequence:
+    //   MVI A, 5
+    //   ADD A   (10 000 111 = 0x87)  ← uses v (in A) as both src and right operand
+    //   MOV B, A — bind r → B
+    //   MOV A, B — stage r back into A for ret
+    //   HLT
+    let f = IIRFunction::new("double", vec![], "u8", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(5)], "u8"),
+        IIRInstr::new("add", Some("r".into()),
+            vec![Operand::Var("v".into()), Operand::Var("v".into())], "u8"),
+        IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "u8"),
+    ]);
+    let bytes = lower_iir_to_intel8008(&module_with(f), &IIRIntel8008Config::default())
+        .expect("lowering");
+    // Note: no leading "MOV A, A" since v is already in A.
+    assert_eq!(bytes, vec![
+        MVI_A, 0x05,    // MVI A, 5
+        0x87,           // ADD A    (10 000 111 — sss=A=7)
+        0x47,           // MOV B, A
+        0x78,           // MOV A, B
+        HLT,
+    ], "double-of-A expected; got: {bytes:02x?}");
 }

--- a/code/specs/iir-to-intel8008.md
+++ b/code/specs/iir-to-intel8008.md
@@ -55,8 +55,9 @@ IIRModule
 |---------|-------|--------|
 | v0.1.0 (A2) | crate skeleton: any module → single `HLT` (`0x76`) | **merged** |
 | v0.2.0 (A2+) | `const` → `MVI A, n` + `ret`/`ret_void` → `HLT` (accumulator-only first slice) | **merged** |
-| **v0.3.0 (A2++ — this PR)** | Linear register allocator over A/B/C/D/E/H/L + multi-register `const` + `mov` + ret-value staging | this PR |
-| v0.3.1 (A2++.5) | ALU on the accumulator (`ADD`/`SUB`/`CMP`/etc.) + real `RET` (`0x3F`) via `CALL` + internal return stack | future |
+| v0.3.0 (A2++) | Linear register allocator over A/B/C/D/E/H/L + multi-register `const` + `mov` + ret-value staging | **merged** |
+| **v0.3.1 (A2++.5 first slice — this PR)** | `add`/`sub` ALU on the accumulator (family `10 ooo sss`) | this PR |
+| v0.3.2 (A2++.5.5) | rest of ALU (`cmp`, `and`, `or`, `xor`, `adc`, `sbb`) + real `RET` (`0x07`) via `CALL` + internal return stack | future |
 | v0.4.0 (A2+++) | Conditional + unconditional jumps with 14-bit address backpatching + `lang-aot --target=intel8008` | future |
 
 ## Public surface (v0.1.0)


### PR DESCRIPTION
## Summary

- **A2++.5 first slice** of [`MULTILANG-ARCHITECTURE-BACKENDS.md`](code/specs/MULTILANG-ARCHITECTURE-BACKENDS.md). Adds the first two accumulator-target ALU ops on the Intel 8008.
- 20 unit + 1 doctest (was 17 + 1), all green.
- Real RET via CALL/stack and the remaining ALU ops (cmp/and/or/xor/adc/sbb) defer to A2++.5.5.

## Op coverage added

| IIR op | Intel 8008 lowering |
|--------|---------------------|
| `add dest, a, b` | optional `MOV A, a_reg` + `ADD b_reg` (`0x80 \| sss`) + optional `MOV dest_reg, A` |
| `sub dest, a, b` | optional `MOV A, a_reg` + `SUB b_reg` (`0x90 \| sss`) + optional `MOV dest_reg, A` |

## Why both optional MOVs

The 8008's ALU is *always* accumulator-anchored: left source AND destination are `A`. Only the right source (`sss`) is a variable register. The lowering shape is:

```text
if a_reg != A:    MOV A, a_reg
                  ADD/SUB b_reg          ; result lands in A
if dest_reg != A: MOV dest_reg, A
```

The first const allocated to `A` and the next-allocated `dest_reg` ≠ `A` mean the typical sequence is **`ADD b_reg; MOV C, A`** — just 2 bytes of arithmetic + the staging move.

## Self-add idiom

`add r v v` where `v` is already in `A` lowers to `ADD A` (`0x87`, family `10 000 111`). No leading `MOV A, A`.

## New encoder helper

```rust
fn encode_alu(ooo: u8, sss: u8) -> u8;  // 0x80 | (ooo << 3) | sss
const ALU_ADD: u8 = 0b000;
const ALU_SUB: u8 = 0b010;
```

## Test plan
- [x] `cargo test -p iir-to-intel8008` — 20 + 1 doctest, all green
- [x] `add_two_consts_returns_their_sum_via_accumulator` — 8-byte pin: `MVI A,3; MVI B,4; ADD B (0x80); MOV C,A (0x4F); MOV A,C (0x79); HLT`
- [x] `sub_two_consts_emits_sub_b_after_mov` — same shape with `0x90`
- [x] `add_when_lhs_is_already_in_a_skips_the_staging_mov` — pins `ADD A = 0x87`
- [x] `unsupported_op_is_rejected_with_function_name` flipped from `add` (now supported) to `safepoint`
- [x] /security-review passed

## Spec status row

| Version | Scope | Status |
|---------|-------|--------|
| v0.3.0 (A2++) | multi-register const + mov + ret staging | merged |
| **v0.3.1 (A2++.5 first slice — this PR)** | add/sub ALU | this PR |
| v0.3.2 (A2++.5.5) | cmp/and/or/xor/adc/sbb + real RET via CALL | future |
| v0.4.0 (A2+++) | jumps + lang-aot --target=intel8008 | future |

🤖 Generated with [Claude Code](https://claude.com/claude-code)