### PR TITLE
feat(iir-to-intel8008): carry-chained accumulator ALU (adc/sbb) — A2++.5.5 second slice

### DIFF
--- a/code/packages/rust/iir-to-intel8008/CHANGELOG.md
+++ b/code/packages/rust/iir-to-intel8008/CHANGELOG.md
@@ -3,6 +3,74 @@
 All notable changes to this crate are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.3.3] — 2026-06-02 (A2++.5.5 second slice — carry/borrow ALU `adc`/`sbb`)
+
+### Added — carry-chained accumulator-target ALU
+
+Extends v0.3.2 with two more accumulator-anchored ALU ops in family
+`10 ooo sss` that read the carry/borrow flag set by a *prior*
+flag-producing op:
+
+| IIR op | Intel 8008 mnemonic | `ooo` | First byte |
+|--------|---------------------|-------|------------|
+| `adc dest, a, b` | `ACA b_reg` | `001` | `0x88 \| sss` |
+| `sbb dest, a, b` | `SCA b_reg` | `011` | `0x98 \| sss` |
+
+The lowering shape is identical to add/sub/and/or/xor — only the
+`ooo` selector changes.  No new encoder code; `encode_alu(ooo, sss)`
+from v0.3.1 carries the wider dispatch.
+
+#### Carry-flag contract (front-end responsibility)
+
+The 8008's `ACA`/`SCA` consume the carry flag bit set by a prior
+flag-affecting ALU op (`ADD`, `SUB`, `ADC`, `SBB`, `ANA`, `ORA`,
+`XRA`, `CMP`).  This backend emits instructions in source order with
+no reordering — so if the IIR front-end emits
+
+```
+add r_lo lo_a lo_b   ; sets carry on overflow
+adc r_hi hi_a hi_b   ; consumes that carry
+```
+
+the carry survives between the two.  However, the staging MOVs
+inserted by the allocator (`MOV A, hi_a`) sit between them.  Per
+Intel's 8008 docs MOV does NOT affect flags, so the carry survives
+the MOV too.  Front-ends MUST NOT insert flag-clobbering ops between
+the producer and the ADC/SBB consumer.
+
+#### Why no `cmp` in this slice?
+
+`cmp` in IIR is shaped `cmp dest, a, b` and produces a boolean dest.
+The 8008's `CMP` (`ooo = 0b111`) computes `A - r`, sets flags, and
+**discards** the result — there's no register dest in 8008-speak.
+Lowering `cmp` therefore requires an additional sequence that
+captures the resulting condition into a register, which is typically
+done as part of the same lowering that handles conditional branches.
+That work lands together in v0.3.4.
+
+#### New opcode constants
+
+* `const ALU_ADC: u8 = 0b001;`
+* `const ALU_SBB: u8 = 0b011;`
+
+#### Tests added (27 total, was 24)
+
+* `adc_two_consts_emits_aca_b_after_mov` — pinned full sequence with
+  `0x88` (ACA B).
+* `sbb_two_consts_emits_sca_b_after_mov` — `0x98` (SCA B).
+* `adc_when_lhs_is_already_in_a_skips_the_staging_mov` — `0x8F`
+  (ACA A) for the self-ADC idiom, generalising the self-add/self-AND
+  tests.
+
+### What is NOT in v0.3.3 (deferred to v0.3.4 / v0.3.5 / A2+++)
+
+* `cmp` — paired with the branch ops in v0.3.4.
+* Real `RET` (`0x07`) via `CALL` (`0x46` + 14-bit address) + the
+  internal return stack — v0.3.5.
+* Conditional + unconditional jumps with 14-bit address backpatching
+  — v0.3.4 (alongside `cmp`).
+* `lang-aot --target=intel8008` wiring — A2+++.
+
 ## [0.3.2] — 2026-06-02 (A2++.5.5 first slice — bitwise ALU `and`/`or`/`xor`)
 
 ### Added — bitwise accumulator-target ALU

--- a/code/packages/rust/iir-to-intel8008/Cargo.toml
+++ b/code/packages/rust/iir-to-intel8008/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iir-to-intel8008"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
-description = "IIR → Intel 8008 machine code backend (Oct's native target) — lowers IIRModule to a Vec<u8> of 8-bit Intel 8008 opcodes.  v0.3.2 (A2++.5.5 first slice): extends v0.3.1's add/sub with the bitwise accumulator-target ALU ops `and` (ANA, 10 100 sss = 0xA0|sss), `or` (ORA, 10 110 sss = 0xB0|sss), `xor` (XRA, 10 101 sss = 0xA8|sss).  cmp/adc/sbb + real RET via CALL/stack still pending (v0.3.3)."
+description = "IIR → Intel 8008 machine code backend (Oct's native target) — lowers IIRModule to a Vec<u8> of 8-bit Intel 8008 opcodes.  v0.3.3 (A2++.5.5 second slice): adds the carry/borrow-chained accumulator ALU ops `adc` (ACA, 10 001 sss = 0x88|sss) and `sbb` (SCA, 10 011 sss = 0x98|sss), enabling multi-byte arithmetic idioms.  `cmp` deferred to v0.3.4 because its IIR semantics (boolean dest) don't match the 8008's flag-only CMP — needs a paired flag-capture sequence wired with the branch ops.  Real RET via CALL/stack still pending (v0.3.5)."
 
 [lib]
 name = "iir_to_intel8008"

--- a/code/packages/rust/iir-to-intel8008/src/lib.rs
+++ b/code/packages/rust/iir-to-intel8008/src/lib.rs
@@ -166,10 +166,18 @@ fn encode_alu(ooo: u8, sss: u8) -> u8 {
 
 /// ALU operation codes (`ooo` field in `10 ooo sss`).
 const ALU_ADD: u8 = 0b000; // ADD r
+const ALU_ADC: u8 = 0b001; // ACA r (add with carry-in)
 const ALU_SUB: u8 = 0b010; // SUB r
+const ALU_SBB: u8 = 0b011; // SCA r (sub with borrow-in)
 const ALU_AND: u8 = 0b100; // ANA r (logical AND)
 const ALU_XOR: u8 = 0b101; // XRA r (logical XOR)
 const ALU_OR:  u8 = 0b110; // ORA r (logical OR)
+// ALU_CMP = 0b111 lives in the v0.3.4 slice — `cmp` produces a
+// boolean dest at the IIR level but the 8008 CMP only sets flags
+// (discards the difference), so the lowering needs an extra
+// flag-to-register capture sequence (typically a conditional load
+// or a paired conditional jump).  That's wired alongside the
+// branch ops, not here.
 
 // ===========================================================================
 // IIRIntel8008Config
@@ -297,6 +305,8 @@ const SUPPORTED_OPS: &[&str] = &[
     "add", "sub",
     // A2++.5.5 — bitwise accumulator ALU
     "and", "or", "xor",
+    // A2++.5.5 second slice — carry/borrow chained ALU
+    "adc", "sbb",
 ];
 
 pub fn lower_iir_to_intel8008(
@@ -388,20 +398,34 @@ pub fn lower_iir_to_intel8008(
                     bytes.push(HLT);
                 }
 
-                // ── add / sub / and / or / xor → MOV A,a; OP b_reg; MOV dest,A
+                // ── add / adc / sub / sbb / and / or / xor → MOV A,a; OP b_reg; MOV dest,A
                 //
-                // All five accumulator-target ALU ops share an identical
+                // All seven accumulator-target ALU ops share an identical
                 // shape, differing only in the 3-bit `ooo` selector:
                 //
                 //   ADD = 0b000   AND = 0b100
-                //   SUB = 0b010   XOR = 0b101
-                //                 OR  = 0b110
+                //   ADC = 0b001   XOR = 0b101
+                //   SUB = 0b010   OR  = 0b110
+                //   SBB = 0b011
+                //
+                // `cmp` (ooo = 0b111) is intentionally NOT here — it sets
+                // flags without producing a register result, so its
+                // lowering needs an extra capture sequence and lands with
+                // the branch ops in v0.3.4.
                 //
                 // The 8008's ALU is *always* accumulator-anchored: left
                 // source AND destination are A; only the right source is
                 // a variable register.  Optional MOVs at the ends collapse
                 // when a_reg or dest_reg already coincide with A.
-                "add" | "sub" | "and" | "or" | "xor" => {
+                //
+                // ADC / SBB read the carry flag bit set by a PRIOR ALU op
+                // — they don't change shape here, but front-ends should
+                // ensure no carry-clobbering op runs between the
+                // producer (e.g. an ADD that overflowed) and the
+                // consumer.  This crate doesn't reorder instructions; it
+                // emits them in source order, so the contract is the
+                // front-end's to uphold.
+                "add" | "adc" | "sub" | "sbb" | "and" | "or" | "xor" => {
                     let dest = require_dest(instr, &instr.op, &f.name)?;
                     let a_name = match instr.srcs.first() {
                         Some(Operand::Var(s)) => s.clone(),
@@ -430,11 +454,13 @@ pub fn lower_iir_to_intel8008(
                     // strings.
                     let ooo = match instr.op.as_str() {
                         "add" => ALU_ADD,
+                        "adc" => ALU_ADC,
                         "sub" => ALU_SUB,
+                        "sbb" => ALU_SBB,
                         "and" => ALU_AND,
                         "or"  => ALU_OR,
                         "xor" => ALU_XOR,
-                        _ => unreachable!("outer arm restricts to these 5"),
+                        _ => unreachable!("outer arm restricts to these 7"),
                     };
                     bytes.push(encode_alu(ooo, b_reg));
                     // Capture the result into dest_reg unless dest_reg is A.

--- a/code/packages/rust/iir-to-intel8008/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-intel8008/tests/test_backend.rs
@@ -512,3 +512,90 @@ fn and_when_lhs_is_already_in_a_skips_the_staging_mov() {
         HLT,
     ], "self-AND expected; got: {bytes:02x?}");
 }
+
+// ===========================================================================
+// 9. A2++.5.5 second slice — carry/borrow chained ALU (ADC, SBB)
+// ===========================================================================
+//
+// Same accumulator-anchored shape as add/sub.  Only the 3-bit `ooo`
+// selector changes:
+//
+//   ADC = 0b001 → ACA r   first byte = 0x88 | sss
+//   SBB = 0b011 → SCA r   first byte = 0x98 | sss
+//
+// These add or subtract the carry/borrow flag set by a PRIOR ALU op.
+// The backend doesn't enforce flag-producer ordering — the front-end
+// must arrange for the producer (an ADD that overflowed) to be the
+// immediately-preceding flag-affecting instruction.
+//
+// In the canonical multi-byte addition idiom:
+//
+//   r_lo = lo_a + lo_b      ; ADD — sets carry if overflow
+//   r_hi = hi_a +carry hi_b ; ADC — consumes carry
+//
+// the two-instruction sequence is what makes ADC useful.
+
+#[test]
+fn adc_two_consts_emits_aca_b_after_mov() {
+    // ACA B = 10 001 000 = 0x88
+    let f = IIRFunction::new("adc_fn", vec![], "u8", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(0x10)], "u8"),
+        IIRInstr::new("const", Some("w".into()), vec![Operand::Int(0x20)], "u8"),
+        IIRInstr::new("adc", Some("r".into()),
+            vec![Operand::Var("v".into()), Operand::Var("w".into())], "u8"),
+        IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "u8"),
+    ]);
+    let bytes = lower_iir_to_intel8008(&module_with(f), &IIRIntel8008Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![
+        MVI_A, 0x10,    // MVI A, 0x10
+        0x06,  0x20,    // MVI B, 0x20
+        0x88,           // ACA B   (10 001 000)
+        0x4F,           // MOV C, A
+        0x79,           // MOV A, C
+        HLT,
+    ], "adc expected; got: {bytes:02x?}");
+}
+
+#[test]
+fn sbb_two_consts_emits_sca_b_after_mov() {
+    // SCA B = 10 011 000 = 0x98
+    let f = IIRFunction::new("sbb_fn", vec![], "u8", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(0x80)], "u8"),
+        IIRInstr::new("const", Some("w".into()), vec![Operand::Int(0x01)], "u8"),
+        IIRInstr::new("sbb", Some("r".into()),
+            vec![Operand::Var("v".into()), Operand::Var("w".into())], "u8"),
+        IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "u8"),
+    ]);
+    let bytes = lower_iir_to_intel8008(&module_with(f), &IIRIntel8008Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![
+        MVI_A, 0x80,    // MVI A, 0x80
+        0x06,  0x01,    // MVI B, 0x01
+        0x98,           // SCA B   (10 011 000)
+        0x4F,           // MOV C, A
+        0x79,           // MOV A, C
+        HLT,
+    ], "sbb expected; got: {bytes:02x?}");
+}
+
+/// Self-op variant of adc — `adc r v v` where v→A skips the staging
+/// MOV, identical to the self-add pattern.  ACA A = 0x89 (10 001 111).
+#[test]
+fn adc_when_lhs_is_already_in_a_skips_the_staging_mov() {
+    let f = IIRFunction::new("self_adc", vec![], "u8", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(0x40)], "u8"),
+        IIRInstr::new("adc", Some("r".into()),
+            vec![Operand::Var("v".into()), Operand::Var("v".into())], "u8"),
+        IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "u8"),
+    ]);
+    let bytes = lower_iir_to_intel8008(&module_with(f), &IIRIntel8008Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![
+        MVI_A, 0x40,    // MVI A, 0x40
+        0x8F,           // ACA A   (10 001 111 — sss=A=7)
+        0x47,           // MOV B, A
+        0x78,           // MOV A, B
+        HLT,
+    ], "self-ADC expected; got: {bytes:02x?}");
+}

--- a/code/specs/iir-to-intel8008.md
+++ b/code/specs/iir-to-intel8008.md
@@ -57,9 +57,11 @@ IIRModule
 | v0.2.0 (A2+) | `const` → `MVI A, n` + `ret`/`ret_void` → `HLT` (accumulator-only first slice) | **merged** |
 | v0.3.0 (A2++) | Linear register allocator over A/B/C/D/E/H/L + multi-register `const` + `mov` + ret-value staging | **merged** |
 | v0.3.1 (A2++.5 first slice) | `add`/`sub` ALU on the accumulator (family `10 ooo sss`) | **merged** |
-| **v0.3.2 (A2++.5.5 first slice — this PR)** | bitwise ALU `and`/`or`/`xor` on the accumulator (same family, `ooo` ∈ {`100`, `110`, `101`}) | this PR |
-| v0.3.3 (A2++.5.5 second slice) | rest of ALU (`cmp`, `adc`, `sbb` — carry-flag-bearing ops) + real `RET` (`0x07`) via `CALL` + internal return stack | future |
-| v0.4.0 (A2+++) | Conditional + unconditional jumps with 14-bit address backpatching + `lang-aot --target=intel8008` | future |
+| v0.3.2 (A2++.5.5 first slice) | bitwise ALU `and`/`or`/`xor` on the accumulator (same family, `ooo` ∈ {`100`, `110`, `101`}) | **merged** |
+| **v0.3.3 (A2++.5.5 second slice — this PR)** | carry/borrow-chained ALU `adc`/`sbb` (same family, `ooo` ∈ {`001`, `011`}) | this PR |
+| v0.3.4 (A2++.5.5 third slice) | `cmp` (`ooo = 0b111`) + conditional jumps with 14-bit address backpatching — paired because `cmp` produces flag state that's only useful as a branch input | future |
+| v0.3.5 (A2++.5.5 fourth slice) | Real `RET` (`0x07`) via `CALL` (`0x46` + 14-bit address) + per-function internal return-stack discipline | future |
+| v0.4.0 (A2+++) | `lang-aot --target=intel8008` wiring + module-level CALL backpatching | future |
 
 ## Public surface (v0.1.0)
 


### PR DESCRIPTION
## Summary

- Extends `iir-to-intel8008` v0.3.2 → **v0.3.3** with two more accumulator-target ALU ops in family `10 ooo sss`: `adc` (ACA, `0x88|sss`) and `sbb` (SCA, `0x98|sss`).
- Byte-for-byte the same lowering shape as add/sub/and/or/xor — just a wider whitelist + wider op→`ooo` dispatch.  No new encoder code.
- Tests grow 24 → 27, each pinning the exact emitted byte sequence including the self-ADC `0x8F` idiom.
- Spec `code/specs/iir-to-intel8008.md` updated: v0.3.2 marked merged; v0.3.3 (this PR); new rows for v0.3.4 (`cmp` + cond-jumps paired), v0.3.5 (real RET/CALL/stack), v0.4.0 (`lang-aot --target=intel8008`).

### Why no `cmp` in this slice?

In IIR \`cmp dest, a, b\` produces a boolean dest, but the 8008's CMP (\`ooo=0b111\`) sets flags and **discards** the result.  Lowering needs an extra flag-capture sequence that's most natural to wire alongside conditional branches.  Paired with cond-jumps in v0.3.4.

### Carry-flag contract

This backend emits instructions in source order with no reordering, so the IIR front-end places the flag-producer (e.g. ADD overflow) immediately before the ADC/SBB consumer.  The allocator's staging MOVs don't clobber flags (MOV is flag-non-affecting on 8008), so the canonical \`add r_lo lo_a lo_b; adc r_hi hi_a hi_b\` u16 sum idiom survives.

| IIR op | Mnemonic | \`ooo\` | First byte    |
| ------ | -------- | ------- | ------------- |
| \`adc\`  | ACA r    | \`001\` | \`0x88 \| sss\` |
| \`sbb\`  | SCA r    | \`011\` | \`0x98 \| sss\` |

## Test plan

- [x] \`cargo test -p iir-to-intel8008\` — 27/27 backend tests pass, 1/1 doctest passes
- [x] Each new op's exact byte sequence pinned
- [x] Self-ADC idiom (\`ACA A = 0x8F\`) tested, mirroring the v0.3.2 self-AND test
- [x] \`unsupported_op_is_rejected_with_function_name\` still probes \`safepoint\` (outside whitelist)
- [x] Security review passed (no vulnerabilities found)
- [ ] CI green
- [ ] No merge conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)