### PR TITLE
feat(iir-to-intel8008): cmp equality w/ flag-to-bool capture — A2++.5.5 fifth slice

### DIFF
--- a/code/packages/rust/iir-to-intel8008/CHANGELOG.md
+++ b/code/packages/rust/iir-to-intel8008/CHANGELOG.md
@@ -3,6 +3,85 @@
 All notable changes to this crate are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.3.6] — 2026-06-02 (A2++.5.5 fifth slice — `cmp` equality with flag-to-bool capture)
+
+### Added — boolean equality comparison
+
+Wires IIR's `cmp dest, a, b` (which produces a boolean `dest = (a == b) ? 1 : 0`)
+to the 8008's `CMP` instruction + an inline flag-to-bool capture
+sequence.  CMP (family `10 111 sss` = `0xB8 | sss`) computes `A - r`,
+sets `Z = 1 iff A == r`, and DISCARDS the difference — so without
+a capture sequence the comparison result would be invisible to
+the rest of the program.
+
+#### Lowering shape
+
+```text
+[optional]  MOV A, a_reg               ; stage left source if not in A
+            CMP b_reg     (0xB8|sss)   ; sets Z
+            MVI dest, 0                ; default false (2 bytes)
+            JFZ <fallthrough>          ; if Z=0 (a != b), skip overwrite
+            MVI dest, 1                ; Z=1 path (a == b) → true
+            <-- fallthrough -->
+```
+
+Total: 8 bytes when `a` is already in A, 9 bytes with the staging MOV.
+
+#### Why an inline forward-JFZ instead of the two-pass backpatcher?
+
+The JFZ's target is always a fixed +4-byte forward offset from the
+JFZ opcode itself.  We can compute it at emit time (`target =
+bytes.len() + 4`) and write the address bytes directly — no need
+to push a `(slot, label)` tuple into `pending_jmps` and resolve
+later.  Benefits:
+
+1. **No synthetic label pollution.**  The user-visible `labels`
+   map stays clean — no `__cmp_skip_0` / `__cmp_skip_1` names
+   leaking through.
+2. **No dependency on the two-pass machinery.**  The capture
+   sequence is fully self-contained and could move into a helper
+   function later without disturbing the backpatcher's invariants.
+3. **Smaller error surface.**  No risk of a synthetic label
+   accidentally colliding with a user label.
+
+The `AddressOutOfRange` check still runs (the inline computed
+target could in principle exceed 14 bits in a hypothetical very
+large function — not reachable today with the 7-register cap, but
+the guard is cheap and consistent with `jmp`'s).
+
+#### New opcode constant (internal)
+
+* `const ALU_CMP: u8 = 0b111;` — the `ooo` selector for `CMP r`
+  (`encode_alu(ALU_CMP, sss) = 0xB8 | sss`).  Internal; no public
+  `CMP` constant exposed because CMP's byte varies with `sss` —
+  callers should compute via `encode_alu` if they need to.
+
+#### Tests added (42 total, was 38)
+
+* `cmp_equal_pins_full_capture_byte_stream` — pinned 14-byte
+  sequence including `B8 0E 00 48 0C 00 0E 01` (the CMP + capture).
+* `cmp_with_lhs_not_in_a_emits_staging_mov` — exercises the
+  optional `MOV A, B` staging path; pins `CMP C = 0xB9`.
+* `cmp_with_same_register_emits_cmp_a_then_capture` — `cmp r v v`
+  case; pins `CMP A = 0xBF`.
+* `cmp_followed_by_jmp_if_true_composes_correctly` — cross-slice
+  composition test: cmp + v0.3.5's `jmp_if_true` produce the
+  expected interleaved byte stream.
+
+### What is NOT in v0.3.6 (deferred to v0.3.7 / v0.3.8 / A2+++)
+
+* Less-than / greater-than / less-than-or-equal / etc — need the
+  sign + carry flags from CMP, and pair with the other 6
+  conditional-jump opcodes for the capture machinery.  Wired in
+  v0.3.7.
+* The remaining 6 conditional-jump opcodes: `JFC` (`0x40`),
+  `JTC` (`0x44`), `JFS` (`0x50`), `JTS` (`0x54`), `JFP` (`0x58`),
+  `JTP` (`0x5C`).  Land alongside lt/gt/etc.
+* Real `RET` (`0x07`) via `CAL` (`0x7E`, NOT `0x46` which is CFZ)
+  + per-function internal return-stack discipline — v0.3.8.
+* `lang-aot --target=intel8008` wiring + module-level CALL
+  backpatching — A2+++.
+
 ## [0.3.5] — 2026-06-02 (A2++.5.5 fourth slice — boolean conditional jumps `jmp_if_true`/`jmp_if_false`)
 
 ### Added — boolean-conditional control flow

--- a/code/packages/rust/iir-to-intel8008/Cargo.toml
+++ b/code/packages/rust/iir-to-intel8008/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iir-to-intel8008"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2021"
-description = "IIR → Intel 8008 machine code backend (Oct's native target) — lowers IIRModule to a Vec<u8> of 8-bit Intel 8008 opcodes.  v0.3.5 (A2++.5.5 fourth slice): adds boolean conditional branches `jmp_if_true` (ANA A + JFZ 0x48) and `jmp_if_false` (ANA A + JTZ 0x4C).  The 8008's TEST-A idiom (`ANA A` = `0xA7`) provokes the zero flag from the cond register so the family-01 zero-flag branch can fire.  `cmp` and the remaining 6 conditional-flag opcodes (JFC/JTC/JFS/JTS/JFP/JTP) defer to v0.3.6; real RET/CALL/stack defers to v0.3.7."
+description = "IIR → Intel 8008 machine code backend (Oct's native target) — lowers IIRModule to a Vec<u8> of 8-bit Intel 8008 opcodes.  v0.3.6 (A2++.5.5 fifth slice): adds `cmp` (equality test) using the 8008's CMP (family `10 111 sss` = `0xB8|sss`, sets Z=1 iff A==r and DISCARDS the difference) with an inline flag-to-bool capture sequence (MVI dest,0; JFZ +4; MVI dest,1).  The capture's forward JFZ is computed inline (NOT via the two-pass backpatcher) so the sequence stays self-contained.  Less-than/greater-than (which need sign + carry flags) and the remaining 6 conditional-jump opcodes defer to v0.3.7; real RET/CAL/stack defers to v0.3.8."
 
 [lib]
 name = "iir_to_intel8008"

--- a/code/packages/rust/iir-to-intel8008/src/lib.rs
+++ b/code/packages/rust/iir-to-intel8008/src/lib.rs
@@ -207,12 +207,9 @@ const ALU_SBB: u8 = 0b011; // SCA r (sub with borrow-in)
 const ALU_AND: u8 = 0b100; // ANA r (logical AND)
 const ALU_XOR: u8 = 0b101; // XRA r (logical XOR)
 const ALU_OR:  u8 = 0b110; // ORA r (logical OR)
-// ALU_CMP = 0b111 lives in the v0.3.4 slice — `cmp` produces a
-// boolean dest at the IIR level but the 8008 CMP only sets flags
-// (discards the difference), so the lowering needs an extra
-// flag-to-register capture sequence (typically a conditional load
-// or a paired conditional jump).  That's wired alongside the
-// branch ops, not here.
+const ALU_CMP: u8 = 0b111; // CMP r — A - r, sets flags, DISCARDS result.
+                           // Z=1 iff A == r.  Wired in v0.3.6 with a
+                           // flag-to-bool capture sequence using JFZ.
 
 // ===========================================================================
 // IIRIntel8008Config
@@ -360,9 +357,11 @@ const SUPPORTED_OPS: &[&str] = &[
     // A2++.5.5 third slice — labels + unconditional jump.
     "label", "jmp",
     // A2++.5.5 fourth slice — boolean-conditional jumps (just the
-    // zero-flag pair JFZ/JTZ; the remaining 6 flag opcodes and
-    // `cmp` defer to v0.3.6).
+    // zero-flag pair JFZ/JTZ; the remaining 6 flag opcodes defer to
+    // v0.3.7).
     "jmp_if_true", "jmp_if_false",
+    // A2++.5.5 fifth slice — equality comparison with flag-to-bool capture.
+    "cmp",
 ];
 
 pub fn lower_iir_to_intel8008(
@@ -567,6 +566,89 @@ pub fn lower_iir_to_intel8008(
                 // a front-end bug we could catch with a validator pass,
                 // but for v0.3.4 the latest definition wins (mirrors
                 // iir-to-riscv's v0.3.1 semantics).
+                // ── cmp dest, a, b → boolean equality test ────────────
+                //
+                // IIR-level `cmp dest, a, b` produces a boolean
+                // (`dest = (a == b) ? 1 : 0`).  The 8008's CMP
+                // (family `10 111 sss` = `0xB8 | sss`) computes
+                // `A - r`, sets the zero flag (`Z = 1 iff A == r`),
+                // and *discards* the difference.  So we need a
+                // flag-to-register capture sequence after CMP.
+                //
+                // Lowering shape (8 bytes when a is already in A,
+                // 9 when it isn't):
+                //
+                //   [optional]  MOV A, a_reg           ; stage a
+                //   CMP b_reg     (0xB8 | b_reg)       ; sets Z
+                //   MVI dest, 0                        ; default false
+                //   JFZ <fallthrough>                  ; Z=0 (a != b) → skip overwrite
+                //   MVI dest, 1                        ; Z=1 (a == b) → set true
+                //   <-- fallthrough lives here -->
+                //
+                // The JFZ's target is computed inline (NOT via the
+                // two-pass `pending_jmps` mechanism) because:
+                //   - The target is always a fixed +4-byte forward
+                //     offset from the JFZ instruction itself, so it
+                //     can be resolved at emit time.
+                //   - This keeps the capture sequence fully
+                //     self-contained — no synthetic label names
+                //     leaking into the user-visible `labels` map.
+                //
+                // Note: only EQUALITY (`a == b`) is supported in
+                // v0.3.6.  Less-than / greater-than need the sign +
+                // carry flags and land with the other 6 conditional
+                // jump opcodes in v0.3.7.
+                "cmp" => {
+                    let dest = require_dest(instr, "cmp", &f.name)?;
+                    let a_name = match instr.srcs.first() {
+                        Some(Operand::Var(s)) => s.clone(),
+                        _ => return Err(IIRIntel8008Error::InvalidOperand {
+                            function: f.name.clone(),
+                            detail: "cmp srcs[0] must be Var".into(),
+                        }),
+                    };
+                    let b_name = match instr.srcs.get(1) {
+                        Some(Operand::Var(s)) => s.clone(),
+                        _ => return Err(IIRIntel8008Error::InvalidOperand {
+                            function: f.name.clone(),
+                            detail: "cmp srcs[1] must be Var".into(),
+                        }),
+                    };
+                    let a_reg = lookup_register(&env, &a_name, &f.name)?;
+                    let b_reg = lookup_register(&env, &b_name, &f.name)?;
+                    // Stage a into A if needed.
+                    if a_reg != REG_A {
+                        bytes.push(encode_mov(REG_A, a_reg));
+                    }
+                    // CMP b_reg — sets Z=1 iff A == b_reg.
+                    bytes.push(encode_alu(ALU_CMP, b_reg));
+                    // Allocate dest_reg and emit the flag-to-bool capture.
+                    let dest_reg = alloc_register(&mut next_reg, dest, &mut env, &f.name)?;
+                    // MVI dest_reg, 0 — default (false).
+                    bytes.push(encode_mvi(dest_reg));
+                    bytes.push(0);
+                    // JFZ <fallthrough> — if Z clear (a != b), skip the
+                    // "set true" path so dest stays 0.
+                    bytes.push(JFZ);
+                    // Compute target: after the JFZ opcode is pushed,
+                    // bytes.len() points at the low-address slot.  We
+                    // need to skip past 2 address bytes + 2 bytes for
+                    // `MVI dest_reg, 1` to land at the byte AFTER the
+                    // capture sequence.  Target = bytes.len() + 4.
+                    let target = bytes.len() + 4;
+                    if target >= 1 << 14 {
+                        return Err(IIRIntel8008Error::AddressOutOfRange {
+                            function: f.name.clone(),
+                            address: target,
+                        });
+                    }
+                    bytes.push((target & 0xFF) as u8);
+                    bytes.push(((target >> 8) & 0x3F) as u8);
+                    // MVI dest_reg, 1 — set true (executed only when Z=1).
+                    bytes.push(encode_mvi(dest_reg));
+                    bytes.push(1);
+                }
+
                 "label" => {
                     let name = match instr.srcs.first() {
                         Some(Operand::Var(s)) => s.clone(),

--- a/code/packages/rust/iir-to-intel8008/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-intel8008/tests/test_backend.rs
@@ -874,6 +874,198 @@ fn jmp_if_true_to_undefined_label_is_rejected() {
     }
 }
 
+// ===========================================================================
+// 12. A2++.5.5 fifth slice — `cmp` (equality) with flag-to-bool capture
+// ===========================================================================
+//
+// `cmp dest, a, b` in IIR produces a boolean (`dest = (a == b) ? 1 : 0`).
+// The 8008's `CMP` instruction (family `10 111 sss`, first byte
+// `0xB8 | sss`) computes `A - r`, sets the zero flag (`Z = 1 iff A == r`),
+// and DISCARDS the difference.  So lowering needs a flag-to-register
+// capture sequence:
+//
+//   [optional]  MOV A, a_reg
+//               CMP b_reg                ; sets Z
+//               MVI dest_reg, 0          ; default false
+//               JFZ <fallthrough>        ; if Z=0 (a != b), skip
+//               MVI dest_reg, 1          ; Z=1 (a == b) → set true
+//               <fallthrough>
+//
+// The JFZ's target is the byte position immediately past
+// `MVI dest_reg, 1` — a fixed +4-byte forward offset from the JFZ
+// itself.  Computed inline (NOT via `pending_jmps`) so the capture
+// stays self-contained and doesn't pollute the user-visible label
+// namespace with synthetic names.
+
+#[test]
+fn cmp_equal_pins_full_capture_byte_stream() {
+    // const v=5; const w=5; cmp r v w; ret r
+    //
+    // Allocator: v→A(7), w→B(0), r→C(1).
+    //
+    //   00 01  MVI A, 5
+    //   02 03  MVI B, 5
+    //   04     CMP B           (0xB8)
+    //   05 06  MVI C, 0        (0x0E 0x00) — default false
+    //   07     JFZ <0x000C>    (0x48 0x0C 0x00)
+    //   08 09  ...address bytes...
+    //   0A 0B  MVI C, 1        (0x0E 0x01) — Z=1 → set true
+    //   0C     MOV A, C        (0x79) — ret r stages r into A
+    //   0D     HLT             (0x76)
+    let f = IIRFunction::new("eq", vec![], "bool", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(5)], "u8"),
+        IIRInstr::new("const", Some("w".into()), vec![Operand::Int(5)], "u8"),
+        IIRInstr::new("cmp",   Some("r".into()),
+            vec![Operand::Var("v".into()), Operand::Var("w".into())], "bool"),
+        IIRInstr::new("ret",   None,             vec![Operand::Var("r".into())], "bool"),
+    ]);
+    let bytes = lower_iir_to_intel8008(&module_with(f), &IIRIntel8008Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![
+        MVI_A, 0x05,    // 00 01   MVI A, 5
+        0x06,  0x05,    // 02 03   MVI B, 5
+        0xB8,           // 04      CMP B (10 111 000)
+        0x0E,  0x00,    // 05 06   MVI C, 0 (default false)
+        JFZ,           // 07      JFZ (0x48)
+        0x0C,  0x00,    // 08 09   target = 0x000C (fallthrough byte)
+        0x0E,  0x01,    // 0A 0B   MVI C, 1 (Z=1 path)
+        0x79,           // 0C      MOV A, C (stage r for ret)
+        HLT,            // 0D
+    ], "cmp full capture expected; got: {bytes:02x?}");
+}
+
+#[test]
+fn cmp_with_lhs_not_in_a_emits_staging_mov() {
+    // const v=10 → A; const w=20 → B; const x=20 → C;
+    // cmp r w x; ret_void
+    //
+    // a (w) is in B, not A → need MOV A, B (0x78) before CMP.
+    // b is x in C.
+    //
+    //   00 01  MVI A, 10        (3E 0A)
+    //   02 03  MVI B, 20        (06 14)
+    //   04 05  MVI C, 20        (0E 14)
+    //   06     MOV A, B         (78)         — stage w
+    //   07     CMP C            (B9 = 10 111 001 — sss=C=1)
+    //   08 09  MVI D, 0         (16 00)
+    //   0A     JFZ <0x000F>     (48)
+    //   0B 0C  ...              (0F 00)
+    //   0D 0E  MVI D, 1         (16 01)
+    //   0F     HLT
+    let f = IIRFunction::new("cmp_b_c", vec![], "void", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(10)], "u8"),
+        IIRInstr::new("const", Some("w".into()), vec![Operand::Int(20)], "u8"),
+        IIRInstr::new("const", Some("x".into()), vec![Operand::Int(20)], "u8"),
+        IIRInstr::new("cmp",   Some("r".into()),
+            vec![Operand::Var("w".into()), Operand::Var("x".into())], "bool"),
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ]);
+    let bytes = lower_iir_to_intel8008(&module_with(f), &IIRIntel8008Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![
+        MVI_A, 0x0A,    // 00 01   MVI A, 10
+        0x06,  0x14,    // 02 03   MVI B, 20
+        0x0E,  0x14,    // 04 05   MVI C, 20
+        0x78,           // 06      MOV A, B  (stage w into A)
+        0xB9,           // 07      CMP C     (10 111 001 — sss=C=1)
+        0x16,  0x00,    // 08 09   MVI D, 0  (D = 2; (2<<3)|0x06 = 0x16)
+        JFZ,           // 0A      JFZ
+        0x0F,  0x00,    // 0B 0C   target = 0x000F (fallthrough)
+        0x16,  0x01,    // 0D 0E   MVI D, 1
+        HLT,            // 0F
+    ], "cmp with staging MOV expected; got: {bytes:02x?}");
+}
+
+/// `cmp r v v` — comparing a value with itself.  Trivially Z=1, so
+/// the runtime always takes the "set true" branch.  Lowering shape
+/// is identical to the standard case — the optimisation of
+/// constant-folding this to `MVI dest, 1` is upstream's job.
+#[test]
+fn cmp_with_same_register_emits_cmp_a_then_capture() {
+    // const v=42; cmp r v v; ret_void
+    //
+    // Both operands are A.  No staging MOV.  CMP A = 0xBF.
+    //
+    //   00 01  MVI A, 42
+    //   02     CMP A       (BF = 10 111 111)
+    //   03 04  MVI B, 0
+    //   05     JFZ <0x000A>
+    //   06 07  ...
+    //   08 09  MVI B, 1
+    //   0A     HLT
+    let f = IIRFunction::new("self_cmp", vec![], "void", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(42)], "u8"),
+        IIRInstr::new("cmp",   Some("r".into()),
+            vec![Operand::Var("v".into()), Operand::Var("v".into())], "bool"),
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ]);
+    let bytes = lower_iir_to_intel8008(&module_with(f), &IIRIntel8008Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![
+        MVI_A, 0x2A,    // 00 01   MVI A, 42
+        0xBF,           // 02      CMP A (10 111 111 — sss=A=7)
+        0x06,  0x00,    // 03 04   MVI B, 0  (B = 0; (0<<3)|0x06 = 0x06)
+        JFZ,           // 05      JFZ
+        0x0A,  0x00,    // 06 07   target = 0x000A
+        0x06,  0x01,    // 08 09   MVI B, 1
+        HLT,            // 0A
+    ], "self-cmp expected; got: {bytes:02x?}");
+}
+
+#[test]
+fn cmp_followed_by_jmp_if_true_composes_correctly() {
+    // const v=3; const w=3; cmp eq v w; jmp_if_true eq, end; ret_void
+    //
+    // This test verifies the v0.3.5 jmp_if_true sequence runs cleanly
+    // after a cmp — the `cmp` capture leaves the Z flag in whatever
+    // state the trailing `MVI dest, 1` left it (Z flag is affected by
+    // most ops but not by `MVI`), so `jmp_if_true` correctly re-tests
+    // via its own `ANA A`.  This is the "happy path" cross-slice
+    // composition test.
+    //
+    // Allocator: v→A, w→B, eq→C.
+    //
+    //   00 01  MVI A, 3
+    //   02 03  MVI B, 3
+    //   04     CMP B    (0xB8)
+    //   05 06  MVI C, 0
+    //   07     JFZ <0x000C>
+    //   08 09  ...
+    //   0A 0B  MVI C, 1
+    //   0C     MOV A, C       (eq is in C, jmp_if_true stages into A)  = 0x79
+    //   0D     ANA A          (TEST)                                   = 0xA7
+    //   0E     JFZ <end>      (0x48)
+    //   0F 10  ...end addr...
+    //   <-- label "end" at offset 0x11 -->
+    //   11     HLT
+    let f = IIRFunction::new("cmp_then_branch", vec![], "void", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(3)], "u8"),
+        IIRInstr::new("const", Some("w".into()), vec![Operand::Int(3)], "u8"),
+        IIRInstr::new("cmp",   Some("eq".into()),
+            vec![Operand::Var("v".into()), Operand::Var("w".into())], "bool"),
+        IIRInstr::new("jmp_if_true", None,
+            vec![Operand::Var("eq".into()), Operand::Var("end".into())], "void"),
+        IIRInstr::new("label", None, vec![Operand::Var("end".into())], "void"),
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ]);
+    let bytes = lower_iir_to_intel8008(&module_with(f), &IIRIntel8008Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![
+        MVI_A, 0x03,    // 00 01   MVI A, 3
+        0x06,  0x03,    // 02 03   MVI B, 3
+        0xB8,           // 04      CMP B
+        0x0E,  0x00,    // 05 06   MVI C, 0
+        JFZ,           // 07      JFZ
+        0x0C,  0x00,    // 08 09   target 0x000C
+        0x0E,  0x01,    // 0A 0B   MVI C, 1
+        0x79,           // 0C      MOV A, C (stage eq into A for jmp_if_true)
+        0xA7,           // 0D      ANA A (TEST A — sets Z from eq's value)
+        JFZ,           // 0E      JFZ end
+        0x11,  0x00,    // 0F 10   end at offset 0x11
+        HLT,            // 11
+    ], "cmp + jmp_if_true compose expected; got: {bytes:02x?}");
+}
+
 // Note on the high-byte split + AddressOutOfRange coverage gap:
 //
 // In v0.3.4 the allocator caps each function at ~25 emitted bytes

--- a/code/specs/iir-to-intel8008.md
+++ b/code/specs/iir-to-intel8008.md
@@ -60,9 +60,10 @@ IIRModule
 | v0.3.2 (A2++.5.5 first slice) | bitwise ALU `and`/`or`/`xor` on the accumulator (same family, `ooo` ∈ {`100`, `110`, `101`}) | **merged** |
 | v0.3.3 (A2++.5.5 second slice) | carry/borrow-chained ALU `adc`/`sbb` (same family, `ooo` ∈ {`001`, `011`}) | **merged** |
 | v0.3.4 (A2++.5.5 third slice) | `label` (zero-byte position marker) + unconditional `jmp` (**`0x7C`**, NOT `0x44`) with per-function two-pass backpatching | **merged** |
-| **v0.3.5 (A2++.5.5 fourth slice — this PR)** | Boolean conditional jumps `jmp_if_true` (`ANA A` + `JFZ` `0x48`) and `jmp_if_false` (`ANA A` + `JTZ` `0x4C`); the 8008's TEST-A idiom provokes the zero flag from a boolean cond register | this PR |
-| v0.3.6 (A2++.5.5 fifth slice) | `cmp` (`CMP` = `0xB8\|sss`, `ooo = 0b111`) with flag-to-bool capture, plus the remaining 6 conditional-flag opcodes (JFC/JTC/JFS/JTS/JFP/JTP) once cmp's machinery is wired | future |
-| v0.3.7 (A2++.5.5 sixth slice) | Real `RET` (`0x07`) via `CAL` (**`0x7E`**, NOT `0x46` — `0x46` is `CFZ`) + per-function internal return-stack discipline | future |
+| v0.3.5 (A2++.5.5 fourth slice) | Boolean conditional jumps `jmp_if_true` (`ANA A` + `JFZ` `0x48`) and `jmp_if_false` (`ANA A` + `JTZ` `0x4C`) | **merged** |
+| **v0.3.6 (A2++.5.5 fifth slice — this PR)** | `cmp` equality (`CMP` family `10 111 sss` = `0xB8\|sss`, `ooo = 0b111`) with inline flag-to-bool capture (`MVI dest,0`; `JFZ +4`; `MVI dest,1`) | this PR |
+| v0.3.7 (A2++.5.5 sixth slice) | Less-than / greater-than comparisons + the remaining 6 conditional-flag opcodes (JFC/JTC/JFS/JTS/JFP/JTP) — paired because lt/gt need sign + carry flags from CMP | future |
+| v0.3.8 (A2++.5.5 seventh slice) | Real `RET` (`0x07`) via `CAL` (**`0x7E`**, NOT `0x46` — `0x46` is `CFZ`) + per-function internal return-stack discipline | future |
 | v0.4.0 (A2+++) | `lang-aot --target=intel8008` wiring + module-level CALL backpatching | future |
 
 ## Encoding cheat-sheet for the jump/call family


### PR DESCRIPTION
## Summary

- Extends \`iir-to-intel8008\` v0.3.5 → **v0.3.6** with boolean equality: \`cmp dest, a, b\` lowers to the 8008's CMP (\`0xB8|sss\`) + an inline 7-byte flag-to-bool capture sequence.
- The JFZ target inside the capture is computed INLINE (not via the two-pass backpatcher) — \`target = bytes.len() + 4\` — so the sequence stays self-contained and doesn't pollute the user-visible label namespace with synthetic skip names.
- Tests grow 38 → 42 including a cross-slice composition test with v0.3.5's \`jmp_if_true\`.

### Lowering shape

\`\`\`text
[optional]  MOV A, a_reg               ; stage left source if not in A
            CMP b_reg     (0xB8|sss)   ; sets Z=1 iff A == b_reg
            MVI dest, 0                ; default false
            JFZ <fallthrough>          ; if Z=0 (a != b), skip overwrite
            MVI dest, 1                ; Z=1 path (a == b) → true
            <fallthrough>
\`\`\`

Total: 8 bytes when \`a\` is already in A, 9 bytes with the staging MOV.

### Why inline target instead of pending_jmps?

The JFZ target is always a fixed +4-byte forward offset from the JFZ opcode itself, so it can be resolved at emit time.  Benefits:
1. No synthetic label pollution (the user-visible \`labels\` map stays clean).
2. No dependency on the two-pass machinery — the capture is fully self-contained.
3. No risk of synthetic-label collision with user-defined labels.

The 14-bit \`AddressOutOfRange\` check still runs against the inline computed target.

### Only equality in this slice

Less-than / greater-than need sign + carry flags from CMP, and pair naturally with the remaining 6 conditional-jump opcodes (JFC/JTC/JFS/JTS/JFP/JTP).  Deferred to **v0.3.7**.

- **v0.3.7** — lt/gt comparisons + 6 cond-jump opcodes (paired)
- **v0.3.8** — real RET via CAL (\`0x7E\` — NOT \`0x46\` which is CFZ) + return-stack discipline
- **v0.4.0** — \`lang-aot --target=intel8008\` wiring (A2+++)

## Test plan

- [x] \`cargo test -p iir-to-intel8008\` — 42/42 backend tests pass, 1/1 doctest passes
- [x] Equality byte stream pinned (\`B8 0E 00 48 0C 00 0E 01\`)
- [x] Staging-MOV path pinned (\`CMP C = 0xB9\`)
- [x] Self-cmp idiom pinned (\`CMP A = 0xBF\`)
- [x] cmp + jmp_if_true composition test pinned (cross-slice integration)
- [x] Security review passed (no vulnerabilities found)
- [ ] CI green
- [ ] No merge conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)