### PR TITLE
Track browser form text entry descriptors

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -805,6 +805,48 @@ def check_browser_expected_lists(
                 require_optional_boolean(button_path, button, field, errors)
             require_string(button_path, button, "method", errors)
             require_string(button_path, button, "text", errors)
+        require_optional_object_list(form_path, form, "text_entries", errors)
+        for entry_index, entry in enumerate(object_list_items(form, "text_entries")):
+            entry_path = f"{form_path}.text_entries[{entry_index}]"
+            require_optional_nullable_string(entry_path, entry, "id", errors)
+            require_string(entry_path, entry, "control_type", errors)
+            for field in (
+                "name",
+                "form_owner",
+                "accessible_name",
+                "accessible_description",
+                "placeholder",
+                "value",
+                "autocomplete",
+                "autocapitalize",
+                "enterkeyhint",
+                "dirname",
+                "spellcheck",
+                "autocorrect",
+                "inputmode",
+                "pattern",
+                "min",
+                "max",
+                "step",
+                "minlength",
+                "maxlength",
+                "size",
+                "rows",
+                "cols",
+                "wrap",
+                "list",
+                "validation_barred_reason",
+            ):
+                require_optional_nullable_string(entry_path, entry, field, errors)
+            require_optional_string_list(entry_path, entry, "labels", errors)
+            require_optional_string_list(entry_path, entry, "autocomplete_tokens", errors)
+            require_optional_string_list(entry_path, entry, "datalist_options", errors)
+            for field in ("disabled", "required", "readonly", "will_validate"):
+                require_optional_boolean(entry_path, entry, field, errors)
+            require_optional_string_list(
+                entry_path, entry, "validation_attributes", errors
+            )
+            require_string(entry_path, entry, "text", errors)
         require_object_list(form_path, form, "controls", errors)
         require_optional_object_list(form_path, form, "submitters", errors)
         for control_index, control in enumerate(object_list_items(form, "controls")):

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -1618,6 +1618,7 @@ pub struct BrowserForm {
     pub successful_controls: Vec<BrowserFormSuccessfulControl>,
     pub validation_controls: Vec<BrowserFormValidationControl>,
     pub buttons: Vec<BrowserFormButton>,
+    pub text_entries: Vec<BrowserFormTextEntry>,
     pub controls: Vec<BrowserFormControl>,
     pub submitters: Vec<BrowserFormSubmitter>,
 }
@@ -1731,6 +1732,46 @@ pub struct BrowserFormButton {
     pub alt: Option<String>,
     pub width: Option<String>,
     pub height: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserFormTextEntry {
+    pub id: Option<String>,
+    pub control_type: String,
+    pub name: Option<String>,
+    pub form_owner: Option<String>,
+    pub labels: Vec<String>,
+    pub accessible_name: Option<String>,
+    pub accessible_description: Option<String>,
+    pub placeholder: Option<String>,
+    pub value: Option<String>,
+    pub text: String,
+    pub autocomplete: Option<String>,
+    pub autocomplete_tokens: Vec<String>,
+    pub autocapitalize: Option<String>,
+    pub enterkeyhint: Option<String>,
+    pub dirname: Option<String>,
+    pub spellcheck: Option<String>,
+    pub autocorrect: Option<String>,
+    pub inputmode: Option<String>,
+    pub pattern: Option<String>,
+    pub min: Option<String>,
+    pub max: Option<String>,
+    pub step: Option<String>,
+    pub minlength: Option<String>,
+    pub maxlength: Option<String>,
+    pub size: Option<String>,
+    pub rows: Option<String>,
+    pub cols: Option<String>,
+    pub wrap: Option<String>,
+    pub list: Option<String>,
+    pub datalist_options: Vec<String>,
+    pub disabled: bool,
+    pub required: bool,
+    pub readonly: bool,
+    pub will_validate: bool,
+    pub validation_attributes: Vec<String>,
+    pub validation_barred_reason: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -12797,6 +12838,7 @@ fn browser_form(
         base_target,
         novalidate,
     );
+    let text_entries = browser_form_text_entries(&controls);
     let submitters = browser_form_submitters(
         &controls,
         action.as_deref(),
@@ -12841,6 +12883,7 @@ fn browser_form(
         successful_controls,
         validation_controls,
         buttons,
+        text_entries,
         controls,
         submitters,
     }
@@ -13304,6 +13347,58 @@ fn is_browser_form_button(control: &BrowserFormControl) -> bool {
 
 fn is_browser_form_submitter(control: &BrowserFormControl) -> bool {
     !control.disabled && matches!(control.control_type.as_str(), "submit" | "image")
+}
+
+fn browser_form_text_entries(controls: &[BrowserFormControl]) -> Vec<BrowserFormTextEntry> {
+    controls
+        .iter()
+        .filter(|control| is_browser_form_text_entry(control))
+        .map(|control| BrowserFormTextEntry {
+            id: control.id.clone(),
+            control_type: control.control_type.clone(),
+            name: control.name.clone(),
+            form_owner: control.form_owner.clone(),
+            labels: control.labels.clone(),
+            accessible_name: control.accessible_name.clone(),
+            accessible_description: control.accessible_description.clone(),
+            placeholder: control.placeholder.clone(),
+            value: control.value.clone(),
+            text: control.text.clone(),
+            autocomplete: control.autocomplete.clone(),
+            autocomplete_tokens: control.autocomplete_tokens.clone(),
+            autocapitalize: control.autocapitalize.clone(),
+            enterkeyhint: control.enterkeyhint.clone(),
+            dirname: control.dirname.clone(),
+            spellcheck: control.spellcheck.clone(),
+            autocorrect: control.autocorrect.clone(),
+            inputmode: control.inputmode.clone(),
+            pattern: control.pattern.clone(),
+            min: control.min.clone(),
+            max: control.max.clone(),
+            step: control.step.clone(),
+            minlength: control.minlength.clone(),
+            maxlength: control.maxlength.clone(),
+            size: control.size.clone(),
+            rows: control.rows.clone(),
+            cols: control.cols.clone(),
+            wrap: control.wrap.clone(),
+            list: control.list.clone(),
+            datalist_options: control.datalist_options.clone(),
+            disabled: control.disabled,
+            required: control.required,
+            readonly: control.readonly,
+            will_validate: control.will_validate,
+            validation_attributes: control.validation_attributes.clone(),
+            validation_barred_reason: control.validation_barred_reason.clone(),
+        })
+        .collect()
+}
+
+fn is_browser_form_text_entry(control: &BrowserFormControl) -> bool {
+    matches!(
+        control.control_type.as_str(),
+        "text" | "search" | "url" | "tel" | "email" | "password" | "number" | "textarea"
+    )
 }
 
 fn collect_form_controls_for_form_into(

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -3,11 +3,12 @@ use coding_adventures_html_parser::{
     BrowserDatalistOption, BrowserDocument, BrowserDocumentMetadata, BrowserEmbeddedContext,
     BrowserForm, BrowserFormButton, BrowserFormControl, BrowserFormDatalist, BrowserFormFieldset,
     BrowserFormLabel, BrowserFormOutput, BrowserFormSelect, BrowserFormSubmitter,
-    BrowserFormSuccessfulControl, BrowserFormValidationControl, BrowserHeading,
-    BrowserHttpEquivHint, BrowserImage, BrowserImageSource, BrowserInteractiveElement, BrowserLink,
-    BrowserMedia, BrowserMeta, BrowserMetadataDirective, BrowserRefresh, BrowserResource,
-    BrowserResourceHint, BrowserScript, BrowserSelectOption, BrowserStructuredItem,
-    BrowserStructuredProperty, BrowserStylesheet, BrowserTable, BrowserTemplate, BrowserThemeColor,
+    BrowserFormSuccessfulControl, BrowserFormTextEntry, BrowserFormValidationControl,
+    BrowserHeading, BrowserHttpEquivHint, BrowserImage, BrowserImageSource,
+    BrowserInteractiveElement, BrowserLink, BrowserMedia, BrowserMeta, BrowserMetadataDirective,
+    BrowserRefresh, BrowserResource, BrowserResourceHint, BrowserScript, BrowserSelectOption,
+    BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet, BrowserTable,
+    BrowserTemplate, BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -731,6 +732,8 @@ struct ExpectedForm {
     validation_controls: Vec<ExpectedFormValidationControl>,
     #[serde(default)]
     buttons: Vec<ExpectedFormButton>,
+    #[serde(default)]
+    text_entries: Vec<ExpectedFormTextEntry>,
     controls: Vec<ExpectedFormControl>,
     #[serde(default)]
     submitters: Vec<ExpectedFormSubmitter>,
@@ -859,6 +862,78 @@ struct ExpectedFormValidationControl {
     will_validate: bool,
     #[serde(default)]
     required: bool,
+    #[serde(default)]
+    validation_attributes: Vec<String>,
+    #[serde(default)]
+    validation_barred_reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedFormTextEntry {
+    #[serde(default)]
+    id: Option<String>,
+    control_type: String,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    form_owner: Option<String>,
+    #[serde(default)]
+    labels: Vec<String>,
+    #[serde(default)]
+    accessible_name: Option<String>,
+    #[serde(default)]
+    accessible_description: Option<String>,
+    #[serde(default)]
+    placeholder: Option<String>,
+    value: Option<String>,
+    text: String,
+    #[serde(default)]
+    autocomplete: Option<String>,
+    #[serde(default)]
+    autocomplete_tokens: Vec<String>,
+    #[serde(default)]
+    autocapitalize: Option<String>,
+    #[serde(default)]
+    enterkeyhint: Option<String>,
+    #[serde(default)]
+    dirname: Option<String>,
+    #[serde(default)]
+    spellcheck: Option<String>,
+    #[serde(default)]
+    autocorrect: Option<String>,
+    #[serde(default)]
+    inputmode: Option<String>,
+    #[serde(default)]
+    pattern: Option<String>,
+    #[serde(default)]
+    min: Option<String>,
+    #[serde(default)]
+    max: Option<String>,
+    #[serde(default)]
+    step: Option<String>,
+    #[serde(default)]
+    minlength: Option<String>,
+    #[serde(default)]
+    maxlength: Option<String>,
+    #[serde(default)]
+    size: Option<String>,
+    #[serde(default)]
+    rows: Option<String>,
+    #[serde(default)]
+    cols: Option<String>,
+    #[serde(default)]
+    wrap: Option<String>,
+    #[serde(default)]
+    list: Option<String>,
+    #[serde(default)]
+    datalist_options: Vec<String>,
+    disabled: bool,
+    #[serde(default)]
+    required: bool,
+    #[serde(default)]
+    readonly: bool,
+    #[serde(default)]
+    will_validate: bool,
     #[serde(default)]
     validation_attributes: Vec<String>,
     #[serde(default)]
@@ -1531,6 +1606,86 @@ fn browser_text_control_descriptor_metadata_tracks_editing_and_layout_hints() {
         actual.forms, expected.forms,
         "text controls should preserve spellcheck, autocorrect, rows, cols, and wrapping hints",
     );
+}
+
+#[test]
+fn browser_form_text_entry_descriptor_metadata_tracks_textual_controls_and_editing_hints() {
+    let document = parse_browser_document(
+        "<form id=profile>\
+         <label for=email>Email</label>\
+         <input id=email type=email name=email placeholder=Email required \
+             autocomplete=\"section-contact email\" inputmode=email minlength=3 maxlength=80 size=30>\
+         <input id=search type=search name=q value=rust autocapitalize=words \
+             enterkeyhint=search dirname=q.dir spellcheck=false autocorrect=off list=suggestions>\
+         <datalist id=suggestions><option value=Rust><option value=HTML label=Markup></datalist>\
+         <textarea id=bio name=bio rows=4 cols=40 wrap=hard readonly maxlength=200>About me</textarea>\
+         <input id=age type=number name=age value=42 min=18 max=120 step=1>\
+         <input id=check type=checkbox name=check checked>\
+         </form>\
+         <textarea id=external form=profile name=outside placeholder=Outside>External note</textarea>",
+    )
+    .expect("form text-entry descriptor fixture should parse");
+
+    let form = document
+        .forms
+        .first()
+        .expect("profile form should be summarized");
+    let ids: Vec<&str> = form
+        .text_entries
+        .iter()
+        .filter_map(|entry| entry.id.as_deref())
+        .collect();
+    assert_eq!(ids, vec!["email", "search", "bio", "age", "external"]);
+
+    let email = &form.text_entries[0];
+    assert_eq!(email.control_type, "email");
+    assert_eq!(email.labels, vec!["Email"]);
+    assert_eq!(email.accessible_name.as_deref(), Some("Email"));
+    assert_eq!(email.placeholder.as_deref(), Some("Email"));
+    assert_eq!(email.autocomplete_tokens, vec!["section-contact", "email"]);
+    assert_eq!(email.inputmode.as_deref(), Some("email"));
+    assert_eq!(email.minlength.as_deref(), Some("3"));
+    assert_eq!(email.maxlength.as_deref(), Some("80"));
+    assert_eq!(email.size.as_deref(), Some("30"));
+    assert!(email.required);
+    assert!(email.will_validate);
+    assert_eq!(
+        email.validation_attributes,
+        vec!["required", "minlength", "maxlength"]
+    );
+
+    let search = &form.text_entries[1];
+    assert_eq!(search.control_type, "search");
+    assert_eq!(search.value.as_deref(), Some("rust"));
+    assert_eq!(search.autocapitalize.as_deref(), Some("words"));
+    assert_eq!(search.enterkeyhint.as_deref(), Some("search"));
+    assert_eq!(search.dirname.as_deref(), Some("q.dir"));
+    assert_eq!(search.spellcheck.as_deref(), Some("false"));
+    assert_eq!(search.autocorrect.as_deref(), Some("off"));
+    assert_eq!(search.list.as_deref(), Some("suggestions"));
+    assert_eq!(search.datalist_options, vec!["Rust", "HTML"]);
+
+    let bio = &form.text_entries[2];
+    assert_eq!(bio.control_type, "textarea");
+    assert_eq!(bio.text, "About me");
+    assert_eq!(bio.rows.as_deref(), Some("4"));
+    assert_eq!(bio.cols.as_deref(), Some("40"));
+    assert_eq!(bio.wrap.as_deref(), Some("hard"));
+    assert!(bio.readonly);
+    assert!(!bio.will_validate);
+    assert_eq!(bio.validation_barred_reason.as_deref(), Some("readonly"));
+
+    let age = &form.text_entries[3];
+    assert_eq!(age.control_type, "number");
+    assert_eq!(age.min.as_deref(), Some("18"));
+    assert_eq!(age.max.as_deref(), Some("120"));
+    assert_eq!(age.step.as_deref(), Some("1"));
+
+    let external = &form.text_entries[4];
+    assert_eq!(external.form_owner.as_deref(), Some("profile"));
+    assert_eq!(external.name.as_deref(), Some("outside"));
+    assert_eq!(external.placeholder.as_deref(), Some("Outside"));
+    assert_eq!(external.text, "External note");
 }
 
 #[test]
@@ -2456,6 +2611,11 @@ impl ExpectedForm {
                 .into_iter()
                 .map(ExpectedFormButton::into_browser_form_button)
                 .collect(),
+            text_entries: self
+                .text_entries
+                .into_iter()
+                .map(ExpectedFormTextEntry::into_browser_form_text_entry)
+                .collect(),
             controls: self
                 .controls
                 .into_iter()
@@ -2583,6 +2743,49 @@ impl ExpectedFormSelect {
                 .map(ExpectedSelectOption::into_browser_select_option)
                 .collect(),
             text: self.text,
+        }
+    }
+}
+
+impl ExpectedFormTextEntry {
+    fn into_browser_form_text_entry(self) -> BrowserFormTextEntry {
+        BrowserFormTextEntry {
+            id: self.id,
+            control_type: self.control_type,
+            name: self.name,
+            form_owner: self.form_owner,
+            labels: self.labels,
+            accessible_name: self.accessible_name,
+            accessible_description: self.accessible_description,
+            placeholder: self.placeholder,
+            value: self.value,
+            text: self.text,
+            autocomplete: self.autocomplete,
+            autocomplete_tokens: self.autocomplete_tokens,
+            autocapitalize: self.autocapitalize,
+            enterkeyhint: self.enterkeyhint,
+            dirname: self.dirname,
+            spellcheck: self.spellcheck,
+            autocorrect: self.autocorrect,
+            inputmode: self.inputmode,
+            pattern: self.pattern,
+            min: self.min,
+            max: self.max,
+            step: self.step,
+            minlength: self.minlength,
+            maxlength: self.maxlength,
+            size: self.size,
+            rows: self.rows,
+            cols: self.cols,
+            wrap: self.wrap,
+            list: self.list,
+            datalist_options: self.datalist_options,
+            disabled: self.disabled,
+            required: self.required,
+            readonly: self.readonly,
+            will_validate: self.will_validate,
+            validation_attributes: self.validation_attributes,
+            validation_barred_reason: self.validation_barred_reason,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -96,6 +96,11 @@
             "buttons": [
               { "control_type": "submit", "name": "go", "accessible_name": "Search", "submitter": true, "action": "/search", "method": "post", "enctype": "multipart/form-data", "target": "results", "effective_target": "results", "text": "Search" }
             ],
+            "text_entries": [
+              { "control_type": "text", "name": "q", "value": "rust html", "text": "", "disabled": false, "will_validate": true },
+              { "control_type": "text", "name": "disabled", "value": "no", "text": "", "disabled": true, "validation_barred_reason": "disabled" },
+              { "control_type": "textarea", "name": "notes", "value": "Line one Line two", "text": "Line one Line two", "disabled": false, "will_validate": true }
+            ],
             "controls": [
               { "control_type": "text", "name": "q", "value": "rust html", "successful": true, "submission_values": ["rust html"], "disabled": false, "will_validate": true, "checked": false, "text": "", "options": [] },
               { "control_type": "hidden", "name": "page", "value": "1", "successful": true, "submission_values": ["1"], "disabled": false, "validation_barred_reason": "input-type-hidden", "checked": false, "text": "", "options": [] },
@@ -253,6 +258,12 @@
             "buttons": [
               { "id": "go", "control_type": "submit", "accessible_name": "Run search", "submitter": true, "action": "run.html", "resolved_action": "https://example.test/search/run.html", "method": "post", "enctype": "application/x-www-form-urlencoded", "target": "results", "effective_target": "results", "novalidate": true, "text": "Go" },
               { "id": "imageGo", "control_type": "image", "name": "image-go", "accessible_name": "Search image", "submitter": true, "action": "find.html", "resolved_action": "https://example.test/search/find.html", "method": "post", "effective_target": "_search", "novalidate": true, "text": "", "src": "buttons/search.png", "resolved_src": "https://example.test/search/buttons/search.png", "alt": "Search image", "width": "32", "height": "16" }
+            ],
+            "text_entries": [
+              { "id": "q", "control_type": "text", "name": "q", "labels": ["Query"], "accessible_name": "Query", "accessible_description": "Query", "placeholder": "Search terms", "value": null, "text": "", "autocomplete": "section-primary shipping search", "autocomplete_tokens": ["section-primary", "shipping", "search"], "autocapitalize": "words", "enterkeyhint": "search", "dirname": "q.dir", "spellcheck": "false", "autocorrect": "off", "inputmode": "search", "pattern": "[A-Za-z ]+", "minlength": "2", "maxlength": "80", "size": "40", "list": "query-suggestions", "datalist_options": ["Rust", "HTML", "Browser APIs"], "disabled": false, "required": true, "will_validate": true, "validation_attributes": ["required", "pattern", "minlength", "maxlength"] },
+              { "id": "count", "control_type": "number", "name": "count", "labels": ["Count"], "accessible_name": "Count", "value": "2", "text": "", "min": "1", "max": "10", "step": "0.5", "disabled": false, "required": true, "will_validate": true, "validation_attributes": ["required", "min", "max", "step"] },
+              { "id": "notes", "control_type": "textarea", "name": "notes", "labels": ["NotesKeep me"], "accessible_name": "NotesKeep me", "placeholder": "Details", "value": "Keep me", "text": "Keep me", "autocapitalize": "sentences", "enterkeyhint": "done", "dirname": "notes.dir", "spellcheck": "true", "autocorrect": "on", "maxlength": "500", "rows": "4", "cols": "40", "wrap": "hard", "disabled": false, "readonly": true, "validation_attributes": ["readonly", "maxlength"], "validation_barred_reason": "readonly" },
+              { "id": "external", "control_type": "text", "name": "outside", "form_owner": "search", "accessible_name": "Outside", "placeholder": "Outside", "value": null, "text": "", "disabled": false, "will_validate": true }
             ],
             "controls": [
               { "id": "q", "control_type": "text", "name": "q", "labels": ["Query"], "accessible_name": "Query", "accessible_description": "Query", "placeholder": "Search terms", "autocomplete": "section-primary shipping search", "autocomplete_tokens": ["section-primary", "shipping", "search"], "autocapitalize": "words", "enterkeyhint": "search", "dirname": "q.dir", "spellcheck": "false", "autocorrect": "off", "inputmode": "search", "pattern": "[A-Za-z ]+", "minlength": "2", "maxlength": "80", "size": "40", "list": "query-suggestions", "datalist_options": ["Rust", "HTML", "Browser APIs"], "value": null, "successful": true, "submission_values": [""], "autofocus": true, "disabled": false, "required": true, "will_validate": true, "validation_attributes": ["required", "pattern", "minlength", "maxlength"], "checked": false, "text": "", "options": [] },


### PR DESCRIPTION
## Summary
- add form-level text entry descriptors for text-like inputs and textareas
- project labels, names, values, editing hints, datalist values, validation metadata, and disabled/readonly state from form controls
- update browser readiness fixtures and fixture schema governance for forms[].text_entries

## Tests
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- cargo test -p coding-adventures-html-parser browser_form_text_entry_descriptor_metadata_tracks_textual_controls_and_editing_hints
- cargo test -p coding-adventures-html-parser browser_form_
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser