### PR TITLE
feat(iir-to-armv7): carry-chained adc/sbb on DP-register family — A3++.5.5 second slice

### DIFF
--- a/code/packages/rust/iir-to-armv7/CHANGELOG.md
+++ b/code/packages/rust/iir-to-armv7/CHANGELOG.md
@@ -3,6 +3,66 @@
 All notable changes to this crate are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.2] — 2026-06-02 (A3++.5.5 second slice — carry-chained `adc`/`sbb` on the DP-register family)
+
+### Added — carry-chained DP-register ALU
+
+Extends v0.4.1 with two more DP-register ops that consume the C flag
+set by a PRIOR flag-affecting ALU op:
+
+| IIR op | ARM mnemonic | Opcode | First word base |
+|--------|--------------|--------|-----------------|
+| `adc dest, a, b` | `ADC Rd, Rn, Rm` | `0101` | `0xE0A0_0000` |
+| `sbb dest, a, b` | `SBC Rd, Rn, Rm` | `0110` | `0xE0C0_0000` |
+
+The match arm widens from `add | sub | and | or | xor` to `add |
+sub | and | or | xor | adc | sbb` — 7-way inner dispatch on
+op-name → encoder.
+
+#### Carry-flag contract
+
+This crate emits the **non-S** form by default (no flag update).
+Front-ends that need the carry chain must arrange for the producer
+to use the S-suffix variant (`ADDS` / `SUBS` etc.) so the C flag
+survives.  The S-suffix flag-setting variants of all seven ops land
+alongside `cmp` in v0.4.3, paired with conditional branches.
+
+In the canonical u16-add idiom:
+
+```text
+adds r_lo lo_a lo_b   ; sets C if overflow
+adc  r_hi hi_a hi_b   ; consumes that C
+```
+
+#### New constants
+
+* `pub const ADC_REG_BASE: u32 = 0xE0A0_0000;`
+* `pub const SBC_REG_BASE: u32 = 0xE0C0_0000;`
+
+#### New encoder helpers
+
+* `encode_adc_reg(rd, rn, rm) -> u32`
+* `encode_sbc_reg(rd, rn, rm) -> u32`
+
+#### Tests added (37 total, was 33)
+
+* `adc_reg_base_pinned_to_0xe0a00000` / `sbc_reg_base_pinned_to_0xe0c00000`.
+* `adc_three_consts_emits_single_adc_instruction` — pinned
+  `ADC r2, r0, r1 = 0xE0A0_2001`.
+* `sbb_three_consts_emits_single_sbc_instruction` — `SBC r2, r0, r1
+  = 0xE0C0_2001`.
+
+### What is NOT in v0.4.2 (deferred to v0.4.3 / A3++.6 / A3+++)
+
+* The S-suffix (flag-setting) variants of all 7 ALU ops (ADDS,
+  SUBS, ANDS, etc.) — needed to make ADC/SBC actually chain.
+* `cmp` (CMP opcode `1010`) + flag-to-bool capture using
+  conditional jumps.
+* Conditional branches via the `cond` field every A32 instruction
+  carries (using bits 31..28 instead of the usual 0xE = always).
+* Function calls via `bl` + stack spilling.
+* `lang-aot --emit=armv7` wiring — A3+++ (v0.5.0).
+
 ## [0.4.1] — 2026-06-02 (A3++.5.5 first slice — bitwise `and`/`or`/`xor` on the DP-register family)
 
 ### Added — bitwise DP-register ALU

--- a/code/packages/rust/iir-to-armv7/Cargo.toml
+++ b/code/packages/rust/iir-to-armv7/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iir-to-armv7"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
-description = "IIR → ARMv7 (A32) machine code backend — lowers IIRModule to a Vec<u32> of encoded 32-bit ARMv7-A instructions.  v0.4.1 (A3++.5.5 first slice): adds bitwise data-processing-register ops `and` (AND opcode 0000 = 0xE000_0000), `or` (ORR opcode 1100 = 0xE180_0000), `xor` (EOR opcode 0001 = 0xE020_0000).  All five DP-register ALU ops now flow through a single 5-way match arm with one shared shape `Rd = Rn op Rm` — no accumulator constraint like the 8008.  ARM mnemonics: ORR (not OR) and EOR (not XOR) are pinned in the constant names; the IIR-facing ops keep the universal `or`/`xor` spellings."
+description = "IIR → ARMv7 (A32) machine code backend — lowers IIRModule to a Vec<u32> of encoded 32-bit ARMv7-A instructions.  v0.4.2 (A3++.5.5 second slice): adds carry-chained `adc` (ADC opcode 0101 = 0xE0A0_0000) and `sbb` (SBC opcode 0110 = 0xE0C0_0000) on the DP-register family.  All seven ALU ops (add/sub/and/or/xor/adc/sbb) now flow through a single 7-way match arm.  ADC/SBC emit the non-S variant by default; front-ends arrange for the producer to use the S-suffix variant so the carry survives.  S-suffix flag-setting variants land alongside `cmp` in v0.4.3."
 
 [lib]
 name = "iir_to_armv7"

--- a/code/packages/rust/iir-to-armv7/src/lib.rs
+++ b/code/packages/rust/iir-to-armv7/src/lib.rs
@@ -329,6 +329,41 @@ pub(crate) fn encode_eor_reg(rd: u8, rn: u8, rm: u8) -> u32 {
     EOR_REG_BASE | ((rn as u32) << 16) | ((rd as u32) << 12) | (rm as u32)
 }
 
+/// ARMv7-A `ADC Rd, Rn, Rm` (add with carry-in) base — `0xE0A0_0000`.
+///
+/// Same shape as `ADD_REG_BASE` but with opcode `0101` (ADC).  The
+/// carry-in comes from the C flag set by a PRIOR flag-affecting ALU
+/// op (`ADDS`, `SUBS`, `ADCS`, etc.).  This crate emits the non-S
+/// (no-flag-update) form by default — front-ends that need the
+/// carry chain must arrange for the producer to use the S-suffix
+/// variant.  The S-form constants land alongside `cmp` in v0.4.3.
+pub const ADC_REG_BASE: u32 = 0xE0A0_0000;
+
+/// ARMv7-A `SBC Rd, Rn, Rm` (subtract with borrow-in) base —
+/// `0xE0C0_0000`.
+///
+/// Same shape as `ADD_REG_BASE` but with opcode `0110` (SBC).  Like
+/// ADC, the borrow-in (inverted carry) comes from a prior flag-
+/// affecting op.  IIR maps `sbb` → `SBC` mirroring the
+/// iir-to-intel8008 and iir-to-riscv naming conventions.
+pub const SBC_REG_BASE: u32 = 0xE0C0_0000;
+
+/// Encode an ARMv7-A `ADC Rd, Rn, Rm` instruction.
+pub(crate) fn encode_adc_reg(rd: u8, rn: u8, rm: u8) -> u32 {
+    debug_assert!(rd <= 15, "rd out of 4-bit range: {rd}");
+    debug_assert!(rn <= 15, "rn out of 4-bit range: {rn}");
+    debug_assert!(rm <= 15, "rm out of 4-bit range: {rm}");
+    ADC_REG_BASE | ((rn as u32) << 16) | ((rd as u32) << 12) | (rm as u32)
+}
+
+/// Encode an ARMv7-A `SBC Rd, Rn, Rm` instruction.
+pub(crate) fn encode_sbc_reg(rd: u8, rn: u8, rm: u8) -> u32 {
+    debug_assert!(rd <= 15, "rd out of 4-bit range: {rd}");
+    debug_assert!(rn <= 15, "rn out of 4-bit range: {rn}");
+    debug_assert!(rm <= 15, "rm out of 4-bit range: {rm}");
+    SBC_REG_BASE | ((rn as u32) << 16) | ((rd as u32) << 12) | (rm as u32)
+}
+
 // ===========================================================================
 // IIRArmv7Config
 // ===========================================================================
@@ -466,6 +501,9 @@ const SUPPORTED_OPS: &[&str] = &[
     // A3++.5.5 first slice — bitwise data-processing-register ALU
     // (and = AND opcode 0000, or = ORR opcode 1100, xor = EOR opcode 0001)
     "and", "or", "xor",
+    // A3++.5.5 second slice — carry-chained DP-register ALU
+    // (adc = ADC opcode 0101, sbb = SBC opcode 0110)
+    "adc", "sbb",
 ];
 
 /// Lower an [`IIRModule`] to a `Vec<u32>` of ARMv7 (A32) opcode words.
@@ -579,15 +617,16 @@ pub fn lower_iir_to_armv7(
                     words.push(BX_LR);
                 }
 
-                // ── add / sub / and / or / xor → DP-register family ─────
+                // ── add/sub/and/or/xor/adc/sbb → DP-register family ─────
                 //
-                // All five data-processing-register ops share an
+                // All seven data-processing-register ALU ops share an
                 // identical shape, differing only in the 4-bit
                 // `opcode` field (bits 24..21):
                 //
                 //   ADD = 0100   AND = 0000
                 //   SUB = 0010   ORR = 1100
-                //                EOR = 0001
+                //   ADC = 0101   EOR = 0001
+                //   SBC = 0110
                 //
                 // Unlike the 8008's accumulator-anchored ALU (which
                 // needs MOV wrappers for non-accumulator operands),
@@ -595,7 +634,13 @@ pub fn lower_iir_to_armv7(
                 // selectors in a single instruction: `Rd = Rn op Rm`.
                 // No staging MOVs.  Same shape as RISC-V's `add rd,
                 // rs1, rs2`.
-                "add" | "sub" | "and" | "or" | "xor" => {
+                //
+                // ADC/SBC consume the C flag set by a PRIOR flag-
+                // affecting ALU op.  This crate emits the non-S
+                // (no-flag-update) form by default — front-ends
+                // arrange for the producer to use the S-suffix
+                // variant so the carry survives.
+                "add" | "sub" | "and" | "or" | "xor" | "adc" | "sbb" => {
                     let dest = require_dest(instr, &instr.op, &f.name)?;
                     let a_name = match instr.srcs.first() {
                         Some(Operand::Var(s)) => s.clone(),
@@ -620,7 +665,9 @@ pub fn lower_iir_to_armv7(
                         "and" => encode_and_reg(rd, rn, rm),
                         "or"  => encode_orr_reg(rd, rn, rm),
                         "xor" => encode_eor_reg(rd, rn, rm),
-                        _ => unreachable!("outer arm restricts to these 5"),
+                        "adc" => encode_adc_reg(rd, rn, rm),
+                        "sbb" => encode_sbc_reg(rd, rn, rm),
+                        _ => unreachable!("outer arm restricts to these 7"),
                     };
                     words.push(word);
                 }

--- a/code/packages/rust/iir-to-armv7/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-armv7/tests/test_backend.rs
@@ -7,8 +7,8 @@ use interpreter_ir::{IIRFunction, IIRInstr, IIRModule, Operand};
 use iir_to_armv7::{
     lower_iir_to_armv7, validate_for_armv7,
     IIRArmv7Config, IIRArmv7Error,
-    ADD_REG_BASE, AND_REG_BASE, BKPT, BX_LR, EOR_REG_BASE,
-    MOV_IMM_R0_BASE, MOV_REG_BASE, ORR_REG_BASE, SUB_REG_BASE,
+    ADC_REG_BASE, ADD_REG_BASE, AND_REG_BASE, BKPT, BX_LR, EOR_REG_BASE,
+    MOV_IMM_R0_BASE, MOV_REG_BASE, ORR_REG_BASE, SBC_REG_BASE, SUB_REG_BASE,
 };
 
 fn module_with(f: IIRFunction) -> IIRModule {
@@ -575,6 +575,77 @@ fn xor_three_consts_emits_single_eor_instruction() {
         0xE1A0_0002,    // MOV r0, r2
         BX_LR,
     ], "xor 0xFF ^ 0x55 expected; got: {words:08x?}");
+}
+
+// ===========================================================================
+// 9. A3++.5.5 second slice — carry-chained DP-register ALU (ADC, SBC)
+// ===========================================================================
+//
+// Same 3-register shape as add/sub.  Only the 4-bit `opcode` field
+// changes:
+//
+//   ADC = 0101 → 0xE0A0_0000 base   (add with carry-in)
+//   SBC = 0110 → 0xE0C0_0000 base   (sub with borrow-in)
+//
+// ADC/SBC consume the C flag set by a PRIOR flag-affecting ALU op.
+// This crate emits the non-S form by default — front-ends arrange
+// for the producer to use the S-suffix variant so the carry chain
+// survives.  The S-suffix variants land alongside `cmp` in v0.4.3.
+
+#[test]
+fn adc_reg_base_pinned_to_0xe0a00000() {
+    assert_eq!(ADC_REG_BASE, 0xE0A0_0000,
+        "ADC Rd, Rn, Rm base should be 0xE0A00000; got 0x{:08x}", ADC_REG_BASE);
+}
+
+#[test]
+fn sbc_reg_base_pinned_to_0xe0c00000() {
+    assert_eq!(SBC_REG_BASE, 0xE0C0_0000,
+        "SBC Rd, Rn, Rm base should be 0xE0C00000; got 0x{:08x}", SBC_REG_BASE);
+}
+
+#[test]
+fn adc_three_consts_emits_single_adc_instruction() {
+    // const v=0x10; const w=0x20; adc r v w; ret r
+    //   ADC r2, r0, r1 = 0xE0A0_0000 | (0<<16) | (2<<12) | 1 = 0xE0A0_2001
+    let f = IIRFunction::new("adc_fn", vec![], "u8", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(0x10)], "u8"),
+        IIRInstr::new("const", Some("w".into()), vec![Operand::Int(0x20)], "u8"),
+        IIRInstr::new("adc", Some("r".into()),
+            vec![Operand::Var("v".into()), Operand::Var("w".into())], "u8"),
+        IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "u8"),
+    ]);
+    let words = lower_iir_to_armv7(&module_with(f), &IIRArmv7Config::default())
+        .expect("lowering");
+    assert_eq!(words, vec![
+        0xE3A0_0010,    // MOV r0, #0x10
+        0xE3A0_1020,    // MOV r1, #0x20
+        0xE0A0_2001,    // ADC r2, r0, r1
+        0xE1A0_0002,    // MOV r0, r2
+        BX_LR,
+    ], "adc expected; got: {words:08x?}");
+}
+
+#[test]
+fn sbb_three_consts_emits_single_sbc_instruction() {
+    // const v=0x80; const w=0x01; sbb r v w; ret r
+    //   SBC r2, r0, r1 = 0xE0C0_0000 | (0<<16) | (2<<12) | 1 = 0xE0C0_2001
+    let f = IIRFunction::new("sbb_fn", vec![], "u8", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(0x80)], "u8"),
+        IIRInstr::new("const", Some("w".into()), vec![Operand::Int(0x01)], "u8"),
+        IIRInstr::new("sbb", Some("r".into()),
+            vec![Operand::Var("v".into()), Operand::Var("w".into())], "u8"),
+        IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "u8"),
+    ]);
+    let words = lower_iir_to_armv7(&module_with(f), &IIRArmv7Config::default())
+        .expect("lowering");
+    assert_eq!(words, vec![
+        0xE3A0_0080,    // MOV r0, #0x80
+        0xE3A0_1001,    // MOV r1, #0x01
+        0xE0C0_2001,    // SBC r2, r0, r1
+        0xE1A0_0002,    // MOV r0, r2
+        BX_LR,
+    ], "sbb expected; got: {words:08x?}");
 }
 
 #[test]

--- a/code/specs/iir-to-armv7.md
+++ b/code/specs/iir-to-armv7.md
@@ -71,7 +71,8 @@ IIRModule
 | v0.2.0 (A3+) | `const` → `MOV r0, #imm8` (accumulator-only) + `ret`/`ret_void` → `BX LR` (AAPCS return) | **merged** |
 | v0.3.0 (A3++) | Linear register allocator over `r0..r12` + multi-register `const` + `mov` + ret-value staging | **merged** |
 | v0.4.0 (A3++.5) | `add`/`sub` on the data-processing-register family — 3-register `Rd = Rn op Rm` | **merged** |
-| **v0.4.1 (A3++.5.5 first slice — this PR)** | Bitwise DP-register ops `and` (AND `0xE000_0000`), `or` (ORR `0xE180_0000`), `xor` (EOR `0xE020_0000`).  ARM uses ORR/EOR mnemonics rather than OR/XOR; the IIR-facing ops keep the universal spellings. | this PR |
+| v0.4.1 (A3++.5.5 first slice) | Bitwise DP-register ops `and` (AND `0xE000_0000`), `or` (ORR `0xE180_0000`), `xor` (EOR `0xE020_0000`) | **merged** |
+| **v0.4.2 (A3++.5.5 second slice — this PR)** | Carry-chained DP-register ops `adc` (ADC `0xE0A0_0000`) and `sbb` (SBC `0xE0C0_0000`).  Non-S form by default; S-suffix flag-setting variants pair with `cmp` in v0.4.3. | this PR |
 | v0.3.x (A3++.5.5) | Comparisons + conditional branches via the cond-field on every A32 instruction (a stronger version of the 8008's flag-based jumps) | future |
 | v0.3.x (A3++.6) | Function calls via `bl` with PC-relative offsets + stack spilling | future |
 | v0.4.0 (A3+++) | `lang-aot --emit=armv7` wiring | future |


### PR DESCRIPTION
## Summary

Extends \`iir-to-armv7\` v0.4.1 → **v0.4.2** with two more DP-register ALU ops that consume the C flag set by a PRIOR flag-affecting op.

| IIR op | ARM mnemonic | Opcode | First word base    |
| ------ | ------------ | ------ | ------------------ |
| \`adc\` | ADC          | \`0101\` | \`0xE0A0_0000\` |
| \`sbb\` | SBC          | \`0110\` | \`0xE0C0_0000\` |

The match arm widens from \`add | sub | and | or | xor\` to \`add | sub | and | or | xor | adc | sbb\` — 7-way inner dispatch on op-name → encoder.

### Carry-flag contract

This crate emits the **non-S** form by default (no flag update).  Front-ends arrange for the producer to use the S-suffix variant (\`ADDS\` / \`SUBS\`) so the C flag survives.  The S-suffix flag-setting variants of all 7 ops land alongside \`cmp\` in **v0.4.3**, paired with conditional branches.

### Deferred to follow-up slices

- **v0.4.3** — S-suffix flag-setting variants + \`cmp\` (opcode \`1010\`) + conditional branches via the \`cond\` field
- **A3++.6** — function calls via \`bl\` + stack spilling
- **A3+++ (v0.5.0)** — \`lang-aot --emit=armv7\` wiring

## Test plan

- [x] \`cargo test -p iir-to-armv7\` — 37/37 backend tests pass, 1/1 doctest passes
- [x] ADC_REG_BASE / SBC_REG_BASE pinned
- [x] Full adc byte stream pinned (\`E0A02001\`)
- [x] Full sbb byte stream pinned (\`E0C02001\`)
- [x] Security review passed (no vulnerabilities found)
- [ ] CI green
- [ ] No merge conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)