### PR TITLE
feat(lang-aot): --emit=intel8008 wiring (A2+++) — source → IIR → Intel 8008 .bin

### DIFF
--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "lang-aot"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
-description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, and Oct to native executables through the shared IIR pipeline.  v0.7.0 (A1+++): adds `--emit=riscv32` flag (aliases `rv32`, `bin`) that routes source → IIR → RV32I machine code (.bin) via iir-to-riscv, cross-platform.  Downstream consumers: riscv-simulator, qemu-riscv32, flash loaders."
+description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, and Oct to native executables through the shared IIR pipeline.  v0.8.0 (A2+++): adds `--emit=intel8008` flag (aliases `i8008`, `8008`) that routes source → IIR → Intel 8008 machine code (.bin) via iir-to-intel8008, cross-platform.  Downstream consumers: the in-tree intel8008-simulator, a 1702 EPROM burner, or any 8008 emulator that consumes raw byte streams.  Previous v0.7.0 (A1+++) adds `--emit=riscv32` for RV32I."
 
 [dependencies]
 twig-aot              = { path = "../twig-aot" }
@@ -15,6 +15,7 @@ interpreter-ir        = { path = "../interpreter-ir" }
 cli-builder           = { path = "../cli-builder" }
 iir-to-llvm           = { path = "../iir-to-llvm" }
 iir-to-riscv          = { path = "../iir-to-riscv" }
+iir-to-intel8008      = { path = "../iir-to-intel8008" }
 
 [[bin]]
 name = "lang-aot"

--- a/code/packages/rust/lang-aot/bin/lang_aot.rs
+++ b/code/packages/rust/lang-aot/bin/lang_aot.rs
@@ -40,13 +40,15 @@ fn main() -> ExitCode {
         None => { eprintln!("lang-aot: missing input file"); print_help(); return ExitCode::from(2); }
     };
     // Default output extension depends on emit mode:
-    //   * Native      → strip extension (foo.bas → foo)
-    //   * LlvmIr      → .ll  (foo.bas → foo.ll),  matching `llc` input convention
-    //   * Riscv32Bin  → .bin (foo.bas → foo.bin), the conventional flat ELF-less name
+    //   * Native       → strip extension (foo.bas → foo)
+    //   * LlvmIr       → .ll  (foo.bas → foo.ll),  matching `llc` input convention
+    //   * Riscv32Bin   → .bin (foo.bas → foo.bin), the conventional flat ELF-less name
+    //   * Intel8008Bin → .bin (foo.oct → foo.bin), shares the `.bin` convention with RV32I
     let output = cmd.output.unwrap_or_else(|| match cmd.emit {
-        EmitMode::Native     => input.with_extension(""),
-        EmitMode::LlvmIr     => input.with_extension("ll"),
-        EmitMode::Riscv32Bin => input.with_extension("bin"),
+        EmitMode::Native       => input.with_extension(""),
+        EmitMode::LlvmIr       => input.with_extension("ll"),
+        EmitMode::Riscv32Bin   => input.with_extension("bin"),
+        EmitMode::Intel8008Bin => input.with_extension("bin"),
     });
 
     let language = match cmd.language {
@@ -81,6 +83,12 @@ enum EmitMode {
     /// Cross-platform (no host gating).  Downstream consumers: the
     /// in-tree `riscv-simulator`, `qemu-riscv32`, or a flash loader.
     Riscv32Bin,
+    /// Flat `.bin` of 8-bit Intel 8008 opcode bytes via
+    /// `iir-to-intel8008`.  Cross-platform.  Downstream consumers:
+    /// the in-tree `intel8008-simulator`, an external 8008 emulator,
+    /// or a 1702 EPROM burner.  Oct's native target — its IIR is
+    /// designed to round-trip through 8008 silicon.
+    Intel8008Bin,
 }
 
 struct CliArgs {
@@ -156,9 +164,10 @@ fn parse_emit_value(v: &str) -> Result<EmitMode, String> {
         "native"                      => Ok(EmitMode::Native),
         "llvm-ir" | "llvm" | "ll"     => Ok(EmitMode::LlvmIr),
         "riscv32" | "rv32" | "bin"    => Ok(EmitMode::Riscv32Bin),
+        "intel8008" | "i8008" | "8008" => Ok(EmitMode::Intel8008Bin),
         other => Err(format!(
             "unknown --emit value {other:?}; expected one of: \
-             native | llvm-ir | riscv32"
+             native | llvm-ir | riscv32 | intel8008"
         )),
     }
 }
@@ -190,6 +199,11 @@ Options:
                                               → flat .bin of little-endian RV32I words
                                                 via iir-to-riscv; cross-platform; load
                                                 into riscv-simulator or qemu-riscv32
+                             intel8008 | i8008 | 8008
+                                              → flat .bin of 8-bit Intel 8008 opcodes
+                                                via iir-to-intel8008; cross-platform;
+                                                load into intel8008-simulator or burn
+                                                to a 1702 EPROM (Oct's native target)
   -h, --help               Show this help.\
 ");
 }
@@ -211,6 +225,14 @@ fn dispatch(
     // encoded words as little-endian bytes.  No linker, no host gating.
     if emit == EmitMode::Riscv32Bin {
         return lang_aot::compile_file_to_riscv32_bin(input, output, language)
+            .map_err(|e| format!("{e}"));
+    }
+    // Intel 8008 .bin emission is also cross-platform — just write the
+    // encoded 8-bit opcodes byte-for-byte.  No linker, no endianness
+    // conversion (the 8008 has no concept of word endianness — every
+    // instruction is a byte sequence).  Oct's native target.
+    if emit == EmitMode::Intel8008Bin {
+        return lang_aot::compile_file_to_intel8008_bin(input, output, language)
             .map_err(|e| format!("{e}"));
     }
     #[cfg(target_os = "linux")]

--- a/code/packages/rust/lang-aot/src/lib.rs
+++ b/code/packages/rust/lang-aot/src/lib.rs
@@ -136,6 +136,12 @@ pub enum LangAotError {
     /// already includes the failing function name and the unsupported
     /// op/type/operand).
     RiscvBackendError(String),
+    /// The Intel 8008 backend rejected the IIR.
+    ///
+    /// Carries the human-readable string from `iir-to-intel8008`
+    /// (which already includes the failing function name and the
+    /// unsupported op/type/operand).
+    Intel8008BackendError(String),
 }
 
 impl fmt::Display for LangAotError {
@@ -149,6 +155,7 @@ impl fmt::Display for LangAotError {
             LangAotError::Io(e) => write!(f, "io: {e}"),
             LangAotError::LlvmBackendError(m) => write!(f, "llvm: {m}"),
             LangAotError::RiscvBackendError(m) => write!(f, "riscv32: {m}"),
+            LangAotError::Intel8008BackendError(m) => write!(f, "intel8008: {m}"),
         }
     }
 }
@@ -308,6 +315,71 @@ pub fn compile_file_to_riscv32_bin(
     for w in &words {
         bytes.extend_from_slice(&w.to_le_bytes());
     }
+    std::fs::write(out, &bytes)?;
+    Ok(())
+}
+
+/// Cross-platform: source → IIR → Intel 8008 machine code (`.bin`) on disk.
+///
+/// Unlike the native-executable pipelines, this one does **not** link
+/// or run any toolchain — it just writes a flat `.bin` of 8-bit Intel
+/// 8008 opcode bytes.  Downstream consumers:
+///
+/// * [`intel8008-simulator`](../intel8008-simulator) — load + execute
+///   in-process via `Simulator::run`.
+/// * An external 8008 emulator that consumes raw byte streams.
+/// * A 1702 EPROM burner — Oct's intended deployment path.  The 8008
+///   is Oct's native target ISA.
+///
+/// No `cfg(target_os = ...)` gating: emitting bytes is platform-agnostic.
+///
+/// # Wire format
+///
+/// Intel 8008 instructions are 1, 2, or 3 bytes each, in the order
+/// the silicon's instruction pointer walks them.  No endianness
+/// conversion — each byte is written exactly as `iir-to-intel8008`
+/// emits it.  Multi-byte instructions (MVI, JMP, CAL, conditional
+/// branches) lay out as `<opcode> <low_byte> [<high_byte>]` per the
+/// 8008 spec (the address bus is 14 bits wide, so the high byte's
+/// top 2 bits are zero).
+///
+/// # Why no host gating?
+///
+/// The 8008 is a historical ISA with no modern host equivalent — we
+/// never produce a "native" binary the host can execute.  The
+/// downstream consumer is always an emulator (in-tree
+/// `intel8008-simulator` or external), an EPROM burner, or actual
+/// 8008 silicon.  All host OSes can write a flat byte file, so the
+/// pipeline is universally available.
+///
+/// # Errors
+///
+/// * `FrontendError` — the language-specific frontend rejected the source.
+/// * `Intel8008BackendError` — the IIR contained an op or type the
+///   Intel 8008 backend does not yet handle (the message names the
+///   function and op).
+/// * `Io` — failed to read the input or write the output.
+///
+/// # Example downstream invocation
+///
+/// ```bash
+/// lang-aot foo.oct --emit=intel8008 -o foo.bin
+/// # Then load foo.bin into the simulator:
+/// intel8008-simulator foo.bin
+/// ```
+pub fn compile_file_to_intel8008_bin(
+    src: &Path,
+    out: &Path,
+    language: Language,
+) -> Result<(), LangAotError> {
+    let source = std::fs::read_to_string(src)?;
+    let stem = src.file_stem().and_then(|s| s.to_str()).unwrap_or("lang");
+    let module = compile_source_to_iir(language, &source, stem)?;
+
+    let cfg = iir_to_intel8008::IIRIntel8008Config::new(stem);
+    let bytes = iir_to_intel8008::lower_iir_to_intel8008(&module, &cfg)
+        .map_err(|e| LangAotError::Intel8008BackendError(format!("{e}")))?;
+
     std::fs::write(out, &bytes)?;
     Ok(())
 }

--- a/code/packages/rust/lang-aot/tests/end_to_end_smoke.rs
+++ b/code/packages/rust/lang-aot/tests/end_to_end_smoke.rs
@@ -954,3 +954,56 @@ fn end_to_end_basic_print_emits_riscv32_bin_via_lang_aot() {
     assert_eq!(last_word_le, &[0x67, 0x80, 0x00, 0x00],
         "last 4 bytes should be the canonical ret encoded little-endian; got: {last_word_le:02x?}");
 }
+
+// ===========================================================================
+// A2+++ — source -> IIR -> Intel 8008 machine code (.bin) via lang-aot
+// ===========================================================================
+//
+// Cross-platform: no linker, no cfg gating.  Confirms the new
+// compile_file_to_intel8008_bin entry point runs the full source ->
+// IIR -> iir-to-intel8008 pipeline and produces a flat .bin of
+// 8-bit Intel 8008 opcode bytes.
+//
+// Why Twig instead of BASIC?  The 8008 is **Oct's** native target,
+// but Oct programs at the LANG VM benchmark sizes routinely exceed
+// the 7-register pool that iir-to-intel8008 v0.3.9 supports (stack
+// spilling lands with A3 or later).  Twig's `42` program — the
+// canonical "return the integer 42" — survives that constraint
+// because it lowers to a single `const v; ret v` IIR sequence which
+// fits in registers A and exits cleanly.
+
+#[test]
+fn end_to_end_twig_42_emits_intel8008_bin_via_lang_aot() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = dir.path().join("smoke.twig");
+    let bin = dir.path().join("smoke.bin");
+    std::fs::write(&src, b"42\n").unwrap();
+
+    if let Err(e) = lang_aot::compile_file_to_intel8008_bin(&src, &bin, lang_aot::Language::Twig) {
+        // Tolerate not-yet-covered op gaps — same convention as the
+        // LLVM + RISC-V paths.  A2++.5.5 covered the IIR core so this
+        // should generally succeed for Twig's `42`, but languages
+        // that emit ops beyond what v0.3.9 supports (e.g. ref<T>
+        // allocation, multi-arg calls) will surface here.
+        let msg = format!("{e}");
+        if msg.contains("UnsupportedOp")
+            || msg.contains("UnsupportedType")
+            || msg.contains("InvalidOperand")
+            || msg.contains("OutOfRegisters")
+        {
+            eprintln!("skipping: Twig Intel 8008 lowering gap (expected): {msg}");
+            return;
+        }
+        panic!("unexpected Twig -> Intel 8008 error: {e}");
+    }
+
+    let bytes = std::fs::read(&bin).expect("read .bin");
+    assert!(!bytes.is_empty(),
+        "Twig `42` should produce a non-empty .bin");
+    // The canonical Twig-`42` lowering is `const v=42 → A; ret v →
+    // HLT` (since main is the entry-point function, ret emits HLT
+    // not RET).  Pinned 3-byte sequence: MVI A, 42 (0x3E 0x2A) + HLT
+    // (0x76).
+    assert_eq!(&bytes[..3.min(bytes.len())], &[0x3E, 0x2A, 0x76],
+        "Twig `42` should produce `MVI A, 42; HLT`; got: {bytes:02x?}");
+}

--- a/code/specs/iir-to-intel8008.md
+++ b/code/specs/iir-to-intel8008.md
@@ -64,8 +64,9 @@ IIRModule
 | v0.3.6 (A2++.5.5 fifth slice) | `cmp` equality with inline flag-to-bool capture | **merged** |
 | v0.3.7 (A2++.5.5 sixth slice) | `cmp_ne`/`cmp_lt`/`cmp_gt` via shared `emit_cmp_capture` helper; introduces `JFC = 0x40`; `cmp_gt` cleverly reuses `cmp_lt` via operand swap | **merged** |
 | v0.3.8 (A2++.5.5 seventh slice) | `cmp_gte`/`cmp_lte` via `JTC = 0x44` (complement of `JFC`); pins remaining 4 cond-jump constants | **merged** |
-| **v0.3.9 (A2++.5.5 EIGHTH AND FINAL SLICE — this PR)** | Real `RET` (`0x07`) + `CAL` (**`0x7E`** — NOT `0x46`/CFZ) + module-level call-site backpatching + entry-point HLT-vs-RET discipline + `call dest, fn_name` IIR op (zero-arg, return-via-A) | this PR |
-| v0.4.0 (A2+++) | `lang-aot --target=intel8008` wiring + argument passing for calls + cross-module CALL backpatching | future |
+| v0.3.9 (A2++.5.5 EIGHTH AND FINAL SLICE) | Real `RET` (`0x07`) + `CAL` (**`0x7E`** — NOT `0x46`/CFZ) + module-level call-site backpatching + entry-point HLT-vs-RET discipline + `call dest, fn_name` IIR op (zero-arg, return-via-A) | **merged** |
+| **A2+++ (this PR, in `lang-aot` v0.7.0 → v0.8.0)** | `lang-aot --emit=intel8008` (aliases `i8008`, `8008`) routes source → IIR → Intel 8008 `.bin` via `iir-to-intel8008`; cross-platform; no host gating; no version bump for this crate | this PR |
+| v0.4.0 (A2++++) | Argument passing for `call` (per-call register-allocation contract) + cross-module CALL backpatching | future |
 
 ## Encoding cheat-sheet for the jump/call family
 


### PR DESCRIPTION
## Summary

After 8 backend slices completing **A2++.5.5**, this PR wires the \`iir-to-intel8008\` backend into the \`lang-aot\` AOT driver.  Mirrors the A1+++ pattern that wired \`iir-to-riscv\` in the previous lang-aot v0.7.0 release.

- New CLI flag: \`lang-aot foo.oct --emit=intel8008 -o foo.bin\` (aliases \`i8008\`, \`8008\`).
- New public API: \`lang_aot::compile_file_to_intel8008_bin(src, out, language)\`.
- New error variant: \`LangAotError::Intel8008BackendError(String)\`.
- E2E smoke test asserting the canonical Twig \`42\` lowers to \`3E 2A 76\` (MVI A, 42 + HLT) through the full pipeline.
- lang-aot version bump 0.7.0 → 0.8.0.

### Downstream consumers of the emitted .bin

- In-tree \`intel8008-simulator\` via \`Simulator::run\`
- External 8008 emulators that consume raw byte streams
- A 1702 EPROM burner — Oct's intended deployment path; the 8008 is Oct's native target ISA.

### Why no host gating?

The 8008 is a historical ISA with no modern host equivalent — we never produce a "native" binary the host can execute.  Downstream is always an emulator, an EPROM burner, or actual 8008 silicon.  All host OSes can write a flat byte file, so the pipeline is universally available.

### A2++.5.5 + A2+++ completes the second architecture-backend lane

Together with A1/A1+/A1++/A1+++ (RV32I, fully merged), the LANG VM backend matrix now spans two architectures at opposite ends of the design space: clean 32-bit RISC and irregular 8-bit accumulator-based CISC.  A3 (ARMv7) onward continues the lane.

### What's left in A2 future work

- **v0.4.0 (A2++++)** — argument passing for \`call\` (per-call register-allocation contract) + cross-module CALL backpatching.

## Test plan

- [x] \`cargo test -p lang-aot\` — 21/21 tests pass
- [x] New \`end_to_end_twig_42_emits_intel8008_bin_via_lang_aot\` asserts the canonical \`3E 2A 76\` byte sequence
- [x] Existing 20 e2e tests still pass (no regression)
- [x] \`--emit=intel8008\` parsing accepts \`intel8008\`, \`i8008\`, \`8008\` aliases
- [x] Default output extension \`.bin\` for Intel8008Bin mode
- [x] Security review passed (no vulnerabilities found)
- [ ] CI green
- [ ] No merge conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)