### PR TITLE
feat(iir-to-armv7): bitwise and/or/xor on DP-register family — A3++.5.5 first slice

### DIFF
--- a/code/packages/rust/iir-to-armv7/CHANGELOG.md
+++ b/code/packages/rust/iir-to-armv7/CHANGELOG.md
@@ -3,6 +3,74 @@
 All notable changes to this crate are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.1] — 2026-06-02 (A3++.5.5 first slice — bitwise `and`/`or`/`xor` on the DP-register family)
+
+### Added — bitwise DP-register ALU
+
+Extends v0.4.0 with three more accumulator-target — wait, NOT
+accumulator-target.  ARMv7's DP-register family is true 3-register
+(`Rd = Rn op Rm`), so unlike the 8008's bitwise ANA/ORA/XRA which
+needed accumulator wrappers, ARMv7's AND/ORR/EOR slot in
+identically to ADD/SUB.
+
+| IIR op | ARM mnemonic | Opcode | First word base |
+|--------|--------------|--------|-----------------|
+| `and dest, a, b` | `AND Rd, Rn, Rm` | `0000` | `0xE000_0000` |
+| `or  dest, a, b` | `ORR Rd, Rn, Rm` | `1100` | `0xE180_0000` |
+| `xor dest, a, b` | `EOR Rd, Rn, Rm` | `0001` | `0xE020_0000` |
+
+ARM uses the older mnemonics **ORR** (OR Register) and **EOR**
+(Exclusive OR) rather than the universal `OR`/`XOR`.  We pin both
+in the constant names so the bytes round-trip correctly through the
+`arm-simulator` disassembler, but the IIR-facing op names keep the
+universal `or`/`xor` spellings (matching iir-to-intel8008 and
+iir-to-riscv).
+
+### Unified DP-register match arm
+
+The `add | sub` arm from v0.4.0 widens to `add | sub | and | or |
+xor` with a 5-way inner match on op-name → encoder.  All five share
+the same operand-extraction/register-allocation/word-push skeleton;
+only the encoder function differs.
+
+### New constants
+
+* `pub const AND_REG_BASE: u32 = 0xE000_0000;`
+* `pub const ORR_REG_BASE: u32 = 0xE180_0000;`
+* `pub const EOR_REG_BASE: u32 = 0xE020_0000;`
+
+### New encoder helpers
+
+* `encode_and_reg(rd, rn, rm) -> u32`
+* `encode_orr_reg(rd, rn, rm) -> u32`
+* `encode_eor_reg(rd, rn, rm) -> u32`
+
+All `debug_assert!` their three 4-bit register selectors.
+
+### Tests added (33 total, was 27)
+
+* `and_reg_base_pinned_to_0xe0000000` / `orr_reg_base_pinned_to_0xe1800000`
+  / `eor_reg_base_pinned_to_0xe0200000`.
+* `and_three_consts_emits_single_and_instruction` — pinned 5-word
+  sequence with `AND r2, r0, r1 = 0xE000_2001`.
+* `or_three_consts_emits_single_orr_instruction` — `ORR r2, r0, r1 =
+  0xE180_2001`.
+* `xor_three_consts_emits_single_eor_instruction` — `EOR r2, r0, r1 =
+  0xE020_2001`.
+
+### What is NOT in v0.4.1 (deferred to v0.4.2 / A3++.6 / A3+++)
+
+* Carry-chained arithmetic (`adc`/`sbc` on the same DP family with
+  opcodes `0101`/`0110`).
+* Comparisons (`cmp` = `1010`, `cmn` = `1011`) — set flags only,
+  need a paired flag-to-bool capture sequence to produce an IIR
+  boolean.
+* Conditional branches via the `cond` field every A32 instruction
+  carries.
+* Function calls via `bl` with PC-relative offsets.
+* Stack spilling once the 13-register pool exhausts.
+* `lang-aot --emit=armv7` wiring — A3+++ (v0.5.0).
+
 ## [0.4.0] — 2026-06-02 (A3++.5 — `add`/`sub` on the data-processing-register family)
 
 ### Added — 3-register ALU

--- a/code/packages/rust/iir-to-armv7/Cargo.toml
+++ b/code/packages/rust/iir-to-armv7/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iir-to-armv7"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
-description = "IIR → ARMv7 (A32) machine code backend — lowers IIRModule to a Vec<u32> of encoded 32-bit ARMv7-A instructions.  v0.4.0 (A3++.5): adds `add` (ADD Rd, Rn, Rm = 0xE080_0000 | Rn<<16 | Rd<<12 | Rm) and `sub` (0xE040_0000 base) on the data-processing-register family.  Unlike the 8008's accumulator-anchored ALU which needed two MOV wrappers, ARMv7's 3-register ADD/SUB produces `Rd = Rn op Rm` in a single instruction — same shape as RV32I.  Bitwise ops (and/or/xor) + cond branches defer to v0.4.x; lang-aot wiring stays at A3+++ (v0.5.0)."
+description = "IIR → ARMv7 (A32) machine code backend — lowers IIRModule to a Vec<u32> of encoded 32-bit ARMv7-A instructions.  v0.4.1 (A3++.5.5 first slice): adds bitwise data-processing-register ops `and` (AND opcode 0000 = 0xE000_0000), `or` (ORR opcode 1100 = 0xE180_0000), `xor` (EOR opcode 0001 = 0xE020_0000).  All five DP-register ALU ops now flow through a single 5-way match arm with one shared shape `Rd = Rn op Rm` — no accumulator constraint like the 8008.  ARM mnemonics: ORR (not OR) and EOR (not XOR) are pinned in the constant names; the IIR-facing ops keep the universal `or`/`xor` spellings."
 
 [lib]
 name = "iir_to_armv7"

--- a/code/packages/rust/iir-to-armv7/src/lib.rs
+++ b/code/packages/rust/iir-to-armv7/src/lib.rs
@@ -281,6 +281,54 @@ pub(crate) fn encode_sub_reg(rd: u8, rn: u8, rm: u8) -> u32 {
     SUB_REG_BASE | ((rn as u32) << 16) | ((rd as u32) << 12) | (rm as u32)
 }
 
+/// ARMv7-A `AND Rd, Rn, Rm` (bitwise AND) base — `0xE000_0000`.
+///
+/// Same shape as `ADD_REG_BASE` but with opcode `0000` (AND).  In
+/// IIR terms this is the lowering target for the `and` op.
+pub const AND_REG_BASE: u32 = 0xE000_0000;
+
+/// ARMv7-A `ORR Rd, Rn, Rm` (bitwise OR — "OR Register") base —
+/// `0xE180_0000`.
+///
+/// Same shape as `ADD_REG_BASE` but with opcode `1100` (ORR).  In
+/// IIR terms this is the lowering target for the `or` op.  ARM
+/// spells it "ORR" rather than "OR" to free up the `OR` mnemonic
+/// for variants like `ORRS` (set flags) and `ORR.W` (Thumb-2 wide).
+pub const ORR_REG_BASE: u32 = 0xE180_0000;
+
+/// ARMv7-A `EOR Rd, Rn, Rm` (bitwise XOR — "Exclusive OR") base —
+/// `0xE020_0000`.
+///
+/// Same shape as `ADD_REG_BASE` but with opcode `0001` (EOR).  In
+/// IIR terms this is the lowering target for the `xor` op.  ARM's
+/// "EOR" is an unusually old-school mnemonic — most modern ISAs
+/// spell this `XOR`.  The bit pattern is the same either way.
+pub const EOR_REG_BASE: u32 = 0xE020_0000;
+
+/// Encode an ARMv7-A `AND Rd, Rn, Rm` instruction.
+pub(crate) fn encode_and_reg(rd: u8, rn: u8, rm: u8) -> u32 {
+    debug_assert!(rd <= 15, "rd out of 4-bit range: {rd}");
+    debug_assert!(rn <= 15, "rn out of 4-bit range: {rn}");
+    debug_assert!(rm <= 15, "rm out of 4-bit range: {rm}");
+    AND_REG_BASE | ((rn as u32) << 16) | ((rd as u32) << 12) | (rm as u32)
+}
+
+/// Encode an ARMv7-A `ORR Rd, Rn, Rm` instruction.
+pub(crate) fn encode_orr_reg(rd: u8, rn: u8, rm: u8) -> u32 {
+    debug_assert!(rd <= 15, "rd out of 4-bit range: {rd}");
+    debug_assert!(rn <= 15, "rn out of 4-bit range: {rn}");
+    debug_assert!(rm <= 15, "rm out of 4-bit range: {rm}");
+    ORR_REG_BASE | ((rn as u32) << 16) | ((rd as u32) << 12) | (rm as u32)
+}
+
+/// Encode an ARMv7-A `EOR Rd, Rn, Rm` instruction.
+pub(crate) fn encode_eor_reg(rd: u8, rn: u8, rm: u8) -> u32 {
+    debug_assert!(rd <= 15, "rd out of 4-bit range: {rd}");
+    debug_assert!(rn <= 15, "rn out of 4-bit range: {rn}");
+    debug_assert!(rm <= 15, "rm out of 4-bit range: {rm}");
+    EOR_REG_BASE | ((rn as u32) << 16) | ((rd as u32) << 12) | (rm as u32)
+}
+
 // ===========================================================================
 // IIRArmv7Config
 // ===========================================================================
@@ -415,6 +463,9 @@ const SUPPORTED_OPS: &[&str] = &[
     "const", "mov", "ret", "ret_void",
     // A3++.5 — data-processing-register ALU
     "add", "sub",
+    // A3++.5.5 first slice — bitwise data-processing-register ALU
+    // (and = AND opcode 0000, or = ORR opcode 1100, xor = EOR opcode 0001)
+    "and", "or", "xor",
 ];
 
 /// Lower an [`IIRModule`] to a `Vec<u32>` of ARMv7 (A32) opcode words.
@@ -528,16 +579,23 @@ pub fn lower_iir_to_armv7(
                     words.push(BX_LR);
                 }
 
-                // ── add / sub → ADD/SUB Rd, Rn, Rm ─────────────────────
+                // ── add / sub / and / or / xor → DP-register family ─────
                 //
-                // Unlike the 8008's accumulator-anchored `ADD r` (which
-                // forces `A = A + r` and needs MOV wrappers to use
-                // non-accumulator operands), ARMv7's data-processing-
-                // register family takes 3 register selectors in a
-                // single instruction: `Rd = Rn op Rm`.  No staging
-                // MOVs.  This is the same shape as RISC-V's `add rd,
+                // All five data-processing-register ops share an
+                // identical shape, differing only in the 4-bit
+                // `opcode` field (bits 24..21):
+                //
+                //   ADD = 0100   AND = 0000
+                //   SUB = 0010   ORR = 1100
+                //                EOR = 0001
+                //
+                // Unlike the 8008's accumulator-anchored ALU (which
+                // needs MOV wrappers for non-accumulator operands),
+                // ARMv7's DP-register family takes 3 register
+                // selectors in a single instruction: `Rd = Rn op Rm`.
+                // No staging MOVs.  Same shape as RISC-V's `add rd,
                 // rs1, rs2`.
-                "add" | "sub" => {
+                "add" | "sub" | "and" | "or" | "xor" => {
                     let dest = require_dest(instr, &instr.op, &f.name)?;
                     let a_name = match instr.srcs.first() {
                         Some(Operand::Var(s)) => s.clone(),
@@ -556,10 +614,13 @@ pub fn lower_iir_to_armv7(
                     let rn = lookup_register(&env, &a_name, &f.name)?;
                     let rm = lookup_register(&env, &b_name, &f.name)?;
                     let rd = alloc_register(&mut next_reg, dest, &mut env, &f.name)?;
-                    let word = if instr.op == "add" {
-                        encode_add_reg(rd, rn, rm)
-                    } else {
-                        encode_sub_reg(rd, rn, rm)
+                    let word = match instr.op.as_str() {
+                        "add" => encode_add_reg(rd, rn, rm),
+                        "sub" => encode_sub_reg(rd, rn, rm),
+                        "and" => encode_and_reg(rd, rn, rm),
+                        "or"  => encode_orr_reg(rd, rn, rm),
+                        "xor" => encode_eor_reg(rd, rn, rm),
+                        _ => unreachable!("outer arm restricts to these 5"),
                     };
                     words.push(word);
                 }

--- a/code/packages/rust/iir-to-armv7/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-armv7/tests/test_backend.rs
@@ -7,7 +7,8 @@ use interpreter_ir::{IIRFunction, IIRInstr, IIRModule, Operand};
 use iir_to_armv7::{
     lower_iir_to_armv7, validate_for_armv7,
     IIRArmv7Config, IIRArmv7Error,
-    ADD_REG_BASE, BKPT, BX_LR, MOV_IMM_R0_BASE, MOV_REG_BASE, SUB_REG_BASE,
+    ADD_REG_BASE, AND_REG_BASE, BKPT, BX_LR, EOR_REG_BASE,
+    MOV_IMM_R0_BASE, MOV_REG_BASE, ORR_REG_BASE, SUB_REG_BASE,
 };
 
 fn module_with(f: IIRFunction) -> IIRModule {
@@ -471,6 +472,111 @@ fn add_with_same_register_uses_it_as_both_rn_and_rm() {
 /// will be the *next* slot, not r0.  To pin "dest_reg is r0" via
 /// this slice we'd need register coalescing.  For now this test is
 /// a placeholder that confirms the simple case works.
+// ===========================================================================
+// 8. A3++.5.5 first slice — bitwise data-processing-register ALU
+// ===========================================================================
+//
+// Identical 3-register shape to add/sub.  Only the 4-bit opcode
+// field (bits 24..21) changes:
+//
+//   AND = 0000 → 0xE000_0000 base
+//   ORR = 1100 → 0xE180_0000 base   (ARM's "OR Register" mnemonic)
+//   EOR = 0001 → 0xE020_0000 base   (ARM's "Exclusive OR" mnemonic)
+//
+// For each op below, the IIR sequence is `const v; const w; OP r v w; ret r`,
+// the allocator places v→r0, w→r1, r→r2, and the emitted word stream
+// follows the canonical:
+//
+//   MVI r0, v_imm
+//   MVI r1, w_imm
+//   OP  r2, r0, r1             ← the only word that varies between the three tests
+//   MOV r0, r2                 ← stage r into r0 for ret
+//   BX LR
+
+#[test]
+fn and_reg_base_pinned_to_0xe0000000() {
+    assert_eq!(AND_REG_BASE, 0xE000_0000,
+        "AND Rd, Rn, Rm base should be 0xE0000000; got 0x{:08x}", AND_REG_BASE);
+}
+
+#[test]
+fn orr_reg_base_pinned_to_0xe1800000() {
+    assert_eq!(ORR_REG_BASE, 0xE180_0000,
+        "ORR Rd, Rn, Rm base should be 0xE1800000; got 0x{:08x}", ORR_REG_BASE);
+}
+
+#[test]
+fn eor_reg_base_pinned_to_0xe0200000() {
+    assert_eq!(EOR_REG_BASE, 0xE020_0000,
+        "EOR Rd, Rn, Rm base should be 0xE0200000; got 0x{:08x}", EOR_REG_BASE);
+}
+
+#[test]
+fn and_three_consts_emits_single_and_instruction() {
+    // const v=0x0F; const w=0x33; and r v w; ret r
+    //   AND r2, r0, r1 = 0xE000_0000 | (0<<16) | (2<<12) | 1 = 0xE000_2001
+    let f = IIRFunction::new("and_fn", vec![], "u8", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(0x0F)], "u8"),
+        IIRInstr::new("const", Some("w".into()), vec![Operand::Int(0x33)], "u8"),
+        IIRInstr::new("and", Some("r".into()),
+            vec![Operand::Var("v".into()), Operand::Var("w".into())], "u8"),
+        IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "u8"),
+    ]);
+    let words = lower_iir_to_armv7(&module_with(f), &IIRArmv7Config::default())
+        .expect("lowering");
+    assert_eq!(words, vec![
+        0xE3A0_000F,    // MOV r0, #0x0F
+        0xE3A0_1033,    // MOV r1, #0x33
+        0xE000_2001,    // AND r2, r0, r1
+        0xE1A0_0002,    // MOV r0, r2
+        BX_LR,
+    ], "and 0x0F & 0x33 expected; got: {words:08x?}");
+}
+
+#[test]
+fn or_three_consts_emits_single_orr_instruction() {
+    // const v=0x0F; const w=0xF0; or r v w; ret r
+    //   ORR r2, r0, r1 = 0xE180_0000 | (0<<16) | (2<<12) | 1 = 0xE180_2001
+    let f = IIRFunction::new("or_fn", vec![], "u8", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(0x0F)], "u8"),
+        IIRInstr::new("const", Some("w".into()), vec![Operand::Int(0xF0)], "u8"),
+        IIRInstr::new("or", Some("r".into()),
+            vec![Operand::Var("v".into()), Operand::Var("w".into())], "u8"),
+        IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "u8"),
+    ]);
+    let words = lower_iir_to_armv7(&module_with(f), &IIRArmv7Config::default())
+        .expect("lowering");
+    assert_eq!(words, vec![
+        0xE3A0_000F,    // MOV r0, #0x0F
+        0xE3A0_10F0,    // MOV r1, #0xF0
+        0xE180_2001,    // ORR r2, r0, r1
+        0xE1A0_0002,    // MOV r0, r2
+        BX_LR,
+    ], "or 0x0F | 0xF0 expected; got: {words:08x?}");
+}
+
+#[test]
+fn xor_three_consts_emits_single_eor_instruction() {
+    // const v=0xFF; const w=0x55; xor r v w; ret r
+    //   EOR r2, r0, r1 = 0xE020_0000 | (0<<16) | (2<<12) | 1 = 0xE020_2001
+    let f = IIRFunction::new("xor_fn", vec![], "u8", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(0xFF)], "u8"),
+        IIRInstr::new("const", Some("w".into()), vec![Operand::Int(0x55)], "u8"),
+        IIRInstr::new("xor", Some("r".into()),
+            vec![Operand::Var("v".into()), Operand::Var("w".into())], "u8"),
+        IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "u8"),
+    ]);
+    let words = lower_iir_to_armv7(&module_with(f), &IIRArmv7Config::default())
+        .expect("lowering");
+    assert_eq!(words, vec![
+        0xE3A0_00FF,    // MOV r0, #0xFF
+        0xE3A0_1055,    // MOV r1, #0x55
+        0xE020_2001,    // EOR r2, r0, r1
+        0xE1A0_0002,    // MOV r0, r2
+        BX_LR,
+    ], "xor 0xFF ^ 0x55 expected; got: {words:08x?}");
+}
+
 #[test]
 fn add_then_ret_into_non_r0_register_emits_staging_mov() {
     // Regression for: the v0.3.0 ret-staging logic still fires for

--- a/code/specs/iir-to-armv7.md
+++ b/code/specs/iir-to-armv7.md
@@ -70,7 +70,8 @@ IIRModule
 | v0.1.0 (A3) | crate skeleton: any module → single `BKPT #0xFFFF` (`0xE12FFF7F`) | **merged** |
 | v0.2.0 (A3+) | `const` → `MOV r0, #imm8` (accumulator-only) + `ret`/`ret_void` → `BX LR` (AAPCS return) | **merged** |
 | v0.3.0 (A3++) | Linear register allocator over `r0..r12` + multi-register `const` + `mov` + ret-value staging | **merged** |
-| **v0.4.0 (A3++.5 — this PR)** | `add`/`sub` on the data-processing-register family (`ADD_REG_BASE = 0xE080_0000`, `SUB_REG_BASE = 0xE040_0000`) — 3-register `Rd = Rn op Rm` with no accumulator constraint, unlike the 8008 | this PR |
+| v0.4.0 (A3++.5) | `add`/`sub` on the data-processing-register family — 3-register `Rd = Rn op Rm` | **merged** |
+| **v0.4.1 (A3++.5.5 first slice — this PR)** | Bitwise DP-register ops `and` (AND `0xE000_0000`), `or` (ORR `0xE180_0000`), `xor` (EOR `0xE020_0000`).  ARM uses ORR/EOR mnemonics rather than OR/XOR; the IIR-facing ops keep the universal spellings. | this PR |
 | v0.3.x (A3++.5.5) | Comparisons + conditional branches via the cond-field on every A32 instruction (a stronger version of the 8008's flag-based jumps) | future |
 | v0.3.x (A3++.6) | Function calls via `bl` with PC-relative offsets + stack spilling | future |
 | v0.4.0 (A3+++) | `lang-aot --emit=armv7` wiring | future |


### PR DESCRIPTION
## Summary

Extends \`iir-to-armv7\` v0.4.0 → **v0.4.1** with three more 3-register data-processing-register ops.

| IIR op | ARM mnemonic | Opcode | First word base    |
| ------ | ------------ | ------ | ------------------ |
| \`and\` | AND          | \`0000\` | \`0xE000_0000\` |
| \`or\`  | ORR          | \`1100\` | \`0xE180_0000\` |
| \`xor\` | EOR          | \`0001\` | \`0xE020_0000\` |

ARM uses the older mnemonics **ORR** (OR Register) and **EOR** (Exclusive OR) rather than the universal \`OR\`/\`XOR\`.  The constant names match the ARM mnemonics; the IIR-facing op names keep the universal \`or\`/\`xor\` spellings.

Unlike the 8008's bitwise ANA/ORA/XRA which needed accumulator wrappers, ARMv7's DP-register family is true 3-register so AND/ORR/EOR slot in identically to ADD/SUB — \`Rd = Rn op Rm\` in a single instruction.

### Unified DP-register match arm

The existing \`add | sub\` arm widens to \`add | sub | and | or | xor\` with a 5-way inner match dispatching on op-name → encoder function.  Single source of truth for the DP-register shape.

### Deferred to follow-up slices

- **v0.4.2** — carry-chained \`adc\`/\`sbc\` (opcodes \`0101\`/\`0110\`)
- **v0.4.3** — \`cmp\` (opcode \`1010\`) + conditional branches via the \`cond\` field
- **A3++.6** — function calls via \`bl\` + stack spilling
- **A3+++ (v0.5.0)** — \`lang-aot --emit=armv7\` wiring

## Test plan

- [x] \`cargo test -p iir-to-armv7\` — 33/33 backend tests pass, 1/1 doctest passes
- [x] AND_REG_BASE / ORR_REG_BASE / EOR_REG_BASE pinned
- [x] Full byte streams pinned for and (\`E0002001\`), or (\`E1802001\`), xor (\`E0202001\`)
- [x] All three preserve the existing 5-word canonical shape
- [x] Security review passed (no vulnerabilities found)
- [ ] CI green
- [ ] No merge conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)