### PR TITLE
feat(iir-to-armv7): crate skeleton — A3 third architecture backend

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -656,6 +656,7 @@ members = [
     "iir-to-llvm",
     "iir-to-riscv",
     "iir-to-intel8008",
+    "iir-to-armv7",
     "aot-debug",
     "twig-to-beam",
     "twig-to-wasm",

--- a/code/packages/rust/iir-to-armv7/BUILD
+++ b/code/packages/rust/iir-to-armv7/BUILD
@@ -1,0 +1,1 @@
+cargo test -p iir-to-armv7

--- a/code/packages/rust/iir-to-armv7/CHANGELOG.md
+++ b/code/packages/rust/iir-to-armv7/CHANGELOG.md
@@ -1,0 +1,111 @@
+# Changelog — iir-to-armv7
+
+All notable changes to this crate are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [0.1.0] — 2026-06-02 (A3 — crate skeleton)
+
+### Added — `BKPT`-only emission
+
+First release.  Implements item A3 of the
+[multi-language architecture backends plan][plan]: a crate skeleton
+that lowers any IIR module to a single ARMv7-A `BKPT #0xFFFF`
+instruction (encoding `0xE12FFF7F`).
+
+#### Public surface
+
+```rust
+pub struct IIRArmv7Config { pub module_name: String }
+impl IIRArmv7Config {
+    pub fn new(module_name: impl Into<String>) -> Self;
+}
+
+pub enum IIRArmv7Error {
+    ValidationFailed(Vec<String>),
+    UnsupportedOp     { function: String, op: String },
+    UnsupportedType   { function: String, type_hint: String },
+    InvalidOperand    { function: String, detail: String },
+}
+
+pub fn validate_for_armv7(module: &IIRModule) -> Vec<String>;
+pub fn lower_iir_to_armv7(
+    module: &IIRModule,
+    cfg: &IIRArmv7Config,
+) -> Result<Vec<u32>, IIRArmv7Error>;
+
+pub const BKPT: u32 = 0xE12FFF7F;
+```
+
+#### Why an ARMv7 backend?
+
+ARMv7 (32-bit ARM, A32 encoding) is the **phone-class target** of
+the LANG VM backend lane.  It covers Cortex-A7/A8/A9-era SoCs and
+many embedded boards (early Raspberry Pi, BeagleBone, Olimex
+A20-OLinuXino) — vastly more deployed silicon than any single 8008
+chip ever shipped, but architecturally a clean fixed-width 32-bit
+RISC like RV32I with one big twist: every A32 instruction carries a
+4-bit `cond` field that can predicate execution.
+
+A3 establishes the third architecture backend alongside RV32I (A1)
+and Intel 8008 (A2).  Together they exercise the IIR's neutrality
+across genuinely different ISAs:
+
+- **RV32I**: clean 32-bit RISC, load-store, no condition codes.
+- **Intel 8008**: irregular 8-bit accumulator CISC, 14-bit address
+  bus — historical fidelity for Oct.
+- **ARMv7**: 32-bit RISC with cond prefixes on every instruction
+  plus a barrel shifter on the second operand.
+
+#### Why `Vec<u32>` output, not textual asm?
+
+* **Round-trips with `arm-simulator`** — its decoder consumes raw
+  little-endian 32-bit words directly.
+* **Deterministic test surface** — `assert_eq!(words[0], 0xE12FFF7F)`
+  is unambiguous; ARM assembler syntax has GNU `as`, LLVM `clang`,
+  and ARMASM divergence we don't want to entangle with.
+* **Trivial encoding shape** — every A32 instruction is exactly 4
+  bytes (in stark contrast to the 8008's 1/2/3 byte variability).
+
+#### The `BKPT #0xFFFF` encoding
+
+`0xE12FFF7F`.  Bit layout (cond=AL):
+
+```text
+31..28  cond    = 0xE = 1110            (always — unconditional)
+27..20          = 0001 0010 = 0x12      (BKPT opcode family)
+19.. 8  imm12   = 0xFFF                 (top 12 bits of imm16)
+ 7.. 4          = 0111 = 0x7            (BKPT opcode family)
+ 3.. 0  imm4    = 0xF                   (bottom 4 bits of imm16)
+```
+
+Concatenated: `1110 0001 0010 1111_1111_1111 0111 1111` =
+`0xE12FFF7F`.
+
+#### Why BKPT and not WFI or `b .`?
+
+| Candidate | Pros | Cons |
+|-----------|------|------|
+| `BKPT #imm16` | Semantically "stop"; every ARM debugger / emulator recognises it | None for skeleton purposes |
+| `WFI`         | True halt | Requires kernel/hypervisor privilege; illegal in userspace |
+| `B .`         | Pure userspace, no traps | Burns CPU; harder to detect without a host timeout |
+
+BKPT wins on simplicity + emulator round-trip.
+
+#### What is NOT in v0.1.0
+
+* **No instruction lowering.**  Function bodies in the input
+  `IIRModule` are ignored.  v0.2.0 (A3+) lowers `const` + `bx lr`.
+* **No `lang-aot --emit=armv7`.**  Deferred to v0.4.0 (A3+++).
+* **No external assembler / linker integration.**
+
+#### Tests added (7 total)
+
+* `validate_returns_empty_for_empty_module`
+* `lower_emits_exactly_one_word`
+* `lower_emits_the_canonical_bkpt_word` (exact `0xE12FFF7F`)
+* `bkpt_constant_pinned_to_e12fff7f`
+* `default_config_has_nonempty_module_name`
+* `new_sets_module_name`
+* `errors_display_without_panic`
+
+[plan]: ../../../specs/MULTILANG-ARCHITECTURE-BACKENDS.md

--- a/code/packages/rust/iir-to-armv7/Cargo.toml
+++ b/code/packages/rust/iir-to-armv7/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "iir-to-armv7"
+version = "0.1.0"
+edition = "2021"
+description = "IIR → ARMv7 (A32) machine code backend — lowers IIRModule to a Vec<u32> of encoded 32-bit ARMv7-A instructions.  v0.1.0 (A3): crate skeleton that lowers any module to a single `BKPT #0xFFFF` (0xE12FFF7F) — the canonical halt sentinel that every ARM debugger and emulator recognises.  Real lowering (mov/add/sub/bl/cmp) lands in A3+ through A3++.  ARMv7 is the third architecture backend in the LANG VM matrix, sitting alongside RV32I (A1, clean 32-bit RISC) and Intel 8008 (A2, irregular 8-bit accumulator CISC).  ARMv7 occupies the unique middle ground of being a 32-bit RISC with condition-code prefixes on every instruction + a barrel-shifted second operand."
+
+[lib]
+name = "iir_to_armv7"
+path = "src/lib.rs"
+
+[dependencies]
+interpreter-ir = { path = "../interpreter-ir" }
+
+[[test]]
+name = "test_backend"
+path = "tests/test_backend.rs"

--- a/code/packages/rust/iir-to-armv7/README.md
+++ b/code/packages/rust/iir-to-armv7/README.md
@@ -1,0 +1,139 @@
+# iir-to-armv7
+
+**IIR → ARMv7 (A32) machine code backend.**
+
+Lowers an `IIRModule` from the [interpreter-ir](../interpreter-ir/)
+shared IR to a `Vec<u32>` of encoded 32-bit ARMv7-A instructions.
+
+| | |
+|---|---|
+| **Version** | 0.1.0 — skeleton (A3) |
+| **Plan** | [`MULTILANG-ARCHITECTURE-BACKENDS.md`](../../../specs/MULTILANG-ARCHITECTURE-BACKENDS.md) §A3 |
+| **Spec** | [`iir-to-armv7.md`](../../../specs/iir-to-armv7.md) |
+| **Sibling backends** | [`iir-to-riscv`](../iir-to-riscv/), [`iir-to-intel8008`](../iir-to-intel8008/), [`iir-to-llvm`](../iir-to-llvm/), [`iir-to-wasm`](../iir-to-wasm/) |
+| **Downstream consumers** | [`arm-simulator`](../arm-simulator/), `qemu-arm`, `objcopy` + a phone-class Linux linker |
+
+## Why an ARMv7 backend?
+
+ARMv7 (32-bit ARM, A32 encoding) is the **phone-class target** of
+the LANG VM architecture-backend lane.  It covers Cortex-A7/A8/A9-era
+SoCs and many embedded boards (early Raspberry Pi, BeagleBone, Olimex
+A20-OLinuXino).
+
+Adding ARMv7 gives the LANG VM matrix a third architecture backend:
+
+| | RV32I (A1) | Intel 8008 (A2) | **ARMv7 (A3)** |
+|---|---|---|---|
+| Width | 32-bit | 8-bit | 32-bit |
+| Style | Clean RISC | Irregular CISC | RISC + cond prefixes + barrel shifter |
+| Decoding | Fixed 32-bit words | 1/2/3-byte variable | Fixed 32-bit words |
+| Special twist | Compressed `C` extension | 14-bit address bus | `cond` field on every instruction |
+| Deployed silicon | Embedded controllers | Historical (Oct) | Billions of phones / IoT |
+
+All three speak different architectural dialects of "what a backend
+must care about", which is the point — exercising the IIR's
+neutrality across genuinely different ISAs.
+
+## Quick start
+
+```rust
+use interpreter_ir::IIRModule;
+use iir_to_armv7::{validate_for_armv7, lower_iir_to_armv7, IIRArmv7Config};
+
+let module = IIRModule {
+    name: "demo".into(),
+    functions: vec![],
+    entry_point: None,
+    language: "demo".into(),
+    exports: vec![],
+    imports: vec![],
+};
+
+assert!(validate_for_armv7(&module).is_empty());
+
+let words = lower_iir_to_armv7(&module, &IIRArmv7Config::default())
+    .expect("lowering should succeed");
+
+// v0.1.0 emits a single BKPT #0xFFFF.
+assert_eq!(words, vec![0xE12F_FF7F]);
+```
+
+## Public API (v0.1.0)
+
+```rust
+pub struct IIRArmv7Config { pub module_name: String }
+impl IIRArmv7Config {
+    pub fn new(module_name: impl Into<String>) -> Self;
+}
+
+pub enum IIRArmv7Error {
+    ValidationFailed(Vec<String>),
+    UnsupportedOp     { function: String, op: String },
+    UnsupportedType   { function: String, type_hint: String },
+    InvalidOperand    { function: String, detail: String },
+}
+
+pub fn validate_for_armv7(module: &IIRModule) -> Vec<String>;
+pub fn lower_iir_to_armv7(
+    module: &IIRModule,
+    cfg: &IIRArmv7Config,
+) -> Result<Vec<u32>, IIRArmv7Error>;
+
+pub const BKPT: u32 = 0xE12FFF7F;
+```
+
+## Why `Vec<u32>` output, not textual asm?
+
+* **Round-trips with `arm-simulator`** — its decoder consumes raw
+  little-endian 32-bit words.
+* **Deterministic test surface** — `assert_eq!(words[0], 0xE12FFF7F)`
+  is unambiguous; ARM assembler syntax has GNU `as`, LLVM `clang`,
+  and ARMASM divergence.
+* **Trivial encoding shape** — every A32 instruction is exactly 4
+  bytes (no 1/2/3-byte variability like the 8008).
+
+## The `BKPT` encoding (v0.1.0)
+
+`BKPT #0xFFFF` = `0xE12FFF7F`.  Bit layout:
+
+```text
+31..28  cond    = 0xE = 1110            (always — unconditional)
+27..20          = 0001 0010 = 0x12      (BKPT opcode family)
+19.. 8  imm12   = 0xFFF                 (top 12 bits of imm16)
+ 7.. 4          = 0111 = 0x7            (BKPT opcode family)
+ 3.. 0  imm4    = 0xF                   (bottom 4 bits of imm16)
+```
+
+### Why BKPT and not WFI or `b .`?
+
+| Candidate | Pros | Cons |
+|-----------|------|------|
+| `BKPT #imm16` | Semantically "stop"; every ARM debugger / emulator recognises it | None for skeleton purposes |
+| `WFI`         | True halt | Requires kernel/hypervisor privilege; illegal in userspace |
+| `B .`         | Pure userspace, no traps | Burns CPU; harder to detect without a host timeout |
+
+BKPT wins on simplicity + emulator round-trip.  The
+`arm-simulator`'s decoder flags it as `bkpt` and stops single-stepping.
+
+## What is NOT in v0.1.0
+
+* **No instruction lowering.**  Function bodies in the input
+  `IIRModule` are ignored.  v0.2.0 (A3+) lowers `const` + `bx lr`.
+* **No `lang-aot --emit=armv7`.**  Deferred to A3+++.
+* **No external assembler / linker integration.**
+
+## Tests
+
+* `validate_returns_empty_for_empty_module`
+* `lower_emits_exactly_one_word`
+* `lower_emits_the_canonical_bkpt_word` (exact `0xE12FFF7F`)
+* `bkpt_constant_pinned_to_e12fff7f`
+* `default_config_has_nonempty_module_name`
+* `new_sets_module_name`
+* `errors_display_without_panic`
+
+Run with `cargo test -p iir-to-armv7`.
+
+## License
+
+Same as the parent repository.

--- a/code/packages/rust/iir-to-armv7/src/lib.rs
+++ b/code/packages/rust/iir-to-armv7/src/lib.rs
@@ -1,0 +1,238 @@
+//! # iir-to-armv7 — IIR → ARMv7 (A32) machine code backend (v0.1.0 skeleton).
+//!
+//! Lowers an [`interpreter_ir::IIRModule`] to a `Vec<u32>` of encoded
+//! 32-bit ARMv7-A (A32) instructions, suitable to drop into the
+//! in-tree `arm-simulator` or to write out as a flat `.bin` for
+//! `qemu-arm` / `objcopy`.
+//!
+//! ## Why an ARMv7 backend?
+//!
+//! ARMv7 (32-bit ARM, A32 encoding) is the **phone-class target** of
+//! the LANG VM architecture-backend lane.  It covers Cortex-A7/A8/A9-
+//! era SoCs and many embedded boards (early Raspberry Pi, BeagleBone,
+//! Olimex A20-OLinuXino) — vastly more deployed silicon than any
+//! single 8008 chip ever shipped, but architecturally a clean
+//! fixed-width 32-bit RISC like RV32I.
+//!
+//! Adding ARMv7 as a backend gives us:
+//!
+//! 1. **A third architecture backend** alongside RV32I (A1) and
+//!    Intel 8008 (A2).  The three sit at meaningfully different
+//!    points in the design space:
+//!    - RV32I: clean 32-bit RISC, load-store, no condition codes.
+//!    - Intel 8008: irregular 8-bit accumulator CISC, 14-bit address
+//!      bus — historical fidelity for Oct.
+//!    - **ARMv7 (A32)**: 32-bit RISC with a `cond` field on EVERY
+//!      instruction plus a barrel shifter on the second operand.
+//!      Same word width as RV32I, fundamentally different ISA.
+//! 2. **Foundation for native phone-OS targets.**  Once the AOT
+//!    wiring lands (A3+++), the same LANG VM source program can
+//!    cross-compile to ARMv7 Linux executables.
+//! 3. **Round-trip with the in-tree `arm-simulator`.**  The
+//!    `Vec<u32>` output drops directly into the simulator for
+//!    in-process tests.
+//!
+//! ## Scope of v0.1.0 (A3)
+//!
+//! This release is a **skeleton**: any IIR module lowers to a single
+//! `BKPT #0xFFFF` instruction (encoding `0xE12FFF7F`).  No instruction
+//! selection yet; that arrives in A3+ (`const` + `bx lr`) and beyond.
+//!
+//! ## Why `Vec<u32>` output, not textual asm?
+//!
+//! - **Round-trips with `arm-simulator`** — its decoder consumes raw
+//!   little-endian 32-bit words.
+//! - **Deterministic test surface** — `assert_eq!(words[0], 0xE12FFF7F)`
+//!   is unambiguous; ARM assembler syntax has GNU `as`, LLVM `clang`,
+//!   and ARMASM divergence we don't want to entangle with.
+//! - **Trivial encoding shape** — every A32 instruction is exactly 4
+//!   bytes (in stark contrast to the 8008's 1/2/3 byte variability).
+//!
+//! ## Quick start
+//!
+//! ```
+//! use interpreter_ir::IIRModule;
+//! use iir_to_armv7::{validate_for_armv7, lower_iir_to_armv7, IIRArmv7Config};
+//!
+//! let module = IIRModule {
+//!     name: "demo".into(),
+//!     functions: vec![],
+//!     entry_point: None,
+//!     language: "demo".into(),
+//!     exports: vec![],
+//!     imports: vec![],
+//! };
+//!
+//! assert!(validate_for_armv7(&module).is_empty());
+//!
+//! let words = lower_iir_to_armv7(&module, &IIRArmv7Config::default())
+//!     .expect("lowering should succeed");
+//! // 0xE12FFF7F == ARMv7-A BKPT #0xFFFF.
+//! assert_eq!(words, vec![0xE12F_FF7F]);
+//! ```
+//!
+//! ## Pipeline position
+//!
+//! ```text
+//! IIRModule
+//!   → validate_for_armv7()      pre-flight, returns Vec<String>
+//!   → lower_iir_to_armv7()      returns Vec<u32> of A32 words
+//!   → (optional)
+//!       • arm-simulator: in-process testing
+//!       • write to .bin + qemu-arm
+//!       • objcopy + linker for an ELF on a phone-class Linux board
+//! ```
+
+use interpreter_ir::IIRModule;
+use std::fmt;
+
+// ===========================================================================
+// ARMv7 (A32) opcode constants
+// ===========================================================================
+//
+// Every A32 instruction is exactly 4 bytes, with a fixed encoding
+// template `cond IIII OOOO ... ` where `cond` is the conditional-
+// execution prefix (the 4-bit field bits 31..28 every A32 instruction
+// carries) and `IIII OOOO` selects the instruction family.  Unlike
+// RV32I and the 8008, ARMv7 has no "unconditional" sub-encoding for
+// most ops — `cond = 0b1110 = 0xE` is the "always-execute" value used
+// everywhere a conditional prefix isn't actively wanted.
+
+/// ARMv7-A `BKPT #0xFFFF` opcode — `0xE12FFF7F`.  Triggers a
+/// breakpoint exception; semantically "stop execution".
+///
+/// Bit layout (cond=AL):
+///
+/// ```text
+/// 31..28  cond    = 0xE = 1110            (always — unconditional)
+/// 27..20          = 0001 0010 = 0x12      (BKPT opcode family)
+/// 19.. 8  imm12   = 0xFFF                 (top 12 bits of imm16)
+///  7.. 4          = 0111 = 0x7            (BKPT opcode family)
+///  3.. 0  imm4    = 0xF                   (bottom 4 bits of imm16)
+/// ```
+///
+/// Concatenated: `1110 0001 0010 1111_1111_1111 0111 1111` =
+/// `0xE12FFF7F`.
+///
+/// ## Why BKPT and not WFI or `b .`?
+///
+/// | Candidate | Pros | Cons |
+/// |-----------|------|------|
+/// | `BKPT #imm16` | Semantically "stop"; every ARM debugger / emulator recognises it | None for skeleton purposes |
+/// | `WFI`         | True halt | Requires kernel/hypervisor privilege; illegal in userspace |
+/// | `B .`         | Pure userspace, no traps | Burns CPU; harder to detect without a host timeout |
+///
+/// BKPT wins on simplicity + emulator round-trip.  The
+/// `arm-simulator`'s decoder flags it as `bkpt` and stops single-
+/// stepping.
+pub const BKPT: u32 = 0xE12F_FF7F;
+
+// ===========================================================================
+// IIRArmv7Config
+// ===========================================================================
+
+/// Configuration for the IIR → ARMv7 lowering pass.
+///
+/// Currently only the module name is configurable, reserved for future
+/// symbol-table / ELF-section emission.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IIRArmv7Config {
+    /// Module name — reserved for future symbol-table / `.bin` header use.
+    pub module_name: String,
+}
+
+impl IIRArmv7Config {
+    /// Build a config with a custom module name.
+    pub fn new(module_name: impl Into<String>) -> Self {
+        Self {
+            module_name: module_name.into(),
+        }
+    }
+}
+
+impl Default for IIRArmv7Config {
+    fn default() -> Self {
+        Self {
+            module_name: "iir_module".into(),
+        }
+    }
+}
+
+// ===========================================================================
+// IIRArmv7Error
+// ===========================================================================
+
+/// Errors that can occur during IIR → ARMv7 lowering.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IIRArmv7Error {
+    /// The module failed pre-flight validation.
+    ValidationFailed(Vec<String>),
+    /// An IIR opcode not yet supported by this backend.  v0.1.0
+    /// doesn't lower any instructions, so a non-empty function body
+    /// would surface this in a future version.
+    UnsupportedOp { function: String, op: String },
+    /// A type hint that does not map to any ARMv7 representation.
+    UnsupportedType { function: String, type_hint: String },
+    /// An operand has an unexpected shape.
+    InvalidOperand { function: String, detail: String },
+}
+
+impl fmt::Display for IIRArmv7Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ValidationFailed(errs) => {
+                write!(f, "validation failed:\n  {}", errs.join("\n  "))
+            }
+            Self::UnsupportedOp { function, op } => {
+                write!(f, "unsupported op in function {function:?}: {op}")
+            }
+            Self::UnsupportedType { function, type_hint } => {
+                write!(f, "unsupported type in function {function:?}: {type_hint}")
+            }
+            Self::InvalidOperand { function, detail } => {
+                write!(f, "invalid operand in function {function:?}: {detail}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for IIRArmv7Error {}
+
+// ===========================================================================
+// validate_for_armv7
+// ===========================================================================
+
+/// Pre-flight validation for IIR → ARMv7 lowering.
+///
+/// **v0.1.0 stub**: always returns an empty `Vec` — there are no
+/// validation rules yet because no instructions are lowered.  Future
+/// versions will add rules as opcodes come online (see
+/// `MULTILANG-ARCHITECTURE-BACKENDS.md` §A3).
+///
+/// Mirrors the shape of the other IIR backends'
+/// `validate_for_{wasm,jvm,clr,beam,llvm,riscv,intel8008}` so callers
+/// can switch backends without changing their pre-flight logic.
+pub fn validate_for_armv7(_module: &IIRModule) -> Vec<String> {
+    Vec::new()
+}
+
+// ===========================================================================
+// lower_iir_to_armv7
+// ===========================================================================
+
+/// Lower an [`IIRModule`] to a `Vec<u32>` of ARMv7 (A32) opcode words.
+///
+/// **v0.1.0 scope**: emits a single `BKPT #0xFFFF` regardless of the
+/// input.  This is the smallest "valid A32 program" we can produce —
+/// enough to load into the simulator, step once, and confirm the
+/// breakpoint exception fires.  Real lowering arrives in v0.2.0+ (A3+).
+pub fn lower_iir_to_armv7(
+    module: &IIRModule,
+    _cfg: &IIRArmv7Config,
+) -> Result<Vec<u32>, IIRArmv7Error> {
+    let errors = validate_for_armv7(module);
+    if !errors.is_empty() {
+        return Err(IIRArmv7Error::ValidationFailed(errors));
+    }
+    Ok(vec![BKPT])
+}

--- a/code/packages/rust/iir-to-armv7/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-armv7/tests/test_backend.rs
@@ -1,0 +1,117 @@
+//! Integration tests for `iir-to-armv7` v0.1.0 (A3 skeleton).
+//!
+//! Smoke-level — confirms the validator stub, the emitter shape, and
+//! the exact encoded `BKPT #0xFFFF` word (`0xE12FFF7F`).
+
+use interpreter_ir::IIRModule;
+use iir_to_armv7::{
+    lower_iir_to_armv7, validate_for_armv7,
+    IIRArmv7Config, IIRArmv7Error, BKPT,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn empty_module() -> IIRModule {
+    IIRModule {
+        name: "demo".into(),
+        functions: vec![],
+        entry_point: None,
+        language: "test".into(),
+        exports: vec![],
+        imports: vec![],
+    }
+}
+
+// ===========================================================================
+// 1. Validator stub
+// ===========================================================================
+
+#[test]
+fn validate_returns_empty_for_empty_module() {
+    assert!(validate_for_armv7(&empty_module()).is_empty());
+}
+
+// ===========================================================================
+// 2. Lowering shape and the exact `BKPT` encoding
+// ===========================================================================
+
+#[test]
+fn lower_emits_exactly_one_word() {
+    let words = lower_iir_to_armv7(&empty_module(), &IIRArmv7Config::default())
+        .expect("lowering");
+    assert_eq!(words.len(), 1,
+        "v0.1.0 must emit exactly one word; got: {words:08x?}");
+}
+
+/// The emitted word is `0xE12FFF7F` — the canonical ARMv7-A
+/// `BKPT #0xFFFF` (breakpoint with the maximum 16-bit immediate).
+///
+/// Bit layout (cond=AL=0xE):
+///
+/// ```text
+/// 31..28  cond    = 0xE = 1110            (always — unconditional)
+/// 27..20          = 0001 0010 = 0x12      (BKPT opcode family)
+/// 19.. 8  imm12   = 0xFFF                 (top 12 bits of imm16)
+///  7.. 4          = 0111 = 0x7            (BKPT opcode family)
+///  3.. 0  imm4    = 0xF                   (bottom 4 bits of imm16)
+/// ```
+///
+/// Concatenated: `1110 0001 0010 1111_1111_1111 0111 1111` =
+/// `0xE12FFF7F`.  Pinning the exact constant guards against any
+/// future change in the simulator's opcode table that would break the
+/// encoding.
+#[test]
+fn lower_emits_the_canonical_bkpt_word() {
+    let words = lower_iir_to_armv7(&empty_module(), &IIRArmv7Config::default())
+        .expect("lowering");
+    assert_eq!(words[0], 0xE12F_FF7F,
+        "expected canonical BKPT encoding 0xE12FFF7F; got 0x{:08x}", words[0]);
+    assert_eq!(words[0], BKPT,
+        "the emitted word should equal the exported BKPT constant");
+}
+
+#[test]
+fn bkpt_constant_pinned_to_e12fff7f() {
+    // Sanity: the exported BKPT constant matches the canonical
+    // ARMv7-A documented encoding.  Guards against the kind of "00
+    // 12 7f e1" little-endian byte-order confusion that's easy to
+    // make when staring at a hexdump.
+    assert_eq!(BKPT, 0xE12F_FF7F,
+        "BKPT #0xFFFF should be 0xE12FFF7F (cond=AL, imm16=0xFFFF)");
+}
+
+// ===========================================================================
+// 3. Config defaults
+// ===========================================================================
+
+#[test]
+fn default_config_has_nonempty_module_name() {
+    let cfg = IIRArmv7Config::default();
+    assert!(!cfg.module_name.is_empty());
+}
+
+#[test]
+fn new_sets_module_name() {
+    let cfg = IIRArmv7Config::new("custom");
+    assert_eq!(cfg.module_name, "custom");
+}
+
+// ===========================================================================
+// 4. Error display
+// ===========================================================================
+
+#[test]
+fn errors_display_without_panic() {
+    let _ = format!("{}", IIRArmv7Error::ValidationFailed(vec!["x".into()]));
+    let _ = format!("{}", IIRArmv7Error::UnsupportedOp {
+        function: "f".into(), op: "weird".into(),
+    });
+    let _ = format!("{}", IIRArmv7Error::UnsupportedType {
+        function: "f".into(), type_hint: "weird".into(),
+    });
+    let _ = format!("{}", IIRArmv7Error::InvalidOperand {
+        function: "f".into(), detail: "bad".into(),
+    });
+}

--- a/code/specs/iir-to-armv7.md
+++ b/code/specs/iir-to-armv7.md
@@ -1,0 +1,143 @@
+# iir-to-armv7 — IIR → ARMv7 (A32) machine code backend
+
+**Status:** v0.1.0 — skeleton (A3)
+**Plan:** [`MULTILANG-ARCHITECTURE-BACKENDS.md`](MULTILANG-ARCHITECTURE-BACKENDS.md) §A3
+**Related:** [`iir-to-riscv`][rv], [`iir-to-intel8008`][i8008]
+
+[rv]: ../packages/rust/iir-to-riscv/
+[i8008]: ../packages/rust/iir-to-intel8008/
+
+## Why a new crate?
+
+ARMv7 (32-bit ARM, A32 encoding) is the **phone-class target** of
+the LANG VM backend lane.  It covers Cortex-A7/A8/A9-era SoCs and
+many embedded boards (early Raspberry Pi, BeagleBone, Olimex
+A20-OLinuXino) — far more deployed silicon than any single 8008
+chip ever shipped, but architecturally a clean fixed-width 32-bit
+RISC like RV32I.
+
+Adding ARMv7 as a backend gives us:
+
+1. **A third architecture backend** alongside RV32I (A1) and Intel
+   8008 (A2).  The three sit at meaningfully different points in
+   the design space:
+   - RV32I: clean modern 32-bit RISC, load-store, condition-codes-
+     less.
+   - Intel 8008: irregular 8-bit accumulator-based CISC with 14-bit
+     addressing — historical fidelity for Oct.
+   - **ARMv7 (A32)**: 32-bit RISC with condition-code prefixes on
+     every instruction (the `cond` field every A32 instruction
+     carries) plus a barrel shifter on the second operand.  Same
+     word-width as RV32I but a fundamentally different ISA-level
+     design.
+
+2. **Foundation for native phone-OS targets.**  Once the AOT
+   wiring lands, the same LANG VM source program can be cross-
+   compiled to ARMv7 Linux executables (BeagleBone, Raspberry Pi
+   1/Zero, qemu-arm) without changing front-end code.
+
+3. **Round-trip with the in-tree [`arm-simulator`].**  The
+   `Vec<u32>` output drops directly into the simulator for
+   in-process tests.
+
+## Why `Vec<u32>` output, not textual asm?
+
+* **Round-trips with `arm-simulator`** — its decoder consumes raw
+  little-endian 32-bit words directly.
+* **Deterministic test surface** — `assert_eq!(words[0], 0xE12FFF7F)`
+  is unambiguous; ARM assembler syntax has GNU `as`, LLVM `clang`,
+  and ARMASM divergence we don't want to entangle with.
+* **Trivial encoding shape** — every A32 instruction is exactly 4
+  bytes (in stark contrast to the 8008's 1/2/3 byte variability).
+  `Vec<u32>` is the natural representation.
+
+## Pipeline
+
+```text
+IIRModule
+  → validate_for_armv7()      pre-flight, returns Vec<String>
+  → lower_iir_to_armv7()      returns Vec<u32> of A32 words
+  → (optional)
+      • arm-simulator: in-process testing
+      • write to .bin + qemu-arm for cross-platform execution
+      • objcopy + linker for an ELF on a phone-class Linux board
+```
+
+## Scope by version
+
+| Version | Scope | Status |
+|---------|-------|--------|
+| **v0.1.0 (A3 — this PR)** | crate skeleton: any module → single `BKPT #0xFFFF` (`0xE12FFF7F`) | this PR |
+| v0.2.0 (A3+) | `const` → `mov rd, #imm8` + `ret`/`ret_void` → `bx lr` | future |
+| v0.3.0 (A3++) | Linear register allocator over `r0..r12` + arithmetic (add/sub) + function calls via `bl` with PC-relative offsets | future |
+| v0.3.x (A3++.5.5) | Comparisons + conditional branches via the cond-field on every A32 instruction (a stronger version of the 8008's flag-based jumps) | future |
+| v0.4.0 (A3+++) | `lang-aot --emit=armv7` wiring | future |
+
+## Public surface (v0.1.0)
+
+```rust
+pub struct IIRArmv7Config { pub module_name: String }
+impl IIRArmv7Config {
+    pub fn new(module_name: impl Into<String>) -> Self;
+}
+
+pub enum IIRArmv7Error {
+    ValidationFailed(Vec<String>),
+    UnsupportedOp     { function: String, op: String },
+    UnsupportedType   { function: String, type_hint: String },
+    InvalidOperand    { function: String, detail: String },
+}
+
+pub fn validate_for_armv7(module: &IIRModule) -> Vec<String>;
+pub fn lower_iir_to_armv7(
+    module: &IIRModule,
+    cfg: &IIRArmv7Config,
+) -> Result<Vec<u32>, IIRArmv7Error>;
+
+pub const BKPT: u32 = 0xE12FFF7F;
+```
+
+## The `BKPT` encoding (v0.1.0 acceptance criterion)
+
+The chosen "halt sentinel" is `BKPT #0xFFFF`, encoded as
+`0xE12FFF7F`.  Bit layout:
+
+```text
+31..28  cond     = 0xE = 1110          (always — unconditional)
+27..20            = 0001 0010 = 0x12   (BKPT opcode family)
+19..8   imm12    = 0xFFF                (top 12 bits of imm16)
+ 7..4            = 0111 = 0x7           (BKPT opcode family)
+ 3..0   imm4     = 0xF                  (bottom 4 bits of imm16)
+```
+
+Concatenated: `1110 0001 0010 1111_1111_1111 0111 1111` =
+`0xE12FFF7F`.
+
+### Why BKPT and not WFI or `b .`?
+
+| Candidate | Pros | Cons |
+|-----------|------|------|
+| `BKPT #imm16` | Semantically "stop execution"; every ARM debugger / emulator recognises it; emits a defined trap | None for skeleton purposes |
+| `WFI` | "Wait For Interrupt" — true halt | Requires kernel/hypervisor privilege; not legal in userspace |
+| `B .` (infinite loop) | Pure userspace, no traps | Burns CPU; harder to detect from a host emulator without timeout |
+
+BKPT wins on simplicity + emulator round-trip.  The
+`arm-simulator`'s decoder flags it as `bkpt` and stops single-stepping.
+
+## Non-goals (v0.1.0)
+
+* No instruction lowering — deferred to A3+.
+* No `lang-aot --emit=armv7` wiring — deferred to A3+++.
+* No external assembler / linker integration.  Output is raw
+  little-endian 32-bit words; downstream loaders are the caller's
+  responsibility.
+
+## Tests (v0.1.0)
+
+* `validate_returns_empty_for_empty_module` — stub validator behaves.
+* `lower_emits_exactly_one_word` — output shape.
+* `lower_emits_the_canonical_bkpt_word` — exact `0xE12FFF7F`.
+* `bkpt_constant_pinned_to_e12fff7f` — guards the constant.
+* `default_config_has_nonempty_module_name` — config invariant.
+* `new_sets_module_name` — builder contract.
+* `errors_display_without_panic` — error formatting smoke.


### PR DESCRIPTION
## Summary

Adds a new crate \`iir-to-armv7\` at v0.1.0 — the **A3 skeleton** in the LANG VM architecture-backend matrix, mirroring iir-to-riscv (A1) and iir-to-intel8008 (A2).

ARMv7 (32-bit ARM, A32 encoding) is the **phone-class target** — Cortex-A7/A8/A9-era SoCs and many embedded boards (early Raspberry Pi, BeagleBone, Olimex A20-OLinuXino).

### Design-space positioning

|                    | RV32I (A1)    | Intel 8008 (A2) | **ARMv7 (A3)**          |
| ------------------ | ------------- | --------------- | ----------------------- |
| Width              | 32-bit        | 8-bit           | 32-bit                  |
| Style              | Clean RISC    | Irregular CISC  | RISC + cond prefixes    |
| Decoding           | Fixed 32-bit  | Var 1/2/3-byte  | Fixed 32-bit            |
| ISA twist          | —             | 14-bit addr bus | barrel-shifted operand + cond on EVERY instruction |
| Deployed silicon   | Embedded      | Historical (Oct)| Billions of phones / IoT|

### v0.1.0 surface

\`\`\`rust
pub struct IIRArmv7Config { pub module_name: String }
pub enum IIRArmv7Error { ValidationFailed, UnsupportedOp, UnsupportedType, InvalidOperand }
pub fn validate_for_armv7(module: &IIRModule) -> Vec<String>;
pub fn lower_iir_to_armv7(module, cfg) -> Result<Vec<u32>, IIRArmv7Error>;
pub const BKPT: u32 = 0xE12FFF7F;
\`\`\`

### Why BKPT #0xFFFF as the halt sentinel?

\`0xE12FFF7F\` — bit layout (cond=AL):

\`\`\`text
31..28  cond  = 0xE = 1110            (always — unconditional)
27..20        = 0001 0010 = 0x12      (BKPT opcode family)
19.. 8  imm12 = 0xFFF                 (top 12 bits of imm16)
 7.. 4        = 0111 = 0x7            (BKPT opcode family)
 3.. 0  imm4  = 0xF                   (bottom 4 bits of imm16)
\`\`\`

Why BKPT and not WFI or \`b .\`?

| Candidate     | Pros | Cons |
| ------------- | ---- | ---- |
| \`BKPT #imm16\` | Semantically "stop"; every ARM debugger / emulator recognises it | None for skeleton purposes |
| \`WFI\`         | True halt | Requires kernel/hypervisor privilege; illegal in userspace |
| \`B .\`         | Pure userspace, no traps | Burns CPU; harder to detect without a host timeout |

### Why Vec<u32> output, not textual asm?

- Round-trips with the in-tree \`arm-simulator\`'s decoder
- Deterministic test surface (\`assert_eq!(words[0], 0xE12FFF7F)\`)
- Avoids GNU \`as\` / LLVM \`clang\` / ARMASM syntax divergence
- Every A32 instruction is exactly 4 bytes — Vec<u32> is the natural representation (no 1/2/3-byte variability like the 8008)

### Future slices

- **v0.2.0 (A3+)**   — \`const\` → \`mov rd, #imm8\`; \`ret\` → \`bx lr\`
- **v0.3.0 (A3++)**  — register allocator over r0..r12 + arithmetic + cross-fn calls via \`bl\`
- **v0.3.x (A3++.5.5)** — comparisons + conditional branches via the cond field
- **v0.4.0 (A3+++)** — \`lang-aot --emit=armv7\` wiring

## Test plan

- [x] \`cargo test -p iir-to-armv7\` — 7/7 backend tests pass, 1/1 doctest passes
- [x] BKPT constant pinned to \`0xE12FFF7F\` against little-endian byte-order confusion
- [x] Lower emits exactly one word
- [x] Lower emits the canonical BKPT word
- [x] Config defaults + builder + error Display smoke
- [x] Workspace Cargo.toml updated
- [x] Spec + README + CHANGELOG + BUILD created
- [x] Security review passed (no vulnerabilities found)
- [ ] CI green
- [ ] No merge conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)