### PR TITLE
feat(iir-to-armv7): linear register allocator + mov + ret staging — A3++

### DIFF
--- a/code/packages/rust/iir-to-armv7/CHANGELOG.md
+++ b/code/packages/rust/iir-to-armv7/CHANGELOG.md
@@ -3,6 +3,75 @@
 All notable changes to this crate are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.3.0] — 2026-06-02 (A3++ — linear register allocator + `mov` + ret-value staging)
+
+### Added — linear register allocator over r0..r12
+
+Extends v0.2.0's accumulator-only `const` to a real allocator that
+hands out the 13 ARMv7 general-purpose registers in order:
+`r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12`.  `r0` comes
+first so the trivial `const v; ret v` case stays at the 2-word shape
+(`MOV r0, #imm; BX LR`) without an extra `MOV r0, X` round-trip.
+
+`r13` (`sp`), `r14` (`lr`), and `r15` (`pc`) are NOT in the pool —
+touching them as locals would break the calling convention's stack
+discipline, the return address, or the instruction pointer.
+
+| IIR op | A32 lowering |
+|--------|--------------|
+| `const dest, Int(n)` | `MOV rrr, #n` (`MOV_IMM_R0_BASE | (rrr << 12) | n`) |
+| `mov dest, src` | `MOV Rd, Rm` (`MOV_REG_BASE | (Rd << 12) | Rm`) |
+| `ret <var>` | stage `var` into `r0` via `MOV r0, var_reg` if needed, then `BX LR` |
+| `ret_void` | `BX LR` |
+
+### New constants
+
+* `pub const MOV_REG_BASE: u32 = 0xE1A0_0000;` — `MOV r0, r0` base
+  encoding for the register-to-register form.  OR in `(Rd << 12) |
+  Rm` for arbitrary register pairs.
+
+CAREFUL: bit-25 distinguishes this from `MOV_IMM_R0_BASE` (which is
+`0xE3A0_0000`).  Data-processing-immediate has bit-25 set; register-
+form doesn't.
+
+### New encoder helper
+
+* `encode_mov_reg(rd: u8, rm: u8) -> u32` — emits `MOV Rd, Rm` with
+  `debug_assert!`s on both 4-bit register selectors.
+
+### New error variants
+
+* `IIRArmv7Error::UndefinedVariable` — `mov` or `ret` referenced a
+  name that was never bound.
+* `IIRArmv7Error::OutOfRegisters` — 14th local exhausted the 13-
+  register pool.  Stack spilling lands in A3++.5 or later.
+
+### Tests added (21 total, was 14)
+
+* `mov_reg_base_pinned_to_0xe1a00000` — guards the new constant.
+* `two_consts_use_r0_then_r1_then_mov_r0_r1_before_bx_lr` — pinned
+  exact 4-word sequence including `MOV r1, #2 = 0xE3A0_1002` (the
+  `1` in the `Rd` nibble) and `MOV r0, r1 = 0xE1A0_0001`.
+* `ret_of_first_const_omits_the_redundant_mov` — regression for
+  the v0.2.0 2-word trivial-case shape (r0-first allocator preserves
+  it).
+* `mov_lowers_to_canonical_mov_rd_rm` — `MOV r1, r0 = 0xE1A0_1000`
+  and `MOV r0, r1 = 0xE1A0_0001` shown side-by-side.
+* `allocator_exhaustion_yields_out_of_registers` — 14 consts → fails
+  on `v13` with `OutOfRegisters`.
+* `undefined_variable_in_mov_is_rejected`.
+* `errors_for_new_variants_display_without_panic`.
+
+### What is NOT in v0.3.0 (deferred to A3++.5 and beyond)
+
+* Arithmetic (`add`/`sub`/`mul`) and the data-processing-register
+  family those expand into.
+* Function calls via `bl` with PC-relative offsets.
+* Comparisons + conditional branches via the `cond` field every
+  A32 instruction carries.
+* Wider immediates via `movw`/`movt` (the ARMv7 16-bit-imm pair).
+* `lang-aot --emit=armv7` wiring — A3+++.
+
 ## [0.2.0] — 2026-06-02 (A3+ — `const` → `MOV r0, #imm8`; `ret`/`ret_void` → `BX LR`)
 
 ### Added — first real instruction lowering

--- a/code/packages/rust/iir-to-armv7/Cargo.toml
+++ b/code/packages/rust/iir-to-armv7/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iir-to-armv7"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
-description = "IIR → ARMv7 (A32) machine code backend — lowers IIRModule to a Vec<u32> of encoded 32-bit ARMv7-A instructions.  v0.2.0 (A3+): first real instruction lowering — `const dest, Int(n)` → `mov r0, #imm8` (data-processing immediate, 0xE3A0_00NN) and `ret <var>`/`ret_void` → `bx lr` (0xE12FFF1E, branch-to-link-register).  Accumulator-only first slice: every const goes into r0, the AAPCS return-value register, so `ret v` doesn't need a staging MOV.  Multi-register allocation + arithmetic lands in A3++.  Carries forward the v0.1.0 (A3) BKPT #0xFFFF (0xE12FFF7F) halt sentinel for the empty-module case."
+description = "IIR → ARMv7 (A32) machine code backend — lowers IIRModule to a Vec<u32> of encoded 32-bit ARMv7-A instructions.  v0.3.0 (A3++): linear register allocator over r0..r12 + multi-register `const` + `mov` (register-to-register, 0xE1A0_0000 base) + ret-value staging.  r0 comes first in the pool to keep the trivial `const v; ret v` case at the 2-word v0.2.0 shape (MOV r0, #imm + BX LR — no redundant staging MOV).  r13 (sp), r14 (lr), and r15 (pc) are NOT in the pool — touching them would break the calling convention.  Stack spilling + arithmetic land in A3++.5."
 
 [lib]
 name = "iir_to_armv7"

--- a/code/packages/rust/iir-to-armv7/src/lib.rs
+++ b/code/packages/rust/iir-to-armv7/src/lib.rs
@@ -84,6 +84,7 @@
 //! ```
 
 use interpreter_ir::{IIRModule, Operand};
+use std::collections::HashMap;
 use std::fmt;
 
 // ===========================================================================
@@ -189,6 +190,43 @@ pub(crate) fn encode_mov_imm(rd: u8, imm8: u8) -> u32 {
     MOV_IMM_R0_BASE | ((rd as u32) << 12) | (imm8 as u32)
 }
 
+/// ARMv7-A `MOV Rd, Rm` (data-processing register) base encoding —
+/// `0xE1A0_0000`.  OR in the destination register (bits 15..12) and
+/// the source register (bits 3..0) to form the full instruction word.
+///
+/// Bit layout (cond=AL, S=0, Rn=0, shift=0, type=00):
+///
+/// ```text
+/// 31..28  cond    = 0xE = 1110            (always — unconditional)
+/// 27..21          = 0001 101             (data-processing register, MOV opcode)
+/// 20      S       = 0                     (don't set flags)
+/// 19..16  Rn      = 0000                  (unused for MOV)
+/// 15..12  Rd      = (in this base, 0)    (target register)
+/// 11.. 7  shift_imm = 00000               (no shift)
+///  6.. 5  type    = 00                    (LSL — but shift_imm=0 means no shift)
+///  4              = 0                     (shift by immediate, not register)
+///  3.. 0  Rm      = (in this base, 0)    (source register)
+/// ```
+///
+/// For `MOV r0, r0`: `1110 0001 1010 0000 0000 0000 0000 0000` =
+/// `0xE1A00000`.  For arbitrary `MOV Rd, Rm`: OR in
+/// `(Rd << 12) | Rm`.
+///
+/// CAREFUL: This is the register-to-register MOV, distinct from
+/// `MOV_IMM_R0_BASE = 0xE3A0_0000` (note the bit-25 difference —
+/// data-processing-immediate has bit-25 set, register form doesn't).
+pub const MOV_REG_BASE: u32 = 0xE1A0_0000;
+
+/// Encode an ARMv7-A `MOV Rd, Rm` (register-to-register) instruction.
+///
+/// Both `rd` and `rm` must be in `[0, 15]` (4-bit ARM register
+/// selectors).
+pub(crate) fn encode_mov_reg(rd: u8, rm: u8) -> u32 {
+    debug_assert!(rd <= 15, "rd out of 4-bit range: {rd}");
+    debug_assert!(rm <= 15, "rm out of 4-bit range: {rm}");
+    MOV_REG_BASE | ((rd as u32) << 12) | (rm as u32)
+}
+
 // ===========================================================================
 // IIRArmv7Config
 // ===========================================================================
@@ -237,6 +275,14 @@ pub enum IIRArmv7Error {
     UnsupportedType { function: String, type_hint: String },
     /// An operand has an unexpected shape.
     InvalidOperand { function: String, detail: String },
+    /// A variable name was used (via `mov` or `ret`) before it was
+    /// bound by `const` or `mov`.
+    UndefinedVariable { function: String, name: String },
+    /// The function tried to bind more locals than the 13 general-
+    /// purpose ARMv7 registers (r0..r12) can hold.  Stack spilling
+    /// lands in a future increment (A3++.5 or later).  r13 (sp),
+    /// r14 (lr), and r15 (pc) are not part of the pool.
+    OutOfRegisters { function: String, name: String },
 }
 
 impl fmt::Display for IIRArmv7Error {
@@ -253,6 +299,12 @@ impl fmt::Display for IIRArmv7Error {
             }
             Self::InvalidOperand { function, detail } => {
                 write!(f, "invalid operand in function {function:?}: {detail}")
+            }
+            Self::UndefinedVariable { function, name } => {
+                write!(f, "undefined variable {name:?} in function {function:?}")
+            }
+            Self::OutOfRegisters { function, name } => {
+                write!(f, "out of ARMv7 registers (r0..r12) while binding {name:?} in function {function:?}; stack spilling not yet supported")
             }
         }
     }
@@ -283,19 +335,29 @@ pub fn validate_for_armv7(_module: &IIRModule) -> Vec<String> {
 // ===========================================================================
 
 /// Register `r0` — the AAPCS first-argument / return-value register.
-/// Every `const` in v0.2.0 (A3+) lowers to `mov r0, #imm` because
-/// we don't yet have a multi-register allocator (A3++).
+/// `ret <var>` stages the value into `r0` (via `MOV r0, var_reg` if
+/// the var lives elsewhere) before `BX LR`.
 const REG_R0: u8 = 0;
 
-/// Supported instruction opcodes in v0.2.0 (A3+).
+/// Linear-allocator pool ordered to keep the trivial `const v; ret v`
+/// case at one MVI byte: r0 is handed out first, so `ret v` finds the
+/// value already in r0 and skips the redundant `MOV r0, X` round-trip.
 ///
-/// * `const dest, Int(n)` lowers to `mov r0, #n` (every value goes
-///   into `r0` in this slice).
-/// * `ret <var>` and `ret_void` both lower to `bx lr` (the AAPCS
-///   return convention — the value is already in `r0` by
-///   construction).
+/// `r13` (`sp`), `r14` (`lr`), and `r15` (`pc`) are NOT in the pool —
+/// touching them as locals would break the calling convention's
+/// stack discipline, the return address, or the instruction pointer
+/// (respectively).
+const REGISTER_POOL: [u8; 13] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+
+/// Supported instruction opcodes in v0.3.0 (A3++).
+///
+/// * `const dest, Int(n)` lowers to `MOV rrr, #n` with `rrr` allocated
+///   from `REGISTER_POOL`.
+/// * `mov dest, src` lowers to `MOV Rd, Rm` (no-op when Rd == Rm).
+/// * `ret <var>` stages the value into `r0` (if not already there) and
+///   emits `BX LR`.  `ret_void` just emits `BX LR`.
 const SUPPORTED_OPS: &[&str] = &[
-    "const", "ret", "ret_void",
+    "const", "mov", "ret", "ret_void",
 ];
 
 /// Lower an [`IIRModule`] to a `Vec<u32>` of ARMv7 (A32) opcode words.
@@ -338,6 +400,15 @@ pub fn lower_iir_to_armv7(
 
     let mut words = Vec::new();
     for f in &module.functions {
+        // ── Per-function allocator state ──────────────────────────────
+        //
+        // IIR var name → its assigned 4-bit register index.  Sequentially
+        // hands out registers from REGISTER_POOL starting with r0 — this
+        // keeps the trivial `const v; ret v` case at the same 2-word
+        // shape as v0.2.0 (no redundant `MOV r0, X` round-trip).
+        let mut env: HashMap<String, u8> = HashMap::new();
+        let mut next_reg: usize = 0;
+
         for instr in &f.instructions {
             if !SUPPORTED_OPS.contains(&instr.op.as_str()) {
                 return Err(IIRArmv7Error::UnsupportedOp {
@@ -346,33 +417,52 @@ pub fn lower_iir_to_armv7(
                 });
             }
             match instr.op.as_str() {
-                // ── const dest, Int(n) → MOV R0, #n ─────────────────
-                //
-                // The accumulator-only first slice: every const goes
-                // into r0.  Multi-register allocation lands in A3++.
+                // ── const dest, Int(n) → MOV rrr, #n ────────────────────
                 "const" => {
-                    let _dest = require_dest(instr, "const", &f.name)?;
+                    let dest = require_dest(instr, "const", &f.name)?;
                     let imm8 = encode_immediate_byte(instr.srcs.first(), &f.name)?;
-                    words.push(encode_mov_imm(REG_R0, imm8));
+                    let rrr = alloc_register(&mut next_reg, dest, &mut env, &f.name)?;
+                    words.push(encode_mov_imm(rrr, imm8));
                 }
 
-                // ── ret <var> → BX LR ──────────────────────────────
+                // ── mov dest, src → MOV Rd, Rm ──────────────────────────
                 //
-                // The value is already in r0 (every const lowers
-                // there in v0.2.0).  Per AAPCS, returning a value
-                // means leaving it in r0 and branching to lr.  No
-                // staging MOV needed in this slice.
+                // If the source and dest happen to be the same register
+                // (unlikely under SSA but possible if upstream re-binds a
+                // name), we emit no word — the move is a no-op.
+                "mov" => {
+                    let dest = require_dest(instr, "mov", &f.name)?;
+                    let src_name = match instr.srcs.first() {
+                        Some(Operand::Var(s)) => s.clone(),
+                        _ => return Err(IIRArmv7Error::InvalidOperand {
+                            function: f.name.clone(),
+                            detail: "mov srcs[0] must be Var".into(),
+                        }),
+                    };
+                    let rm = lookup_register(&env, &src_name, &f.name)?;
+                    let rd = alloc_register(&mut next_reg, dest, &mut env, &f.name)?;
+                    if rd != rm {
+                        words.push(encode_mov_reg(rd, rm));
+                    }
+                }
+
+                // ── ret <var>: stage value in r0, then BX LR ────────────
+                //
+                // If `var`'s register is already r0, the MOV is omitted.
+                // Per AAPCS, the return value lives in r0; we
+                // unconditionally branch to lr after staging.
                 "ret" => {
-                    // Validate that srcs[0] is a Var — front-end bugs
-                    // surface as `InvalidOperand` rather than producing
-                    // surprising silence.
-                    match instr.srcs.first() {
-                        Some(Operand::Var(_)) => {}
+                    let src_name = match instr.srcs.first() {
+                        Some(Operand::Var(s)) => s.clone(),
                         _ => return Err(IIRArmv7Error::InvalidOperand {
                             function: f.name.clone(),
                             detail: "ret srcs[0] must be Var".into(),
                         }),
                     };
+                    let rm = lookup_register(&env, &src_name, &f.name)?;
+                    if rm != REG_R0 {
+                        words.push(encode_mov_reg(REG_R0, rm));
+                    }
                     words.push(BX_LR);
                 }
 
@@ -407,6 +497,35 @@ fn require_dest<'a>(
     instr.dest.as_deref().ok_or_else(|| IIRArmv7Error::InvalidOperand {
         function: fn_name.to_string(),
         detail: format!("{op} requires a dest"),
+    })
+}
+
+fn alloc_register(
+    next_reg: &mut usize,
+    dest: &str,
+    env: &mut HashMap<String, u8>,
+    fn_name: &str,
+) -> Result<u8, IIRArmv7Error> {
+    if *next_reg >= REGISTER_POOL.len() {
+        return Err(IIRArmv7Error::OutOfRegisters {
+            function: fn_name.to_string(),
+            name: dest.to_string(),
+        });
+    }
+    let rrr = REGISTER_POOL[*next_reg];
+    *next_reg += 1;
+    env.insert(dest.to_string(), rrr);
+    Ok(rrr)
+}
+
+fn lookup_register(
+    env: &HashMap<String, u8>,
+    name: &str,
+    fn_name: &str,
+) -> Result<u8, IIRArmv7Error> {
+    env.get(name).copied().ok_or_else(|| IIRArmv7Error::UndefinedVariable {
+        function: fn_name.to_string(),
+        name: name.to_string(),
     })
 }
 

--- a/code/packages/rust/iir-to-armv7/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-armv7/tests/test_backend.rs
@@ -6,7 +6,7 @@
 use interpreter_ir::{IIRFunction, IIRInstr, IIRModule, Operand};
 use iir_to_armv7::{
     lower_iir_to_armv7, validate_for_armv7,
-    IIRArmv7Config, IIRArmv7Error, BKPT, BX_LR, MOV_IMM_R0_BASE,
+    IIRArmv7Config, IIRArmv7Error, BKPT, BX_LR, MOV_IMM_R0_BASE, MOV_REG_BASE,
 };
 
 fn module_with(f: IIRFunction) -> IIRModule {
@@ -227,4 +227,132 @@ fn unsupported_op_is_rejected_with_function_name() {
         }
         other => panic!("expected UnsupportedOp, got: {other:?}"),
     }
+}
+
+// ===========================================================================
+// 6. A3++ (v0.3.0) — multi-register allocator + `mov` + ret-value staging
+// ===========================================================================
+//
+// `const` rounds out a register from REGISTER_POOL.  r0 is handed out
+// first so the trivial `const v; ret v` case keeps its 2-word shape
+// (no redundant MOV r0, X round-trip).  Subsequent consts spill into
+// r1, r2, ..., r12 in order.
+
+#[test]
+fn mov_reg_base_pinned_to_0xe1a00000() {
+    // MOV r0, r0 (no shift, S=0) = 0xE1A00000.  Subsequent tests OR
+    // in (Rd << 12) | Rm to form the full instruction.
+    assert_eq!(MOV_REG_BASE, 0xE1A0_0000,
+        "MOV Rd, Rm base should be 0xE1A00000; got 0x{:08x}", MOV_REG_BASE);
+}
+
+#[test]
+fn two_consts_use_r0_then_r1_then_mov_r0_r1_before_bx_lr() {
+    // const v=1; const w=2; ret w
+    //   MOV r0, #1   = 0xE3A0_0001
+    //   MOV r1, #2   = 0xE3A0_1002   (Rd=1)
+    //   MOV r0, r1   = 0xE1A0_0001   ← stage w into r0
+    //   BX LR        = 0xE12F_FF1E
+    let f = IIRFunction::new("f", vec![], "u8", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(1)], "u8"),
+        IIRInstr::new("const", Some("w".into()), vec![Operand::Int(2)], "u8"),
+        IIRInstr::new("ret",   None,             vec![Operand::Var("w".into())], "u8"),
+    ]);
+    let words = lower_iir_to_armv7(&module_with(f), &IIRArmv7Config::default())
+        .expect("lowering");
+    assert_eq!(words, vec![
+        0xE3A0_0001,    // MOV r0, #1   (v)
+        0xE3A0_1002,    // MOV r1, #2   (w)  — Rd=1 → bits 15..12 = 0001
+        0xE1A0_0001,    // MOV r0, r1   (stage w into r0)
+        BX_LR,
+    ], "expected 4-word sequence; got: {words:08x?}");
+}
+
+#[test]
+fn ret_of_first_const_omits_the_redundant_mov() {
+    // Regression for the v0.2.0 pinned 2-word shape: when the value
+    // being returned is already in r0, no `MOV r0, X` is emitted.
+    let f = IIRFunction::new("f", vec![], "u8", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(42)], "u8"),
+        IIRInstr::new("ret",   None,             vec![Operand::Var("v".into())], "u8"),
+    ]);
+    let words = lower_iir_to_armv7(&module_with(f), &IIRArmv7Config::default())
+        .expect("lowering");
+    assert_eq!(words, vec![0xE3A0_002A, BX_LR],
+        "r0-first allocator should keep the trivial case at 2 words; got: {words:08x?}");
+}
+
+#[test]
+fn mov_lowers_to_canonical_mov_rd_rm() {
+    // const v=7; mov w=v; ret w
+    // v is in r0 (first allocated). w is in r1 (next pool slot).
+    //   MOV r0, #7   = 0xE3A0_0007
+    //   MOV r1, r0   = 0xE1A0_1000   (Rd=1, Rm=0)
+    //   MOV r0, r1   = 0xE1A0_0001   ← stage w back into r0 for ret
+    //   BX LR
+    let f = IIRFunction::new("f", vec![], "u8", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(7)], "u8"),
+        IIRInstr::new("mov",   Some("w".into()), vec![Operand::Var("v".into())], "u8"),
+        IIRInstr::new("ret",   None,             vec![Operand::Var("w".into())], "u8"),
+    ]);
+    let words = lower_iir_to_armv7(&module_with(f), &IIRArmv7Config::default())
+        .expect("lowering");
+    assert_eq!(words, vec![
+        0xE3A0_0007,    // MOV r0, #7
+        0xE1A0_1000,    // MOV r1, r0   (Rd=1, Rm=0 → bits 15..12 = 0001, bits 3..0 = 0000)
+        0xE1A0_0001,    // MOV r0, r1   (Rd=0, Rm=1)
+        BX_LR,
+    ], "expected MOV r0,#7 + MOV r1,r0 + MOV r0,r1 + BX LR; got: {words:08x?}");
+}
+
+#[test]
+fn allocator_exhaustion_yields_out_of_registers() {
+    // 13 consts fill the pool [r0..r12]; the 14th triggers OutOfRegisters.
+    let mut body = Vec::new();
+    for i in 0..14 {
+        body.push(IIRInstr::new(
+            "const",
+            Some(format!("v{i}")),
+            vec![Operand::Int((i % 256) as i64)],
+            "u8",
+        ));
+    }
+    body.push(IIRInstr::new("ret_void", None, vec![], "void"));
+    let f = IIRFunction::new("greedy", vec![], "void", body);
+    let err = lower_iir_to_armv7(&module_with(f), &IIRArmv7Config::default())
+        .expect_err("14 consts should exhaust the 13-register pool");
+    match err {
+        IIRArmv7Error::OutOfRegisters { function, name } => {
+            assert_eq!(function, "greedy");
+            assert_eq!(name, "v13", "should fail on the 14th local");
+        }
+        other => panic!("expected OutOfRegisters, got: {other:?}"),
+    }
+}
+
+#[test]
+fn undefined_variable_in_mov_is_rejected() {
+    let f = IIRFunction::new("f", vec![], "void", vec![
+        IIRInstr::new("mov", Some("w".into()),
+            vec![Operand::Var("ghost".into())], "u8"),
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ]);
+    let err = lower_iir_to_armv7(&module_with(f), &IIRArmv7Config::default())
+        .expect_err("mov from undefined var should fail");
+    match err {
+        IIRArmv7Error::UndefinedVariable { name, .. } => {
+            assert_eq!(name, "ghost");
+        }
+        other => panic!("expected UndefinedVariable, got: {other:?}"),
+    }
+}
+
+#[test]
+fn errors_for_new_variants_display_without_panic() {
+    let _ = format!("{}", IIRArmv7Error::UndefinedVariable {
+        function: "f".into(), name: "ghost".into(),
+    });
+    let _ = format!("{}", IIRArmv7Error::OutOfRegisters {
+        function: "greedy".into(), name: "v13".into(),
+    });
 }

--- a/code/specs/iir-to-armv7.md
+++ b/code/specs/iir-to-armv7.md
@@ -68,9 +68,11 @@ IIRModule
 | Version | Scope | Status |
 |---------|-------|--------|
 | v0.1.0 (A3) | crate skeleton: any module → single `BKPT #0xFFFF` (`0xE12FFF7F`) | **merged** |
-| **v0.2.0 (A3+ — this PR)** | `const` → `MOV r0, #imm8` (accumulator-only) + `ret`/`ret_void` → `BX LR` (AAPCS return) | this PR |
-| v0.3.0 (A3++) | Linear register allocator over `r0..r12` + arithmetic (add/sub) + function calls via `bl` with PC-relative offsets | future |
+| v0.2.0 (A3+) | `const` → `MOV r0, #imm8` (accumulator-only) + `ret`/`ret_void` → `BX LR` (AAPCS return) | **merged** |
+| **v0.3.0 (A3++ — this PR)** | Linear register allocator over `r0..r12` + multi-register `const` + `mov` (`MOV Rd, Rm`, `0xE1A0_0000` base) + ret-value staging via `MOV r0, var_reg` | this PR |
+| v0.3.x (A3++.5) | Arithmetic (`add`/`sub`) on the data-processing-register family | future |
 | v0.3.x (A3++.5.5) | Comparisons + conditional branches via the cond-field on every A32 instruction (a stronger version of the 8008's flag-based jumps) | future |
+| v0.3.x (A3++.6) | Function calls via `bl` with PC-relative offsets + stack spilling | future |
 | v0.4.0 (A3+++) | `lang-aot --emit=armv7` wiring | future |
 
 ## Public surface (v0.1.0)


### PR DESCRIPTION
## Summary

Extends \`iir-to-armv7\` v0.2.0 → **v0.3.0** with a linear register allocator over \`r0..r12\` + \`mov\` (register-to-register) + ret-value staging.  Mirrors iir-to-intel8008 v0.3.0 (A2++) structurally.

| IIR op | A32 lowering |
| ------ | ------------ |
| \`const dest, Int(n)\` | \`MOV rrr, #n\` (\`rrr\` from REGISTER_POOL) |
| \`mov dest, src\` | \`MOV Rd, Rm\` (\`MOV_REG_BASE | (Rd << 12) | Rm\`) |
| \`ret <var>\` | (\`MOV r0, var_reg\` if needed) + \`BX LR\` |
| \`ret_void\` | \`BX LR\` |

### Register pool

\`[r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12]\` — 13 registers.

\`r0\` comes first so the trivial \`const v; ret v\` case stays at 2 words (no redundant staging MOV — same shape as v0.2.0).

\`r13\` (sp), \`r14\` (lr), and \`r15\` (pc) are NOT in the pool — touching them as locals would break the calling convention's stack discipline, the return address, or the instruction pointer.

### New constant

\`pub const MOV_REG_BASE: u32 = 0xE1A0_0000;\` — MOV Rd, Rm base.

**🚨 CAREFUL**: bit-25 distinguishes this from \`MOV_IMM_R0_BASE = 0xE3A0_0000\`.  Data-processing-immediate has bit-25 set; register-form doesn't.

### New error variants

- \`UndefinedVariable { function, name }\` — mov/ret referenced an unbound name
- \`OutOfRegisters { function, name }\` — 14th local exhausted the 13-register pool.  Stack spilling lands in A3++.5+.

## Test plan

- [x] \`cargo test -p iir-to-armv7\` — 21/21 backend tests pass, 1/1 doctest passes
- [x] MOV_REG_BASE pinned
- [x] Two-consts byte sequence pinned (\`MOV r0,#1; MOV r1,#2; MOV r0,r1; BX LR\` = \`E3A00001 E3A01002 E1A00001 E12FFF1E\`)
- [x] v0.2.0 2-word regression preserved (r0-first allocator)
- [x] MOV r1,r0 (= 0xE1A0_1000) and MOV r0,r1 (= 0xE1A0_0001) shown side-by-side
- [x] Allocator exhaustion: 14 consts → fails on v13
- [x] Undefined variable in mov rejected
- [x] Security review passed (no vulnerabilities found)
- [ ] CI green
- [ ] No merge conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)