### PR TITLE
feat(iir-to-armv7): cmp equality via EQ condition prefix — A3++.5.5 third slice

### DIFF
--- a/code/packages/rust/iir-to-armv7/CHANGELOG.md
+++ b/code/packages/rust/iir-to-armv7/CHANGELOG.md
@@ -3,6 +3,76 @@
 All notable changes to this crate are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.3] — 2026-06-02 (A3++.5.5 third slice — `cmp` equality via the EQ condition prefix)
+
+### Added — boolean equality with conditional MOV capture
+
+Wires IIR's `cmp dest, a, b` (boolean equality) to ARMv7's CMP +
+flag-to-bool capture using the **EQ condition prefix on MOV** — a
+feature unique to ARMv7 among the three architecture backends.
+
+#### Lowering shape (4 words after the const-loads — no
+backpatching!)
+
+```text
+CMP   rn, rm             ; sets Z if rn == rm
+MOV   dest, #0           ; default false (cond = AL)
+MOVEQ dest, #1           ; if Z=1 (equal), overwrite to true
+```
+
+The cond-field is the 4 high bits of every A32 instruction.  Setting
+it to **EQ = 0000** instead of the usual **AL = 1110** changes the
+opcode word from `0xE3A0_X00N` to `0x03A0_X00N` — the silicon
+checks the Z flag and either executes or no-ops the instruction.
+
+#### Compare with other backends' flag-to-bool capture
+
+| Backend | Words/bytes | Mechanism |
+|---------|-------------|-----------|
+| **ARMv7** | **4 words** | CMP + MOV + MOVEQ — no backpatching |
+| RV32I | 1 word (`sltu`) | Set-less-than-unsigned reads the comparison and writes 0/1 directly |
+| Intel 8008 | 8 bytes | CMP + MVI dest,0 + JFZ + 2 addr bytes + MVI dest,1 — inline-backpatched JFZ target |
+
+ARMv7's `cond` field gives it middle ground: more verbose than
+RV32I's purpose-built SLT but cleaner than the 8008's address-
+backpatched skip-jump-over-MVI dance.
+
+#### New constants
+
+* `pub const CMP_REG_BASE: u32 = 0xE150_0000;` — CMP Rn, Rm base
+  (S=1 forced, no Rd output).
+* `pub const MOV_IMM_EQ_BASE: u32 = 0x03A0_0000;` — MOV imm under
+  EQ condition prefix.  Identical to `MOV_IMM_R0_BASE` except the
+  top nibble is `0` (EQ) instead of `E` (AL).
+
+#### New encoder helpers
+
+* `encode_cmp_reg(rn, rm) -> u32` — note: only two args because
+  CMP has no Rd.
+* `encode_mov_imm_eq(rd, imm8) -> u32` — MOV imm with EQ cond.
+
+#### Tests added (41 total, was 37)
+
+* `cmp_reg_base_pinned_to_0xe1500000` / `mov_imm_eq_base_pinned_to_0x03a00000`.
+* `cmp_pins_full_capture_word_stream` — pinned full 7-word sequence
+  `0xE3A0_0005 0xE3A0_1005 0xE150_0001 0xE3A0_2000 0x03A0_2001
+  0xE1A0_0002 0xE12F_FF1E`.
+* `cmp_with_same_register_emits_cmp_a_a_then_capture` — `cmp r v v`
+  case: `CMP r0, r0 = 0xE150_0000`.
+
+### What is NOT in v0.4.3 (deferred to v0.4.4 / A3++.6 / A3+++)
+
+* `cmp_ne`/`cmp_lt`/`cmp_gt`/`cmp_gte`/`cmp_lte` — would use NE,
+  CC, HI, CS, LS condition prefixes respectively.  The same capture
+  shape applies; only the cond-field on the second MOV varies.
+* Conditional branches (`Bcond`) — `B` opcode with a non-AL cond
+  prefix.
+* S-suffix flag-setting variants of all 7 ALU ops (ADDS, SUBS,
+  ANDS, etc.) — needed for cmp_lt / cmp_gt which read the carry
+  and sign flags.
+* Function calls via `bl` + stack spilling.
+* `lang-aot --emit=armv7` wiring — A3+++ (v0.5.0).
+
 ## [0.4.2] — 2026-06-02 (A3++.5.5 second slice — carry-chained `adc`/`sbb` on the DP-register family)
 
 ### Added — carry-chained DP-register ALU

--- a/code/packages/rust/iir-to-armv7/Cargo.toml
+++ b/code/packages/rust/iir-to-armv7/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iir-to-armv7"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
-description = "IIR → ARMv7 (A32) machine code backend — lowers IIRModule to a Vec<u32> of encoded 32-bit ARMv7-A instructions.  v0.4.2 (A3++.5.5 second slice): adds carry-chained `adc` (ADC opcode 0101 = 0xE0A0_0000) and `sbb` (SBC opcode 0110 = 0xE0C0_0000) on the DP-register family.  All seven ALU ops (add/sub/and/or/xor/adc/sbb) now flow through a single 7-way match arm.  ADC/SBC emit the non-S variant by default; front-ends arrange for the producer to use the S-suffix variant so the carry survives.  S-suffix flag-setting variants land alongside `cmp` in v0.4.3."
+description = "IIR → ARMv7 (A32) machine code backend — lowers IIRModule to a Vec<u32> of encoded 32-bit ARMv7-A instructions.  v0.4.3 (A3++.5.5 third slice): adds `cmp` (CMP opcode 1010 = 0xE150_0000, no Rd output — only sets flags) with a flag-to-bool capture sequence using `MOVEQ` (0x03A0_0000 = MOV imm under the EQ condition prefix).  ARMv7's 4-bit `cond` field on every instruction makes this elegantly 4 words with no address backpatching, vs the 8008's 8-byte JFZ-skip-MVI dance.  Equality only — less-than/greater-than need MOVCC/MOVGT etc. and land alongside conditional branches in future slices."
 
 [lib]
 name = "iir_to_armv7"

--- a/code/packages/rust/iir-to-armv7/src/lib.rs
+++ b/code/packages/rust/iir-to-armv7/src/lib.rs
@@ -364,6 +364,77 @@ pub(crate) fn encode_sbc_reg(rd: u8, rn: u8, rm: u8) -> u32 {
     SBC_REG_BASE | ((rn as u32) << 16) | ((rd as u32) << 12) | (rm as u32)
 }
 
+/// ARMv7-A `CMP Rn, Rm` (compare register) base — `0xE150_0000`.
+///
+/// Same shape as `SUB_REG_BASE` (opcode `1010` for CMP vs `0010` for
+/// SUB) but with **S=1 forced** (bit 20) and **Rd discarded** (bits
+/// 15..12 are zero — CMP has no register output, it only sets flags).
+///
+/// Bit layout (cond=AL, S=1, Rd=0000):
+///
+/// ```text
+/// 31..28  cond      = 0xE = 1110         (always — unconditional)
+/// 27..25            = 000                 (data-processing register)
+/// 24..21  opcode    = 1010                (CMP)
+/// 20      S         = 1                   (CMP IS the flag-setting variant)
+/// 19..16  Rn        = (in this base, 0)  (first compare operand)
+/// 15..12            = 0000                (Rd field — unused by CMP)
+/// 11.. 7  shift_imm = 00000                (no shift)
+///  6.. 5  type      = 00                   (LSL — no-op when shift=0)
+///  4                = 0                    (immediate shift)
+///  3.. 0  Rm        = (in this base, 0)  (second compare operand)
+/// ```
+///
+/// For `CMP r0, r0`: `1110 0001 0101 0000 0000 0000 0000 0000` =
+/// `0xE150_0000`.  For arbitrary `CMP Rn, Rm`: OR in
+/// `(Rn << 16) | Rm`.
+///
+/// CMP semantically computes `Rn - Rm` and updates Z/C/N/V — the
+/// difference itself is discarded.  IIR-level `cmp dest, a, b`
+/// produces a boolean dest; the capture sequence after CMP uses
+/// `MOVEQ` (MOV under the EQ condition prefix) to set the dest to 1
+/// only when Z=1 (i.e. equal).  See `MOV_IMM_EQ_BASE` below.
+pub const CMP_REG_BASE: u32 = 0xE150_0000;
+
+/// ARMv7-A `MOVEQ Rd, #imm8` base — `0x03A0_0000`.
+///
+/// Identical encoding to `MOV_IMM_R0_BASE` (`0xE3A0_0000`) EXCEPT the
+/// 4-bit `cond` field at bits 31..28 is `0000` (EQ — execute only if
+/// Z flag is set) instead of `1110` (AL — always execute).
+///
+/// This is the canonical ARMv7 "flag-to-bool capture" idiom:
+///
+/// ```text
+/// CMP   Rn, Rm                ; sets Z if Rn == Rm
+/// MOV   dest, #0              ; default false (cond=AL)
+/// MOVEQ dest, #1              ; if Z=1 (equal), overwrite to true
+/// ```
+///
+/// Compare with the 8008's much more verbose flag-to-bool capture
+/// (CMP + MVI dest, 0 + JFZ + 2 addr bytes + MVI dest, 1 = 8 bytes
+/// with address-backpatching), or RV32I's typical SLT-based pattern.
+/// ARMv7's `cond` field on every instruction makes this naturally
+/// 4 words with no backpatching.
+pub const MOV_IMM_EQ_BASE: u32 = 0x03A0_0000;
+
+/// Encode an ARMv7-A `CMP Rn, Rm` instruction.
+///
+/// Note: CMP has no Rd — it only sets the Z/C/N/V flags.  The Rd
+/// nibble (bits 15..12) is the architecturally-defined "should-be-
+/// zero" field.
+pub(crate) fn encode_cmp_reg(rn: u8, rm: u8) -> u32 {
+    debug_assert!(rn <= 15, "rn out of 4-bit range: {rn}");
+    debug_assert!(rm <= 15, "rm out of 4-bit range: {rm}");
+    CMP_REG_BASE | ((rn as u32) << 16) | (rm as u32)
+}
+
+/// Encode an ARMv7-A `MOVEQ Rd, #imm8` instruction (MOV immediate
+/// under the EQ condition prefix — "move only if Z flag is set").
+pub(crate) fn encode_mov_imm_eq(rd: u8, imm8: u8) -> u32 {
+    debug_assert!(rd <= 15, "rd out of 4-bit range: {rd}");
+    MOV_IMM_EQ_BASE | ((rd as u32) << 12) | (imm8 as u32)
+}
+
 // ===========================================================================
 // IIRArmv7Config
 // ===========================================================================
@@ -504,6 +575,9 @@ const SUPPORTED_OPS: &[&str] = &[
     // A3++.5.5 second slice — carry-chained DP-register ALU
     // (adc = ADC opcode 0101, sbb = SBC opcode 0110)
     "adc", "sbb",
+    // A3++.5.5 third slice — equality comparison with flag-to-bool
+    // capture via the EQ condition prefix on every A32 instruction.
+    "cmp",
 ];
 
 /// Lower an [`IIRModule`] to a `Vec<u32>` of ARMv7 (A32) opcode words.
@@ -615,6 +689,54 @@ pub fn lower_iir_to_armv7(
                 // ── ret_void → BX LR ───────────────────────────────
                 "ret_void" => {
                     words.push(BX_LR);
+                }
+
+                // ── cmp dest, a, b → CMP + MOV/MOVEQ capture ───────────
+                //
+                // IIR `cmp dest, a, b` produces a boolean (`dest =
+                // (a == b) ? 1 : 0`).  ARMv7's CMP sets Z/C/N/V from
+                // `Rn - Rm` and discards the difference.
+                //
+                // ARMv7's KEY architectural feature — the 4-bit `cond`
+                // field at bits 31..28 of every A32 instruction —
+                // makes the flag-to-bool capture remarkably clean:
+                //
+                //   CMP   rn, rm                ; sets Z if rn == rm
+                //   MOV   dest, #0              ; default false (cond=AL)
+                //   MOVEQ dest, #1              ; if Z=1, overwrite to true
+                //
+                // 4 words total.  Compare with the 8008 backend's
+                // 8-byte CMP + MVI dest, 0 + JFZ + 2-byte address + MVI
+                // dest, 1 sequence (with the JFZ target backpatched
+                // inline) — ARMv7 needs no backpatching at all.
+                //
+                // Only equality (`a == b`) lands in this slice.
+                // Less-than (which would use MOVCC — MOV under the CC
+                // condition for "carry clear") and greater-than land
+                // in future slices alongside the S-suffix ALU
+                // variants that need to produce the right flags.
+                "cmp" => {
+                    let dest = require_dest(instr, "cmp", &f.name)?;
+                    let a_name = match instr.srcs.first() {
+                        Some(Operand::Var(s)) => s.clone(),
+                        _ => return Err(IIRArmv7Error::InvalidOperand {
+                            function: f.name.clone(),
+                            detail: "cmp srcs[0] must be Var".into(),
+                        }),
+                    };
+                    let b_name = match instr.srcs.get(1) {
+                        Some(Operand::Var(s)) => s.clone(),
+                        _ => return Err(IIRArmv7Error::InvalidOperand {
+                            function: f.name.clone(),
+                            detail: "cmp srcs[1] must be Var".into(),
+                        }),
+                    };
+                    let rn = lookup_register(&env, &a_name, &f.name)?;
+                    let rm = lookup_register(&env, &b_name, &f.name)?;
+                    let rd = alloc_register(&mut next_reg, dest, &mut env, &f.name)?;
+                    words.push(encode_cmp_reg(rn, rm));
+                    words.push(encode_mov_imm(rd, 0));
+                    words.push(encode_mov_imm_eq(rd, 1));
                 }
 
                 // ── add/sub/and/or/xor/adc/sbb → DP-register family ─────

--- a/code/packages/rust/iir-to-armv7/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-armv7/tests/test_backend.rs
@@ -7,8 +7,9 @@ use interpreter_ir::{IIRFunction, IIRInstr, IIRModule, Operand};
 use iir_to_armv7::{
     lower_iir_to_armv7, validate_for_armv7,
     IIRArmv7Config, IIRArmv7Error,
-    ADC_REG_BASE, ADD_REG_BASE, AND_REG_BASE, BKPT, BX_LR, EOR_REG_BASE,
-    MOV_IMM_R0_BASE, MOV_REG_BASE, ORR_REG_BASE, SBC_REG_BASE, SUB_REG_BASE,
+    ADC_REG_BASE, ADD_REG_BASE, AND_REG_BASE, BKPT, BX_LR, CMP_REG_BASE,
+    EOR_REG_BASE, MOV_IMM_EQ_BASE, MOV_IMM_R0_BASE, MOV_REG_BASE,
+    ORR_REG_BASE, SBC_REG_BASE, SUB_REG_BASE,
 };
 
 fn module_with(f: IIRFunction) -> IIRModule {
@@ -646,6 +647,100 @@ fn sbb_three_consts_emits_single_sbc_instruction() {
         0xE1A0_0002,    // MOV r0, r2
         BX_LR,
     ], "sbb expected; got: {words:08x?}");
+}
+
+// ===========================================================================
+// 10. A3++.5.5 third slice — `cmp` equality with flag-to-bool capture
+// ===========================================================================
+//
+// ARMv7's KEY architectural feature — the 4-bit `cond` field at
+// bits 31..28 of every A32 instruction — makes the equality capture
+// remarkably clean:
+//
+//   CMP   rn, rm        ; sets Z if rn == rm
+//   MOV   dest, #0      ; default false (cond = AL = 0xE)
+//   MOVEQ dest, #1      ; if Z=1, overwrite to true (cond = EQ = 0x0)
+//
+// 4 words.  No address backpatching (the 8008 needed an inline
+// JFZ + 2-byte address slot), no synthetic labels.
+
+#[test]
+fn cmp_reg_base_pinned_to_0xe1500000() {
+    // CMP r0, r0 (S=1 forced, no Rd) = 0xE150_0000.
+    assert_eq!(CMP_REG_BASE, 0xE150_0000,
+        "CMP Rn, Rm base should be 0xE1500000; got 0x{:08x}", CMP_REG_BASE);
+}
+
+#[test]
+fn mov_imm_eq_base_pinned_to_0x03a00000() {
+    // MOVEQ r0, #0 = 0x03A0_0000.  Identical to MOV_IMM_R0_BASE
+    // (0xE3A0_0000) except the top nibble (cond field) is 0 (EQ)
+    // instead of E (AL).
+    assert_eq!(MOV_IMM_EQ_BASE, 0x03A0_0000,
+        "MOVEQ Rd, #imm base should be 0x03A00000; got 0x{:08x}", MOV_IMM_EQ_BASE);
+}
+
+#[test]
+fn cmp_pins_full_capture_word_stream() {
+    // const v=5; const w=5; cmp r v w; ret r
+    //
+    // Allocator: v→r0, w→r1, r→r2.
+    //   MOV r0, #5    = 0xE3A0_0005
+    //   MOV r1, #5    = 0xE3A0_1005
+    //   CMP r0, r1    = 0xE150_0000 | (0<<16) | 1 = 0xE150_0001
+    //   MOV r2, #0    = 0xE3A0_2000
+    //   MOVEQ r2, #1  = 0x03A0_2001  ← cond=EQ (0) instead of AL (E)
+    //   MOV r0, r2    = 0xE1A0_0002  ← stage r into r0 for ret
+    //   BX LR         = 0xE12F_FF1E
+    let f = IIRFunction::new("eq", vec![], "bool", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(5)], "u8"),
+        IIRInstr::new("const", Some("w".into()), vec![Operand::Int(5)], "u8"),
+        IIRInstr::new("cmp", Some("r".into()),
+            vec![Operand::Var("v".into()), Operand::Var("w".into())], "bool"),
+        IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "bool"),
+    ]);
+    let words = lower_iir_to_armv7(&module_with(f), &IIRArmv7Config::default())
+        .expect("lowering");
+    assert_eq!(words, vec![
+        0xE3A0_0005,    // MOV r0, #5
+        0xE3A0_1005,    // MOV r1, #5
+        0xE150_0001,    // CMP r0, r1
+        0xE3A0_2000,    // MOV r2, #0   (default false)
+        0x03A0_2001,    // MOVEQ r2, #1 (Z=1 path)
+        0xE1A0_0002,    // MOV r0, r2   (stage r into r0 for ret)
+        BX_LR,
+    ], "cmp expected 7-word sequence; got: {words:08x?}");
+}
+
+/// `cmp r v v` — same register as both operands.  The CMP encodes
+/// with Rn == Rm; the result is always Z=1 at runtime.  Lowering
+/// shape is identical — the optimisation of constant-folding this to
+/// `MOV r, #1` is upstream's job.
+#[test]
+fn cmp_with_same_register_emits_cmp_a_a_then_capture() {
+    // const v=42; cmp r v v; ret_void
+    //
+    // Allocator: v→r0, r→r1.
+    //   MOV r0, #42      = 0xE3A0_002A
+    //   CMP r0, r0       = 0xE150_0000 | (0<<16) | 0 = 0xE150_0000
+    //   MOV r1, #0       = 0xE3A0_1000
+    //   MOVEQ r1, #1     = 0x03A0_1001
+    //   BX LR
+    let f = IIRFunction::new("self_cmp", vec![], "void", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(42)], "u8"),
+        IIRInstr::new("cmp", Some("r".into()),
+            vec![Operand::Var("v".into()), Operand::Var("v".into())], "bool"),
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ]);
+    let words = lower_iir_to_armv7(&module_with(f), &IIRArmv7Config::default())
+        .expect("lowering");
+    assert_eq!(words, vec![
+        0xE3A0_002A,    // MOV r0, #42
+        0xE150_0000,    // CMP r0, r0 (Rn=Rm=0)
+        0xE3A0_1000,    // MOV r1, #0
+        0x03A0_1001,    // MOVEQ r1, #1
+        BX_LR,
+    ], "self-cmp expected; got: {words:08x?}");
 }
 
 #[test]

--- a/code/specs/iir-to-armv7.md
+++ b/code/specs/iir-to-armv7.md
@@ -72,7 +72,8 @@ IIRModule
 | v0.3.0 (A3++) | Linear register allocator over `r0..r12` + multi-register `const` + `mov` + ret-value staging | **merged** |
 | v0.4.0 (A3++.5) | `add`/`sub` on the data-processing-register family — 3-register `Rd = Rn op Rm` | **merged** |
 | v0.4.1 (A3++.5.5 first slice) | Bitwise DP-register ops `and` (AND `0xE000_0000`), `or` (ORR `0xE180_0000`), `xor` (EOR `0xE020_0000`) | **merged** |
-| **v0.4.2 (A3++.5.5 second slice — this PR)** | Carry-chained DP-register ops `adc` (ADC `0xE0A0_0000`) and `sbb` (SBC `0xE0C0_0000`).  Non-S form by default; S-suffix flag-setting variants pair with `cmp` in v0.4.3. | this PR |
+| v0.4.2 (A3++.5.5 second slice) | Carry-chained DP-register ops `adc` (`0xE0A0_0000`) and `sbb` (`0xE0C0_0000`) | **merged** |
+| **v0.4.3 (A3++.5.5 third slice — this PR)** | `cmp` equality (`CMP_REG_BASE = 0xE150_0000`) with flag-to-bool capture via `MOVEQ` (`MOV_IMM_EQ_BASE = 0x03A0_0000`) — uses ARMv7's 4-bit `cond` field on every instruction.  No address backpatching needed (vs the 8008's 8-byte JFZ-skip-MVI sequence). | this PR |
 | v0.3.x (A3++.5.5) | Comparisons + conditional branches via the cond-field on every A32 instruction (a stronger version of the 8008's flag-based jumps) | future |
 | v0.3.x (A3++.6) | Function calls via `bl` with PC-relative offsets + stack spilling | future |
 | v0.4.0 (A3+++) | `lang-aot --emit=armv7` wiring | future |


### PR DESCRIPTION
## Summary

Wires IIR's \`cmp dest, a, b\` (boolean equality) to ARMv7's CMP + flag-to-bool capture using the **EQ condition prefix on MOV** — a feature unique to ARMv7 among the three architecture backends.

### Lowering shape — 3 words, no backpatching

\`\`\`text
CMP   rn, rm        ; sets Z if rn == rm
MOV   dest, #0      ; default false (cond = AL = 0xE)
MOVEQ dest, #1      ; if Z=1 (equal), overwrite to true (cond = EQ = 0)
\`\`\`

The cond-field is the 4 high bits of every A32 instruction.  Setting it to **EQ = 0000** instead of **AL = 1110** changes the opcode word from \`0xE3A0_X00N\` to \`0x03A0_X00N\` — the silicon checks the Z flag and either executes or no-ops the instruction.

### Comparison across all three architecture backends

| Backend     | Words/bytes | Mechanism                          |
| ----------- | ----------- | ---------------------------------- |
| **ARMv7**   | **4 words** | CMP + MOV + MOVEQ — no backpatch   |
| RV32I       | 1 word \`sltu\` | Purpose-built set-less-than-u  |
| Intel 8008  | 8 bytes     | CMP + MVI + JFZ + 2 addr + MVI — inline-backpatched JFZ target |

ARMv7's \`cond\` field gives it elegant middle ground.

### New public constants

- \`CMP_REG_BASE = 0xE150_0000\` (S=1 forced, no Rd output)
- \`MOV_IMM_EQ_BASE = 0x03A0_0000\` (MOV imm under EQ cond prefix)

### Deferred to follow-up slices

- **v0.4.4** — \`cmp_ne\`/\`cmp_lt\`/\`cmp_gt\`/\`cmp_gte\`/\`cmp_lte\` using NE/CC/HI/CS/LS condition prefixes
- **v0.4.5** — conditional branches (\`Bcond\`) via the cond field on the B instruction
- **A3++.6** — function calls via \`bl\` + stack spilling
- **A3+++ (v0.5.0)** — \`lang-aot --emit=armv7\` wiring

## Test plan

- [x] \`cargo test -p iir-to-armv7\` — 41/41 backend tests pass, 1/1 doctest passes
- [x] CMP_REG_BASE / MOV_IMM_EQ_BASE pinned
- [x] Full 7-word cmp byte stream pinned including the \`0x03A0_2001\` MOVEQ
- [x] Self-cmp (\`cmp r v v\`) emits \`CMP r0, r0 = 0xE150_0000\`
- [x] Security review passed (no vulnerabilities found)
- [ ] CI green
- [ ] No merge conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)