### PR TITLE
feat(iir-to-intel8008): bitwise accumulator ALU (and/or/xor) — A2++.5.5 first slice

### DIFF
--- a/code/packages/rust/iir-to-intel8008/CHANGELOG.md
+++ b/code/packages/rust/iir-to-intel8008/CHANGELOG.md
@@ -3,6 +3,79 @@
 All notable changes to this crate are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.3.2] — 2026-06-02 (A2++.5.5 first slice — bitwise ALU `and`/`or`/`xor`)
+
+### Added — bitwise accumulator-target ALU
+
+Extends v0.3.1 with three more accumulator-anchored ALU ops in family
+`10 ooo sss`.  Identical lowering shape to add/sub — only the `ooo`
+field changes:
+
+| IIR op | Intel 8008 mnemonic | `ooo` | First byte |
+|--------|---------------------|-------|------------|
+| `and dest, a, b` | `ANA b_reg` | `100` | `0xA0 \| sss` |
+| `xor dest, a, b` | `XRA b_reg` | `101` | `0xA8 \| sss` |
+| `or  dest, a, b` | `ORA b_reg` | `110` | `0xB0 \| sss` |
+
+The full sequence remains:
+
+```text
+if a_reg != A:    MOV A, a_reg
+                  ANA/ORA/XRA b_reg     ; result lands in A
+if dest_reg != A: MOV dest_reg, A
+```
+
+#### Code-gen shape (worked example)
+
+`r = v & w` with v→A, w→B, r→C lowers to:
+
+```
+MVI A, v_imm
+MVI B, w_imm
+ANA B            ; 0xA0
+MOV C, A         ; 0x4F
+```
+
+i.e. one byte of bitwise op plus the staging move (same as `add`/`sub`).
+
+#### Self-op idiom
+
+`and r v v` where `v` is already in `A` lowers to `ANA A` (`0xA7`,
+family `10 100 111`) — same as the self-add shape: no leading
+`MOV A, A`.
+
+#### New opcode constants
+
+* `const ALU_AND: u8 = 0b100;`
+* `const ALU_XOR: u8 = 0b101;`
+* `const ALU_OR:  u8 = 0b110;`
+
+The `encode_alu(ooo, sss)` helper from v0.3.1 carries them all — no
+new encoder code, just a wider dispatch in the lowering match arm.
+
+#### Tests added (24 total, was 20)
+
+* `and_two_consts_emits_ana_b_after_mov` — pinned full sequence with
+  `0xA0` (ANA B).
+* `or_two_consts_emits_ora_b_after_mov` — `0xB0` (ORA B).
+* `xor_two_consts_emits_xra_b_after_mov` — `0xA8` (XRA B).
+* `and_when_lhs_is_already_in_a_skips_the_staging_mov` — `0xA7`
+  (ANA A) for the self-AND idiom, generalising the self-add test.
+
+The `unsupported_op_is_rejected_with_function_name` test still probes
+`safepoint`, which remains outside the whitelist.
+
+### What is NOT in v0.3.2 (deferred to v0.3.3 / A2+++)
+
+* `cmp`, `adc`, `sbb` — same family, different `ooo` codes
+  (`cmp = 0b111`, `adc = 0b001`, `sbb = 0b011`).  `cmp` needs flag
+  observation wiring; `adc`/`sbb` need the carry flag plumbed from a
+  prior arithmetic op.  All three land together once the carry-flag
+  story is settled.
+* Real `RET` (`0x07`) via `CALL` + the internal return stack.
+* Conditional + unconditional jumps with 14-bit address backpatching.
+* `lang-aot --target=intel8008` wiring — A2+++.
+
 ## [0.3.1] — 2026-06-02 (A2++.5 first slice — `add`/`sub` on the accumulator)
 
 ### Added — accumulator-target ALU

--- a/code/packages/rust/iir-to-intel8008/Cargo.toml
+++ b/code/packages/rust/iir-to-intel8008/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iir-to-intel8008"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
-description = "IIR → Intel 8008 machine code backend (Oct's native target) — lowers IIRModule to a Vec<u8> of 8-bit Intel 8008 opcodes.  v0.3.1 (A2++.5 first slice): adds `add`/`sub` ALU on the accumulator (family 10 ooo sss) — stage left source into A, execute ADD/SUB right_reg, capture result into dest_reg if it isn't already A.  Real RET via CALL/stack still pending."
+description = "IIR → Intel 8008 machine code backend (Oct's native target) — lowers IIRModule to a Vec<u8> of 8-bit Intel 8008 opcodes.  v0.3.2 (A2++.5.5 first slice): extends v0.3.1's add/sub with the bitwise accumulator-target ALU ops `and` (ANA, 10 100 sss = 0xA0|sss), `or` (ORA, 10 110 sss = 0xB0|sss), `xor` (XRA, 10 101 sss = 0xA8|sss).  cmp/adc/sbb + real RET via CALL/stack still pending (v0.3.3)."
 
 [lib]
 name = "iir_to_intel8008"

--- a/code/packages/rust/iir-to-intel8008/src/lib.rs
+++ b/code/packages/rust/iir-to-intel8008/src/lib.rs
@@ -167,6 +167,9 @@ fn encode_alu(ooo: u8, sss: u8) -> u8 {
 /// ALU operation codes (`ooo` field in `10 ooo sss`).
 const ALU_ADD: u8 = 0b000; // ADD r
 const ALU_SUB: u8 = 0b010; // SUB r
+const ALU_AND: u8 = 0b100; // ANA r (logical AND)
+const ALU_XOR: u8 = 0b101; // XRA r (logical XOR)
+const ALU_OR:  u8 = 0b110; // ORA r (logical OR)
 
 // ===========================================================================
 // IIRIntel8008Config
@@ -292,6 +295,8 @@ const SUPPORTED_OPS: &[&str] = &[
     "const", "mov", "ret", "ret_void",
     // A2++.5 — accumulator ALU
     "add", "sub",
+    // A2++.5.5 — bitwise accumulator ALU
+    "and", "or", "xor",
 ];
 
 pub fn lower_iir_to_intel8008(
@@ -383,18 +388,20 @@ pub fn lower_iir_to_intel8008(
                     bytes.push(HLT);
                 }
 
-                // ── add dest, a, b → MOV A,a; ADD b_reg; MOV dest,A ─────
+                // ── add / sub / and / or / xor → MOV A,a; OP b_reg; MOV dest,A
                 //
-                // The 8008's accumulator-based ALU forces all binary ops
-                // through `A`.  If `a` already lives there, the leading
-                // `MOV A, a_reg` is skipped.  Likewise, if the
-                // newly-allocated `dest_reg` IS A, the trailing
-                // `MOV dest_reg, A` is skipped — common when this is the
-                // first arithmetic op in the function and the allocator
-                // hands out A.
+                // All five accumulator-target ALU ops share an identical
+                // shape, differing only in the 3-bit `ooo` selector:
                 //
-                // sub: identical shape, just family-`10 010 sss`.
-                "add" | "sub" => {
+                //   ADD = 0b000   AND = 0b100
+                //   SUB = 0b010   XOR = 0b101
+                //                 OR  = 0b110
+                //
+                // The 8008's ALU is *always* accumulator-anchored: left
+                // source AND destination are A; only the right source is
+                // a variable register.  Optional MOVs at the ends collapse
+                // when a_reg or dest_reg already coincide with A.
+                "add" | "sub" | "and" | "or" | "xor" => {
                     let dest = require_dest(instr, &instr.op, &f.name)?;
                     let a_name = match instr.srcs.first() {
                         Some(Operand::Var(s)) => s.clone(),
@@ -416,8 +423,19 @@ pub fn lower_iir_to_intel8008(
                     if a_reg != REG_A {
                         bytes.push(encode_mov(REG_A, a_reg));
                     }
-                    // Execute the ALU op (result lands in A).
-                    let ooo = if instr.op == "add" { ALU_ADD } else { ALU_SUB };
+                    // Execute the ALU op (result lands in A).  Dispatch
+                    // on op-name → 3-bit `ooo` selector.  The `_` arm is
+                    // unreachable because the outer match arm above is the
+                    // only path here and it covers exactly these five
+                    // strings.
+                    let ooo = match instr.op.as_str() {
+                        "add" => ALU_ADD,
+                        "sub" => ALU_SUB,
+                        "and" => ALU_AND,
+                        "or"  => ALU_OR,
+                        "xor" => ALU_XOR,
+                        _ => unreachable!("outer arm restricts to these 5"),
+                    };
                     bytes.push(encode_alu(ooo, b_reg));
                     // Capture the result into dest_reg unless dest_reg is A.
                     let dest_reg = alloc_register(&mut next_reg, dest, &mut env, &f.name)?;

--- a/code/packages/rust/iir-to-intel8008/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-intel8008/tests/test_backend.rs
@@ -401,3 +401,114 @@ fn add_when_lhs_is_already_in_a_skips_the_staging_mov() {
         HLT,
     ], "double-of-A expected; got: {bytes:02x?}");
 }
+
+// ===========================================================================
+// 8. A2++.5.5 — bitwise accumulator-target ALU (AND, OR, XOR)
+// ===========================================================================
+//
+// Identical accumulator-anchored shape to add/sub.  Only the 3-bit `ooo`
+// selector changes:
+//
+//   AND = 0b100 → ANA r   first byte = 0xA0 | sss
+//   XOR = 0b101 → XRA r   first byte = 0xA8 | sss
+//   OR  = 0b110 → ORA r   first byte = 0xB0 | sss
+//
+// For each op below, the IIR sequence is `const v; const w; OP r v w; ret r`,
+// the allocator places v→A, w→B, r→C, and the emitted byte stream
+// follows the canonical:
+//
+//   MVI A, v_imm
+//   MVI B, w_imm
+//   OP  B            ← the only byte that varies between the three tests
+//   MOV C, A
+//   MOV A, C         (stage r into A for ret)
+//   HLT
+
+#[test]
+fn and_two_consts_emits_ana_b_after_mov() {
+    // ANA B = 10 100 000 = 0xA0
+    let f = IIRFunction::new("and_fn", vec![], "u8", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(0x0F)], "u8"),
+        IIRInstr::new("const", Some("w".into()), vec![Operand::Int(0x33)], "u8"),
+        IIRInstr::new("and", Some("r".into()),
+            vec![Operand::Var("v".into()), Operand::Var("w".into())], "u8"),
+        IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "u8"),
+    ]);
+    let bytes = lower_iir_to_intel8008(&module_with(f), &IIRIntel8008Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![
+        MVI_A, 0x0F,    // MVI A, 0x0F
+        0x06,  0x33,    // MVI B, 0x33
+        0xA0,           // ANA B   (10 100 000)
+        0x4F,           // MOV C, A
+        0x79,           // MOV A, C
+        HLT,
+    ], "and 0x0F & 0x33 expected; got: {bytes:02x?}");
+}
+
+#[test]
+fn or_two_consts_emits_ora_b_after_mov() {
+    // ORA B = 10 110 000 = 0xB0
+    let f = IIRFunction::new("or_fn", vec![], "u8", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(0x0F)], "u8"),
+        IIRInstr::new("const", Some("w".into()), vec![Operand::Int(0xF0)], "u8"),
+        IIRInstr::new("or", Some("r".into()),
+            vec![Operand::Var("v".into()), Operand::Var("w".into())], "u8"),
+        IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "u8"),
+    ]);
+    let bytes = lower_iir_to_intel8008(&module_with(f), &IIRIntel8008Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![
+        MVI_A, 0x0F,    // MVI A, 0x0F
+        0x06,  0xF0,    // MVI B, 0xF0
+        0xB0,           // ORA B   (10 110 000)
+        0x4F,           // MOV C, A
+        0x79,           // MOV A, C
+        HLT,
+    ], "or 0x0F | 0xF0 expected; got: {bytes:02x?}");
+}
+
+#[test]
+fn xor_two_consts_emits_xra_b_after_mov() {
+    // XRA B = 10 101 000 = 0xA8
+    let f = IIRFunction::new("xor_fn", vec![], "u8", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(0xFF)], "u8"),
+        IIRInstr::new("const", Some("w".into()), vec![Operand::Int(0x55)], "u8"),
+        IIRInstr::new("xor", Some("r".into()),
+            vec![Operand::Var("v".into()), Operand::Var("w".into())], "u8"),
+        IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "u8"),
+    ]);
+    let bytes = lower_iir_to_intel8008(&module_with(f), &IIRIntel8008Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![
+        MVI_A, 0xFF,    // MVI A, 0xFF
+        0x06,  0x55,    // MVI B, 0x55
+        0xA8,           // XRA B   (10 101 000)
+        0x4F,           // MOV C, A
+        0x79,           // MOV A, C
+        HLT,
+    ], "xor 0xFF ^ 0x55 expected; got: {bytes:02x?}");
+}
+
+/// Sanity that the self-op skip-staging optimisation generalises to the
+/// bitwise ops too: `and r v v` with v→A produces `ANA A` (0xA7), no
+/// leading `MOV A, A`.
+#[test]
+fn and_when_lhs_is_already_in_a_skips_the_staging_mov() {
+    // ANA A = 10 100 111 = 0xA7
+    let f = IIRFunction::new("self_and", vec![], "u8", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(0xAA)], "u8"),
+        IIRInstr::new("and", Some("r".into()),
+            vec![Operand::Var("v".into()), Operand::Var("v".into())], "u8"),
+        IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "u8"),
+    ]);
+    let bytes = lower_iir_to_intel8008(&module_with(f), &IIRIntel8008Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![
+        MVI_A, 0xAA,    // MVI A, 0xAA
+        0xA7,           // ANA A   (10 100 111 — sss=A=7)
+        0x47,           // MOV B, A
+        0x78,           // MOV A, B
+        HLT,
+    ], "self-AND expected; got: {bytes:02x?}");
+}

--- a/code/specs/iir-to-intel8008.md
+++ b/code/specs/iir-to-intel8008.md
@@ -56,8 +56,9 @@ IIRModule
 | v0.1.0 (A2) | crate skeleton: any module → single `HLT` (`0x76`) | **merged** |
 | v0.2.0 (A2+) | `const` → `MVI A, n` + `ret`/`ret_void` → `HLT` (accumulator-only first slice) | **merged** |
 | v0.3.0 (A2++) | Linear register allocator over A/B/C/D/E/H/L + multi-register `const` + `mov` + ret-value staging | **merged** |
-| **v0.3.1 (A2++.5 first slice — this PR)** | `add`/`sub` ALU on the accumulator (family `10 ooo sss`) | this PR |
-| v0.3.2 (A2++.5.5) | rest of ALU (`cmp`, `and`, `or`, `xor`, `adc`, `sbb`) + real `RET` (`0x07`) via `CALL` + internal return stack | future |
+| v0.3.1 (A2++.5 first slice) | `add`/`sub` ALU on the accumulator (family `10 ooo sss`) | **merged** |
+| **v0.3.2 (A2++.5.5 first slice — this PR)** | bitwise ALU `and`/`or`/`xor` on the accumulator (same family, `ooo` ∈ {`100`, `110`, `101`}) | this PR |
+| v0.3.3 (A2++.5.5 second slice) | rest of ALU (`cmp`, `adc`, `sbb` — carry-flag-bearing ops) + real `RET` (`0x07`) via `CALL` + internal return stack | future |
 | v0.4.0 (A2+++) | Conditional + unconditional jumps with 14-bit address backpatching + `lang-aot --target=intel8008` | future |
 
 ## Public surface (v0.1.0)


### PR DESCRIPTION
## Summary

- Extends `iir-to-intel8008` v0.3.1 → **v0.3.2** with three more accumulator-target ALU ops in family `10 ooo sss`: `and` (ANA, `0xA0|sss`), `or` (ORA, `0xB0|sss`), `xor` (XRA, `0xA8|sss`).
- The `"add" | "sub"` lowering arm widens to `"add" | "sub" | "and" | "or" | "xor"`; the op→`ooo` selector moves from `if/else` to a `match`. No new encoder code — `encode_alu(ooo, sss)` from v0.3.1 carries all five.
- Tests grow from 20 → 24, each pinning the exact emitted byte sequence including the self-AND `0xA7` idiom (no `MOV A, A` when v is already in A).
- Spec `code/specs/iir-to-intel8008.md` updated: v0.3.1 marked merged; v0.3.2 (this PR); new v0.3.3 row for the deferred carry-flag-bearing ALU (`cmp`/`adc`/`sbb`) + real RET/CALL stack.

### Lowering shape (unchanged from v0.3.1, just more op-name → ooo entries)

```text
if a_reg != A:    MOV A, a_reg
                  ANA / ORA / XRA b_reg     ; result lands in A
if dest_reg != A: MOV dest_reg, A
```

| IIR op | Mnemonic | `ooo` | First byte    |
| ------ | -------- | ----- | ------------- |
| `and`  | ANA r    | `100` | `0xA0 \| sss` |
| `xor`  | XRA r    | `101` | `0xA8 \| sss` |
| `or`   | ORA r    | `110` | `0xB0 \| sss` |

### Deferred to v0.3.3 (A2++.5.5 second slice)

- `cmp`, `adc`, `sbb` — same family, but each needs the carry/zero flag plumbed (cmp for branch observation, adc/sbb for chained multi-byte arithmetic). Grouped because the flag wiring is a shared prerequisite.
- Real `RET` (`0x07`) via `CALL` + internal return stack.
- Conditional + unconditional jumps with 14-bit address backpatching stays in v0.4.0 (A2+++).

## Test plan

- [x] `cargo test -p iir-to-intel8008` — 24/24 backend tests pass, 1/1 doctest passes
- [x] Each new op's exact byte sequence pinned (no opcode-table drift in future)
- [x] Self-AND idiom (`ANA A = 0xA7`) tested, mirroring the v0.3.1 self-add test
- [x] `unsupported_op_is_rejected_with_function_name` still probes `safepoint` (outside whitelist)
- [x] Security review passed (no vulnerabilities found)
- [ ] CI green
- [ ] No merge conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)