### PR TITLE
feat(iir-to-intel8008): boolean conditional jumps (jmp_if_true/false) — A2++.5.5 fourth slice

### DIFF
--- a/code/packages/rust/iir-to-intel8008/CHANGELOG.md
+++ b/code/packages/rust/iir-to-intel8008/CHANGELOG.md
@@ -3,6 +3,82 @@
 All notable changes to this crate are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.3.5] — 2026-06-02 (A2++.5.5 fourth slice — boolean conditional jumps `jmp_if_true`/`jmp_if_false`)
+
+### Added — boolean-conditional control flow
+
+Wires the next control-flow primitive: IIR's boolean branches lower
+to a TEST-A + zero-flag-jump pair on the 8008.  The 8008 has no
+"branch on register" — every conditional jump reads ONE of the four
+CPU flags from the last arithmetic/logical op.  Boolean cond
+variables hold 0 or non-zero, so we provoke the zero flag via
+`ANA A` (the 8008's "TEST A" idiom — same role as `test eax, eax`
+on x86).
+
+| IIR op | 8008 lowering shape |
+|--------|---------------------|
+| `jmp_if_true  cond, L` | (optional `MOV A, cond_reg`) + `ANA A` (`0xA7`) + `JFZ L` (`0x48`) + low/high addr |
+| `jmp_if_false cond, L` | (optional `MOV A, cond_reg`) + `ANA A` (`0xA7`) + `JTZ L` (`0x4C`) + low/high addr |
+
+#### Why JFZ for "true" / JTZ for "false"?
+
+The 8008's zero flag is SET when the last op produced 0.  So:
+- `cond_var == 0` (false) → `ANA A` produces 0 → Z=1
+- `cond_var != 0` (true)  → `ANA A` produces non-zero → Z=0
+
+The mnemonic names mirror this:
+- `JFZ` = Jump if Flag Zero is Clear (Z=0) → branch when cond was true
+- `JTZ` = Jump if Flag Zero is seT  (Z=1) → branch when cond was false
+
+#### Why we even need `ANA A` (TEST A)
+
+`MOV A, cond_reg` does NOT set flags on the 8008 — MOV is
+flag-non-affecting.  Without the `ANA A` flag-setter between the
+load and the conditional jump, JFZ/JTZ would consume STALE flags
+from whatever ALU op last ran.
+
+The `ANA A` is unconditional — emitted even when `cond_reg` is
+already A (in which case the MOV is elided but `ANA A` still runs).
+
+#### New constants
+
+* `pub const JFZ: u8 = 0x48;` — jump if zero flag clear
+* `pub const JTZ: u8 = 0x4C;` — jump if zero flag set
+
+Both pinned in their own tests.  Bit patterns spelled out so the
+v0.3.6 slice (which adds the other 6 flag opcodes) doesn't get the
+nibbling wrong.
+
+#### Tests added (38 total, was 32)
+
+* `jfz_constant_pinned_to_0x48`
+* `jtz_constant_pinned_to_0x4c`
+* `jmp_if_true_emits_ana_a_then_jfz_with_backpatched_target` — full
+  pinned byte stream including `A7 48 08 00`.
+* `jmp_if_false_emits_ana_a_then_jtz_with_backpatched_target` —
+  `A7 4C 08 00`.
+* `jmp_if_true_with_cond_not_in_a_emits_staging_mov` — exercises
+  the optional `MOV A, B` (`0x78`) staging path.
+* `jmp_if_true_to_undefined_label_is_rejected` — confirms the
+  existing `UndefinedLabel` error path reaches these new ops via
+  the same two-pass backpatcher.
+
+### What is NOT in v0.3.5 (deferred to v0.3.6 / v0.3.7 / A2+++)
+
+* `cmp` — the 8008's CMP (`ooo = 0b111`) sets flags and discards
+  the difference; lowering needs a flag-to-bool capture sequence
+  using a conditional jump over an `MVI dest, 0/1` pair.  Paired
+  with the other flag-jump opcodes in v0.3.6 so the same
+  capture machinery is reused.
+* The other 6 conditional-jump opcodes: `JFC` (`0x40`), `JTC`
+  (`0x44`), `JFS` (`0x50`), `JTS` (`0x54`), `JFP` (`0x58`),
+  `JTP` (`0x5C`).  Useful once `cmp` and the carry-flag-producing
+  ALU sequences need them.
+* Real `RET` (`0x07`) via `CAL` (`0x7E` — NOT `0x46` which is
+  CFZ) + the internal return stack.  Lands in v0.3.7.
+* `lang-aot --target=intel8008` wiring + module-level CALL
+  backpatching — A2+++.
+
 ## [0.3.4] — 2026-06-02 (A2++.5.5 third slice — `label` + unconditional `jmp` + two-pass backpatching)
 
 ### Added — control flow primitive (unconditional jump)

--- a/code/packages/rust/iir-to-intel8008/Cargo.toml
+++ b/code/packages/rust/iir-to-intel8008/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iir-to-intel8008"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
-description = "IIR → Intel 8008 machine code backend (Oct's native target) — lowers IIRModule to a Vec<u8> of 8-bit Intel 8008 opcodes.  v0.3.4 (A2++.5.5 third slice): adds `label` (zero-byte position marker) and unconditional `jmp` (0x7C + 14-bit absolute target) with per-function two-pass backpatching.  CRITICAL: JMP unconditional is 0x7C, NOT 0x44 (which is JFC, the conditional jump-if-flag-carry-clear).  Conditional jumps + `cmp` (with flag-to-bool capture) defer to v0.3.5; real RET/CALL/stack discipline defers to v0.3.6."
+description = "IIR → Intel 8008 machine code backend (Oct's native target) — lowers IIRModule to a Vec<u8> of 8-bit Intel 8008 opcodes.  v0.3.5 (A2++.5.5 fourth slice): adds boolean conditional branches `jmp_if_true` (ANA A + JFZ 0x48) and `jmp_if_false` (ANA A + JTZ 0x4C).  The 8008's TEST-A idiom (`ANA A` = `0xA7`) provokes the zero flag from the cond register so the family-01 zero-flag branch can fire.  `cmp` and the remaining 6 conditional-flag opcodes (JFC/JTC/JFS/JTS/JFP/JTP) defer to v0.3.6; real RET/CALL/stack defers to v0.3.7."
 
 [lib]
 name = "iir_to_intel8008"

--- a/code/packages/rust/iir-to-intel8008/src/lib.rs
+++ b/code/packages/rust/iir-to-intel8008/src/lib.rs
@@ -105,6 +105,24 @@ pub const HLT: u8 = 0x76;
 /// immediate byte.
 pub const MVI_A: u8 = 0x3E;
 
+/// Intel 8008 conditional `JFZ addr` (jump if flag-zero clear) first
+/// byte — `0x48`.  Three-byte instruction (`JFZ` + low addr + high addr).
+///
+/// Bit pattern: `01 001 000` (jump family `01 ccc T 00`, where
+/// `ccc = 001 = zero flag` and `T = 0 = jump if flag is *clear*`).
+/// "Flag clear" for the zero flag means the last arithmetic/logical
+/// op produced a NON-zero result.  So `JFZ` is the "jump if true"
+/// half of a boolean test.
+pub const JFZ: u8 = 0x48;
+
+/// Intel 8008 conditional `JTZ addr` (jump if flag-zero set) first
+/// byte — `0x4C`.  Three-byte instruction.
+///
+/// Bit pattern: `01 001 100` (`ccc = 001 = zero`, `T = 1 = jump if
+/// flag is *set*`).  "Flag set" means the last op produced a zero
+/// result, so `JTZ` is the "jump if false" half.
+pub const JTZ: u8 = 0x4C;
+
 /// Intel 8008 unconditional `JMP addr` first byte — `0x7C`.  Followed
 /// by two address bytes (low byte then high byte) — the 8008 has a
 /// 14-bit address space so only the bottom 6 bits of the high byte are
@@ -339,10 +357,12 @@ const SUPPORTED_OPS: &[&str] = &[
     "and", "or", "xor",
     // A2++.5.5 second slice — carry/borrow chained ALU
     "adc", "sbb",
-    // A2++.5.5 third slice — labels + unconditional jump (`cmp` and
-    // conditional jumps deferred to v0.3.5; they need flag-to-bool
-    // capture).
+    // A2++.5.5 third slice — labels + unconditional jump.
     "label", "jmp",
+    // A2++.5.5 fourth slice — boolean-conditional jumps (just the
+    // zero-flag pair JFZ/JTZ; the remaining 6 flag opcodes and
+    // `cmp` defer to v0.3.6).
+    "jmp_if_true", "jmp_if_false",
 ];
 
 pub fn lower_iir_to_intel8008(
@@ -578,6 +598,73 @@ pub fn lower_iir_to_intel8008(
                         }),
                     };
                     bytes.push(JMP);
+                    let slot = bytes.len();
+                    bytes.push(0); // low-address placeholder
+                    bytes.push(0); // high-address placeholder
+                    pending_jmps.push((slot, target));
+                }
+
+                // ── jmp_if_true / jmp_if_false ─────────────────────────
+                //
+                // Operand layout: srcs = [Var(cond), Var(target_label)].
+                //
+                // The 8008 has no "branch on register" — every
+                // conditional branch reads ONE of the four CPU flags
+                // (carry, zero, sign, parity) set by the LAST
+                // arithmetic/logical op.  To branch on a boolean
+                // register's value we have to provoke a flag from it:
+                //
+                //   MOV A, cond_reg   ; load cond into A (skipped if
+                //                     ; cond already in A — MOV is
+                //                     ; flag-non-affecting on 8008)
+                //   ANA A             ; A := A & A (no change), sets
+                //                     ; Z flag from A's value
+                //   JFZ target        ; if Z==0 (A was non-zero, i.e.
+                //                     ; cond was true)  → jump
+                //   JTZ target        ; if Z==1 (A was zero, i.e.
+                //                     ; cond was false) → jump
+                //
+                // ANA A (`0xA7`) is the canonical 8008 "TEST A"
+                // idiom — same role as `test eax, eax` on x86.
+                //
+                // The MOV is elided when cond_reg is already A,
+                // which is common when this branch immediately
+                // follows the cond's producer (e.g. an `add` that
+                // landed in A).
+                //
+                // Choice of JFZ for "true" / JTZ for "false":
+                //   Z=1 iff A==0 iff cond is the boolean "false".
+                //   So we jump-if-false on JTZ ("zero flag SET")
+                //   and jump-if-true  on JFZ ("zero flag CLEAR").
+                "jmp_if_true" | "jmp_if_false" => {
+                    let cond_name = match instr.srcs.first() {
+                        Some(Operand::Var(s)) => s.clone(),
+                        _ => return Err(IIRIntel8008Error::InvalidOperand {
+                            function: f.name.clone(),
+                            detail: format!("{} requires srcs[0] = Operand::Var(cond)", instr.op),
+                        }),
+                    };
+                    let target = match instr.srcs.get(1) {
+                        Some(Operand::Var(s)) => s.clone(),
+                        _ => return Err(IIRIntel8008Error::InvalidOperand {
+                            function: f.name.clone(),
+                            detail: format!("{} requires srcs[1] = Operand::Var(target_label)", instr.op),
+                        }),
+                    };
+                    let cond_reg = lookup_register(&env, &cond_name, &f.name)?;
+                    // Stage cond into A if not already there.
+                    if cond_reg != REG_A {
+                        bytes.push(encode_mov(REG_A, cond_reg));
+                    }
+                    // ANA A — sets Z flag from A's current value (TEST idiom).
+                    bytes.push(encode_alu(ALU_AND, REG_A));
+                    // The branch opcode encodes the polarity.
+                    let branch_opcode = if instr.op == "jmp_if_true" {
+                        JFZ // jump if Z clear (cond was non-zero / true)
+                    } else {
+                        JTZ // jump if Z set (cond was zero / false)
+                    };
+                    bytes.push(branch_opcode);
                     let slot = bytes.len();
                     bytes.push(0); // low-address placeholder
                     bytes.push(0); // high-address placeholder

--- a/code/packages/rust/iir-to-intel8008/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-intel8008/tests/test_backend.rs
@@ -6,7 +6,7 @@
 use interpreter_ir::{IIRFunction, IIRInstr, IIRModule, Operand};
 use iir_to_intel8008::{
     lower_iir_to_intel8008, validate_for_intel8008,
-    IIRIntel8008Config, IIRIntel8008Error, HLT, JMP, MVI_A,
+    IIRIntel8008Config, IIRIntel8008Error, HLT, JFZ, JMP, JTZ, MVI_A,
 };
 
 fn module_with(f: IIRFunction) -> IIRModule {
@@ -732,6 +732,146 @@ fn label_emits_no_bytes() {
     let labeled = lower_iir_to_intel8008(&module_with(f_labeled), &cfg).expect("labeled");
     assert_eq!(bare, labeled,
         "a `label` op must not emit any bytes; bare={bare:02x?} labeled={labeled:02x?}");
+}
+
+// ===========================================================================
+// 11. A2++.5.5 fourth slice — boolean conditional jumps (jmp_if_true/false)
+// ===========================================================================
+//
+// The 8008 has no "branch on register" — every conditional jump
+// reads ONE of the four CPU flags (carry/zero/sign/parity) from the
+// last arithmetic/logical op.  To branch on a boolean register's
+// value we provoke the zero flag via `ANA A` (the 8008's "TEST A"
+// idiom), then JFZ ("jump if Z clear" → cond was non-zero / true) or
+// JTZ ("jump if Z set" → cond was zero / false).
+//
+// Lowering shape:
+//
+//   [optional]  MOV A, cond_reg     ; skipped when cond_reg == A
+//               ANA A    (0xA7)     ; sets Z from A's value
+//               JFZ/JTZ target      ; 3-byte conditional jump
+//
+// Opcode constants pinned in their own tests below to guard against
+// any future copy-paste regression in the family-01 jump table.
+
+#[test]
+fn jfz_constant_pinned_to_0x48() {
+    // JFZ = 01 001 000 (ccc=001 zero, T=0 clear)
+    assert_eq!(JFZ, 0x48,
+        "JFZ (jump if zero clear) should be 0x48; got 0x{:02x}", JFZ);
+}
+
+#[test]
+fn jtz_constant_pinned_to_0x4c() {
+    // JTZ = 01 001 100 (ccc=001 zero, T=1 set)
+    assert_eq!(JTZ, 0x4C,
+        "JTZ (jump if zero set) should be 0x4C; got 0x{:02x}", JTZ);
+}
+
+#[test]
+fn jmp_if_true_emits_ana_a_then_jfz_with_backpatched_target() {
+    // const cond=1; jmp_if_true cond, end; const x=0; label end; ret_void
+    //
+    // cond → A (first const).  No staging MOV needed.
+    //
+    //   00,01: MVI A, 1       (3E 01)
+    //   02:    ANA A          (A7) — set Z from A=1 → Z=0
+    //   03:    JFZ <fwd>      (48 ?? ??)
+    //   06,07: MVI B, 0       (06 00)  unreachable
+    //   <-- label "end" at offset 8 -->
+    //   08:    HLT
+    let f = IIRFunction::new("if_true", vec![], "void", vec![
+        IIRInstr::new("const", Some("cond".into()), vec![Operand::Int(1)], "bool"),
+        IIRInstr::new("jmp_if_true", None,
+            vec![Operand::Var("cond".into()), Operand::Var("end".into())], "void"),
+        IIRInstr::new("const", Some("x".into()), vec![Operand::Int(0)], "u8"),
+        IIRInstr::new("label", None, vec![Operand::Var("end".into())], "void"),
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ]);
+    let bytes = lower_iir_to_intel8008(&module_with(f), &IIRIntel8008Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![
+        MVI_A, 0x01,    // 00 01    cond=1 → A
+        0xA7,           // 02       ANA A (TEST A) — sets Z=0
+        JFZ,  0x08, 0x00, // 03 04 05  JFZ 0x0008
+        0x06, 0x00,     // 06 07    MVI B, 0 (unreachable)
+        // label "end" lands at offset 8
+        HLT,            // 08
+    ], "jmp_if_true expected; got: {bytes:02x?}");
+}
+
+#[test]
+fn jmp_if_false_emits_ana_a_then_jtz_with_backpatched_target() {
+    // const cond=0; jmp_if_false cond, end; const x=99; label end; ret_void
+    let f = IIRFunction::new("if_false", vec![], "void", vec![
+        IIRInstr::new("const", Some("cond".into()), vec![Operand::Int(0)], "bool"),
+        IIRInstr::new("jmp_if_false", None,
+            vec![Operand::Var("cond".into()), Operand::Var("end".into())], "void"),
+        IIRInstr::new("const", Some("x".into()), vec![Operand::Int(99)], "u8"),
+        IIRInstr::new("label", None, vec![Operand::Var("end".into())], "void"),
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ]);
+    let bytes = lower_iir_to_intel8008(&module_with(f), &IIRIntel8008Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![
+        MVI_A, 0x00,    // 00 01    cond=0 → A
+        0xA7,           // 02       ANA A — Z=1
+        JTZ,  0x08, 0x00, // 03 04 05  JTZ 0x0008
+        0x06, 0x63,     // 06 07    MVI B, 99 (unreachable)
+        HLT,            // 08
+    ], "jmp_if_false expected; got: {bytes:02x?}");
+}
+
+#[test]
+fn jmp_if_true_with_cond_not_in_a_emits_staging_mov() {
+    // const v=1 → A; const cond=0 → B; jmp_if_true cond, end; ret_void
+    //
+    // cond is in B, not A → need MOV A, B before ANA A.
+    //
+    //   00,01: MVI A, 1   (v) → A
+    //   02,03: MVI B, 0   (cond) → B
+    //   04:    MOV A, B   (stage cond into A)        = 0x78
+    //   05:    ANA A      = 0xA7
+    //   06:    JFZ end    = 0x48 ?? ??
+    //   <-- label end at offset 9 -->
+    //   09:    HLT
+    let f = IIRFunction::new("if_b", vec![], "void", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(1)], "u8"),
+        IIRInstr::new("const", Some("cond".into()), vec![Operand::Int(0)], "bool"),
+        IIRInstr::new("jmp_if_true", None,
+            vec![Operand::Var("cond".into()), Operand::Var("end".into())], "void"),
+        IIRInstr::new("label", None, vec![Operand::Var("end".into())], "void"),
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ]);
+    let bytes = lower_iir_to_intel8008(&module_with(f), &IIRIntel8008Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![
+        MVI_A, 0x01,    // 00 01    v=1 → A
+        0x06,  0x00,    // 02 03    cond=0 → B
+        0x78,           // 04       MOV A, B (stage cond)
+        0xA7,           // 05       ANA A
+        JFZ,  0x09, 0x00, // 06 07 08  JFZ 0x0009
+        HLT,            // 09
+    ], "jmp_if_true with staging MOV expected; got: {bytes:02x?}");
+}
+
+#[test]
+fn jmp_if_true_to_undefined_label_is_rejected() {
+    let f = IIRFunction::new("dangling_cond", vec![], "void", vec![
+        IIRInstr::new("const", Some("cond".into()), vec![Operand::Int(1)], "bool"),
+        IIRInstr::new("jmp_if_true", None,
+            vec![Operand::Var("cond".into()), Operand::Var("nowhere".into())], "void"),
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ]);
+    let err = lower_iir_to_intel8008(&module_with(f), &IIRIntel8008Config::default())
+        .expect_err("jmp_if_true to nonexistent label should fail");
+    match err {
+        IIRIntel8008Error::UndefinedLabel { function, label } => {
+            assert_eq!(function, "dangling_cond");
+            assert_eq!(label, "nowhere");
+        }
+        other => panic!("expected UndefinedLabel, got: {other:?}"),
+    }
 }
 
 // Note on the high-byte split + AddressOutOfRange coverage gap:

--- a/code/specs/iir-to-intel8008.md
+++ b/code/specs/iir-to-intel8008.md
@@ -59,9 +59,10 @@ IIRModule
 | v0.3.1 (A2++.5 first slice) | `add`/`sub` ALU on the accumulator (family `10 ooo sss`) | **merged** |
 | v0.3.2 (A2++.5.5 first slice) | bitwise ALU `and`/`or`/`xor` on the accumulator (same family, `ooo` ∈ {`100`, `110`, `101`}) | **merged** |
 | v0.3.3 (A2++.5.5 second slice) | carry/borrow-chained ALU `adc`/`sbb` (same family, `ooo` ∈ {`001`, `011`}) | **merged** |
-| **v0.3.4 (A2++.5.5 third slice — this PR)** | `label` (zero-byte position marker) + unconditional `jmp` (**`0x7C`**, NOT `0x44`) with per-function two-pass backpatching of the 14-bit absolute target | this PR |
-| v0.3.5 (A2++.5.5 fourth slice) | Conditional jumps (`jmp_if_true`/`jmp_if_false` over the four 8008 flags) + `cmp` (`ooo = 0b111`) paired with flag-to-bool capture | future |
-| v0.3.6 (A2++.5.5 fifth slice) | Real `RET` (`0x07`) via `CALL` (**`0x7E`**, NOT `0x46` — `0x46` is CFZ) + per-function internal return-stack discipline | future |
+| v0.3.4 (A2++.5.5 third slice) | `label` (zero-byte position marker) + unconditional `jmp` (**`0x7C`**, NOT `0x44`) with per-function two-pass backpatching | **merged** |
+| **v0.3.5 (A2++.5.5 fourth slice — this PR)** | Boolean conditional jumps `jmp_if_true` (`ANA A` + `JFZ` `0x48`) and `jmp_if_false` (`ANA A` + `JTZ` `0x4C`); the 8008's TEST-A idiom provokes the zero flag from a boolean cond register | this PR |
+| v0.3.6 (A2++.5.5 fifth slice) | `cmp` (`CMP` = `0xB8\|sss`, `ooo = 0b111`) with flag-to-bool capture, plus the remaining 6 conditional-flag opcodes (JFC/JTC/JFS/JTS/JFP/JTP) once cmp's machinery is wired | future |
+| v0.3.7 (A2++.5.5 sixth slice) | Real `RET` (`0x07`) via `CAL` (**`0x7E`**, NOT `0x46` — `0x46` is `CFZ`) + per-function internal return-stack discipline | future |
 | v0.4.0 (A2+++) | `lang-aot --target=intel8008` wiring + module-level CALL backpatching | future |
 
 ## Encoding cheat-sheet for the jump/call family


### PR DESCRIPTION
## Summary

- Extends \`iir-to-intel8008\` v0.3.4 → **v0.3.5** with boolean conditional branches: \`jmp_if_true\` and \`jmp_if_false\`.
- The 8008 has no branch-on-register, so we provoke the zero flag from the cond register via \`ANA A\` (the 8008's TEST-A idiom, same role as \`test eax, eax\` on x86), then JFZ/JTZ.
- Reuses v0.3.4's two-pass backpatcher unchanged — same \`UndefinedLabel\` error path, same 14-bit \`AddressOutOfRange\` guard.
- Tests grow 32 → 38, including the staging-MOV path when the cond is not already in A.

### Lowering shape

| IIR op                  | 8008 byte stream                                |
| ----------------------- | ----------------------------------------------- |
| \`jmp_if_true cond, L\`  | (\`MOV A, cond\`?) + \`ANA A\` (\`0xA7\`) + \`JFZ\` (\`0x48\`) + low/hi addr |
| \`jmp_if_false cond, L\` | (\`MOV A, cond\`?) + \`ANA A\` (\`0xA7\`) + \`JTZ\` (\`0x4C\`) + low/hi addr |

### Why JFZ for "true", JTZ for "false"?

The 8008's zero flag is SET when the last op produced 0.  So:
- cond == 0 (false) → \`ANA A\` produces 0 → Z=1
- cond != 0 (true)  → \`ANA A\` produces non-zero → Z=0

The mnemonic names mirror this:
- \`JFZ\` = "jump if F-zero clear" (Z=0) → branch when cond was **true**
- \`JTZ\` = "jump if T-zero set"   (Z=1) → branch when cond was **false**

### Why we need ANA A even when cond is already in A

\`MOV A, cond_reg\` does NOT set flags on the 8008.  Without \`ANA A\` between the load and the conditional jump, JFZ/JTZ would consume STALE flags from whatever ALU op last ran.  So \`ANA A\` (0xA7) is emitted unconditionally — even when the MOV is elided.

### Deferred to follow-up slices

- **v0.3.6** — \`cmp\` (\`0xB8\|sss\`) + flag-to-bool capture + remaining 6 cond-jump opcodes (JFC/JTC/JFS/JTS/JFP/JTP).  Paired because \`cmp\` needs the cond-jump infrastructure for capture.
- **v0.3.7** — real \`RET\` (\`0x07\`) via \`CAL\` (\`0x7E\`, NOT \`0x46\` — \`0x46\` is CFZ) + per-function internal return-stack discipline.
- **v0.4.0** — \`lang-aot --target=intel8008\` wiring + module-level CALL backpatching.

## Test plan

- [x] \`cargo test -p iir-to-intel8008\` — 38/38 backend tests pass, 1/1 doctest passes
- [x] Both new opcode constants pinned (JFZ=0x48, JTZ=0x4C)
- [x] Full byte stream pinned for jmp_if_true (\`A7 48 08 00\`) and jmp_if_false (\`A7 4C 08 00\`)
- [x] Staging-MOV path tested (cond in B → \`MOV A, B\` = \`0x78\`)
- [x] Undefined-label error path verified
- [x] Security review passed (no vulnerabilities found)
- [ ] CI green
- [ ] No merge conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)