### PR TITLE
feat(iir-to-intel8008): cmp_ne / cmp_lt / cmp_gt via shared capture helper — A2++.5.5 sixth slice

### DIFF
--- a/code/packages/rust/iir-to-intel8008/CHANGELOG.md
+++ b/code/packages/rust/iir-to-intel8008/CHANGELOG.md
@@ -3,6 +3,91 @@
 All notable changes to this crate are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.3.7] — 2026-06-02 (A2++.5.5 sixth slice — `cmp_ne`/`cmp_lt`/`cmp_gt` via shared capture helper)
+
+### Added — inequality + ordering comparisons
+
+Extends v0.3.6 with three more boolean comparison ops:
+
+| IIR op | Skip-jump opcode | Operand swap? | Semantics |
+|--------|------------------|---------------|-----------|
+| `cmp_ne dest, a, b` | `JTZ` (`0x4C`) | no | `dest = (a != b) ? 1 : 0` |
+| `cmp_lt dest, a, b` | **`JFC` (`0x40`)** | no | `dest = (a <  b) ? 1 : 0` |
+| `cmp_gt dest, a, b` | `JFC` | **yes** | `dest = (a >  b) ? 1 : 0` |
+
+All four boolean comparisons (`cmp` + the three new ones) now share
+a single capture-emission helper `emit_cmp_capture`.  The four-line
+match arm picks the skip-jump opcode and swap flag, then delegates:
+
+```rust
+let (skip_op, swap) = match instr.op.as_str() {
+    "cmp"    => (JFZ, false),
+    "cmp_ne" => (JTZ, false),
+    "cmp_lt" => (JFC, false),
+    "cmp_gt" => (JFC, true),
+    _ => unreachable!("outer arm restricts to these 4"),
+};
+let (left, right) = if swap { (b_reg, a_reg) } else { (a_reg, b_reg) };
+emit_cmp_capture(&mut bytes, left, right, dest_reg, skip_op, &f.name)?;
+```
+
+#### Why `cmp_gt = cmp_lt + operand swap`
+
+`cmp_gt a, b` (is `a > b`?) is logically equivalent to `cmp_lt b, a`
+(is `b < a`?).  Both compute "carry-set after CMP" — for cmp_lt that
+means A=a, CMP b, carry-set ⇔ `a < b`.  For cmp_gt, swapping puts
+A=b, CMP a, carry-set ⇔ `b < a` ⇔ `a > b`.  Same skeleton, just
+different staging direction.
+
+This avoids needing a new "JFC AND NOT JTZ" combined jump (which the
+8008 doesn't have anyway) and keeps the lowering uniform.
+
+#### New constant
+
+* `pub const JFC: u8 = 0x40;` — jump if flag-carry CLEAR (i.e. when
+  `A >= r` after `CMP r`).  Bit pattern `01 000 000`: jump family
+  `01 ccc T 00` with `ccc = 000` (carry flag) and `T = 0` (test-clear).
+
+#### Refactor — shared `emit_cmp_capture` helper
+
+The v0.3.6 inline CMP + capture sequence was extracted to a helper:
+
+```rust
+fn emit_cmp_capture(
+    bytes: &mut Vec<u8>,
+    left_reg: u8,
+    right_reg: u8,
+    dest_reg: u8,
+    skip_op: u8,
+    fn_name: &str,
+) -> Result<(), IIRIntel8008Error>;
+```
+
+Single source of truth for the 7-byte (or 8-byte with staging MOV)
+boolean-comparison capture sequence.  Future cmp_lte / cmp_gte / etc.
+hook in by passing their own skip-jump opcode + swap polarity.
+
+#### Tests added (46 total, was 42)
+
+* `jfc_constant_pinned_to_0x40` — guards the JFC constant.
+* `cmp_ne_pins_full_capture_byte_stream` — `B8 0E 00 4C 0C 00 0E 01`.
+* `cmp_lt_pins_full_capture_byte_stream` — `B8 0E 00 40 0C 00 0E 01`.
+* `cmp_gt_swaps_operands_then_uses_jfc` — pins the swap-induced
+  `MOV A, B; CMP A` (`78 BF`) prefix.
+
+### What is NOT in v0.3.7 (deferred to v0.3.8 / v0.3.9 / A2+++)
+
+* `cmp_lte` / `cmp_gte` — need either a two-branch capture (`Z=1 OR
+  C=1`) or a `cmp_lt` + boolean negation; both more complex than
+  the single-skip-jump pattern this helper assumes.  Land alongside
+  the remaining 5 conditional-flag jump opcodes.
+* The remaining 5 conditional-flag jump opcodes: `JTC` (`0x44`),
+  `JFS` (`0x50`), `JTS` (`0x54`), `JFP` (`0x58`), `JTP` (`0x5C`).
+* Real `RET` (`0x07`) via `CAL` (`0x7E`, NOT `0x46` which is CFZ) +
+  per-function internal return-stack discipline — v0.3.9.
+* `lang-aot --target=intel8008` wiring + module-level CALL
+  backpatching — A2+++.
+
 ## [0.3.6] — 2026-06-02 (A2++.5.5 fifth slice — `cmp` equality with flag-to-bool capture)
 
 ### Added — boolean equality comparison

--- a/code/packages/rust/iir-to-intel8008/Cargo.toml
+++ b/code/packages/rust/iir-to-intel8008/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iir-to-intel8008"
-version = "0.3.6"
+version = "0.3.7"
 edition = "2021"
-description = "IIR → Intel 8008 machine code backend (Oct's native target) — lowers IIRModule to a Vec<u8> of 8-bit Intel 8008 opcodes.  v0.3.6 (A2++.5.5 fifth slice): adds `cmp` (equality test) using the 8008's CMP (family `10 111 sss` = `0xB8|sss`, sets Z=1 iff A==r and DISCARDS the difference) with an inline flag-to-bool capture sequence (MVI dest,0; JFZ +4; MVI dest,1).  The capture's forward JFZ is computed inline (NOT via the two-pass backpatcher) so the sequence stays self-contained.  Less-than/greater-than (which need sign + carry flags) and the remaining 6 conditional-jump opcodes defer to v0.3.7; real RET/CAL/stack defers to v0.3.8."
+description = "IIR → Intel 8008 machine code backend (Oct's native target) — lowers IIRModule to a Vec<u8> of 8-bit Intel 8008 opcodes.  v0.3.7 (A2++.5.5 sixth slice): adds `cmp_ne` (inequality, uses JTZ), `cmp_lt` (less-than, uses new JFC = 0x40 to observe the carry flag set by CMP when A<r), and `cmp_gt` (greater-than, implemented as cmp_lt with operands swapped — clever single-instruction-family reuse).  All four boolean comparisons (cmp/cmp_ne/cmp_lt/cmp_gt) share a unified `emit_cmp_capture` helper.  cmp_lte/cmp_gte + remaining 5 cond-jump opcodes (JTC/JFS/JTS/JFP/JTP) defer to v0.3.8; real RET/CAL/stack to v0.3.9."
 
 [lib]
 name = "iir_to_intel8008"

--- a/code/packages/rust/iir-to-intel8008/src/lib.rs
+++ b/code/packages/rust/iir-to-intel8008/src/lib.rs
@@ -105,6 +105,17 @@ pub const HLT: u8 = 0x76;
 /// immediate byte.
 pub const MVI_A: u8 = 0x3E;
 
+/// Intel 8008 conditional `JFC addr` (jump if flag-carry clear) first
+/// byte — `0x40`.  Three-byte instruction (`JFC` + low + high).
+///
+/// Bit pattern: `01 000 000` (jump family `01 ccc T 00`, where
+/// `ccc = 000 = carry flag` and `T = 0 = jump if flag clear`).
+/// After a `CMP r` (which computes `A - r`), carry is SET iff
+/// `A < r` (i.e. a borrow happened).  So `JFC` is the "skip if
+/// `A >= r`" half — used by the `cmp_lt` capture to default-out of
+/// the "set-true" path.
+pub const JFC: u8 = 0x40;
+
 /// Intel 8008 conditional `JFZ addr` (jump if flag-zero clear) first
 /// byte — `0x48`.  Three-byte instruction (`JFZ` + low addr + high addr).
 ///
@@ -362,6 +373,12 @@ const SUPPORTED_OPS: &[&str] = &[
     "jmp_if_true", "jmp_if_false",
     // A2++.5.5 fifth slice — equality comparison with flag-to-bool capture.
     "cmp",
+    // A2++.5.5 sixth slice — inequality + ordering comparisons.  All
+    // share the same "CMP + capture sequence" skeleton as `cmp`,
+    // differing only in (a) which conditional jump opcode skips the
+    // "set true" path, and (b) whether the operands are swapped
+    // before staging.
+    "cmp_ne", "cmp_lt", "cmp_gt",
 ];
 
 pub fn lower_iir_to_intel8008(
@@ -598,55 +615,60 @@ pub fn lower_iir_to_intel8008(
                 // v0.3.6.  Less-than / greater-than need the sign +
                 // carry flags and land with the other 6 conditional
                 // jump opcodes in v0.3.7.
-                "cmp" => {
-                    let dest = require_dest(instr, "cmp", &f.name)?;
+                // ── cmp / cmp_ne / cmp_lt / cmp_gt ──────────────────────
+                //
+                // All four boolean comparisons share the same CMP +
+                // flag-to-bool capture skeleton.  They differ only in
+                // two parameters:
+                //
+                //   1. Whether to swap operands before staging.
+                //      `cmp_gt a, b` is just `cmp_lt b, a` — both
+                //      compute "carry set after CMP" → `a < b` (for
+                //      cmp_lt, after staging a; for cmp_gt, after
+                //      staging b so the CMP becomes `b - a` and
+                //      carry-set means `b < a` ⇔ `a > b`).
+                //
+                //   2. Which conditional jump opcode SKIPS the
+                //      "set-true" overwrite:
+                //        cmp     → JFZ (skip when Z clear / a != b)
+                //        cmp_ne  → JTZ (skip when Z set   / a == b)
+                //        cmp_lt  → JFC (skip when C clear / a >= b)
+                //        cmp_gt  → JFC (skip when C clear / b >= a)
+                //
+                // Both axes feed a single helper below so any future
+                // tweak to the capture shape (e.g. shrinking via a
+                // different idiom) only needs one site change.
+                "cmp" | "cmp_ne" | "cmp_lt" | "cmp_gt" => {
+                    let dest = require_dest(instr, &instr.op, &f.name)?;
                     let a_name = match instr.srcs.first() {
                         Some(Operand::Var(s)) => s.clone(),
                         _ => return Err(IIRIntel8008Error::InvalidOperand {
                             function: f.name.clone(),
-                            detail: "cmp srcs[0] must be Var".into(),
+                            detail: format!("{} srcs[0] must be Var", instr.op),
                         }),
                     };
                     let b_name = match instr.srcs.get(1) {
                         Some(Operand::Var(s)) => s.clone(),
                         _ => return Err(IIRIntel8008Error::InvalidOperand {
                             function: f.name.clone(),
-                            detail: "cmp srcs[1] must be Var".into(),
+                            detail: format!("{} srcs[1] must be Var", instr.op),
                         }),
                     };
                     let a_reg = lookup_register(&env, &a_name, &f.name)?;
                     let b_reg = lookup_register(&env, &b_name, &f.name)?;
-                    // Stage a into A if needed.
-                    if a_reg != REG_A {
-                        bytes.push(encode_mov(REG_A, a_reg));
-                    }
-                    // CMP b_reg — sets Z=1 iff A == b_reg.
-                    bytes.push(encode_alu(ALU_CMP, b_reg));
-                    // Allocate dest_reg and emit the flag-to-bool capture.
+                    // Decide skip-jump opcode AND whether to swap.
+                    let (skip_op, swap) = match instr.op.as_str() {
+                        "cmp"    => (JFZ, false),
+                        "cmp_ne" => (JTZ, false),
+                        "cmp_lt" => (JFC, false),
+                        "cmp_gt" => (JFC, true),
+                        _ => unreachable!("outer arm restricts to these 4"),
+                    };
+                    let (left, right) = if swap { (b_reg, a_reg) } else { (a_reg, b_reg) };
+                    // Allocate dest_reg up front so the helper can
+                    // emit MVI dest, {0,1} sequences.
                     let dest_reg = alloc_register(&mut next_reg, dest, &mut env, &f.name)?;
-                    // MVI dest_reg, 0 — default (false).
-                    bytes.push(encode_mvi(dest_reg));
-                    bytes.push(0);
-                    // JFZ <fallthrough> — if Z clear (a != b), skip the
-                    // "set true" path so dest stays 0.
-                    bytes.push(JFZ);
-                    // Compute target: after the JFZ opcode is pushed,
-                    // bytes.len() points at the low-address slot.  We
-                    // need to skip past 2 address bytes + 2 bytes for
-                    // `MVI dest_reg, 1` to land at the byte AFTER the
-                    // capture sequence.  Target = bytes.len() + 4.
-                    let target = bytes.len() + 4;
-                    if target >= 1 << 14 {
-                        return Err(IIRIntel8008Error::AddressOutOfRange {
-                            function: f.name.clone(),
-                            address: target,
-                        });
-                    }
-                    bytes.push((target & 0xFF) as u8);
-                    bytes.push(((target >> 8) & 0x3F) as u8);
-                    // MVI dest_reg, 1 — set true (executed only when Z=1).
-                    bytes.push(encode_mvi(dest_reg));
-                    bytes.push(1);
+                    emit_cmp_capture(&mut bytes, left, right, dest_reg, skip_op, &f.name)?;
                 }
 
                 "label" => {
@@ -865,4 +887,63 @@ fn lookup_register(
         function: fn_name.to_string(),
         name: name.to_string(),
     })
+}
+
+/// Emit the shared CMP + flag-to-bool capture sequence used by
+/// `cmp` / `cmp_ne` / `cmp_lt` / `cmp_gt`.
+///
+/// Stages `left_reg` into `A` if needed (MOV is flag-non-affecting on
+/// 8008, so the flag the CMP sets afterwards isn't polluted), runs
+/// `CMP right_reg` to populate Z and C, then emits the 7-byte capture:
+///
+/// ```text
+/// MVI dest_reg, 0
+/// <skip_op> <fallthrough>     ; 3-byte conditional jump
+/// MVI dest_reg, 1
+/// <fallthrough>
+/// ```
+///
+/// `skip_op` is the conditional jump that should be TAKEN when the
+/// comparison result is the BOOLEAN `false`.  For equality (`cmp`)
+/// that's `JFZ` (Z clear = not equal).  For ordering (`cmp_lt`/
+/// `cmp_gt`) that's `JFC` (carry clear = not less).  For inequality
+/// (`cmp_ne`) that's `JTZ` (Z set = equal).
+///
+/// The forward target is computed inline (`bytes.len() + 4`) — the
+/// same self-contained approach used by v0.3.6's `cmp` so no
+/// synthetic labels leak into the user-visible namespace.  The
+/// 14-bit `AddressOutOfRange` guard still runs.
+fn emit_cmp_capture(
+    bytes: &mut Vec<u8>,
+    left_reg: u8,
+    right_reg: u8,
+    dest_reg: u8,
+    skip_op: u8,
+    fn_name: &str,
+) -> Result<(), IIRIntel8008Error> {
+    // Stage left into A.
+    if left_reg != REG_A {
+        bytes.push(encode_mov(REG_A, left_reg));
+    }
+    // CMP right_reg — sets Z and C flags.
+    bytes.push(encode_alu(ALU_CMP, right_reg));
+    // Capture: default to false.
+    bytes.push(encode_mvi(dest_reg));
+    bytes.push(0);
+    // Conditional skip jump (its semantics determine which 8008 flag
+    // we observe and which polarity makes the boolean false).
+    bytes.push(skip_op);
+    let target = bytes.len() + 4;
+    if target >= 1 << 14 {
+        return Err(IIRIntel8008Error::AddressOutOfRange {
+            function: fn_name.to_string(),
+            address: target,
+        });
+    }
+    bytes.push((target & 0xFF) as u8);
+    bytes.push(((target >> 8) & 0x3F) as u8);
+    // Set true (executed only when the skip jump WASN'T taken).
+    bytes.push(encode_mvi(dest_reg));
+    bytes.push(1);
+    Ok(())
 }

--- a/code/packages/rust/iir-to-intel8008/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-intel8008/tests/test_backend.rs
@@ -6,7 +6,7 @@
 use interpreter_ir::{IIRFunction, IIRInstr, IIRModule, Operand};
 use iir_to_intel8008::{
     lower_iir_to_intel8008, validate_for_intel8008,
-    IIRIntel8008Config, IIRIntel8008Error, HLT, JFZ, JMP, JTZ, MVI_A,
+    IIRIntel8008Config, IIRIntel8008Error, HLT, JFC, JFZ, JMP, JTZ, MVI_A,
 };
 
 fn module_with(f: IIRFunction) -> IIRModule {
@@ -1064,6 +1064,148 @@ fn cmp_followed_by_jmp_if_true_composes_correctly() {
         0x11,  0x00,    // 0F 10   end at offset 0x11
         HLT,            // 11
     ], "cmp + jmp_if_true compose expected; got: {bytes:02x?}");
+}
+
+// ===========================================================================
+// 13. A2++.5.5 sixth slice — cmp_ne / cmp_lt / cmp_gt
+// ===========================================================================
+//
+// All three reuse v0.3.6's CMP + capture skeleton, differing only
+// in (a) which conditional jump skips the "set-true" overwrite and
+// (b) whether the operands are swapped before staging:
+//
+//   cmp     → skip=JFZ (skip if Z clear / a != b), no swap
+//   cmp_ne  → skip=JTZ (skip if Z set   / a == b), no swap
+//   cmp_lt  → skip=JFC (skip if C clear / a >= b), no swap
+//   cmp_gt  → skip=JFC, OPERANDS SWAPPED so CMP becomes b - a
+//             ⇒ carry-set iff b < a iff a > b.
+//
+// Byte streams below pin each variant against the canonical
+// "v=10, w=20" template.  Allocator: v→A, w→B, r→C.
+//
+//   00 01  MVI A, 10                        (3E 0A)
+//   02 03  MVI B, 20                        (06 14)
+//   04     CMP B                            (B8)
+//   05 06  MVI C, 0                         (0E 00)
+//   07     <skip_op>                        (one of JFZ/JTZ/JFC)
+//   08 09  target = 0x000C
+//   0A 0B  MVI C, 1                         (0E 01)
+//   0C     MOV A, C  (ret r into A)         (79)
+//   0D     HLT                              (76)
+//
+// For cmp_gt the only byte that changes is the CMP source register
+// (B becomes A because we swapped — a was in A, b was in B, after
+// swap left=B's reg, right=A's reg; staging emits MOV A, B then
+// CMP A) — so the byte stream differs by one MOV + one CMP byte.
+
+#[test]
+fn jfc_constant_pinned_to_0x40() {
+    // JFC = 01 000 000 (ccc=000 carry, T=0 clear)
+    assert_eq!(JFC, 0x40,
+        "JFC (jump if carry clear) should be 0x40; got 0x{:02x}", JFC);
+}
+
+#[test]
+fn cmp_ne_pins_full_capture_byte_stream() {
+    // const v=10; const w=20; cmp_ne r v w; ret r
+    let f = IIRFunction::new("ne", vec![], "bool", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(10)], "u8"),
+        IIRInstr::new("const", Some("w".into()), vec![Operand::Int(20)], "u8"),
+        IIRInstr::new("cmp_ne", Some("r".into()),
+            vec![Operand::Var("v".into()), Operand::Var("w".into())], "bool"),
+        IIRInstr::new("ret",   None,             vec![Operand::Var("r".into())], "bool"),
+    ]);
+    let bytes = lower_iir_to_intel8008(&module_with(f), &IIRIntel8008Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![
+        MVI_A, 0x0A,    // 00 01  MVI A, 10
+        0x06,  0x14,    // 02 03  MVI B, 20
+        0xB8,           // 04     CMP B
+        0x0E,  0x00,    // 05 06  MVI C, 0 (default false)
+        JTZ,           // 07     JTZ (skip if Z set / a == b)
+        0x0C,  0x00,    // 08 09  target = 0x000C
+        0x0E,  0x01,    // 0A 0B  MVI C, 1
+        0x79,           // 0C     MOV A, C (ret r)
+        HLT,            // 0D
+    ], "cmp_ne expected; got: {bytes:02x?}");
+}
+
+#[test]
+fn cmp_lt_pins_full_capture_byte_stream() {
+    // const v=10; const w=20; cmp_lt r v w; ret r
+    // v < w → carry SET after CMP, JFC NOT taken, falls through → MVI C, 1 → dest=1 ✓
+    let f = IIRFunction::new("lt", vec![], "bool", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(10)], "u8"),
+        IIRInstr::new("const", Some("w".into()), vec![Operand::Int(20)], "u8"),
+        IIRInstr::new("cmp_lt", Some("r".into()),
+            vec![Operand::Var("v".into()), Operand::Var("w".into())], "bool"),
+        IIRInstr::new("ret",   None,             vec![Operand::Var("r".into())], "bool"),
+    ]);
+    let bytes = lower_iir_to_intel8008(&module_with(f), &IIRIntel8008Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![
+        MVI_A, 0x0A,    // 00 01  MVI A, 10
+        0x06,  0x14,    // 02 03  MVI B, 20
+        0xB8,           // 04     CMP B
+        0x0E,  0x00,    // 05 06  MVI C, 0
+        JFC,           // 07     JFC (skip if carry clear / a >= b)
+        0x0C,  0x00,    // 08 09  target = 0x000C
+        0x0E,  0x01,    // 0A 0B  MVI C, 1
+        0x79,           // 0C     MOV A, C
+        HLT,            // 0D
+    ], "cmp_lt expected; got: {bytes:02x?}");
+}
+
+#[test]
+fn cmp_gt_swaps_operands_then_uses_jfc() {
+    // const v=10; const w=20; cmp_gt r v w; ret r
+    //
+    // cmp_gt a, b is implemented as cmp_lt b, a — swap operands then
+    // emit identical skeleton.  After swap: left=w(B), right=v(A).
+    //
+    // Staging: B → A via MOV A, B (0x78), then CMP A (since right=v in A).
+    // CMP A = 0xBF (10 111 111).
+    //
+    //   00 01  MVI A, 10        (v → A)
+    //   02 03  MVI B, 20        (w → B)
+    //   04     MOV A, B         (stage w into A — was in B)   = 0x78
+    //   05     CMP A            (right=A which was the v reg) = 0xBF
+    //
+    // Wait — the swap means left=b_reg (=B=0), right=a_reg (=A=7).
+    // Staging emits MOV A, B because left=0 != A.  Then CMP right=A
+    // → CMP A.  So CMP A = 0xBF.
+    //
+    //   00 01  MVI A, 10
+    //   02 03  MVI B, 20
+    //   04     MOV A, B    (0x78)
+    //   05     CMP A       (0xBF)
+    //   06 07  MVI C, 0
+    //   08     JFC
+    //   09 0A  target = 0x0D
+    //   0B 0C  MVI C, 1
+    //   0D     MOV A, C
+    //   0E     HLT
+    let f = IIRFunction::new("gt", vec![], "bool", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(10)], "u8"),
+        IIRInstr::new("const", Some("w".into()), vec![Operand::Int(20)], "u8"),
+        IIRInstr::new("cmp_gt", Some("r".into()),
+            vec![Operand::Var("v".into()), Operand::Var("w".into())], "bool"),
+        IIRInstr::new("ret",   None,             vec![Operand::Var("r".into())], "bool"),
+    ]);
+    let bytes = lower_iir_to_intel8008(&module_with(f), &IIRIntel8008Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![
+        MVI_A, 0x0A,    // 00 01   MVI A, 10
+        0x06,  0x14,    // 02 03   MVI B, 20
+        0x78,           // 04      MOV A, B (stage swapped left=B into A)
+        0xBF,           // 05      CMP A    (right=A after swap)
+        0x0E,  0x00,    // 06 07   MVI C, 0
+        JFC,           // 08      JFC (skip if carry clear / b >= a / NOT a>b)
+        0x0D,  0x00,    // 09 0A   target = 0x000D
+        0x0E,  0x01,    // 0B 0C   MVI C, 1
+        0x79,           // 0D      MOV A, C
+        HLT,            // 0E
+    ], "cmp_gt expected; got: {bytes:02x?}");
 }
 
 // Note on the high-byte split + AddressOutOfRange coverage gap:

--- a/code/specs/iir-to-intel8008.md
+++ b/code/specs/iir-to-intel8008.md
@@ -61,9 +61,10 @@ IIRModule
 | v0.3.3 (A2++.5.5 second slice) | carry/borrow-chained ALU `adc`/`sbb` (same family, `ooo` ∈ {`001`, `011`}) | **merged** |
 | v0.3.4 (A2++.5.5 third slice) | `label` (zero-byte position marker) + unconditional `jmp` (**`0x7C`**, NOT `0x44`) with per-function two-pass backpatching | **merged** |
 | v0.3.5 (A2++.5.5 fourth slice) | Boolean conditional jumps `jmp_if_true` (`ANA A` + `JFZ` `0x48`) and `jmp_if_false` (`ANA A` + `JTZ` `0x4C`) | **merged** |
-| **v0.3.6 (A2++.5.5 fifth slice — this PR)** | `cmp` equality (`CMP` family `10 111 sss` = `0xB8\|sss`, `ooo = 0b111`) with inline flag-to-bool capture (`MVI dest,0`; `JFZ +4`; `MVI dest,1`) | this PR |
-| v0.3.7 (A2++.5.5 sixth slice) | Less-than / greater-than comparisons + the remaining 6 conditional-flag opcodes (JFC/JTC/JFS/JTS/JFP/JTP) — paired because lt/gt need sign + carry flags from CMP | future |
-| v0.3.8 (A2++.5.5 seventh slice) | Real `RET` (`0x07`) via `CAL` (**`0x7E`**, NOT `0x46` — `0x46` is `CFZ`) + per-function internal return-stack discipline | future |
+| v0.3.6 (A2++.5.5 fifth slice) | `cmp` equality with inline flag-to-bool capture | **merged** |
+| **v0.3.7 (A2++.5.5 sixth slice — this PR)** | `cmp_ne`/`cmp_lt`/`cmp_gt` via shared `emit_cmp_capture` helper; introduces `JFC = 0x40`; `cmp_gt` cleverly reuses `cmp_lt` via operand swap | this PR |
+| v0.3.8 (A2++.5.5 seventh slice) | `cmp_lte`/`cmp_gte` + remaining 5 conditional-flag opcodes (`JTC` `0x44`, `JFS` `0x50`, `JTS` `0x54`, `JFP` `0x58`, `JTP` `0x5C`) | future |
+| v0.3.9 (A2++.5.5 eighth slice) | Real `RET` (`0x07`) via `CAL` (**`0x7E`**, NOT `0x46` — `0x46` is `CFZ`) + per-function internal return-stack discipline | future |
 | v0.4.0 (A2+++) | `lang-aot --target=intel8008` wiring + module-level CALL backpatching | future |
 
 ## Encoding cheat-sheet for the jump/call family


### PR DESCRIPTION
## Summary

- Extends \`iir-to-intel8008\` v0.3.6 → **v0.3.7** with three more boolean comparisons: \`cmp_ne\`, \`cmp_lt\`, \`cmp_gt\`.
- Introduces \`JFC = 0x40\` (jump if carry clear) — observes the carry flag set by CMP when \`A < r\`.
- \`cmp_gt\` cleverly reuses \`cmp_lt\` via operand swap: \`cmp_gt a, b\` ≡ \`cmp_lt b, a\`.  No need for a "JFC AND NOT JTZ" combined jump.
- Refactor: extracted v0.3.6's inline cmp arm into \`emit_cmp_capture(bytes, left, right, dest, skip_op, fn_name)\` — single source of truth for all four boolean comparisons.
- Tests grow 42 → 46.

### Skip-jump opcode table

| IIR op | Skip-jump opcode | Operand swap | Skip-condition |
| ------ | ---------------- | ------------ | -------------- |
| \`cmp\`     | \`JFZ\` (0x48) | no  | Z clear (a != b) |
| \`cmp_ne\`  | \`JTZ\` (0x4C) | no  | Z set   (a == b) |
| \`cmp_lt\`  | **\`JFC\` (0x40)** | no  | C clear (a >= b) |
| \`cmp_gt\`  | \`JFC\` | **yes** | C clear after swap (b >= a) |

### Deferred to follow-up slices

- **v0.3.8** — \`cmp_lte\` / \`cmp_gte\` + remaining 5 cond-jump opcodes (\`JTC\` 0x44, \`JFS\` 0x50, \`JTS\` 0x54, \`JFP\` 0x58, \`JTP\` 0x5C)
- **v0.3.9** — real \`RET\` (\`0x07\`) via \`CAL\` (\`0x7E\` — NOT \`0x46\` which is CFZ) + return-stack discipline
- **v0.4.0** — \`lang-aot --target=intel8008\` wiring (A2+++)

## Test plan

- [x] \`cargo test -p iir-to-intel8008\` — 46/46 backend tests pass, 1/1 doctest passes
- [x] JFC opcode pinned to 0x40
- [x] cmp_ne / cmp_lt full capture byte streams pinned
- [x] cmp_gt swap-induced \`MOV A, B; CMP A\` (\`78 BF\`) prefix pinned
- [x] Security review passed (no vulnerabilities found)
- [ ] CI green
- [ ] No merge conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)