### PR TITLE
feat(iir-to-intel8008): label + unconditional jmp w/ backpatching — A2++.5.5 third slice

### DIFF
--- a/code/packages/rust/iir-to-intel8008/CHANGELOG.md
+++ b/code/packages/rust/iir-to-intel8008/CHANGELOG.md
@@ -3,6 +3,94 @@
 All notable changes to this crate are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.3.4] — 2026-06-02 (A2++.5.5 third slice — `label` + unconditional `jmp` + two-pass backpatching)
+
+### Added — control flow primitive (unconditional jump)
+
+Wires the first control-flow lowering on the 8008.  Adds two IIR ops:
+
+| IIR op | Intel 8008 lowering |
+|--------|---------------------|
+| `label "<name>"` | zero bytes; records `(name → current_byte_offset)` in a per-function label table |
+| `jmp "<name>"` | `0x7C` + low address byte + high address byte (3 bytes total) |
+
+#### Why the encoding matters
+
+`JMP unconditional = 0x7C` (bit pattern `01 111 100`), NOT `0x44`.
+
+`0x44` is `JFC` (jump if flag-carry clear) — a **conditional** jump.
+The 8008's group-01 instruction family disambiguates by `ddd` (bits
+5-3): `ddd = 111` is the unconditional variant; `ddd ≤ 011` selects
+one of the four flag-tested conditional jumps.  Emitting `0x44`
+instead of `0x7C` would compile to a jump that silently takes or
+skips based on whichever carry-flag state the silicon happened to
+have at that moment — a debugging nightmare.
+
+This nightmare was caught during implementation by cross-checking
+against the in-tree `intel8008-simulator`, which is the
+crate's authoritative round-trip target.  The new
+`jmp_constant_pinned_to_0x7c` test guards the constant against any
+future copy-paste regression.
+
+#### Two-pass backpatching
+
+The 8008 has no PC-relative addressing — every `jmp` carries a full
+14-bit absolute target.  Pass 1 emits each `jmp` as `0x7C 0x00 0x00`,
+recording the placeholder's byte offset and the target label name.
+Pass 2 walks the table, resolves each label to its byte offset, and
+backpatches the two address bytes:
+
+```
+bytes[slot]     = (target & 0xFF) as u8;       // low byte
+bytes[slot + 1] = ((target >> 8) & 0x3F) as u8; // high byte (6 bits)
+```
+
+The top 2 bits of the high byte are written as zero — the 8008's
+address bus is 14 bits wide, so the silicon ignores them.  Emitting
+clean zeros means downstream disassemblers reproduce the same
+`JMP addr` regardless of how they sign-extend.
+
+Labels are scoped per-function.  Cross-function jumps (which would
+also need module-level resolution like `iir-to-riscv`'s A1++.5.5)
+aren't supported in v0.3.4.
+
+#### New constants + error variants
+
+* `pub const JMP: u8 = 0x7C;` (exposed for round-trip tests downstream)
+* `IIRIntel8008Error::UndefinedLabel { function, label }`
+* `IIRIntel8008Error::AddressOutOfRange { function, address }` —
+  forward-compatibility guard for the 14-bit (16384-byte) address
+  space; not yet triggerable in v0.3.4 because the 7-register
+  allocator caps each function at ~25 bytes.
+
+#### Tests added (32 total, was 27)
+
+* `jmp_constant_pinned_to_0x7c` — guards `JMP` against the easy
+  `0x44 ↔ 0x7C` confusion.
+* `jmp_to_forward_label_backpatches_target_address` — full pinned
+  byte stream including `7C 07 00` for a label at offset 7.
+* `jmp_to_backward_label_backpatches_target_address` — `7C 00 00`
+  for a loop back to offset 0.
+* `jmp_to_undefined_label_is_rejected` — pins the `UndefinedLabel`
+  error variant and message contents.
+* `label_emits_no_bytes` — differential test: a function with vs.
+  without a leading `label` must emit identical byte streams.
+
+`errors_display_without_panic` extended to cover the two new
+variants.
+
+### What is NOT in v0.3.4 (deferred to v0.3.5 / v0.3.6 / A2+++)
+
+* Conditional jumps (`jmp_if_true` / `jmp_if_false`) — 8 opcodes
+  (JFC/JFZ/JFS/JFP and their T-bit complements JTC/JTZ/JTS/JTP),
+  same 3-byte shape but driven by the four 8008 condition flags.
+* `cmp` — needs the conditional-jump infrastructure above to
+  capture the 8008's flag-only CMP result into a register dest.
+* Real `RET` (`0x07`) via `CALL` (`0x7E`, not `0x46`!) + the
+  per-function internal return stack.
+* `lang-aot --target=intel8008` wiring + module-level CALL
+  backpatching — A2+++.
+
 ## [0.3.3] — 2026-06-02 (A2++.5.5 second slice — carry/borrow ALU `adc`/`sbb`)
 
 ### Added — carry-chained accumulator-target ALU

--- a/code/packages/rust/iir-to-intel8008/Cargo.toml
+++ b/code/packages/rust/iir-to-intel8008/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iir-to-intel8008"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
-description = "IIR → Intel 8008 machine code backend (Oct's native target) — lowers IIRModule to a Vec<u8> of 8-bit Intel 8008 opcodes.  v0.3.3 (A2++.5.5 second slice): adds the carry/borrow-chained accumulator ALU ops `adc` (ACA, 10 001 sss = 0x88|sss) and `sbb` (SCA, 10 011 sss = 0x98|sss), enabling multi-byte arithmetic idioms.  `cmp` deferred to v0.3.4 because its IIR semantics (boolean dest) don't match the 8008's flag-only CMP — needs a paired flag-capture sequence wired with the branch ops.  Real RET via CALL/stack still pending (v0.3.5)."
+description = "IIR → Intel 8008 machine code backend (Oct's native target) — lowers IIRModule to a Vec<u8> of 8-bit Intel 8008 opcodes.  v0.3.4 (A2++.5.5 third slice): adds `label` (zero-byte position marker) and unconditional `jmp` (0x7C + 14-bit absolute target) with per-function two-pass backpatching.  CRITICAL: JMP unconditional is 0x7C, NOT 0x44 (which is JFC, the conditional jump-if-flag-carry-clear).  Conditional jumps + `cmp` (with flag-to-bool capture) defer to v0.3.5; real RET/CALL/stack discipline defers to v0.3.6."
 
 [lib]
 name = "iir_to_intel8008"

--- a/code/packages/rust/iir-to-intel8008/src/lib.rs
+++ b/code/packages/rust/iir-to-intel8008/src/lib.rs
@@ -105,6 +105,23 @@ pub const HLT: u8 = 0x76;
 /// immediate byte.
 pub const MVI_A: u8 = 0x3E;
 
+/// Intel 8008 unconditional `JMP addr` first byte — `0x7C`.  Followed
+/// by two address bytes (low byte then high byte) — the 8008 has a
+/// 14-bit address space so only the bottom 6 bits of the high byte are
+/// significant (top 2 bits ignored by the silicon).
+///
+/// Bit pattern: `01 111 100`.  In the group-01 family the disambiguation
+/// is via `ddd` (bits 5-3): `ddd = 111` is the unconditional variant;
+/// `ddd ≤ 011` selects one of the four conditional jump opcodes (JFC,
+/// JFZ, JFS, JFP at `ddd = 000…011`; JTC, JTZ, JTS, JTP at the matching
+/// `01 ccc 100` with T-bit set in `sss`).  Three-byte instruction total.
+///
+/// CAREFUL: it is NOT `0x44` — `0x44` is JFC (jump if flag-carry clear),
+/// a *conditional* jump that the silicon will silently take in unexpected
+/// states.  Pin to `0x7C` so the simulator's disassembler correctly
+/// reports "JMP" and the silicon takes the branch unconditionally.
+pub const JMP: u8 = 0x7C;
+
 // ===========================================================================
 // Intel 8008 register encoding
 // ===========================================================================
@@ -234,6 +251,15 @@ pub enum IIRIntel8008Error {
     /// general-purpose registers (A/B/C/D/E/H/L) can hold.  Stack
     /// spilling lands in a future increment (A2++.5 or later).
     OutOfRegisters { function: String, name: String },
+    /// A `jmp` referenced a label name that wasn't defined by a
+    /// `label` op anywhere in the same function.  Cross-function
+    /// jumps aren't supported — labels are per-function in v0.3.4.
+    UndefinedLabel { function: String, label: String },
+    /// A function emitted more than the 8008's 14-bit address space
+    /// (16384 bytes) — `jmp` targets cannot be encoded.  Practical
+    /// programs are tens to hundreds of bytes so this is a guard
+    /// against runaway expansion, not a real workload concern.
+    AddressOutOfRange { function: String, address: usize },
 }
 
 impl fmt::Display for IIRIntel8008Error {
@@ -256,6 +282,12 @@ impl fmt::Display for IIRIntel8008Error {
             }
             Self::OutOfRegisters { function, name } => {
                 write!(f, "out of 8008 registers (A/B/C/D/E/H/L) while binding {name:?} in function {function:?}; stack spilling not yet supported")
+            }
+            Self::UndefinedLabel { function, label } => {
+                write!(f, "undefined label {label:?} referenced by jmp in function {function:?}")
+            }
+            Self::AddressOutOfRange { function, address } => {
+                write!(f, "function {function:?} grew to address 0x{address:04x}, exceeding the 8008's 14-bit (16384-byte) address space")
             }
         }
     }
@@ -307,6 +339,10 @@ const SUPPORTED_OPS: &[&str] = &[
     "and", "or", "xor",
     // A2++.5.5 second slice — carry/borrow chained ALU
     "adc", "sbb",
+    // A2++.5.5 third slice — labels + unconditional jump (`cmp` and
+    // conditional jumps deferred to v0.3.5; they need flag-to-bool
+    // capture).
+    "label", "jmp",
 ];
 
 pub fn lower_iir_to_intel8008(
@@ -334,6 +370,37 @@ pub fn lower_iir_to_intel8008(
         // shape as v0.2.0 (no redundant `MOV A, X` round-trip).
         let mut env: HashMap<String, u8> = HashMap::new();
         let mut next_reg: usize = 0;
+
+        // ── Per-function label-resolution state (v0.3.4) ──────────────
+        //
+        // The 8008 has no PC-relative addressing — every `jmp` carries
+        // a full 14-bit absolute target.  We emit jumps in pass 1 with
+        // placeholder zero bytes at the address slots, recording
+        // `(slot_byte_offset, target_label)` in `pending_jmps`.  After
+        // the function's instruction list is walked, pass 2 looks up
+        // each pending jmp's label in `labels` and backpatches the two
+        // address bytes (low then high; only the bottom 6 bits of the
+        // high byte are significant — the 8008's address bus is 14
+        // bits wide).
+        //
+        // A `jmp` to a label defined LATER in the function (forward
+        // jump) is the whole point of the two-pass approach — pass 1
+        // can't know the address yet.
+        //
+        // Labels are scoped per-function.  A `jmp` to a label that
+        // isn't defined in the same function surfaces as
+        // `UndefinedLabel`; cross-function jumps (which would also
+        // need module-level call-site resolution like A1++.5.5)
+        // aren't supported in v0.3.4.
+        //
+        // Byte offsets here are *relative to the start of the module*
+        // (not the start of the function), because that's the actual
+        // physical address each instruction will reside at when the
+        // module's `Vec<u8>` is loaded at address 0 in the 8008's
+        // memory map.  For now we assume modules load at address 0;
+        // wider relocation lands with the AOT wiring in A2+++.
+        let mut labels: HashMap<String, usize> = HashMap::new();
+        let mut pending_jmps: Vec<(usize, String)> = Vec::new();
 
         for instr in &f.instructions {
             if !SUPPORTED_OPS.contains(&instr.op.as_str()) {
@@ -470,8 +537,85 @@ pub fn lower_iir_to_intel8008(
                     }
                 }
 
+                // ── label "<name>": record the current byte offset ──────
+                //
+                // Zero bytes emitted.  `label` is purely a marker so a
+                // subsequent (or preceding, via pass-2 backpatching)
+                // `jmp` can resolve to a concrete 14-bit address.
+                //
+                // A duplicate label name overwrites the prior position —
+                // a front-end bug we could catch with a validator pass,
+                // but for v0.3.4 the latest definition wins (mirrors
+                // iir-to-riscv's v0.3.1 semantics).
+                "label" => {
+                    let name = match instr.srcs.first() {
+                        Some(Operand::Var(s)) => s.clone(),
+                        _ => return Err(IIRIntel8008Error::InvalidOperand {
+                            function: f.name.clone(),
+                            detail: "label requires srcs[0] = Operand::Var(name)".into(),
+                        }),
+                    };
+                    labels.insert(name, bytes.len());
+                }
+
+                // ── jmp "<name>": unconditional 3-byte jump (`JMP addr`)
+                //
+                // Pass 1: emit `0x7C` followed by two zero bytes as
+                // placeholders for the 14-bit absolute target.  Record
+                // the offset of the low-address byte so pass 2 can
+                // backpatch in `(addr & 0xFF, (addr >> 8) & 0x3F)`.
+                //
+                // CRITICAL: `JMP` is `0x7C`, NOT `0x44`.  `0x44` is JFC
+                // (jump if flag-carry clear) — a *conditional* jump.
+                // In the 8008's group-01 family the unconditional
+                // variant has `ddd = 111`, encoded as `01 111 100`.
+                "jmp" => {
+                    let target = match instr.srcs.first() {
+                        Some(Operand::Var(s)) => s.clone(),
+                        _ => return Err(IIRIntel8008Error::InvalidOperand {
+                            function: f.name.clone(),
+                            detail: "jmp requires srcs[0] = Operand::Var(target_label)".into(),
+                        }),
+                    };
+                    bytes.push(JMP);
+                    let slot = bytes.len();
+                    bytes.push(0); // low-address placeholder
+                    bytes.push(0); // high-address placeholder
+                    pending_jmps.push((slot, target));
+                }
+
                 _ => unreachable!("SUPPORTED_OPS guard above prevents this"),
             }
+        }
+
+        // ── Pass 2: backpatch pending jmps ────────────────────────────
+        //
+        // Each pending entry is `(low_byte_slot, label_name)`.  Look up
+        // the label's recorded byte position, range-check against the
+        // 14-bit address space (16384 bytes), then write the low byte
+        // and the bottom 6 bits of the high byte at `slot` and
+        // `slot + 1` respectively.
+        //
+        // The top 2 bits of the high address byte are written as zero —
+        // the 8008's address bus is 14 bits wide, so the silicon
+        // ignores them, but emitting clean zeros makes the byte stream
+        // unambiguously disassemble back to the same `JMP addr` even
+        // when downstream tools sign-extend or print all 8 bits.
+        for (slot, label) in pending_jmps {
+            let target = *labels.get(&label).ok_or_else(|| {
+                IIRIntel8008Error::UndefinedLabel {
+                    function: f.name.clone(),
+                    label: label.clone(),
+                }
+            })?;
+            if target >= 1 << 14 {
+                return Err(IIRIntel8008Error::AddressOutOfRange {
+                    function: f.name.clone(),
+                    address: target,
+                });
+            }
+            bytes[slot]     = (target & 0xFF) as u8;
+            bytes[slot + 1] = ((target >> 8) & 0x3F) as u8;
         }
     }
 

--- a/code/packages/rust/iir-to-intel8008/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-intel8008/tests/test_backend.rs
@@ -6,7 +6,7 @@
 use interpreter_ir::{IIRFunction, IIRInstr, IIRModule, Operand};
 use iir_to_intel8008::{
     lower_iir_to_intel8008, validate_for_intel8008,
-    IIRIntel8008Config, IIRIntel8008Error, HLT, MVI_A,
+    IIRIntel8008Config, IIRIntel8008Error, HLT, JMP, MVI_A,
 };
 
 fn module_with(f: IIRFunction) -> IIRModule {
@@ -106,6 +106,13 @@ fn errors_display_without_panic() {
     });
     let _ = format!("{}", IIRIntel8008Error::InvalidOperand {
         function: "f".into(), detail: "bad".into(),
+    });
+    // v0.3.4 — new branch-related variants
+    let _ = format!("{}", IIRIntel8008Error::UndefinedLabel {
+        function: "f".into(), label: "ghost".into(),
+    });
+    let _ = format!("{}", IIRIntel8008Error::AddressOutOfRange {
+        function: "f".into(), address: 0x4000,
     });
 }
 
@@ -599,3 +606,145 @@ fn adc_when_lhs_is_already_in_a_skips_the_staging_mov() {
         HLT,
     ], "self-ADC expected; got: {bytes:02x?}");
 }
+
+// ===========================================================================
+// 10. A2++.5.5 third slice — labels + unconditional jump (`jmp` + backpatching)
+// ===========================================================================
+//
+// The 8008's JMP is a 3-byte absolute-address instruction in family
+// `01 ddd 100`:
+//
+//   JMP unconditional = 01 111 100 = 0x7C    ← what we emit
+//   JFC (carry-clear) = 01 000 100 = 0x40    ← what `0x44` would imply
+//                                              if we got it wrong; pin
+//                                              `JMP` to `0x7C` so the
+//                                              simulator round-trips
+//                                              as unconditional.
+//
+// Two-pass per-function lowering: pass 1 emits each `jmp` as
+// `0x7C 0x00 0x00` and records (slot, target_label).  Pass 2 looks up
+// each pending jmp's target in the per-function `labels` table and
+// backpatches the two address bytes (low then high; the 8008 is
+// little-endian for jump targets and uses 14 bits total — top 2 bits
+// of the high byte are zero/ignored).
+
+#[test]
+fn jmp_constant_pinned_to_0x7c() {
+    // Smoke: the exported JMP constant is the unconditional opcode,
+    // NOT the JFC (0x44) conditional one.  Regression for the easy
+    // mistake of reading the bit pattern `01 000 100` and assuming
+    // `ddd=000` means "unconditional" — it actually means JFC.
+    assert_eq!(JMP, 0x7C,
+        "JMP unconditional should be 0x7C (01 111 100), not 0x44");
+}
+
+#[test]
+fn jmp_to_forward_label_backpatches_target_address() {
+    // const v=42; jmp end; const w=99; label end; ret v
+    //
+    // Pass 1 emits:
+    //   00: MVI A, 0x2A         (3E 2A)
+    //   02: JMP <forward>       (7C ?? ??)
+    //   05: MVI B, 0x63         (06 63)
+    //   07: <label "end" here>
+    //   07: HLT                  (ret of v, v is in A so MOV elided)
+    //
+    // Pass 2: label "end" was recorded at offset 7 (= 0x0007).
+    // The JMP slot is at offset 3 (low) / 4 (high), so they become
+    // 0x07 and 0x00.
+    let f = IIRFunction::new("fwd", vec![], "u8", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(0x2A)], "u8"),
+        IIRInstr::new("jmp",   None,             vec![Operand::Var("end".into())], "void"),
+        IIRInstr::new("const", Some("w".into()), vec![Operand::Int(0x63)], "u8"),
+        IIRInstr::new("label", None,             vec![Operand::Var("end".into())], "void"),
+        IIRInstr::new("ret",   None,             vec![Operand::Var("v".into())], "u8"),
+    ]);
+    let bytes = lower_iir_to_intel8008(&module_with(f), &IIRIntel8008Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![
+        MVI_A, 0x2A,    // 00 01   MVI A, 0x2A
+        JMP,   0x07, 0x00, // 02 03 04   JMP 0x0007
+        0x06,  0x63,    // 05 06   MVI B, 0x63 (unreachable after the jmp)
+        // <-- label "end" lands at offset 7 -->
+        HLT,            // 07      ret v (v is already in A — no MOV)
+    ], "forward jmp expected; got: {bytes:02x?}");
+}
+
+#[test]
+fn jmp_to_backward_label_backpatches_target_address() {
+    // label loop; const v=1; jmp loop; ret_void
+    //
+    // Pass 1:
+    //   00: <label "loop" here>
+    //   00: MVI A, 0x01         (3E 01)
+    //   02: JMP <backward>      (7C ?? ??)
+    //   05: HLT
+    //
+    // Pass 2: "loop" recorded at offset 0.  JMP target = 0x0000.
+    let f = IIRFunction::new("backward", vec![], "void", vec![
+        IIRInstr::new("label", None,             vec![Operand::Var("loop".into())], "void"),
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(0x01)], "u8"),
+        IIRInstr::new("jmp",   None,             vec![Operand::Var("loop".into())], "void"),
+        IIRInstr::new("ret_void", None,          vec![], "void"),
+    ]);
+    let bytes = lower_iir_to_intel8008(&module_with(f), &IIRIntel8008Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![
+        MVI_A, 0x01,    // 00 01   MVI A, 1
+        JMP,   0x00, 0x00, // 02 03 04   JMP 0x0000 (back to top)
+        HLT,            // 05      ret_void (unreachable, but emitted)
+    ], "backward jmp expected; got: {bytes:02x?}");
+}
+
+#[test]
+fn jmp_to_undefined_label_is_rejected() {
+    let f = IIRFunction::new("dangling", vec![], "void", vec![
+        IIRInstr::new("jmp", None, vec![Operand::Var("nowhere".into())], "void"),
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ]);
+    let err = lower_iir_to_intel8008(&module_with(f), &IIRIntel8008Config::default())
+        .expect_err("jmp to nonexistent label should fail");
+    match err {
+        IIRIntel8008Error::UndefinedLabel { function, label } => {
+            assert_eq!(function, "dangling");
+            assert_eq!(label, "nowhere");
+        }
+        other => panic!("expected UndefinedLabel, got: {other:?}"),
+    }
+}
+
+#[test]
+fn label_emits_no_bytes() {
+    // A bare label alone should not emit any bytes — verify by
+    // comparing a const-only function with and without a leading
+    // label: both must produce the same byte stream.
+    let f_bare = IIRFunction::new("bare", vec![], "u8", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(7)], "u8"),
+        IIRInstr::new("ret",   None,             vec![Operand::Var("v".into())], "u8"),
+    ]);
+    let f_labeled = IIRFunction::new("labeled", vec![], "u8", vec![
+        IIRInstr::new("label", None,             vec![Operand::Var("entry".into())], "void"),
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(7)], "u8"),
+        IIRInstr::new("ret",   None,             vec![Operand::Var("v".into())], "u8"),
+    ]);
+    let cfg = IIRIntel8008Config::default();
+    let bare    = lower_iir_to_intel8008(&module_with(f_bare),    &cfg).expect("bare");
+    let labeled = lower_iir_to_intel8008(&module_with(f_labeled), &cfg).expect("labeled");
+    assert_eq!(bare, labeled,
+        "a `label` op must not emit any bytes; bare={bare:02x?} labeled={labeled:02x?}");
+}
+
+// Note on the high-byte split + AddressOutOfRange coverage gap:
+//
+// In v0.3.4 the allocator caps each function at ~25 emitted bytes
+// before exhausting the 7-register pool (the test
+// `allocator_exhaustion_yields_out_of_registers` pins this).  That's
+// nowhere near the 256-byte boundary where the JMP target high byte
+// would become nonzero, let alone the 16384-byte ceiling that would
+// trigger `AddressOutOfRange`.
+//
+// The `AddressOutOfRange` error variant exists for forward
+// compatibility with the stack-spilled future slices that can emit
+// arbitrarily large functions.  The high-byte split itself is plain
+// `(target >> 8) & 0x3F` arithmetic which the two range-tested cases
+// above (`0x0007` and `0x0000`) exercise with their low-byte branches.

--- a/code/specs/iir-to-intel8008.md
+++ b/code/specs/iir-to-intel8008.md
@@ -58,10 +58,34 @@ IIRModule
 | v0.3.0 (A2++) | Linear register allocator over A/B/C/D/E/H/L + multi-register `const` + `mov` + ret-value staging | **merged** |
 | v0.3.1 (A2++.5 first slice) | `add`/`sub` ALU on the accumulator (family `10 ooo sss`) | **merged** |
 | v0.3.2 (A2++.5.5 first slice) | bitwise ALU `and`/`or`/`xor` on the accumulator (same family, `ooo` ∈ {`100`, `110`, `101`}) | **merged** |
-| **v0.3.3 (A2++.5.5 second slice — this PR)** | carry/borrow-chained ALU `adc`/`sbb` (same family, `ooo` ∈ {`001`, `011`}) | this PR |
-| v0.3.4 (A2++.5.5 third slice) | `cmp` (`ooo = 0b111`) + conditional jumps with 14-bit address backpatching — paired because `cmp` produces flag state that's only useful as a branch input | future |
-| v0.3.5 (A2++.5.5 fourth slice) | Real `RET` (`0x07`) via `CALL` (`0x46` + 14-bit address) + per-function internal return-stack discipline | future |
+| v0.3.3 (A2++.5.5 second slice) | carry/borrow-chained ALU `adc`/`sbb` (same family, `ooo` ∈ {`001`, `011`}) | **merged** |
+| **v0.3.4 (A2++.5.5 third slice — this PR)** | `label` (zero-byte position marker) + unconditional `jmp` (**`0x7C`**, NOT `0x44`) with per-function two-pass backpatching of the 14-bit absolute target | this PR |
+| v0.3.5 (A2++.5.5 fourth slice) | Conditional jumps (`jmp_if_true`/`jmp_if_false` over the four 8008 flags) + `cmp` (`ooo = 0b111`) paired with flag-to-bool capture | future |
+| v0.3.6 (A2++.5.5 fifth slice) | Real `RET` (`0x07`) via `CALL` (**`0x7E`**, NOT `0x46` — `0x46` is CFZ) + per-function internal return-stack discipline | future |
 | v0.4.0 (A2+++) | `lang-aot --target=intel8008` wiring + module-level CALL backpatching | future |
+
+## Encoding cheat-sheet for the jump/call family
+
+The 8008's group-01 instruction family packs MOV, HLT, jumps, and
+calls into the same opcode space; disambiguation is via `ddd` (bits
+5-3).  Easy mistakes:
+
+| Mnemonic | Bits | Hex | What it does |
+|----------|------|-----|--------------|
+| `JFC addr` | `01 000 100` | `0x40`* / `0x44`† | Jump if Flag Carry clear (conditional) |
+| `JFZ addr` | `01 001 100` | `0x48` / `0x4C` | Jump if Flag Zero clear (conditional) |
+| `JFS addr` | `01 010 100` | `0x50` / `0x54` | Jump if Flag Sign clear (conditional) |
+| `JFP addr` | `01 011 100` | `0x58` / `0x5C` | Jump if Flag Parity clear (conditional) |
+| `JMP addr` | `01 111 100` | **`0x7C`** | Unconditional jump (this is what `jmp` lowers to) |
+| `CAL addr` | `01 111 110` | **`0x7E`** | Unconditional call (deferred to v0.3.6) |
+| `RET` | `00 000 111` | `0x07` | Unconditional return (deferred to v0.3.6) |
+
+\* The T=0 variant (sss=000) jumps when the flag is clear.<br>
+† The T=1 variant (sss=100) jumps when the flag is set (JTC/JTZ/JTS/JTP).
+
+These are the silicon's actual encodings — pinning them here so
+future slices don't repeat the `0x44 ↔ 0x7C` confusion that nearly
+shipped in v0.3.4.
 
 ## Public surface (v0.1.0)
 


### PR DESCRIPTION
## Summary

- Extends \`iir-to-intel8008\` v0.3.3 → **v0.3.4** with the first control-flow primitive: \`label\` (zero-byte position marker) + unconditional \`jmp\` (3-byte: \`0x7C\` + low addr + high addr).
- Per-function two-pass backpatching: pass 1 emits jmps with placeholder address bytes; pass 2 resolves labels and writes \`(target & 0xFF, (target >> 8) & 0x3F)\` — 14-bit absolute address.
- Tests grow 27 → 32; \`AddressOutOfRange\` error variant added for forward-compat (not yet triggerable due to 7-register cap).
- Spec updated with full encoding cheat-sheet for the 8008 group-01 jump/call family.

### 🚨 Critical encoding finding: JMP = 0x7C, NOT 0x44

\`0x44\` is **JFC** (jump if flag-carry clear) — a *conditional* jump.  In the 8008's group-01 family the disambiguation is via \`ddd\` (bits 5-3): \`ddd = 111\` is the unconditional variant.  Emitting \`0x44\` where we meant JMP would compile to a jump that silently takes or skips based on whichever carry-flag state happened to be live.

Caught by cross-checking against the in-tree \`intel8008-simulator\`.  The new \`jmp_constant_pinned_to_0x7c\` test guards against future regression, and the spec's encoding cheat-sheet now lists every group-01 jump/call opcode side-by-side so the v0.3.6 CALL/RET slice doesn't repeat the same mistake (\`CAL\` is \`0x7E\`, not \`0x46\` — \`0x46\` is \`CFZ\`).

### Lowering shape

| IIR op          | Bytes emitted (pass 1)        | Pass 2 backpatch              |
| --------------- | ----------------------------- | ----------------------------- |
| \`label foo\`   | (none — zero bytes)           | (records foo → bytes.len())   |
| \`jmp foo\`     | \`7C 00 00\` (placeholders)   | writes addr bytes at slot     |

### Deferred to follow-up slices

- **v0.3.5** — conditional jumps (\`jmp_if_true\` / \`jmp_if_false\` over 8 condition opcodes) + \`cmp\` (with flag-to-bool capture paired with the new conditional branch infrastructure).
- **v0.3.6** — real \`RET\` (\`0x07\`) via \`CAL\` (\`0x7E\` + 14-bit addr — NOT \`0x46\`) + per-function internal return-stack discipline.
- **v0.4.0** — \`lang-aot --target=intel8008\` wiring + module-level CALL backpatching.

## Test plan

- [x] \`cargo test -p iir-to-intel8008\` — 32/32 backend tests pass, 1/1 doctest passes
- [x] Forward jump byte stream pinned (label at offset 7)
- [x] Backward jump byte stream pinned (loop-back to offset 0)
- [x] Undefined label surfaces \`UndefinedLabel { function, label }\`
- [x] \`label_emits_no_bytes\` — differential: with/without label produces identical bytes
- [x] Both new error variants display without panicking
- [x] Security review passed (no vulnerabilities found)
- [ ] CI green
- [ ] No merge conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)