### PR TITLE
feat(iir-to-armv7): add/sub on data-processing-register family — A3++.5

### DIFF
--- a/code/packages/rust/iir-to-armv7/CHANGELOG.md
+++ b/code/packages/rust/iir-to-armv7/CHANGELOG.md
@@ -3,6 +3,66 @@
 All notable changes to this crate are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.0] — 2026-06-02 (A3++.5 — `add`/`sub` on the data-processing-register family)
+
+### Added — 3-register ALU
+
+Extends v0.3.0 with two ALU ops on the data-processing-register
+encoding family.  Unlike the 8008's `ADD r` (accumulator-anchored —
+`A = A + r`), ARMv7's `ADD Rd, Rn, Rm` is a true 3-register
+operation: `Rd = Rn + Rm` in a single instruction with no staging
+MOVs.  Same shape as RV32I's `add rd, rs1, rs2`.
+
+| IIR op | A32 lowering |
+|--------|--------------|
+| `add dest, a, b` | `ADD Rd, Rn, Rm` (`0xE080_0000 \| (Rn << 16) \| (Rd << 12) \| Rm`) |
+| `sub dest, a, b` | `SUB Rd, Rn, Rm` (`0xE040_0000 \| ...`) |
+
+### New constants
+
+* `pub const ADD_REG_BASE: u32 = 0xE080_0000;` — `ADD r0, r0, r0`
+  base (cond=AL, opcode=0100, S=0, no shift).
+* `pub const SUB_REG_BASE: u32 = 0xE040_0000;` — same shape, opcode
+  `0010` (SUB).
+
+The opcode field (bits 24..21) is the only differing nibble between
+ADD and SUB.  Both fit inside the 7-bit `cond | 000 | opcode | S`
+prefix.
+
+### New encoder helpers
+
+* `encode_add_reg(rd: u8, rn: u8, rm: u8) -> u32`
+* `encode_sub_reg(rd: u8, rn: u8, rm: u8) -> u32`
+
+Both `debug_assert!` their three 4-bit register selectors.
+
+### Tests added (27 total, was 21)
+
+* `add_reg_base_pinned_to_0xe0800000` / `sub_reg_base_pinned_to_0xe0400000`.
+* `add_three_consts_emits_single_instruction_no_staging` — pinned
+  5-word sequence `0xE3A0_0003 0xE3A0_1004 0xE080_2001 0xE1A0_0002
+  0xE12F_FF1E` (MOV r0,#3 / MOV r1,#4 / ADD r2,r0,r1 / MOV r0,r2 /
+  BX LR).
+* `sub_three_consts_emits_sub_instruction_with_correct_opcode_field`
+  — same shape, `SUB r2, r0, r1 = 0xE040_2001`.
+* `add_with_same_register_uses_it_as_both_rn_and_rm` — `add r v v`
+  case: `ADD r1, r0, r0 = 0xE080_1000`.
+* `add_then_ret_into_non_r0_register_emits_staging_mov` — regression
+  that the v0.3.0 ret-staging logic still fires for ALU dest
+  registers.
+
+### What is NOT in v0.4.0 (deferred to A3++.5.5 / A3++.6 / A3+++)
+
+* Bitwise ops `and`/`or`/`xor` (opcodes `0000`, `1100`, `0001` in
+  the same data-processing-register family) — straightforward
+  extension once the test patterns are in place.
+* Wider arithmetic (`mul`/`mla` on the multiply family).
+* Comparisons + conditional branches via the cond-field every A32
+  instruction carries.
+* Function calls via `bl` with PC-relative offsets + stack
+  spilling.
+* `lang-aot --emit=armv7` wiring — A3+++ (v0.5.0).
+
 ## [0.3.0] — 2026-06-02 (A3++ — linear register allocator + `mov` + ret-value staging)
 
 ### Added — linear register allocator over r0..r12

--- a/code/packages/rust/iir-to-armv7/Cargo.toml
+++ b/code/packages/rust/iir-to-armv7/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iir-to-armv7"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
-description = "IIR → ARMv7 (A32) machine code backend — lowers IIRModule to a Vec<u32> of encoded 32-bit ARMv7-A instructions.  v0.3.0 (A3++): linear register allocator over r0..r12 + multi-register `const` + `mov` (register-to-register, 0xE1A0_0000 base) + ret-value staging.  r0 comes first in the pool to keep the trivial `const v; ret v` case at the 2-word v0.2.0 shape (MOV r0, #imm + BX LR — no redundant staging MOV).  r13 (sp), r14 (lr), and r15 (pc) are NOT in the pool — touching them would break the calling convention.  Stack spilling + arithmetic land in A3++.5."
+description = "IIR → ARMv7 (A32) machine code backend — lowers IIRModule to a Vec<u32> of encoded 32-bit ARMv7-A instructions.  v0.4.0 (A3++.5): adds `add` (ADD Rd, Rn, Rm = 0xE080_0000 | Rn<<16 | Rd<<12 | Rm) and `sub` (0xE040_0000 base) on the data-processing-register family.  Unlike the 8008's accumulator-anchored ALU which needed two MOV wrappers, ARMv7's 3-register ADD/SUB produces `Rd = Rn op Rm` in a single instruction — same shape as RV32I.  Bitwise ops (and/or/xor) + cond branches defer to v0.4.x; lang-aot wiring stays at A3+++ (v0.5.0)."
 
 [lib]
 name = "iir_to_armv7"

--- a/code/packages/rust/iir-to-armv7/src/lib.rs
+++ b/code/packages/rust/iir-to-armv7/src/lib.rs
@@ -227,6 +227,60 @@ pub(crate) fn encode_mov_reg(rd: u8, rm: u8) -> u32 {
     MOV_REG_BASE | ((rd as u32) << 12) | (rm as u32)
 }
 
+/// ARMv7-A `ADD Rd, Rn, Rm` (data-processing register) base encoding —
+/// `0xE080_0000`.  OR in `(Rn << 16) | (Rd << 12) | Rm` to form the
+/// full instruction word.
+///
+/// Bit layout (cond=AL, S=0, no shift):
+///
+/// ```text
+/// 31..28  cond      = 0xE = 1110          (always — unconditional)
+/// 27..25            = 000                  (data-processing register)
+/// 24..21  opcode    = 0100                 (ADD)
+/// 20      S         = 0                    (don't set flags)
+/// 19..16  Rn        = (in this base, 0)   (first source register)
+/// 15..12  Rd        = (in this base, 0)   (destination register)
+/// 11.. 7  shift_imm = 00000                (no shift on Rm)
+///  6.. 5  type      = 00                   (LSL — but shift_imm=0 means no shift)
+///  4                = 0                    (immediate shift, not register)
+///  3.. 0  Rm        = (in this base, 0)   (second source register)
+/// ```
+///
+/// For `ADD r0, r0, r0`: `1110 0000 1000 0000 0000 0000 0000 0000` =
+/// `0xE0800000`.  For `ADD Rd, Rn, Rm`: OR in
+/// `(Rn << 16) | (Rd << 12) | Rm`.
+///
+/// Unlike the 8008's `ADD r` (which forces A = A + r — accumulator-
+/// anchored), ARMv7's `ADD` is a 3-register operation: `Rd = Rn + Rm`.
+/// No staging MOVs needed.
+pub const ADD_REG_BASE: u32 = 0xE080_0000;
+
+/// ARMv7-A `SUB Rd, Rn, Rm` (data-processing register) base encoding —
+/// `0xE040_0000`.  Same shape as `ADD_REG_BASE` but with opcode
+/// `0010` (SUB) instead of `0100` (ADD).  OR in
+/// `(Rn << 16) | (Rd << 12) | Rm` for arbitrary operand triples.
+///
+/// `Rd = Rn - Rm`.  Same 3-register no-staging shape as ADD.
+pub const SUB_REG_BASE: u32 = 0xE040_0000;
+
+/// Encode an ARMv7-A `ADD Rd, Rn, Rm` instruction.
+///
+/// All three register selectors must be in `[0, 15]`.
+pub(crate) fn encode_add_reg(rd: u8, rn: u8, rm: u8) -> u32 {
+    debug_assert!(rd <= 15, "rd out of 4-bit range: {rd}");
+    debug_assert!(rn <= 15, "rn out of 4-bit range: {rn}");
+    debug_assert!(rm <= 15, "rm out of 4-bit range: {rm}");
+    ADD_REG_BASE | ((rn as u32) << 16) | ((rd as u32) << 12) | (rm as u32)
+}
+
+/// Encode an ARMv7-A `SUB Rd, Rn, Rm` instruction.
+pub(crate) fn encode_sub_reg(rd: u8, rn: u8, rm: u8) -> u32 {
+    debug_assert!(rd <= 15, "rd out of 4-bit range: {rd}");
+    debug_assert!(rn <= 15, "rn out of 4-bit range: {rn}");
+    debug_assert!(rm <= 15, "rm out of 4-bit range: {rm}");
+    SUB_REG_BASE | ((rn as u32) << 16) | ((rd as u32) << 12) | (rm as u32)
+}
+
 // ===========================================================================
 // IIRArmv7Config
 // ===========================================================================
@@ -357,7 +411,10 @@ const REGISTER_POOL: [u8; 13] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
 /// * `ret <var>` stages the value into `r0` (if not already there) and
 ///   emits `BX LR`.  `ret_void` just emits `BX LR`.
 const SUPPORTED_OPS: &[&str] = &[
+    // A3 / A3+ / A3++
     "const", "mov", "ret", "ret_void",
+    // A3++.5 — data-processing-register ALU
+    "add", "sub",
 ];
 
 /// Lower an [`IIRModule`] to a `Vec<u32>` of ARMv7 (A32) opcode words.
@@ -469,6 +526,42 @@ pub fn lower_iir_to_armv7(
                 // ── ret_void → BX LR ───────────────────────────────
                 "ret_void" => {
                     words.push(BX_LR);
+                }
+
+                // ── add / sub → ADD/SUB Rd, Rn, Rm ─────────────────────
+                //
+                // Unlike the 8008's accumulator-anchored `ADD r` (which
+                // forces `A = A + r` and needs MOV wrappers to use
+                // non-accumulator operands), ARMv7's data-processing-
+                // register family takes 3 register selectors in a
+                // single instruction: `Rd = Rn op Rm`.  No staging
+                // MOVs.  This is the same shape as RISC-V's `add rd,
+                // rs1, rs2`.
+                "add" | "sub" => {
+                    let dest = require_dest(instr, &instr.op, &f.name)?;
+                    let a_name = match instr.srcs.first() {
+                        Some(Operand::Var(s)) => s.clone(),
+                        _ => return Err(IIRArmv7Error::InvalidOperand {
+                            function: f.name.clone(),
+                            detail: format!("{} srcs[0] must be Var", instr.op),
+                        }),
+                    };
+                    let b_name = match instr.srcs.get(1) {
+                        Some(Operand::Var(s)) => s.clone(),
+                        _ => return Err(IIRArmv7Error::InvalidOperand {
+                            function: f.name.clone(),
+                            detail: format!("{} srcs[1] must be Var", instr.op),
+                        }),
+                    };
+                    let rn = lookup_register(&env, &a_name, &f.name)?;
+                    let rm = lookup_register(&env, &b_name, &f.name)?;
+                    let rd = alloc_register(&mut next_reg, dest, &mut env, &f.name)?;
+                    let word = if instr.op == "add" {
+                        encode_add_reg(rd, rn, rm)
+                    } else {
+                        encode_sub_reg(rd, rn, rm)
+                    };
+                    words.push(word);
                 }
 
                 _ => unreachable!("SUPPORTED_OPS guard above prevents this"),

--- a/code/packages/rust/iir-to-armv7/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-armv7/tests/test_backend.rs
@@ -6,7 +6,8 @@
 use interpreter_ir::{IIRFunction, IIRInstr, IIRModule, Operand};
 use iir_to_armv7::{
     lower_iir_to_armv7, validate_for_armv7,
-    IIRArmv7Config, IIRArmv7Error, BKPT, BX_LR, MOV_IMM_R0_BASE, MOV_REG_BASE,
+    IIRArmv7Config, IIRArmv7Error,
+    ADD_REG_BASE, BKPT, BX_LR, MOV_IMM_R0_BASE, MOV_REG_BASE, SUB_REG_BASE,
 };
 
 fn module_with(f: IIRFunction) -> IIRModule {
@@ -355,4 +356,138 @@ fn errors_for_new_variants_display_without_panic() {
     let _ = format!("{}", IIRArmv7Error::OutOfRegisters {
         function: "greedy".into(), name: "v13".into(),
     });
+}
+
+// ===========================================================================
+// 7. A3++.5 (v0.4.0) — data-processing-register ALU (ADD, SUB)
+// ===========================================================================
+//
+// Unlike the 8008's `ADD r` (accumulator-anchored — `A = A + r`),
+// ARMv7's `ADD Rd, Rn, Rm` is a 3-register operation: any pair of
+// source registers can produce any destination register in a single
+// instruction.  No staging MOVs.  Same shape as RV32I's `add rd, rs1,
+// rs2`.
+
+#[test]
+fn add_reg_base_pinned_to_0xe0800000() {
+    // ADD r0, r0, r0 (no shift, S=0) = 0xE0800000.
+    assert_eq!(ADD_REG_BASE, 0xE080_0000,
+        "ADD Rd, Rn, Rm base should be 0xE0800000; got 0x{:08x}", ADD_REG_BASE);
+}
+
+#[test]
+fn sub_reg_base_pinned_to_0xe0400000() {
+    // SUB r0, r0, r0 (no shift, S=0) = 0xE0400000.
+    assert_eq!(SUB_REG_BASE, 0xE040_0000,
+        "SUB Rd, Rn, Rm base should be 0xE0400000; got 0x{:08x}", SUB_REG_BASE);
+}
+
+#[test]
+fn add_three_consts_emits_single_instruction_no_staging() {
+    // const v=3; const w=4; add r v w; ret r
+    //
+    // Allocator: v→r0, w→r1, r→r2.
+    //   MOV r0, #3       = 0xE3A0_0003
+    //   MOV r1, #4       = 0xE3A0_1004
+    //   ADD r2, r0, r1   = 0xE080_0000 | (0<<16) | (2<<12) | 1
+    //                     = 0xE080_2001    ← Rn=0, Rd=2, Rm=1
+    //   MOV r0, r2       = 0xE1A0_0002    ← stage r into r0 for ret
+    //   BX LR            = 0xE12F_FF1E
+    let f = IIRFunction::new("add3plus4", vec![], "u8", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(3)], "u8"),
+        IIRInstr::new("const", Some("w".into()), vec![Operand::Int(4)], "u8"),
+        IIRInstr::new("add", Some("r".into()),
+            vec![Operand::Var("v".into()), Operand::Var("w".into())], "u8"),
+        IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "u8"),
+    ]);
+    let words = lower_iir_to_armv7(&module_with(f), &IIRArmv7Config::default())
+        .expect("lowering");
+    assert_eq!(words, vec![
+        0xE3A0_0003,    // MOV r0, #3
+        0xE3A0_1004,    // MOV r1, #4
+        0xE080_2001,    // ADD r2, r0, r1
+        0xE1A0_0002,    // MOV r0, r2
+        BX_LR,
+    ], "add 3+4 expected; got: {words:08x?}");
+}
+
+#[test]
+fn sub_three_consts_emits_sub_instruction_with_correct_opcode_field() {
+    // const v=10; const w=4; sub r v w; ret r
+    //   SUB r2, r0, r1 = 0xE040_0000 | (0<<16) | (2<<12) | 1 = 0xE040_2001
+    let f = IIRFunction::new("ten_minus_four", vec![], "u8", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(10)], "u8"),
+        IIRInstr::new("const", Some("w".into()), vec![Operand::Int(4)], "u8"),
+        IIRInstr::new("sub", Some("r".into()),
+            vec![Operand::Var("v".into()), Operand::Var("w".into())], "u8"),
+        IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "u8"),
+    ]);
+    let words = lower_iir_to_armv7(&module_with(f), &IIRArmv7Config::default())
+        .expect("lowering");
+    assert_eq!(words, vec![
+        0xE3A0_000A,    // MOV r0, #10
+        0xE3A0_1004,    // MOV r1, #4
+        0xE040_2001,    // SUB r2, r0, r1
+        0xE1A0_0002,    // MOV r0, r2
+        BX_LR,
+    ], "sub 10-4 expected; got: {words:08x?}");
+}
+
+/// `add r v v` — same register used as both Rn and Rm.  The 8008
+/// equivalent (`add r v v` where v is already in A) skips the
+/// leading staging MOV; ARMv7 simply uses the same register for
+/// both source slots in the single ADD instruction.
+#[test]
+fn add_with_same_register_uses_it_as_both_rn_and_rm() {
+    // const v=5; add r v v; ret r
+    //
+    // Allocator: v→r0, r→r1.
+    //   MOV r0, #5       = 0xE3A0_0005
+    //   ADD r1, r0, r0   = 0xE080_0000 | (0<<16) | (1<<12) | 0 = 0xE080_1000
+    //   MOV r0, r1       = 0xE1A0_0001
+    //   BX LR
+    let f = IIRFunction::new("double", vec![], "u8", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(5)], "u8"),
+        IIRInstr::new("add", Some("r".into()),
+            vec![Operand::Var("v".into()), Operand::Var("v".into())], "u8"),
+        IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "u8"),
+    ]);
+    let words = lower_iir_to_armv7(&module_with(f), &IIRArmv7Config::default())
+        .expect("lowering");
+    assert_eq!(words, vec![
+        0xE3A0_0005,    // MOV r0, #5
+        0xE080_1000,    // ADD r1, r0, r0
+        0xE1A0_0001,    // MOV r0, r1
+        BX_LR,
+    ], "self-add expected; got: {words:08x?}");
+}
+
+/// If the destination register matches the AAPCS return register r0,
+/// the `ret r` stage-MOV is elided (just like the v0.2.0
+/// `ret_of_first_const_omits_the_redundant_mov` regression).
+///
+/// We engineer this by burning r0 with the first const, then
+/// re-using r0... but actually under the linear allocator the dest
+/// will be the *next* slot, not r0.  To pin "dest_reg is r0" via
+/// this slice we'd need register coalescing.  For now this test is
+/// a placeholder that confirms the simple case works.
+#[test]
+fn add_then_ret_into_non_r0_register_emits_staging_mov() {
+    // Regression for: the v0.3.0 ret-staging logic still fires for
+    // ALU dest registers.
+    let f = IIRFunction::new("f", vec![], "u8", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(1)], "u8"),
+        IIRInstr::new("const", Some("w".into()), vec![Operand::Int(2)], "u8"),
+        IIRInstr::new("add", Some("r".into()),
+            vec![Operand::Var("v".into()), Operand::Var("w".into())], "u8"),
+        IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "u8"),
+    ]);
+    let words = lower_iir_to_armv7(&module_with(f), &IIRArmv7Config::default())
+        .expect("lowering");
+    // 5 words: 2 MVI + 1 ADD + 1 stage MOV + BX LR.
+    assert_eq!(words.len(), 5);
+    // The 4th word (index 3) is the stage MOV r0, r2 = 0xE1A0_0002.
+    assert_eq!(words[3], 0xE1A0_0002,
+        "expected stage MOV r0, r2 at index 3; got 0x{:08x}", words[3]);
+    assert_eq!(words[4], BX_LR);
 }

--- a/code/specs/iir-to-armv7.md
+++ b/code/specs/iir-to-armv7.md
@@ -69,8 +69,8 @@ IIRModule
 |---------|-------|--------|
 | v0.1.0 (A3) | crate skeleton: any module → single `BKPT #0xFFFF` (`0xE12FFF7F`) | **merged** |
 | v0.2.0 (A3+) | `const` → `MOV r0, #imm8` (accumulator-only) + `ret`/`ret_void` → `BX LR` (AAPCS return) | **merged** |
-| **v0.3.0 (A3++ — this PR)** | Linear register allocator over `r0..r12` + multi-register `const` + `mov` (`MOV Rd, Rm`, `0xE1A0_0000` base) + ret-value staging via `MOV r0, var_reg` | this PR |
-| v0.3.x (A3++.5) | Arithmetic (`add`/`sub`) on the data-processing-register family | future |
+| v0.3.0 (A3++) | Linear register allocator over `r0..r12` + multi-register `const` + `mov` + ret-value staging | **merged** |
+| **v0.4.0 (A3++.5 — this PR)** | `add`/`sub` on the data-processing-register family (`ADD_REG_BASE = 0xE080_0000`, `SUB_REG_BASE = 0xE040_0000`) — 3-register `Rd = Rn op Rm` with no accumulator constraint, unlike the 8008 | this PR |
 | v0.3.x (A3++.5.5) | Comparisons + conditional branches via the cond-field on every A32 instruction (a stronger version of the 8008's flag-based jumps) | future |
 | v0.3.x (A3++.6) | Function calls via `bl` with PC-relative offsets + stack spilling | future |
 | v0.4.0 (A3+++) | `lang-aot --emit=armv7` wiring | future |


### PR DESCRIPTION
## Summary

Extends \`iir-to-armv7\` v0.3.0 → **v0.4.0** with \`add\`/\`sub\` on the ARMv7 data-processing-register family.

| IIR op | A32 lowering |
| ------ | ------------ |
| \`add dest, a, b\` | \`ADD Rd, Rn, Rm\` (\`0xE080_0000 | (Rn<<16) | (Rd<<12) | Rm\`) |
| \`sub dest, a, b\` | \`SUB Rd, Rn, Rm\` (\`0xE040_0000\` base) |

### Why much cleaner than the 8008 equivalent

Unlike the 8008's \`ADD r\` (accumulator-anchored — \`A = A + r\`) which needs two MOV wrappers to handle non-accumulator operands, ARMv7's \`ADD Rd, Rn, Rm\` is a true **3-register operation**: \`Rd = Rn + Rm\` in a **single instruction** with no staging MOVs.  Same shape as RV32I's \`add rd, rs1, rs2\`.

The opcode field (bits 24..21) is the **only** differing nibble between ADD (\`0100\`) and SUB (\`0010\`).  Both fit inside the 7-bit \`cond | 000 | opcode | S\` prefix.

### New public constants

- \`ADD_REG_BASE = 0xE080_0000\`
- \`SUB_REG_BASE = 0xE040_0000\`

### Deferred to follow-up slices

- **A3++.5.5** — bitwise ops (\`and\`/\`or\`/\`xor\`) + comparisons + conditional branches via the \`cond\` field every A32 instruction carries
- **A3++.6** — function calls via \`bl\` with PC-relative offsets + stack spilling
- **A3+++ (v0.5.0)** — \`lang-aot --emit=armv7\` wiring

## Test plan

- [x] \`cargo test -p iir-to-armv7\` — 27/27 backend tests pass, 1/1 doctest passes
- [x] ADD_REG_BASE / SUB_REG_BASE pinned
- [x] Full add byte stream pinned (\`E3A00003 E3A01004 E080_2001 E1A00002 E12FFF1E\`)
- [x] Full sub byte stream pinned with correct opcode field
- [x] Self-add (\`add r v v\`) uses same register as both Rn and Rm (\`ADD r1, r0, r0 = 0xE080_1000\`)
- [x] Ret-staging logic preserved for ALU dest registers (v0.3.0 regression)
- [x] Security review passed (no vulnerabilities found)
- [ ] CI green
- [ ] No merge conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)