### PR TITLE
feat(iir-to-intel8008): cmp_gte/cmp_lte via JTC + remaining 5 cond-jump constants — A2++.5.5 seventh slice

### DIFF
--- a/code/packages/rust/iir-to-intel8008/CHANGELOG.md
+++ b/code/packages/rust/iir-to-intel8008/CHANGELOG.md
@@ -3,6 +3,98 @@
 All notable changes to this crate are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.3.8] — 2026-06-02 (A2++.5.5 seventh slice — `cmp_gte`/`cmp_lte` + remaining 5 cond-jump opcode constants)
+
+### Added — closed-end ordering comparisons
+
+Extends v0.3.7's six-way `emit_cmp_capture` dispatch with the two
+final boolean comparisons:
+
+| IIR op | Skip-jump opcode | Operand swap? | Skip-condition |
+|--------|------------------|---------------|----------------|
+| `cmp_gte dest, a, b` | **`JTC` (`0x44`)** | no | carry SET (a < b) |
+| `cmp_lte dest, a, b` | `JTC` | **yes** | carry SET after swap (b < a) |
+
+#### Why the OR-composition approach in the prompt was unnecessary
+
+The prompt suggested composing `cmp_lt + cmp` and OR-ing the results.
+That's correct semantically but requires:
+- Two CMP + capture sequences (16 bytes vs 7)
+- Two booleans staged into different registers
+- An `ORA` to combine
+- Final result staging
+
+The simpler observation: `a >= b ⇔ NOT (a < b) ⇔ carry CLEAR after CMP b`.
+So we can use the SAME 7-byte single-skip capture pattern, just with
+the inverse polarity jump: `JTC` (skip when carry SET) instead of
+`JFC` (skip when carry CLEAR).
+
+`cmp_lte a, b ⇔ cmp_gte b, a` plugs in via the same operand-swap
+trick v0.3.7 used for `cmp_gt`.  Two new IIR ops, ZERO new helper
+code — the dispatch table just grows two entries.
+
+#### Now all six boolean comparisons share one code path
+
+```rust
+let (skip_op, swap) = match instr.op.as_str() {
+    "cmp"     => (JFZ, false),
+    "cmp_ne"  => (JTZ, false),
+    "cmp_lt"  => (JFC, false),
+    "cmp_gt"  => (JFC, true),
+    "cmp_gte" => (JTC, false),  // NEW
+    "cmp_lte" => (JTC, true),   // NEW
+    _ => unreachable!("outer arm restricts to these 6"),
+};
+let (left, right) = if swap { (b_reg, a_reg) } else { (a_reg, b_reg) };
+emit_cmp_capture(&mut bytes, left, right, dest_reg, skip_op, &f.name)?;
+```
+
+The (skip-jump, swap) tuple cleanly tabulates all six comparisons.
+
+#### New opcode constants (5 of them — `JTC` actually wired)
+
+* `pub const JTC: u8 = 0x44;` — jump if carry SET.  **Used by
+  `cmp_gte` and `cmp_lte`** lowerings.  Bit pattern `01 000 100`:
+  carry flag, T-bit set (complement of `JFC`).  Confusion alert:
+  `0x44` is NOT the unconditional `JMP` (which is `0x7C`) and NOT
+  any of the call opcodes (`CFC` is at `0x42`).
+* `pub const JFS: u8 = 0x50;` — jump if sign clear.  Pinned for
+  future signed-integer ordering lowerings.
+* `pub const JTS: u8 = 0x54;` — jump if sign set.
+* `pub const JFP: u8 = 0x58;` — jump if parity clear (odd).
+* `pub const JTP: u8 = 0x5C;` — jump if parity set (even).
+
+The four `JFS`/`JTS`/`JFP`/`JTP` constants aren't yet consumed by
+any lowering — they exist so the public surface matches the
+encoding cheat-sheet in `code/specs/iir-to-intel8008.md` and so
+signed/parity-based extensions in future slices can reach for them
+without rediscovering the bit patterns.
+
+#### Tests added (53 total, was 46)
+
+* `jtc_constant_pinned_to_0x44` — guards JTC against the
+  `JMP ↔ JTC` confusion.
+* `jfs_constant_pinned_to_0x50` / `jts_constant_pinned_to_0x54` /
+  `jfp_constant_pinned_to_0x58` / `jtp_constant_pinned_to_0x5c` —
+  one-liner regression guards for the four unwired-but-public
+  constants.
+* `cmp_gte_pins_full_capture_byte_stream` —
+  `B8 0E 00 44 0C 00 0E 01` (the JTC-driven capture).
+* `cmp_lte_swaps_operands_then_uses_jtc` — pins the
+  `MOV A, B; CMP A` (`78 BF`) prefix that distinguishes lte from
+  gte by exactly two bytes (same shape as v0.3.7's
+  `cmp_gt_swaps_operands_then_uses_jfc`).
+
+### What is NOT in v0.3.8 (deferred to v0.3.9 / A2+++)
+
+* Real `RET` (`0x07`) via `CAL` (**`0x7E`**, NOT `0x46` which is
+  `CFZ`) + per-function internal return-stack discipline.  Lands
+  in v0.3.9.
+* Wiring `JFS`/`JTS`/`JFP`/`JTP` into actual lowerings (waiting on
+  signed-integer or parity-based IIR ops to materialise upstream).
+* `lang-aot --target=intel8008` wiring + module-level CALL
+  backpatching — A2+++.
+
 ## [0.3.7] — 2026-06-02 (A2++.5.5 sixth slice — `cmp_ne`/`cmp_lt`/`cmp_gt` via shared capture helper)
 
 ### Added — inequality + ordering comparisons

--- a/code/packages/rust/iir-to-intel8008/Cargo.toml
+++ b/code/packages/rust/iir-to-intel8008/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iir-to-intel8008"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
-description = "IIR → Intel 8008 machine code backend (Oct's native target) — lowers IIRModule to a Vec<u8> of 8-bit Intel 8008 opcodes.  v0.3.7 (A2++.5.5 sixth slice): adds `cmp_ne` (inequality, uses JTZ), `cmp_lt` (less-than, uses new JFC = 0x40 to observe the carry flag set by CMP when A<r), and `cmp_gt` (greater-than, implemented as cmp_lt with operands swapped — clever single-instruction-family reuse).  All four boolean comparisons (cmp/cmp_ne/cmp_lt/cmp_gt) share a unified `emit_cmp_capture` helper.  cmp_lte/cmp_gte + remaining 5 cond-jump opcodes (JTC/JFS/JTS/JFP/JTP) defer to v0.3.8; real RET/CAL/stack to v0.3.9."
+description = "IIR → Intel 8008 machine code backend (Oct's native target) — lowers IIRModule to a Vec<u8> of 8-bit Intel 8008 opcodes.  v0.3.8 (A2++.5.5 seventh slice): adds `cmp_gte` (uses new JTC = 0x44 to observe carry SET, complement of JFC) and `cmp_lte` (cmp_gte with swapped operands).  All six boolean comparisons (cmp/cmp_ne/cmp_lt/cmp_gt/cmp_gte/cmp_lte) now flow through the single `emit_cmp_capture` helper — no OR composition needed.  Also pins the remaining 4 cond-jump opcode constants (JFS=0x50, JTS=0x54, JFP=0x58, JTP=0x5C) for forward compatibility with signed/parity lowerings.  Real RET/CAL/stack defers to v0.3.9; lang-aot wiring defers to v0.4.0."
 
 [lib]
 name = "iir_to_intel8008"

--- a/code/packages/rust/iir-to-intel8008/src/lib.rs
+++ b/code/packages/rust/iir-to-intel8008/src/lib.rs
@@ -116,6 +116,48 @@ pub const MVI_A: u8 = 0x3E;
 /// the "set-true" path.
 pub const JFC: u8 = 0x40;
 
+/// Intel 8008 conditional `JTC addr` (jump if flag-carry set) first
+/// byte — `0x44`.  Three-byte instruction.
+///
+/// Bit pattern: `01 000 100` (carry flag, `T = 1 = jump if flag set`).
+/// `JTC` is the "skip if `A < r`" half — used by `cmp_gte` to default
+/// to `0` and only set `1` when the carry isn't set after CMP.
+///
+/// CAREFUL: `0x44` is NOT the unconditional `JMP` (which is `0x7C`).
+/// The encoding cheat-sheet in `iir-to-intel8008.md` lists every
+/// group-01 jump/call opcode side-by-side so this confusion doesn't
+/// recur — same hazard the v0.3.4 commit message flagged for
+/// `JMP ↔ JFC` and `CAL ↔ CFZ`.
+pub const JTC: u8 = 0x44;
+
+/// Intel 8008 conditional `JFS addr` (jump if sign clear, "positive
+/// or zero") first byte — `0x50`.  Three-byte instruction.
+///
+/// Bit pattern: `01 010 000` (sign flag, T = 0).  After `CMP r`,
+/// sign is SET when the high bit of `A - r` is 1 — useful only for
+/// signed integer ordering, which doesn't yet land in IIR.  Pinned
+/// here so the spec's encoding cheat-sheet stays in sync with the
+/// public surface.
+pub const JFS: u8 = 0x50;
+
+/// Intel 8008 conditional `JTS addr` (jump if sign set, "negative")
+/// first byte — `0x54`.  Three-byte instruction.  Bit pattern:
+/// `01 010 100`.  Sibling of `JFS`; both pinned for forward
+/// compatibility with signed-arithmetic lowerings.
+pub const JTS: u8 = 0x54;
+
+/// Intel 8008 conditional `JFP addr` (jump if parity clear, "odd")
+/// first byte — `0x58`.  Three-byte instruction.  Bit pattern:
+/// `01 011 000`.  Parity flag is rarely used by high-level IIR
+/// constructs; pinned for completeness and round-trip fidelity with
+/// the simulator's decoder.
+pub const JFP: u8 = 0x58;
+
+/// Intel 8008 conditional `JTP addr` (jump if parity set, "even")
+/// first byte — `0x5C`.  Three-byte instruction.  Bit pattern:
+/// `01 011 100`.  Sibling of `JFP`.
+pub const JTP: u8 = 0x5C;
+
 /// Intel 8008 conditional `JFZ addr` (jump if flag-zero clear) first
 /// byte — `0x48`.  Three-byte instruction (`JFZ` + low addr + high addr).
 ///
@@ -379,6 +421,12 @@ const SUPPORTED_OPS: &[&str] = &[
     // "set true" path, and (b) whether the operands are swapped
     // before staging.
     "cmp_ne", "cmp_lt", "cmp_gt",
+    // A2++.5.5 seventh slice — closed-end ordering (a >= b, a <= b).
+    // Both slot into the same shared `emit_cmp_capture` helper via
+    // `JTC` (jump if carry SET) — the natural complement of `JFC` —
+    // with `cmp_lte` reusing `cmp_gte` via the same operand-swap
+    // trick that v0.3.7 used for `cmp_gt`.
+    "cmp_gte", "cmp_lte",
 ];
 
 pub fn lower_iir_to_intel8008(
@@ -638,7 +686,7 @@ pub fn lower_iir_to_intel8008(
                 // Both axes feed a single helper below so any future
                 // tweak to the capture shape (e.g. shrinking via a
                 // different idiom) only needs one site change.
-                "cmp" | "cmp_ne" | "cmp_lt" | "cmp_gt" => {
+                "cmp" | "cmp_ne" | "cmp_lt" | "cmp_gt" | "cmp_gte" | "cmp_lte" => {
                     let dest = require_dest(instr, &instr.op, &f.name)?;
                     let a_name = match instr.srcs.first() {
                         Some(Operand::Var(s)) => s.clone(),
@@ -658,11 +706,17 @@ pub fn lower_iir_to_intel8008(
                     let b_reg = lookup_register(&env, &b_name, &f.name)?;
                     // Decide skip-jump opcode AND whether to swap.
                     let (skip_op, swap) = match instr.op.as_str() {
-                        "cmp"    => (JFZ, false),
-                        "cmp_ne" => (JTZ, false),
-                        "cmp_lt" => (JFC, false),
-                        "cmp_gt" => (JFC, true),
-                        _ => unreachable!("outer arm restricts to these 4"),
+                        "cmp"     => (JFZ, false),
+                        "cmp_ne"  => (JTZ, false),
+                        "cmp_lt"  => (JFC, false),
+                        "cmp_gt"  => (JFC, true),
+                        // a >= b iff NOT (a < b) iff carry CLEAR after CMP b.
+                        // Skip-when-true (false) means skip when carry SET → JTC.
+                        "cmp_gte" => (JTC, false),
+                        // a <= b iff b >= a — same skip opcode as cmp_gte,
+                        // operands swapped (so CMP a runs after staging b).
+                        "cmp_lte" => (JTC, true),
+                        _ => unreachable!("outer arm restricts to these 6"),
                     };
                     let (left, right) = if swap { (b_reg, a_reg) } else { (a_reg, b_reg) };
                     // Allocate dest_reg up front so the helper can

--- a/code/packages/rust/iir-to-intel8008/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-intel8008/tests/test_backend.rs
@@ -6,7 +6,8 @@
 use interpreter_ir::{IIRFunction, IIRInstr, IIRModule, Operand};
 use iir_to_intel8008::{
     lower_iir_to_intel8008, validate_for_intel8008,
-    IIRIntel8008Config, IIRIntel8008Error, HLT, JFC, JFZ, JMP, JTZ, MVI_A,
+    IIRIntel8008Config, IIRIntel8008Error,
+    HLT, JFC, JFP, JFS, JFZ, JMP, JTC, JTP, JTS, JTZ, MVI_A,
 };
 
 fn module_with(f: IIRFunction) -> IIRModule {
@@ -1206,6 +1207,133 @@ fn cmp_gt_swaps_operands_then_uses_jfc() {
         0x79,           // 0D      MOV A, C
         HLT,            // 0E
     ], "cmp_gt expected; got: {bytes:02x?}");
+}
+
+// ===========================================================================
+// 14. A2++.5.5 seventh slice — cmp_gte / cmp_lte + remaining 5 cond-jump opcodes
+// ===========================================================================
+//
+// `cmp_gte a, b` (a >= b) ⇔ NOT (a < b) ⇔ "carry clear after CMP b".
+// In the shared `emit_cmp_capture` skeleton the "skip" jump fires when
+// the boolean would be false — i.e. when carry is SET (a < b).  That's
+// `JTC` (jump if flag-carry set, 0x44).
+//
+// `cmp_lte a, b` (a <= b) ⇔ (b >= a) — same skeleton as cmp_gte
+// with operands swapped before staging.  Mirrors how v0.3.7 expressed
+// `cmp_gt` as a swap of `cmp_lt`.
+//
+// Pinning every byte of the byte stream guards against silent skip-
+// opcode drift between cmp_lt/cmp_gt/cmp_gte/cmp_lte.
+
+#[test]
+fn jtc_constant_pinned_to_0x44() {
+    // JTC = 01 000 100 (ccc=000 carry, T=1 set)
+    assert_eq!(JTC, 0x44,
+        "JTC (jump if carry set) should be 0x44; got 0x{:02x}", JTC);
+}
+
+#[test]
+fn jfs_constant_pinned_to_0x50() {
+    // JFS = 01 010 000 (ccc=010 sign, T=0 clear)
+    assert_eq!(JFS, 0x50);
+}
+
+#[test]
+fn jts_constant_pinned_to_0x54() {
+    // JTS = 01 010 100 (ccc=010 sign, T=1 set)
+    assert_eq!(JTS, 0x54);
+}
+
+#[test]
+fn jfp_constant_pinned_to_0x58() {
+    // JFP = 01 011 000 (ccc=011 parity, T=0 clear)
+    assert_eq!(JFP, 0x58);
+}
+
+#[test]
+fn jtp_constant_pinned_to_0x5c() {
+    // JTP = 01 011 100 (ccc=011 parity, T=1 set)
+    assert_eq!(JTP, 0x5C);
+}
+
+#[test]
+fn cmp_gte_pins_full_capture_byte_stream() {
+    // const v=10; const w=20; cmp_gte r v w; ret r
+    //
+    // 10 >= 20 is false → CMP B sets carry (since A < B).  JTC fires,
+    // skipping the "set true" path; dest stays 0.
+    //
+    //   00 01  MVI A, 10
+    //   02 03  MVI B, 20
+    //   04     CMP B
+    //   05 06  MVI C, 0
+    //   07     JTC          (skip if carry set / a < b)
+    //   08 09  target 0x000C
+    //   0A 0B  MVI C, 1
+    //   0C     MOV A, C (ret r)
+    //   0D     HLT
+    let f = IIRFunction::new("gte", vec![], "bool", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(10)], "u8"),
+        IIRInstr::new("const", Some("w".into()), vec![Operand::Int(20)], "u8"),
+        IIRInstr::new("cmp_gte", Some("r".into()),
+            vec![Operand::Var("v".into()), Operand::Var("w".into())], "bool"),
+        IIRInstr::new("ret",   None,             vec![Operand::Var("r".into())], "bool"),
+    ]);
+    let bytes = lower_iir_to_intel8008(&module_with(f), &IIRIntel8008Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![
+        MVI_A, 0x0A,    // 00 01  MVI A, 10
+        0x06,  0x14,    // 02 03  MVI B, 20
+        0xB8,           // 04     CMP B
+        0x0E,  0x00,    // 05 06  MVI C, 0
+        JTC,           // 07     JTC (skip if carry set)
+        0x0C,  0x00,    // 08 09  target 0x000C
+        0x0E,  0x01,    // 0A 0B  MVI C, 1
+        0x79,           // 0C     MOV A, C
+        HLT,            // 0D
+    ], "cmp_gte expected; got: {bytes:02x?}");
+}
+
+#[test]
+fn cmp_lte_swaps_operands_then_uses_jtc() {
+    // const v=10; const w=20; cmp_lte r v w; ret r
+    //
+    // cmp_lte a, b → cmp_gte b, a — swap operands then identical
+    // skeleton.  After swap: left=w (in B), right=v (in A).
+    //
+    // Staging MOV A, B (0x78), CMP A (0xBF, since right=v=A).
+    //
+    //   00 01  MVI A, 10
+    //   02 03  MVI B, 20
+    //   04     MOV A, B    (stage w into A — swapped left)
+    //   05     CMP A       (right=A after swap)
+    //   06 07  MVI C, 0
+    //   08     JTC
+    //   09 0A  target 0x0D
+    //   0B 0C  MVI C, 1
+    //   0D     MOV A, C
+    //   0E     HLT
+    let f = IIRFunction::new("lte", vec![], "bool", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(10)], "u8"),
+        IIRInstr::new("const", Some("w".into()), vec![Operand::Int(20)], "u8"),
+        IIRInstr::new("cmp_lte", Some("r".into()),
+            vec![Operand::Var("v".into()), Operand::Var("w".into())], "bool"),
+        IIRInstr::new("ret",   None,             vec![Operand::Var("r".into())], "bool"),
+    ]);
+    let bytes = lower_iir_to_intel8008(&module_with(f), &IIRIntel8008Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![
+        MVI_A, 0x0A,    // 00 01   MVI A, 10
+        0x06,  0x14,    // 02 03   MVI B, 20
+        0x78,           // 04      MOV A, B (stage swapped left=B)
+        0xBF,           // 05      CMP A    (right=A after swap)
+        0x0E,  0x00,    // 06 07   MVI C, 0
+        JTC,           // 08      JTC
+        0x0D,  0x00,    // 09 0A   target 0x000D
+        0x0E,  0x01,    // 0B 0C   MVI C, 1
+        0x79,           // 0D      MOV A, C
+        HLT,            // 0E
+    ], "cmp_lte expected; got: {bytes:02x?}");
 }
 
 // Note on the high-byte split + AddressOutOfRange coverage gap:

--- a/code/specs/iir-to-intel8008.md
+++ b/code/specs/iir-to-intel8008.md
@@ -62,8 +62,8 @@ IIRModule
 | v0.3.4 (A2++.5.5 third slice) | `label` (zero-byte position marker) + unconditional `jmp` (**`0x7C`**, NOT `0x44`) with per-function two-pass backpatching | **merged** |
 | v0.3.5 (A2++.5.5 fourth slice) | Boolean conditional jumps `jmp_if_true` (`ANA A` + `JFZ` `0x48`) and `jmp_if_false` (`ANA A` + `JTZ` `0x4C`) | **merged** |
 | v0.3.6 (A2++.5.5 fifth slice) | `cmp` equality with inline flag-to-bool capture | **merged** |
-| **v0.3.7 (A2++.5.5 sixth slice — this PR)** | `cmp_ne`/`cmp_lt`/`cmp_gt` via shared `emit_cmp_capture` helper; introduces `JFC = 0x40`; `cmp_gt` cleverly reuses `cmp_lt` via operand swap | this PR |
-| v0.3.8 (A2++.5.5 seventh slice) | `cmp_lte`/`cmp_gte` + remaining 5 conditional-flag opcodes (`JTC` `0x44`, `JFS` `0x50`, `JTS` `0x54`, `JFP` `0x58`, `JTP` `0x5C`) | future |
+| v0.3.7 (A2++.5.5 sixth slice) | `cmp_ne`/`cmp_lt`/`cmp_gt` via shared `emit_cmp_capture` helper; introduces `JFC = 0x40`; `cmp_gt` cleverly reuses `cmp_lt` via operand swap | **merged** |
+| **v0.3.8 (A2++.5.5 seventh slice — this PR)** | `cmp_gte`/`cmp_lte` via `JTC = 0x44` (complement of `JFC`); pins remaining 4 cond-jump constants `JFS`/`JTS`/`JFP`/`JTP` (forward-compat for signed/parity lowerings) | this PR |
 | v0.3.9 (A2++.5.5 eighth slice) | Real `RET` (`0x07`) via `CAL` (**`0x7E`**, NOT `0x46` — `0x46` is `CFZ`) + per-function internal return-stack discipline | future |
 | v0.4.0 (A2+++) | `lang-aot --target=intel8008` wiring + module-level CALL backpatching | future |
 


### PR DESCRIPTION
## Summary

- Extends \`iir-to-intel8008\` v0.3.7 → **v0.3.8** with the final two boolean comparisons: \`cmp_gte\` and \`cmp_lte\`.
- All six boolean comparisons (cmp/cmp_ne/cmp_lt/cmp_gt/cmp_gte/cmp_lte) now flow through the single \`emit_cmp_capture\` helper.
- Introduces \`JTC = 0x44\` (jump if carry SET — natural complement of \`JFC\`) and pins 4 more cond-jump constants (\`JFS\`/\`JTS\`/\`JFP\`/\`JTP\`) for forward compatibility with signed/parity lowerings.
- Tests grow 46 → 53.

### Skip-jump dispatch table (all six comparisons)

| IIR op   | Skip-jump | Swap?  | Skip-condition           |
| -------- | --------- | ------ | ------------------------ |
| \`cmp\`     | JFZ 0x48  | no     | Z clear (a != b)         |
| \`cmp_ne\`  | JTZ 0x4C  | no     | Z set   (a == b)         |
| \`cmp_lt\`  | JFC 0x40  | no     | C clear (a >= b)         |
| \`cmp_gt\`  | JFC 0x40  | YES    | C clear after swap       |
| \`cmp_gte\` | **JTC 0x44**  | no     | C set   (a < b)          |
| \`cmp_lte\` | JTC 0x44  | YES    | C set   after swap       |

### Why not the OR-composition approach the slice prompt suggested?

The prompt suggested composing \`cmp_lt + cmp\` and OR-ing — that's correct semantically but requires two CMP + capture sequences (16 bytes), an ORA, plus result staging.

The simpler observation: \`a >= b ⇔ NOT (a < b) ⇔ carry CLEAR after CMP b\`.  So the same 7-byte single-skip pattern works with the inverse polarity jump — \`JTC\` (skip when carry SET) instead of \`JFC\` (skip when carry CLEAR).

\`cmp_lte a, b ⇔ cmp_gte b, a\` plugs in via the same operand-swap trick v0.3.7 used for \`cmp_gt\`.  **Two new IIR ops, ZERO new helper code** — the dispatch table just grows two entries.

### Forward-compat opcode constants

- \`JFS = 0x50\` (sign clear), \`JTS = 0x54\` (sign set) — for future signed-integer ordering
- \`JFP = 0x58\` (parity clear), \`JTP = 0x5C\` (parity set) — rarely used by high-level IIR but pinned for completeness with the encoding cheat-sheet

### Deferred to follow-up slices

- **v0.3.9** — real \`RET\` (\`0x07\`) via \`CAL\` (\`0x7E\`, NOT \`0x46\` which is CFZ) + per-function internal return-stack discipline
- **v0.4.0** — \`lang-aot --target=intel8008\` wiring (A2+++)

The boolean-comparison and control-flow surface is now complete.

## Test plan

- [x] \`cargo test -p iir-to-intel8008\` — 53/53 backend tests pass, 1/1 doctest passes
- [x] All 5 new opcode constants pinned in their own tests
- [x] cmp_gte full capture byte stream pinned (\`B8 0E 00 44 0C 00 0E 01\`)
- [x] cmp_lte swap-induced \`MOV A, B; CMP A\` (\`78 BF\`) prefix pinned
- [x] Security review passed (no vulnerabilities found)
- [ ] CI green
- [ ] No merge conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)