### PR TITLE
feat(iir-to-armv7): const → MOV r0, #imm8; ret → BX LR — A3+ first lowering

### DIFF
--- a/code/packages/rust/iir-to-armv7/CHANGELOG.md
+++ b/code/packages/rust/iir-to-armv7/CHANGELOG.md
@@ -3,6 +3,95 @@
 All notable changes to this crate are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.2.0] — 2026-06-02 (A3+ — `const` → `MOV r0, #imm8`; `ret`/`ret_void` → `BX LR`)
+
+### Added — first real instruction lowering
+
+Extends v0.1.0's BKPT-only skeleton with three IIR ops:
+
+| IIR op | A32 lowering |
+|--------|--------------|
+| `const dest, Int(n)` (8-bit imm) | `mov r0, #n` (`0xE3A0_00NN`) |
+| `ret <var>` (int) | `bx lr` (`0xE12FFF1E`) — `var` is already in `r0` |
+| `ret_void` | `bx lr` |
+
+The accumulator-only first slice: every `const` goes into `r0`.
+Multi-register allocation (`r1..r12`) and a real linear allocator
+land in A3++ alongside arithmetic.
+
+#### Why `BX LR` for both `ret` and `ret_void`?
+
+In the ARM AAPCS calling convention, `r0` (a.k.a. `a1`) is the
+return-value register.  Since every `const` already lands in `r0`,
+`ret <var>` doesn't need any staging MOV — the value is in the
+right place by construction.  `ret_void` simply doesn't care about
+the value, so the same `bx lr` works.
+
+(Compared to the 8008 backend's v0.2.0 which used `HLT` for `ret`
+as a temporary stand-in until v0.3.9 wired up real `RET`, ARMv7's
+`bx lr` is a proper return from the start.)
+
+#### Why `BX LR` over `MOV PC, LR`?
+
+`MOV PC, LR` would work on pure A32 cores but doesn't switch
+instruction sets when the lr's low bit signals "return to Thumb
+mode".  `BX LR` reads the low bit, switches mode accordingly, and
+branches — the canonical AAPCS return.  On a pure A32 module
+emitted by this crate, the low bit will always be 0 so both
+behave identically, but emitting `BX LR` keeps the output
+interop-correct with any caller that mixes A32 and Thumb code.
+
+#### New constants in the public surface
+
+* `pub const BX_LR: u32 = 0xE12FFF1E;` — branch-to-link-register
+  (AAPCS return).
+* `pub const MOV_IMM_R0_BASE: u32 = 0xE3A0_0000;` — `mov r0, #0`
+  base; OR in the 8-bit immediate to form `MOV r0, #N`.
+
+CAREFUL: `BX_LR = 0xE12FFF1E` vs `BKPT = 0xE12FFF7F` — bit-7
+differs.  Both share the same `12F_FF` family bits, so the bit-7
+nibble difference is the canonical confusion point.
+
+#### Immediate byte range
+
+`const` accepts integers in `[-128, 255]`:
+* `[0, 255]` cast straight to `u8`.
+* `[-128, -1]` reinterpreted as two's-complement (`-1 → 0xFF`).
+* Anything outside → `InvalidOperand` with a message naming the
+  8-bit limit and pointing forward to `movw`/`movt` (the ARMv7+
+  wide-immediate idiom that lands in A3++).
+
+#### New internal helper
+
+* `encode_mov_imm(rd: u8, imm8: u8) -> u32` — encodes the full
+  `MOV Rd, #imm8` word.  `debug_assert!`s on the 4-bit `rd` range.
+
+#### Tests added (14 total, was 7)
+
+* `bx_lr_constant_pinned_to_e12fff1e` — guards against the
+  `BKPT ↔ BX_LR` (bit-7) confusion.
+* `mov_imm_r0_base_pinned_to_0xe3a00000`.
+* `const_42_then_ret_lowers_to_mov_r0_42_then_bx_lr` — pinned
+  exact 2-word sequence `0xE3A0002A 0xE12FFF1E`.
+* `const_negative_uses_twos_complement_byte` (`-1 → 0xFF`).
+* `const_out_of_byte_range_is_rejected` (1000 overflows).
+* `ret_void_alone_emits_just_bx_lr`.
+* `unsupported_op_is_rejected_with_function_name` — `safepoint`
+  rejected with function name preserved in the error.
+
+### What is NOT in v0.2.0 (deferred to A3++ and beyond)
+
+* Multi-register allocator over `r1..r12` + `mov rd, rs` register-
+  to-register lowering.
+* Arithmetic (`add`/`sub`/`mul`).
+* Wider immediates via `movw`/`movt` (ARMv7's 16-bit-imm pair) or
+  rotated 8-bit values (the A32 12-bit-imm field's full power).
+* Function calls via `bl` and PC-relative offsets.
+* Comparisons + conditional branches via the `cond` field every
+  A32 instruction carries (a stronger version of the 8008's
+  flag-based jumps).
+* `lang-aot --emit=armv7` wiring — A3+++.
+
 ## [0.1.0] — 2026-06-02 (A3 — crate skeleton)
 
 ### Added — `BKPT`-only emission

--- a/code/packages/rust/iir-to-armv7/Cargo.toml
+++ b/code/packages/rust/iir-to-armv7/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iir-to-armv7"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
-description = "IIR → ARMv7 (A32) machine code backend — lowers IIRModule to a Vec<u32> of encoded 32-bit ARMv7-A instructions.  v0.1.0 (A3): crate skeleton that lowers any module to a single `BKPT #0xFFFF` (0xE12FFF7F) — the canonical halt sentinel that every ARM debugger and emulator recognises.  Real lowering (mov/add/sub/bl/cmp) lands in A3+ through A3++.  ARMv7 is the third architecture backend in the LANG VM matrix, sitting alongside RV32I (A1, clean 32-bit RISC) and Intel 8008 (A2, irregular 8-bit accumulator CISC).  ARMv7 occupies the unique middle ground of being a 32-bit RISC with condition-code prefixes on every instruction + a barrel-shifted second operand."
+description = "IIR → ARMv7 (A32) machine code backend — lowers IIRModule to a Vec<u32> of encoded 32-bit ARMv7-A instructions.  v0.2.0 (A3+): first real instruction lowering — `const dest, Int(n)` → `mov r0, #imm8` (data-processing immediate, 0xE3A0_00NN) and `ret <var>`/`ret_void` → `bx lr` (0xE12FFF1E, branch-to-link-register).  Accumulator-only first slice: every const goes into r0, the AAPCS return-value register, so `ret v` doesn't need a staging MOV.  Multi-register allocation + arithmetic lands in A3++.  Carries forward the v0.1.0 (A3) BKPT #0xFFFF (0xE12FFF7F) halt sentinel for the empty-module case."
 
 [lib]
 name = "iir_to_armv7"

--- a/code/packages/rust/iir-to-armv7/src/lib.rs
+++ b/code/packages/rust/iir-to-armv7/src/lib.rs
@@ -83,7 +83,7 @@
 //!       • objcopy + linker for an ELF on a phone-class Linux board
 //! ```
 
-use interpreter_ir::IIRModule;
+use interpreter_ir::{IIRModule, Operand};
 use std::fmt;
 
 // ===========================================================================
@@ -126,6 +126,68 @@ use std::fmt;
 /// `arm-simulator`'s decoder flags it as `bkpt` and stops single-
 /// stepping.
 pub const BKPT: u32 = 0xE12F_FF7F;
+
+/// ARMv7-A `BX LR` opcode — `0xE12FFF1E`.  Branches to the address in
+/// the link register (`r14`), exchanging instruction sets (which on
+/// pure A32 code is a no-op — A32 → A32).  Semantically: "return from
+/// this function" per the AAPCS calling convention.
+///
+/// Bit layout (cond=AL):
+///
+/// ```text
+/// 31..28  cond  = 0xE = 1110            (always — unconditional)
+/// 27..20        = 0001 0010 = 0x12      (BX opcode family)
+/// 19.. 8        = 1111 1111 1111 = 0xFFF
+///  7.. 4        = 0001 = 0x1            (BX opcode family)
+///  3.. 0  Rm    = 1110 = 0xE            (Rm = lr = r14)
+/// ```
+///
+/// Concatenated: `1110 0001 0010 1111_1111_1111 0001 1110` =
+/// `0xE12FFF1E`.
+///
+/// CAREFUL: BX is `0xE12FFF1E`, NOT `0xE12FFF7F` (which is BKPT —
+/// the bit-7 difference distinguishes "branch & exchange" from
+/// "breakpoint").  Both share the same `12F_FF` family bits.
+pub const BX_LR: u32 = 0xE12F_FF1E;
+
+/// ARMv7-A `MOV Rd, #imm8` (data-processing immediate) base
+/// encoding for `Rd = r0` — `0xE3A0_0000`.  OR in the 8-bit immediate
+/// (bits 7..0) and the destination register (bits 15..12) to form the
+/// full instruction word.
+///
+/// Bit layout (cond=AL, S=0, Rn=0):
+///
+/// ```text
+/// 31..28  cond     = 0xE = 1110           (always — unconditional)
+/// 27..25           = 001                   (data-processing immediate)
+/// 24..21  opcode   = 1101                 (MOV)
+/// 20      S        = 0                     (don't set flags)
+/// 19..16  Rn       = 0000                  (unused for MOV)
+/// 15..12  Rd       = (in this base, 0)    (target register)
+/// 11.. 8  rotate   = 0000                  (no rotation on the imm)
+///  7.. 0  imm8     = (in this base, 0)    (the 8-bit value)
+/// ```
+///
+/// Concatenated for `MOV r0, #0`: `1110 0011 1010 0000 0000 0000 0000 0000`
+/// = `0xE3A00000`.
+///
+/// For `MOV r0, #N`: OR in `N` (8 bits).
+/// For `MOV Rd, #N`: OR in `(Rd << 12) | N`.
+pub const MOV_IMM_R0_BASE: u32 = 0xE3A0_0000;
+
+/// Encode an `ARMv7-A `MOV Rd, #imm8`` instruction.
+///
+/// `rd` must be in `[0, 15]` (4-bit ARM register selector).  `imm8`
+/// is the immediate value, range `[0, 255]`.
+///
+/// Wider immediates (9-32 bits) require either a rotate (the 12-bit
+/// immediate field encodes 8 value bits + 4 rotation bits, allowing
+/// any rotated 8-bit value) or a `movw`/`movt` pair (ARMv7+).  Those
+/// land in A3++ — v0.2.0's `const` only supports 8-bit values.
+pub(crate) fn encode_mov_imm(rd: u8, imm8: u8) -> u32 {
+    debug_assert!(rd <= 15, "rd out of 4-bit range: {rd}");
+    MOV_IMM_R0_BASE | ((rd as u32) << 12) | (imm8 as u32)
+}
 
 // ===========================================================================
 // IIRArmv7Config
@@ -220,12 +282,45 @@ pub fn validate_for_armv7(_module: &IIRModule) -> Vec<String> {
 // lower_iir_to_armv7
 // ===========================================================================
 
+/// Register `r0` — the AAPCS first-argument / return-value register.
+/// Every `const` in v0.2.0 (A3+) lowers to `mov r0, #imm` because
+/// we don't yet have a multi-register allocator (A3++).
+const REG_R0: u8 = 0;
+
+/// Supported instruction opcodes in v0.2.0 (A3+).
+///
+/// * `const dest, Int(n)` lowers to `mov r0, #n` (every value goes
+///   into `r0` in this slice).
+/// * `ret <var>` and `ret_void` both lower to `bx lr` (the AAPCS
+///   return convention — the value is already in `r0` by
+///   construction).
+const SUPPORTED_OPS: &[&str] = &[
+    "const", "ret", "ret_void",
+];
+
 /// Lower an [`IIRModule`] to a `Vec<u32>` of ARMv7 (A32) opcode words.
 ///
-/// **v0.1.0 scope**: emits a single `BKPT #0xFFFF` regardless of the
-/// input.  This is the smallest "valid A32 program" we can produce —
-/// enough to load into the simulator, step once, and confirm the
-/// breakpoint exception fires.  Real lowering arrives in v0.2.0+ (A3+).
+/// **v0.2.0 scope** (A3+ — first real lowering):
+///
+/// | IIR op | A32 lowering |
+/// |--------|--------------|
+/// | `const dest, Int(n)` (8-bit imm) | `mov r0, #n` (`0xE3A0_00NN`) |
+/// | `ret <var>` (int) | `bx lr` (`0xE12FFF1E`) — `var` is already in `r0` |
+/// | `ret_void` | `bx lr` |
+///
+/// ### Accumulator-only first slice
+///
+/// Every `const` allocates to `r0` — the AAPCS return-value register.
+/// A real linear allocator over `r0..r12` (and the v0.3.x ARM
+/// equivalent of v0.3.0's RISC-V move) arrives in A3++.
+///
+/// ### Empty-module contract
+///
+/// Preserves v0.1.0's behaviour for the trivial "`fn main() {}`" case:
+/// any module with no functions emits a single `BKPT #0xFFFF` so the
+/// in-tree `arm-simulator` halts deterministically.  Once at least
+/// one function is lowered, the BKPT is replaced by the function's
+/// real instruction stream.
 pub fn lower_iir_to_armv7(
     module: &IIRModule,
     _cfg: &IIRArmv7Config,
@@ -234,5 +329,112 @@ pub fn lower_iir_to_armv7(
     if !errors.is_empty() {
         return Err(IIRArmv7Error::ValidationFailed(errors));
     }
-    Ok(vec![BKPT])
+
+    // Trivial empty-module contract — preserves v0.1.0 callable behaviour
+    // for the canonical "fn main() {}" minimal case.
+    if module.functions.is_empty() {
+        return Ok(vec![BKPT]);
+    }
+
+    let mut words = Vec::new();
+    for f in &module.functions {
+        for instr in &f.instructions {
+            if !SUPPORTED_OPS.contains(&instr.op.as_str()) {
+                return Err(IIRArmv7Error::UnsupportedOp {
+                    function: f.name.clone(),
+                    op: instr.op.clone(),
+                });
+            }
+            match instr.op.as_str() {
+                // ── const dest, Int(n) → MOV R0, #n ─────────────────
+                //
+                // The accumulator-only first slice: every const goes
+                // into r0.  Multi-register allocation lands in A3++.
+                "const" => {
+                    let _dest = require_dest(instr, "const", &f.name)?;
+                    let imm8 = encode_immediate_byte(instr.srcs.first(), &f.name)?;
+                    words.push(encode_mov_imm(REG_R0, imm8));
+                }
+
+                // ── ret <var> → BX LR ──────────────────────────────
+                //
+                // The value is already in r0 (every const lowers
+                // there in v0.2.0).  Per AAPCS, returning a value
+                // means leaving it in r0 and branching to lr.  No
+                // staging MOV needed in this slice.
+                "ret" => {
+                    // Validate that srcs[0] is a Var — front-end bugs
+                    // surface as `InvalidOperand` rather than producing
+                    // surprising silence.
+                    match instr.srcs.first() {
+                        Some(Operand::Var(_)) => {}
+                        _ => return Err(IIRArmv7Error::InvalidOperand {
+                            function: f.name.clone(),
+                            detail: "ret srcs[0] must be Var".into(),
+                        }),
+                    };
+                    words.push(BX_LR);
+                }
+
+                // ── ret_void → BX LR ───────────────────────────────
+                "ret_void" => {
+                    words.push(BX_LR);
+                }
+
+                _ => unreachable!("SUPPORTED_OPS guard above prevents this"),
+            }
+        }
+    }
+
+    // Defensive — if a function had no instructions at all, fall back
+    // to BKPT so the output is still a valid halting program.
+    if words.is_empty() {
+        words.push(BKPT);
+    }
+
+    Ok(words)
+}
+
+// ---------------------------------------------------------------------------
+// Per-instruction helpers
+// ---------------------------------------------------------------------------
+
+fn require_dest<'a>(
+    instr: &'a interpreter_ir::IIRInstr,
+    op: &str,
+    fn_name: &str,
+) -> Result<&'a str, IIRArmv7Error> {
+    instr.dest.as_deref().ok_or_else(|| IIRArmv7Error::InvalidOperand {
+        function: fn_name.to_string(),
+        detail: format!("{op} requires a dest"),
+    })
+}
+
+fn encode_immediate_byte(
+    op: Option<&Operand>,
+    fn_name: &str,
+) -> Result<u8, IIRArmv7Error> {
+    let n = match op {
+        Some(Operand::Int(n)) => *n,
+        Some(Operand::Bool(b)) => if *b { 1 } else { 0 },
+        _ => return Err(IIRArmv7Error::InvalidOperand {
+            function: fn_name.to_string(),
+            detail: "const srcs[0] must be Int or Bool".into(),
+        }),
+    };
+    if (0..=255).contains(&n) {
+        Ok(n as u8)
+    } else if (-128..0).contains(&n) {
+        Ok((n as i8) as u8)
+    } else {
+        Err(IIRArmv7Error::InvalidOperand {
+            function: fn_name.to_string(),
+            detail: format!(
+                "const {n} exceeds 8-bit byte range ([-128, 255]); A32's \
+                 12-bit MOV immediate field supports rotated 8-bit values \
+                 — wider raw immediates need a `movw`/`movt` pair, which \
+                 lands in A3++"
+            ),
+        })
+    }
 }

--- a/code/packages/rust/iir-to-armv7/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-armv7/tests/test_backend.rs
@@ -3,11 +3,23 @@
 //! Smoke-level — confirms the validator stub, the emitter shape, and
 //! the exact encoded `BKPT #0xFFFF` word (`0xE12FFF7F`).
 
-use interpreter_ir::IIRModule;
+use interpreter_ir::{IIRFunction, IIRInstr, IIRModule, Operand};
 use iir_to_armv7::{
     lower_iir_to_armv7, validate_for_armv7,
-    IIRArmv7Config, IIRArmv7Error, BKPT,
+    IIRArmv7Config, IIRArmv7Error, BKPT, BX_LR, MOV_IMM_R0_BASE,
 };
+
+fn module_with(f: IIRFunction) -> IIRModule {
+    let entry = f.name.clone();
+    IIRModule {
+        name: "test".into(),
+        functions: vec![f],
+        entry_point: Some(entry),
+        language: "test".into(),
+        exports: vec![],
+        imports: vec![],
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -114,4 +126,105 @@ fn errors_display_without_panic() {
     let _ = format!("{}", IIRArmv7Error::InvalidOperand {
         function: "f".into(), detail: "bad".into(),
     });
+}
+
+// ===========================================================================
+// 5. A3+ (v0.2.0) — `const` lowers to `MOV r0, #imm8`; `ret` → `BX LR`
+// ===========================================================================
+//
+// The accumulator-only first slice: every `const` goes into `r0`;
+// multi-register allocation (r1..r12) lands in A3++.  `ret`/`ret_void`
+// both lower to `bx lr` — the AAPCS return convention.  No staging
+// MOV needed since the value is already in r0 by construction.
+
+#[test]
+fn bx_lr_constant_pinned_to_e12fff1e() {
+    // BX LR = 0xE12FFF1E.  Bit-7 distinguishes this from BKPT (which
+    // is 0xE12FFF7F) — both share the same 12F_FF family bits, so
+    // the bit-7 nibble difference is the canonical confusion point.
+    assert_eq!(BX_LR, 0xE12F_FF1E,
+        "BX LR should be 0xE12FFF1E (cond=AL, Rm=lr=14); got 0x{:08x}", BX_LR);
+}
+
+#[test]
+fn mov_imm_r0_base_pinned_to_0xe3a00000() {
+    // MOV r0, #0 (no rotation, S=0) = 0xE3A00000.  Subsequent tests
+    // OR in (Rd << 12) | imm8 to form the full instruction.
+    assert_eq!(MOV_IMM_R0_BASE, 0xE3A0_0000,
+        "MOV r0, #0 base should be 0xE3A00000; got 0x{:08x}", MOV_IMM_R0_BASE);
+}
+
+#[test]
+fn const_42_then_ret_lowers_to_mov_r0_42_then_bx_lr() {
+    // const v=42 → r0; ret v → bx lr (v is in r0)
+    //
+    //   00:  MOV r0, #42   = 0xE3A0_002A
+    //   04:  BX LR          = 0xE12F_FF1E
+    let f = IIRFunction::new("answer", vec![], "i32", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(42)], "i32"),
+        IIRInstr::new("ret",   None,             vec![Operand::Var("v".into())], "i32"),
+    ]);
+    let words = lower_iir_to_armv7(&module_with(f), &IIRArmv7Config::default())
+        .expect("lowering");
+    assert_eq!(words, vec![0xE3A0_002A, 0xE12F_FF1E],
+        "expected MOV r0, #42 (0xE3A0_002A) + BX LR (0xE12F_FF1E); got: {words:08x?}");
+}
+
+#[test]
+fn const_negative_uses_twos_complement_byte() {
+    // -1 → 0xFF via two's-complement reinterpretation, then MOV r0, #0xFF.
+    let f = IIRFunction::new("f", vec![], "i8", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(-1)], "i8"),
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ]);
+    let words = lower_iir_to_armv7(&module_with(f), &IIRArmv7Config::default())
+        .expect("lowering");
+    assert_eq!(words, vec![0xE3A0_00FF, BX_LR],
+        "expected MOV r0, #0xFF + BX LR for `const -1`; got: {words:08x?}");
+}
+
+#[test]
+fn const_out_of_byte_range_is_rejected() {
+    let f = IIRFunction::new("f", vec![], "i16", vec![
+        // 1000 fits in i16 but exceeds the 8-bit MOV immediate.
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(1000)], "i16"),
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ]);
+    let err = lower_iir_to_armv7(&module_with(f), &IIRArmv7Config::default())
+        .expect_err("1000 should overflow the 8-bit immediate");
+    match err {
+        IIRArmv7Error::InvalidOperand { detail, .. } => {
+            assert!(detail.contains("8-bit"),
+                "expected message naming the 8-bit limit; got: {detail}");
+        }
+        other => panic!("expected InvalidOperand, got: {other:?}"),
+    }
+}
+
+#[test]
+fn ret_void_alone_emits_just_bx_lr() {
+    let f = IIRFunction::new("main", vec![], "void", vec![
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ]);
+    let words = lower_iir_to_armv7(&module_with(f), &IIRArmv7Config::default())
+        .expect("lowering");
+    assert_eq!(words, vec![BX_LR],
+        "ret_void-only function should emit just BX LR; got: {words:08x?}");
+}
+
+#[test]
+fn unsupported_op_is_rejected_with_function_name() {
+    let f = IIRFunction::new("boom", vec![], "void", vec![
+        IIRInstr::new("safepoint", None, vec![], "void"),
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ]);
+    let err = lower_iir_to_armv7(&module_with(f), &IIRArmv7Config::default())
+        .expect_err("`safepoint` should be UnsupportedOp");
+    match err {
+        IIRArmv7Error::UnsupportedOp { function, op } => {
+            assert_eq!(function, "boom");
+            assert_eq!(op, "safepoint");
+        }
+        other => panic!("expected UnsupportedOp, got: {other:?}"),
+    }
 }

--- a/code/specs/iir-to-armv7.md
+++ b/code/specs/iir-to-armv7.md
@@ -67,8 +67,8 @@ IIRModule
 
 | Version | Scope | Status |
 |---------|-------|--------|
-| **v0.1.0 (A3 — this PR)** | crate skeleton: any module → single `BKPT #0xFFFF` (`0xE12FFF7F`) | this PR |
-| v0.2.0 (A3+) | `const` → `mov rd, #imm8` + `ret`/`ret_void` → `bx lr` | future |
+| v0.1.0 (A3) | crate skeleton: any module → single `BKPT #0xFFFF` (`0xE12FFF7F`) | **merged** |
+| **v0.2.0 (A3+ — this PR)** | `const` → `MOV r0, #imm8` (accumulator-only) + `ret`/`ret_void` → `BX LR` (AAPCS return) | this PR |
 | v0.3.0 (A3++) | Linear register allocator over `r0..r12` + arithmetic (add/sub) + function calls via `bl` with PC-relative offsets | future |
 | v0.3.x (A3++.5.5) | Comparisons + conditional branches via the cond-field on every A32 instruction (a stronger version of the 8008's flag-based jumps) | future |
 | v0.4.0 (A3+++) | `lang-aot --emit=armv7` wiring | future |


### PR DESCRIPTION
## Summary

Extends \`iir-to-armv7\` v0.1.0 → **v0.2.0** with the first real instruction lowering, mirroring iir-to-intel8008 v0.2.0's structure.

| IIR op | A32 lowering |
| ------ | ------------ |
| \`const dest, Int(n)\` (8-bit imm) | \`MOV r0, #n\` (\`0xE3A0_00NN\`) |
| \`ret <var>\` (int) | \`BX LR\` (\`0xE12FFF1E\`) — \`var\` is already in \`r0\` |
| \`ret_void\` | \`BX LR\` |

### Why BX LR for both ret and ret_void?

In the ARM AAPCS calling convention, \`r0\` (= a1) is the return-value register.  Since every \`const\` already lands in \`r0\`, \`ret <var>\` doesn't need any staging MOV — the value is in the right place by construction.

Compared to the 8008 backend's v0.2.0 which used \`HLT\` for \`ret\` as a temporary stand-in until v0.3.9 wired real \`RET\`, ARMv7 gets proper return semantics from the start.

### Why BX LR over MOV PC, LR?

\`MOV PC, LR\` works on pure A32 cores but doesn't switch instruction sets when \`lr\`'s low bit signals "return to Thumb mode".  \`BX LR\` reads the low bit, switches mode accordingly, and branches — the canonical AAPCS return.

### New public constants

- \`BX_LR = 0xE12FFF1E\` (branch-to-link-register)
- \`MOV_IMM_R0_BASE = 0xE3A0_0000\` (MOV r0, #0 base; OR in imm8)

**🚨 CAREFUL**: \`BX_LR = 0xE12FFF1E\` vs \`BKPT = 0xE12FFF7F\` — **bit-7 differs**.  Both share the same \`12F_FF\` family bits.  Pinned in their own tests against this exact hazard.

### Immediate byte range

\`[-128, 255]\` (same shape as the v0.2.0 8008 backend).  Out-of-range surfaces \`InvalidOperand\` with a message pointing forward to \`movw\`/\`movt\` for A3++.

## Test plan

- [x] \`cargo test -p iir-to-armv7\` — 14/14 backend tests pass, 1/1 doctest passes
- [x] BX_LR pinned against BKPT bit-7 confusion
- [x] \`MOV r0, #42; BX LR\` byte sequence pinned (\`E3A0002A E12FFF1E\`)
- [x] Two's-complement negative const (\`-1 → 0xFF\`)
- [x] Out-of-byte-range rejection with 8-bit-limit error message
- [x] ret_void emits BX LR alone
- [x] Unsupported op rejection preserves function name
- [x] Security review passed (no vulnerabilities found)
- [ ] CI green
- [ ] No merge conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)