### PR TITLE
feat(iir-to-armv7): full comparison family via condition prefixes — A3++.5.5 fourth slice

### DIFF
--- a/code/packages/rust/iir-to-armv7/CHANGELOG.md
+++ b/code/packages/rust/iir-to-armv7/CHANGELOG.md
@@ -3,6 +3,89 @@
 All notable changes to this crate are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.4] — 2026-06-02 (A3++.5.5 fourth slice — `cmp_ne`/`cmp_lt`/`cmp_gt`/`cmp_gte`/`cmp_lte` via condition prefixes)
+
+### Added — full boolean comparison family
+
+Completes the boolean-comparison surface with the remaining 5
+variants.  All share v0.4.3's CMP + MOV + MOV<cond> capture
+skeleton — only the trailing MOV's 4-bit condition prefix changes:
+
+| IIR op   | Condition | MOV-cond base | Skip-true unless         |
+|----------|-----------|---------------|--------------------------|
+| `cmp`    | `EQ`      | `0x03A0_0000` | Z=1 (equal)              |
+| `cmp_ne` | `NE`      | `0x13A0_0000` | Z=0 (not equal)          |
+| `cmp_lt` | `CC`      | `0x33A0_0000` | C=0 (unsigned <)         |
+| `cmp_gt` | `HI`      | `0x83A0_0000` | C=1 ∧ Z=0 (unsigned >)   |
+| `cmp_gte`| `CS`      | `0x23A0_0000` | C=1 (unsigned >=)        |
+| `cmp_lte`| `LS`      | `0x93A0_0000` | C=0 ∨ Z=1 (unsigned <=)  |
+
+The condition prefix sits in bits 31..28 of every A32 instruction;
+each new MOV<cond> base is just `(cond << 28) | 0x03A0_0000`.
+
+#### Why ARMv7's HI condition is special
+
+ARMv7 ships a dedicated condition for "unsigned greater than" (HI),
+so `cmp_gt` doesn't need the operand-swap trick the 8008 and RV32I
+backends use (`cmp_gt a, b ⇔ cmp_lt b, a`).  Same number of
+instructions emitted, but conceptually cleaner.
+
+#### Unified 6-way match arm
+
+The v0.4.3 `"cmp"` arm widens to `"cmp" | "cmp_ne" | "cmp_lt" |
+"cmp_gt" | "cmp_gte" | "cmp_lte"` with an inner match on op-name →
+condition-MOV base.  The encode_mov_imm_cond helper takes the base
+and emits the cond-prefixed word:
+
+```rust
+let cond_mov_base = match instr.op.as_str() {
+    "cmp"     => MOV_IMM_EQ_BASE,
+    "cmp_ne"  => MOV_IMM_NE_BASE,
+    "cmp_lt"  => MOV_IMM_CC_BASE,
+    "cmp_gt"  => MOV_IMM_HI_BASE,
+    "cmp_gte" => MOV_IMM_CS_BASE,
+    "cmp_lte" => MOV_IMM_LS_BASE,
+    _ => unreachable!(),
+};
+words.push(encode_cmp_reg(rn, rm));
+words.push(encode_mov_imm(rd, 0));
+words.push(encode_mov_imm_cond(cond_mov_base, rd, 1));
+```
+
+#### New constants (5 of them)
+
+* `pub const MOV_IMM_NE_BASE: u32 = 0x13A0_0000;`
+* `pub const MOV_IMM_CC_BASE: u32 = 0x33A0_0000;`
+* `pub const MOV_IMM_CS_BASE: u32 = 0x23A0_0000;`
+* `pub const MOV_IMM_HI_BASE: u32 = 0x83A0_0000;`
+* `pub const MOV_IMM_LS_BASE: u32 = 0x93A0_0000;`
+
+#### New generic encoder helper
+
+* `encode_mov_imm_cond(cond_base: u32, rd: u8, imm8: u8) -> u32` —
+  ORs in `(rd << 12) | imm8` over any cond-MOV base.  Avoids 6
+  nearly-identical named helpers; the v0.4.3 `encode_mov_imm_eq`
+  is kept as a named convenience but now delegates conceptually
+  to this generic shape.
+
+#### Tests added (51 total, was 41)
+
+* 5 constant-pinning tests guarding each new condition-MOV base.
+* 5 lowering tests using a shared `assert_cmp_variant` helper that
+  pins the full 7-word output for each variant against the
+  canonical `v=10, w=20, r=v OP w; ret r` template — only the
+  expected MOV<cond> word at index 4 changes per test.
+
+### What is NOT in v0.4.4 (deferred to v0.4.5 / A3++.6 / A3+++)
+
+* Conditional branches (`Bcond`) — `B` opcode with a non-AL cond
+  prefix.  Same condition-field mechanism, different instruction
+  family.
+* Signed comparisons (`cmp_slt`/`cmp_sgt` via LT/GT conditions
+  which read the V overflow flag together with N sign flag).
+* Function calls via `bl` + stack spilling.
+* `lang-aot --emit=armv7` wiring — A3+++ (v0.5.0).
+
 ## [0.4.3] — 2026-06-02 (A3++.5.5 third slice — `cmp` equality via the EQ condition prefix)
 
 ### Added — boolean equality with conditional MOV capture

--- a/code/packages/rust/iir-to-armv7/Cargo.toml
+++ b/code/packages/rust/iir-to-armv7/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iir-to-armv7"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
-description = "IIR → ARMv7 (A32) machine code backend — lowers IIRModule to a Vec<u32> of encoded 32-bit ARMv7-A instructions.  v0.4.3 (A3++.5.5 third slice): adds `cmp` (CMP opcode 1010 = 0xE150_0000, no Rd output — only sets flags) with a flag-to-bool capture sequence using `MOVEQ` (0x03A0_0000 = MOV imm under the EQ condition prefix).  ARMv7's 4-bit `cond` field on every instruction makes this elegantly 4 words with no address backpatching, vs the 8008's 8-byte JFZ-skip-MVI dance.  Equality only — less-than/greater-than need MOVCC/MOVGT etc. and land alongside conditional branches in future slices."
+description = "IIR → ARMv7 (A32) machine code backend — lowers IIRModule to a Vec<u32> of encoded 32-bit ARMv7-A instructions.  v0.4.4 (A3++.5.5 fourth slice): completes the boolean comparison family with `cmp_ne` (NE = 0x13A0..), `cmp_lt` (CC = 0x33A0..), `cmp_gt` (HI = 0x83A0..), `cmp_gte` (CS = 0x23A0..), `cmp_lte` (LS = 0x93A0..).  All six comparisons share the CMP + MOV + MOV<cond> capture skeleton; only the trailing MOV's condition prefix nibble changes.  ARMv7's HI condition handles unsigned > natively — no operand-swap trick like 8008/RV32I.  A new `encode_mov_imm_cond(base, rd, imm8)` helper avoids cluttering the API with 6 nearly-identical encoders."
 
 [lib]
 name = "iir_to_armv7"

--- a/code/packages/rust/iir-to-armv7/src/lib.rs
+++ b/code/packages/rust/iir-to-armv7/src/lib.rs
@@ -435,6 +435,50 @@ pub(crate) fn encode_mov_imm_eq(rd: u8, imm8: u8) -> u32 {
     MOV_IMM_EQ_BASE | ((rd as u32) << 12) | (imm8 as u32)
 }
 
+/// ARMv7-A `MOVNE Rd, #imm8` base — `0x13A0_0000`.  Cond = NE
+/// (`0001`) — execute only if Z flag is CLEAR.  Used by `cmp_ne`.
+pub const MOV_IMM_NE_BASE: u32 = 0x13A0_0000;
+
+/// ARMv7-A `MOVCC Rd, #imm8` base — `0x33A0_0000`.  Cond = CC
+/// (`0011`) — execute only if Carry flag is CLEAR.  After CMP this
+/// fires when `A < r` (unsigned compare).  Used by `cmp_lt`.
+pub const MOV_IMM_CC_BASE: u32 = 0x33A0_0000;
+
+/// ARMv7-A `MOVCS Rd, #imm8` base — `0x23A0_0000`.  Cond = CS
+/// (`0010`) — execute only if Carry flag is SET.  After CMP this
+/// fires when `A >= r` (unsigned compare).  Used by `cmp_gte`.
+pub const MOV_IMM_CS_BASE: u32 = 0x23A0_0000;
+
+/// ARMv7-A `MOVHI Rd, #imm8` base — `0x83A0_0000`.  Cond = HI
+/// (`1000`) — execute only if Carry SET AND Zero CLEAR.  After CMP
+/// this fires when `A > r` (unsigned compare).  Used by `cmp_gt`.
+///
+/// Note: ARMv7's HI condition does the right thing for unsigned
+/// "greater than" without the operand-swap trick the 8008 and RV32I
+/// backends had to use.
+pub const MOV_IMM_HI_BASE: u32 = 0x83A0_0000;
+
+/// ARMv7-A `MOVLS Rd, #imm8` base — `0x93A0_0000`.  Cond = LS
+/// (`1001`) — execute only if Carry CLEAR OR Zero SET.  After CMP
+/// this fires when `A <= r` (unsigned compare).  Used by `cmp_lte`.
+pub const MOV_IMM_LS_BASE: u32 = 0x93A0_0000;
+
+/// Encode an ARMv7-A `MOV<cond> Rd, #imm8` instruction with an
+/// arbitrary condition prefix.
+///
+/// `cond_base` must be one of `MOV_IMM_{EQ,NE,CC,CS,HI,LS}_BASE`
+/// (or a future addition).  The function ORs in the destination
+/// register (bits 15..12) and the 8-bit immediate (bits 7..0).
+///
+/// This generic helper avoids cluttering the public surface with
+/// six nearly-identical `encode_mov_imm_{eq,ne,cc,cs,hi,ls}` fns.
+/// `encode_mov_imm_eq` is kept as a named convenience for v0.4.3's
+/// equality lowering which existed before this generalisation.
+pub(crate) fn encode_mov_imm_cond(cond_base: u32, rd: u8, imm8: u8) -> u32 {
+    debug_assert!(rd <= 15, "rd out of 4-bit range: {rd}");
+    cond_base | ((rd as u32) << 12) | (imm8 as u32)
+}
+
 // ===========================================================================
 // IIRArmv7Config
 // ===========================================================================
@@ -578,6 +622,9 @@ const SUPPORTED_OPS: &[&str] = &[
     // A3++.5.5 third slice — equality comparison with flag-to-bool
     // capture via the EQ condition prefix on every A32 instruction.
     "cmp",
+    // A3++.5.5 fourth slice — remaining 5 comparison ops using
+    // distinct condition prefixes on the trailing MOV.
+    "cmp_ne", "cmp_lt", "cmp_gt", "cmp_gte", "cmp_lte",
 ];
 
 /// Lower an [`IIRModule`] to a `Vec<u32>` of ARMv7 (A32) opcode words.
@@ -691,52 +738,63 @@ pub fn lower_iir_to_armv7(
                     words.push(BX_LR);
                 }
 
-                // ── cmp dest, a, b → CMP + MOV/MOVEQ capture ───────────
+                // ── cmp / cmp_ne / cmp_lt / cmp_gt / cmp_gte / cmp_lte ─
                 //
-                // IIR `cmp dest, a, b` produces a boolean (`dest =
-                // (a == b) ? 1 : 0`).  ARMv7's CMP sets Z/C/N/V from
-                // `Rn - Rm` and discards the difference.
+                // All six boolean comparisons share the same shape:
                 //
-                // ARMv7's KEY architectural feature — the 4-bit `cond`
-                // field at bits 31..28 of every A32 instruction —
-                // makes the flag-to-bool capture remarkably clean:
+                //   CMP    rn, rm           ; sets Z/C/N/V flags
+                //   MOV    dest, #0         ; default false (cond=AL)
+                //   MOV<C> dest, #1         ; flip to true under cond <C>
                 //
-                //   CMP   rn, rm                ; sets Z if rn == rm
-                //   MOV   dest, #0              ; default false (cond=AL)
-                //   MOVEQ dest, #1              ; if Z=1, overwrite to true
+                // The (operation → condition prefix) mapping:
                 //
-                // 4 words total.  Compare with the 8008 backend's
-                // 8-byte CMP + MVI dest, 0 + JFZ + 2-byte address + MVI
-                // dest, 1 sequence (with the JFZ target backpatched
-                // inline) — ARMv7 needs no backpatching at all.
+                //   cmp     → EQ (0x03A0..)  : Z=1 (equal)
+                //   cmp_ne  → NE (0x13A0..)  : Z=0
+                //   cmp_lt  → CC (0x33A0..)  : C=0 (unsigned A < r)
+                //   cmp_gt  → HI (0x83A0..)  : C=1 & Z=0
+                //   cmp_gte → CS (0x23A0..)  : C=1
+                //   cmp_lte → LS (0x93A0..)  : C=0 | Z=1
                 //
-                // Only equality (`a == b`) lands in this slice.
-                // Less-than (which would use MOVCC — MOV under the CC
-                // condition for "carry clear") and greater-than land
-                // in future slices alongside the S-suffix ALU
-                // variants that need to produce the right flags.
-                "cmp" => {
-                    let dest = require_dest(instr, "cmp", &f.name)?;
+                // The four-bit `cond` field at bits 31..28 of every
+                // A32 instruction is the only thing that varies
+                // between the six lowerings — same CMP+MOV+MOV
+                // skeleton, the trailing MOV's top nibble selects
+                // the comparison.
+                //
+                // ARMv7's HI condition does the right thing for
+                // unsigned "greater than" natively — no operand-swap
+                // trick like the 8008 and RV32I backends needed.
+                "cmp" | "cmp_ne" | "cmp_lt" | "cmp_gt" | "cmp_gte" | "cmp_lte" => {
+                    let dest = require_dest(instr, &instr.op, &f.name)?;
                     let a_name = match instr.srcs.first() {
                         Some(Operand::Var(s)) => s.clone(),
                         _ => return Err(IIRArmv7Error::InvalidOperand {
                             function: f.name.clone(),
-                            detail: "cmp srcs[0] must be Var".into(),
+                            detail: format!("{} srcs[0] must be Var", instr.op),
                         }),
                     };
                     let b_name = match instr.srcs.get(1) {
                         Some(Operand::Var(s)) => s.clone(),
                         _ => return Err(IIRArmv7Error::InvalidOperand {
                             function: f.name.clone(),
-                            detail: "cmp srcs[1] must be Var".into(),
+                            detail: format!("{} srcs[1] must be Var", instr.op),
                         }),
                     };
                     let rn = lookup_register(&env, &a_name, &f.name)?;
                     let rm = lookup_register(&env, &b_name, &f.name)?;
                     let rd = alloc_register(&mut next_reg, dest, &mut env, &f.name)?;
+                    let cond_mov_base = match instr.op.as_str() {
+                        "cmp"     => MOV_IMM_EQ_BASE,
+                        "cmp_ne"  => MOV_IMM_NE_BASE,
+                        "cmp_lt"  => MOV_IMM_CC_BASE,
+                        "cmp_gt"  => MOV_IMM_HI_BASE,
+                        "cmp_gte" => MOV_IMM_CS_BASE,
+                        "cmp_lte" => MOV_IMM_LS_BASE,
+                        _ => unreachable!("outer arm restricts to these 6"),
+                    };
                     words.push(encode_cmp_reg(rn, rm));
                     words.push(encode_mov_imm(rd, 0));
-                    words.push(encode_mov_imm_eq(rd, 1));
+                    words.push(encode_mov_imm_cond(cond_mov_base, rd, 1));
                 }
 
                 // ── add/sub/and/or/xor/adc/sbb → DP-register family ─────

--- a/code/packages/rust/iir-to-armv7/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-armv7/tests/test_backend.rs
@@ -8,7 +8,9 @@ use iir_to_armv7::{
     lower_iir_to_armv7, validate_for_armv7,
     IIRArmv7Config, IIRArmv7Error,
     ADC_REG_BASE, ADD_REG_BASE, AND_REG_BASE, BKPT, BX_LR, CMP_REG_BASE,
-    EOR_REG_BASE, MOV_IMM_EQ_BASE, MOV_IMM_R0_BASE, MOV_REG_BASE,
+    EOR_REG_BASE,
+    MOV_IMM_CC_BASE, MOV_IMM_CS_BASE, MOV_IMM_EQ_BASE, MOV_IMM_HI_BASE,
+    MOV_IMM_LS_BASE, MOV_IMM_NE_BASE, MOV_IMM_R0_BASE, MOV_REG_BASE,
     ORR_REG_BASE, SBC_REG_BASE, SUB_REG_BASE,
 };
 
@@ -741,6 +743,114 @@ fn cmp_with_same_register_emits_cmp_a_a_then_capture() {
         0x03A0_1001,    // MOVEQ r1, #1
         BX_LR,
     ], "self-cmp expected; got: {words:08x?}");
+}
+
+// ===========================================================================
+// 11. A3++.5.5 fourth slice — cmp_ne / cmp_lt / cmp_gt / cmp_gte / cmp_lte
+// ===========================================================================
+//
+// Same CMP + MOV + MOV<cond> capture skeleton as v0.4.3's `cmp` —
+// only the trailing MOV's condition prefix changes.  The (op →
+// condition) mapping is:
+//
+//   cmp_ne  → NE (0x13A0..)
+//   cmp_lt  → CC (0x33A0..)
+//   cmp_gt  → HI (0x83A0..)
+//   cmp_gte → CS (0x23A0..)
+//   cmp_lte → LS (0x93A0..)
+//
+// The byte streams below pin each variant against the canonical
+// "v=10, w=20" template.  Allocator: v→r0, w→r1, r→r2.  CMP r0, r1
+// = 0xE150_0001 (Rn=0, Rm=1).
+//
+//   00:  MOV r0, #10               (0xE3A0_000A)
+//   01:  MOV r1, #20               (0xE3A0_1014)
+//   02:  CMP r0, r1                (0xE150_0001)
+//   03:  MOV r2, #0                (0xE3A0_2000)
+//   04:  MOV<cond> r2, #1          (<cond_base> | 0x2001)
+//   05:  MOV r0, r2                (0xE1A0_0002)
+//   06:  BX LR
+
+#[test]
+fn mov_imm_ne_base_pinned_to_0x13a00000() {
+    assert_eq!(MOV_IMM_NE_BASE, 0x13A0_0000,
+        "MOVNE Rd, #imm base should be 0x13A00000; got 0x{:08x}", MOV_IMM_NE_BASE);
+}
+
+#[test]
+fn mov_imm_cc_base_pinned_to_0x33a00000() {
+    assert_eq!(MOV_IMM_CC_BASE, 0x33A0_0000);
+}
+
+#[test]
+fn mov_imm_cs_base_pinned_to_0x23a00000() {
+    assert_eq!(MOV_IMM_CS_BASE, 0x23A0_0000);
+}
+
+#[test]
+fn mov_imm_hi_base_pinned_to_0x83a00000() {
+    assert_eq!(MOV_IMM_HI_BASE, 0x83A0_0000);
+}
+
+#[test]
+fn mov_imm_ls_base_pinned_to_0x93a00000() {
+    assert_eq!(MOV_IMM_LS_BASE, 0x93A0_0000);
+}
+
+/// Shared helper used by the five comparison-variant tests below.
+/// Builds the canonical "const v=10; const w=20; OP r v w; ret r"
+/// IIR sequence, runs lowering, and asserts the 7-word output
+/// matches the standard CMP-capture template with the given
+/// condition-MOV word at index 4.
+fn assert_cmp_variant(op: &str, expected_cond_mov: u32) {
+    let f = IIRFunction::new(op, vec![], "bool", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(10)], "u8"),
+        IIRInstr::new("const", Some("w".into()), vec![Operand::Int(20)], "u8"),
+        IIRInstr::new(op, Some("r".into()),
+            vec![Operand::Var("v".into()), Operand::Var("w".into())], "bool"),
+        IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "bool"),
+    ]);
+    let words = lower_iir_to_armv7(&module_with(f), &IIRArmv7Config::default())
+        .expect("lowering");
+    assert_eq!(words, vec![
+        0xE3A0_000A,           // MOV r0, #10
+        0xE3A0_1014,           // MOV r1, #20
+        0xE150_0001,           // CMP r0, r1
+        0xE3A0_2000,           // MOV r2, #0
+        expected_cond_mov,     // MOV<cond> r2, #1
+        0xE1A0_0002,           // MOV r0, r2 (stage r)
+        BX_LR,
+    ], "{op} expected; got: {words:08x?}");
+}
+
+#[test]
+fn cmp_ne_uses_movne_for_set_true() {
+    // MOVNE r2, #1 = 0x13A0_0000 | (2<<12) | 1 = 0x13A0_2001
+    assert_cmp_variant("cmp_ne", 0x13A0_2001);
+}
+
+#[test]
+fn cmp_lt_uses_movcc_for_set_true() {
+    // MOVCC r2, #1 = 0x33A0_0000 | (2<<12) | 1 = 0x33A0_2001
+    assert_cmp_variant("cmp_lt", 0x33A0_2001);
+}
+
+#[test]
+fn cmp_gt_uses_movhi_for_set_true() {
+    // MOVHI r2, #1 = 0x83A0_0000 | (2<<12) | 1 = 0x83A0_2001
+    assert_cmp_variant("cmp_gt", 0x83A0_2001);
+}
+
+#[test]
+fn cmp_gte_uses_movcs_for_set_true() {
+    // MOVCS r2, #1 = 0x23A0_0000 | (2<<12) | 1 = 0x23A0_2001
+    assert_cmp_variant("cmp_gte", 0x23A0_2001);
+}
+
+#[test]
+fn cmp_lte_uses_movls_for_set_true() {
+    // MOVLS r2, #1 = 0x93A0_0000 | (2<<12) | 1 = 0x93A0_2001
+    assert_cmp_variant("cmp_lte", 0x93A0_2001);
 }
 
 #[test]

--- a/code/specs/iir-to-armv7.md
+++ b/code/specs/iir-to-armv7.md
@@ -73,7 +73,8 @@ IIRModule
 | v0.4.0 (A3++.5) | `add`/`sub` on the data-processing-register family — 3-register `Rd = Rn op Rm` | **merged** |
 | v0.4.1 (A3++.5.5 first slice) | Bitwise DP-register ops `and` (AND `0xE000_0000`), `or` (ORR `0xE180_0000`), `xor` (EOR `0xE020_0000`) | **merged** |
 | v0.4.2 (A3++.5.5 second slice) | Carry-chained DP-register ops `adc` (`0xE0A0_0000`) and `sbb` (`0xE0C0_0000`) | **merged** |
-| **v0.4.3 (A3++.5.5 third slice — this PR)** | `cmp` equality (`CMP_REG_BASE = 0xE150_0000`) with flag-to-bool capture via `MOVEQ` (`MOV_IMM_EQ_BASE = 0x03A0_0000`) — uses ARMv7's 4-bit `cond` field on every instruction.  No address backpatching needed (vs the 8008's 8-byte JFZ-skip-MVI sequence). | this PR |
+| v0.4.3 (A3++.5.5 third slice) | `cmp` equality with flag-to-bool capture via `MOVEQ` (`0x03A0_0000`) | **merged** |
+| **v0.4.4 (A3++.5.5 fourth slice — this PR)** | Full comparison family: `cmp_ne` (NE `0x13A0..`), `cmp_lt` (CC `0x33A0..`), `cmp_gt` (HI `0x83A0..` — handles unsigned > natively), `cmp_gte` (CS `0x23A0..`), `cmp_lte` (LS `0x93A0..`).  Shared `encode_mov_imm_cond(base, rd, imm8)` helper covers all six. | this PR |
 | v0.3.x (A3++.5.5) | Comparisons + conditional branches via the cond-field on every A32 instruction (a stronger version of the 8008's flag-based jumps) | future |
 | v0.3.x (A3++.6) | Function calls via `bl` with PC-relative offsets + stack spilling | future |
 | v0.4.0 (A3+++) | `lang-aot --emit=armv7` wiring | future |


### PR DESCRIPTION
## Summary

Completes the boolean-comparison surface for ARMv7 with the 5 remaining variants: \`cmp_ne\`, \`cmp_lt\`, \`cmp_gt\`, \`cmp_gte\`, \`cmp_lte\`.

All share v0.4.3's CMP + MOV + MOV<cond> capture skeleton — only the trailing MOV's 4-bit condition prefix changes:

| IIR op   | Cond | MOV-cond base | Fires when               |
| -------- | ---- | ------------- | ------------------------ |
| \`cmp\`    | EQ   | \`0x03A0_0000\` | Z=1 (equal)              |
| \`cmp_ne\` | NE   | \`0x13A0_0000\` | Z=0 (not equal)          |
| \`cmp_lt\` | CC   | \`0x33A0_0000\` | C=0 (unsigned <)         |
| \`cmp_gt\` | HI   | \`0x83A0_0000\` | C=1 ∧ Z=0 (unsigned >)   |
| \`cmp_gte\`| CS   | \`0x23A0_0000\` | C=1 (unsigned >=)        |
| \`cmp_lte\`| LS   | \`0x93A0_0000\` | C=0 ∨ Z=1 (unsigned <=)  |

The condition nibble sits in bits 31..28 of every A32 instruction; each new MOV<cond> base is just \`(cond << 28) | 0x03A0_0000\`.

### Why ARMv7's HI condition is special

ARMv7 ships a dedicated condition for "unsigned greater than", so \`cmp_gt\` doesn't need the operand-swap trick the 8008 and RV32I backends use.  Same number of instructions emitted, conceptually cleaner.

### Unified 6-way match arm + generic encoder

The v0.4.3 cmp arm widens to a 6-way match with an inner dispatch table picking the cond-MOV base.  A new generic helper \`encode_mov_imm_cond(cond_base, rd, imm8) -> u32\` avoids cluttering the API with 6 nearly-identical encoders.

### Deferred to follow-up slices

- **v0.4.5** — conditional branches (\`Bcond\`) via the same cond-field mechanism, different instruction family
- **A3++.6** — function calls via \`bl\` + stack spilling
- **A3+++ (v0.5.0)** — \`lang-aot --emit=armv7\` wiring

## Test plan

- [x] \`cargo test -p iir-to-armv7\` — 51/51 backend tests pass, 1/1 doctest passes
- [x] All 5 new MOV<cond> constants pinned
- [x] All 5 cmp variants pinned to their canonical 7-word output via a shared \`assert_cmp_variant\` helper
- [x] Security review passed (no vulnerabilities found)
- [ ] CI green
- [ ] No merge conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)