### PR TITLE
feat(ml-framework-core-ts): backward dispatch + end-to-end MLP test (JS/TS pilot PR #4/5)

### DIFF
--- a/code/packages/typescript/ml-framework-core/CHANGELOG.md
+++ b/code/packages/typescript/ml-framework-core/CHANGELOG.md
@@ -2,6 +2,95 @@
 
 ## Unreleased
 
+### Added — v0.4.0: backward dispatch + end-to-end MLP training test
+
+PR #4 of 5 in the JS/TS pilot.  Adds `backward(outputGrad)` to all 15
+Function subclasses from v0.3.0, plus an end-to-end test that trains a
+2-layer MLP and asserts loss decreases.  The full PyTorch-shaped
+forward+backward+SGD loop now works in pure TypeScript.
+
+#### Backward formulas (mirroring Ruby PR #7 + Python `autograd.py`)
+
+| Op       | Saves in forward    | Backward formula                                  |
+|----------|---------------------|---------------------------------------------------|
+| Add      | (nothing)           | `[g, g]`                                          |
+| Sub      | (nothing)           | `[g, -g]`                                         |
+| Mul      | inputs a, b         | `[g * b, g * a]`                                  |
+| Div      | inputs a, b         | `[g / b, -g * a / b²]`                            |
+| Neg      | (nothing)           | `[-g]`                                            |
+| Abs      | input a             | `[g * sign(a)]`  (sign(0) = 0)                    |
+| Pow      | input a, scalar e   | `[g * e * a^(e-1)]`  (e gets no grad)             |
+| MatMul   | inputs A, B         | `[g @ B^T, A^T @ g]`                              |
+| ReLU     | input a             | `[g * (a > 0 ? 1 : 0)]`                           |
+| Sigmoid  | output y            | `[g * y * (1 - y)]`                               |
+| Tanh     | output y            | `[g * (1 - y²)]`                                  |
+| GELU     | input a             | `[g * (0.5*(1+tanh_v) + 0.5*x*sech²*d_inner)]`    |
+| Softmax  | output y            | `[y * (g - Σ(g*y))]` per-row over last axis       |
+| Sum      | input shape         | `[broadcast(g[0], shape)]`                        |
+| Mean     | input shape, numel  | `[broadcast(g[0] / numel, shape)]`                |
+
+All backward implementations are pure TypeScript for v0.4.0.  Routing
+through Rust (mirroring v0.3.0's forward dispatch) would require new
+envelope shapes per backward op — deferred to a follow-up.  The pure-TS
+versions are correct and fast enough for parameter-shaped tensors.
+
+#### MatMul backward uses internal static helpers
+
+`MatMulOp._matmulNaive` and `_transpose2D` are pure functions that
+operate on raw `ArrayLike<number>` data.  Backward uses them directly
+(not `MatMulOp.apply(...)`) so the backward computation stays a leaf
+math operation — no extra autograd subgraph.
+
+#### End-to-end MLP test
+
+New file `tests/end-to-end-training.test.ts` runs a real training loop:
+
+```ts
+let w1 = new Tensor([[0.5, -0.3]]); w1.requiresGrad = true;
+let w2 = new Tensor([[0.4], [0.7]]); w2.requiresGrad = true;
+
+for (let step = 0; step < 30; step++) {
+  const pred = x.matmul(w1).relu().matmul(w2);
+  const diff = pred.sub(target);
+  const loss = diff.mul(diff).mean();
+  loss.backward();
+  w1 = sgdStep(w1, 0.01);
+  w2 = sgdStep(w2, 0.01);
+}
+expect(finalLoss).toBeLessThan(initialLoss * 0.25);  // 75%+ drop
+```
+
+Synthetic dataset (4 samples, regress `y = 2x + 3`) — converges
+substantially in 30 SGD steps.  Mostly-monotonic check allows up to
+⌊steps/3⌋ noisy up-steps (SGD is noisy).
+
+Companion test: 1-layer linear regression converges `w` from 0.5 to
+≈2.0 in 20 steps.
+
+#### Tests added (19 new vitest cases)
+
+- `BackwardCorrectness` (17 tests in tests/ops.test.ts):
+  - One test per op for analytical cases: Add, Sub, Mul, Div, Neg,
+    Abs, Pow, MatMul, ReLU, Sigmoid, Tanh, Softmax (uniform → zero),
+    Sum, Mean
+  - Numerical-gradient checking via finite differences for the
+    transcendentals (GELU at x=1, Softmax at x=[1,2,3] with seed
+    grad [1,0,0])
+  - Chained-op backward: x → Mul → Add → Sum → backward; assert x.grad
+    propagates through the chain
+- `EndToEndTraining` (2 tests in new file): MLP loss drops 75%+; 1-layer
+  linear regression converges
+
+All existing tests still pass — no regressions.
+
+Total: 148 tests, 0 failures.
+
+#### What's next
+
+- PR #5: benchmark script + v1.0.0 polish.  Bumps to v1.0.0 —
+  complete TS ML framework on top of the Rust matrix-cpu engine via
+  matrix-rust-napi.
+
 ### Added — v0.3.0: forward op dispatch (15 Function subclasses)
 
 PR #3 of 5 in the JS/TS pilot.  Adds the 15 differentiable operations on

--- a/code/packages/typescript/ml-framework-core/package.json
+++ b/code/packages/typescript/ml-framework-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/ml-framework-core",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Idiomatic TypeScript Tensor + autograd on top of the Rust matrix-cpu engine.  v0.1.0 ships the Tensor layer (factories, shape ops, named element-wise methods); autograd + 15 op dispatch + end-to-end MLP land in PRs #2–#5.",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/ml-framework-core/src/ops.ts
+++ b/code/packages/typescript/ml-framework-core/src/ops.ts
@@ -281,14 +281,13 @@ function unaryElementwise(
 }
 
 // ===========================================================================
-// Stub for not-yet-implemented backward — every Op below uses this.
-// ===========================================================================
-function notImplementedBackward(): never {
-  throw new Error("backward not implemented; lands in PR #4");
-}
-
-// ===========================================================================
-// The 15 differentiable ops.
+// The 15 differentiable ops — forward + backward.
+//
+// Backward formulas mirror Python autograd.py / Ruby PR #7 exactly.  All
+// done in pure TS for v0.4.0 (the formulas are mostly element-wise muls
+// + reductions; routing through Rust would require new envelope shapes
+// per backward op — deferred to a follow-up).  Pure-TS is correct and
+// fast enough for the parameter-shaped tensors that typify training.
 // ===========================================================================
 
 // ────────── Binary elementwise: Add / Sub / Mul / Div ──────────
@@ -297,28 +296,82 @@ export class AddOp extends Function {
   forward(...inputs: unknown[]): Tensor {
     return binaryElementwise("Add", inputs[0] as Tensor, inputs[1] as Tensor, (x, y) => x + y);
   }
-  backward(): (Tensor | null)[] { return notImplementedBackward(); }
+  // d/dx (x + y) = 1, d/dy (x + y) = 1.  Pass-through to both parents.
+  // Build fresh Tensors so each parent gets its own copy.
+  backward(grad: Tensor): (Tensor | null)[] {
+    const g = Array.from(grad.data);
+    return [
+      new Tensor(g.slice(), { shape: grad.shape.slice() }),
+      new Tensor(g.slice(), { shape: grad.shape.slice() }),
+    ];
+  }
 }
 
 export class SubOp extends Function {
   forward(...inputs: unknown[]): Tensor {
     return binaryElementwise("Sub", inputs[0] as Tensor, inputs[1] as Tensor, (x, y) => x - y);
   }
-  backward(): (Tensor | null)[] { return notImplementedBackward(); }
+  // d/dx (x - y) = 1, d/dy (x - y) = -1.
+  backward(grad: Tensor): (Tensor | null)[] {
+    const g = Array.from(grad.data);
+    return [
+      new Tensor(g.slice(), { shape: grad.shape.slice() }),
+      new Tensor(g.map((v) => -v), { shape: grad.shape.slice() }),
+    ];
+  }
 }
 
 export class MulOp extends Function {
   forward(...inputs: unknown[]): Tensor {
-    return binaryElementwise("Mul", inputs[0] as Tensor, inputs[1] as Tensor, (x, y) => x * y);
+    const a = inputs[0] as Tensor;
+    const b = inputs[1] as Tensor;
+    this.savedForBackward.a = a;
+    this.savedForBackward.b = b;
+    return binaryElementwise("Mul", a, b, (x, y) => x * y);
   }
-  backward(): (Tensor | null)[] { return notImplementedBackward(); }
+  // d/dx (x*y) = y, d/dy (x*y) = x.  Element-wise chain rule.
+  backward(grad: Tensor): (Tensor | null)[] {
+    const a = this.savedForBackward.a as Tensor;
+    const b = this.savedForBackward.b as Tensor;
+    const gData = grad.data;
+    const outA = new Array(a.numel);
+    const outB = new Array(b.numel);
+    for (let i = 0; i < a.numel; i++) {
+      outA[i] = gData[i]! * b.data[i]!;
+      outB[i] = gData[i]! * a.data[i]!;
+    }
+    return [
+      new Tensor(outA, { shape: a.shape.slice() }),
+      new Tensor(outB, { shape: b.shape.slice() }),
+    ];
+  }
 }
 
 export class DivOp extends Function {
   forward(...inputs: unknown[]): Tensor {
-    return binaryElementwise("Div", inputs[0] as Tensor, inputs[1] as Tensor, (x, y) => x / y);
+    const a = inputs[0] as Tensor;
+    const b = inputs[1] as Tensor;
+    this.savedForBackward.a = a;
+    this.savedForBackward.b = b;
+    return binaryElementwise("Div", a, b, (x, y) => x / y);
   }
-  backward(): (Tensor | null)[] { return notImplementedBackward(); }
+  // d/dx (x/y) = 1/y, d/dy (x/y) = -x/y².  Standard quotient rule.
+  backward(grad: Tensor): (Tensor | null)[] {
+    const a = this.savedForBackward.a as Tensor;
+    const b = this.savedForBackward.b as Tensor;
+    const gData = grad.data;
+    const outA = new Array(a.numel);
+    const outB = new Array(b.numel);
+    for (let i = 0; i < a.numel; i++) {
+      const bv = b.data[i]!;
+      outA[i] = gData[i]! / bv;
+      outB[i] = -gData[i]! * a.data[i]! / (bv * bv);
+    }
+    return [
+      new Tensor(outA, { shape: a.shape.slice() }),
+      new Tensor(outB, { shape: b.shape.slice() }),
+    ];
+  }
 }
 
 // ────────── Unary elementwise: Neg / Abs / Tanh ──────────
@@ -327,34 +380,74 @@ export class NegOp extends Function {
   forward(...inputs: unknown[]): Tensor {
     return unaryElementwise("Neg", inputs[0] as Tensor, (v) => -v);
   }
-  backward(): (Tensor | null)[] { return notImplementedBackward(); }
+  // d/dx (-x) = -1.
+  backward(grad: Tensor): (Tensor | null)[] {
+    return [new Tensor(Array.from(grad.data).map((v) => -v), { shape: grad.shape.slice() })];
+  }
 }
 
 export class AbsOp extends Function {
   forward(...inputs: unknown[]): Tensor {
-    return unaryElementwise("Abs", inputs[0] as Tensor, (v) => Math.abs(v));
+    const a = inputs[0] as Tensor;
+    this.savedForBackward.a = a;
+    return unaryElementwise("Abs", a, (v) => Math.abs(v));
   }
-  backward(): (Tensor | null)[] { return notImplementedBackward(); }
+  // d/dx |x| = sign(x).  Convention: sign(0) = 0 (PyTorch).
+  backward(grad: Tensor): (Tensor | null)[] {
+    const a = this.savedForBackward.a as Tensor;
+    const out = new Array(a.numel);
+    for (let i = 0; i < a.numel; i++) {
+      const av = a.data[i]!;
+      out[i] = av > 0 ? grad.data[i]! : av < 0 ? -grad.data[i]! : 0;
+    }
+    return [new Tensor(out, { shape: a.shape.slice() })];
+  }
 }
 
 export class TanhOp extends Function {
   forward(...inputs: unknown[]): Tensor {
-    return unaryElementwise("Tanh", inputs[0] as Tensor, (v) => Math.tanh(v));
+    // Save the OUTPUT (not the input) — tanh backward is 1 - tanh²(x)
+    // which is cheaper to compute as 1 - y² from the already-computed
+    // forward output.
+    const out = unaryElementwise("Tanh", inputs[0] as Tensor, (v) => Math.tanh(v));
+    this.savedForBackward.output = out;
+    return out;
   }
-  backward(): (Tensor | null)[] { return notImplementedBackward(); }
+  // d/dx tanh(x) = 1 - tanh²(x) = 1 - y².
+  backward(grad: Tensor): (Tensor | null)[] {
+    const y = this.savedForBackward.output as Tensor;
+    const out = new Array(y.numel);
+    for (let i = 0; i < y.numel; i++) {
+      const yv = y.data[i]!;
+      out[i] = grad.data[i]! * (1 - yv * yv);
+    }
+    return [new Tensor(out, { shape: y.shape.slice() })];
+  }
 }
 
-// ────────── Pow: scalar exponent, pure TS for v0.3.0 ──────────
+// ────────── Pow: scalar exponent ──────────
 
 export class PowOp extends Function {
   forward(...inputs: unknown[]): Tensor {
     const a = inputs[0] as Tensor;
     const exponent = inputs[1] as number;
+    this.savedForBackward.a = a;
+    this.savedForBackward.exponent = exponent;
     const out = new Array(a.numel);
     for (let i = 0; i < a.numel; i++) out[i] = Math.pow(a.data[i]!, exponent);
     return new Tensor(out, { shape: a.shape.slice() });
   }
-  backward(): (Tensor | null)[] { return notImplementedBackward(); }
+  // d/dx x^e = e * x^(e-1).  Only one Tensor parent (exponent is a Numeric,
+  // filtered out by Function.apply); return a 1-element Array to match.
+  backward(grad: Tensor): (Tensor | null)[] {
+    const a = this.savedForBackward.a as Tensor;
+    const e = this.savedForBackward.exponent as number;
+    const out = new Array(a.numel);
+    for (let i = 0; i < a.numel; i++) {
+      out[i] = grad.data[i]! * e * Math.pow(a.data[i]!, e - 1);
+    }
+    return [new Tensor(out, { shape: a.shape.slice() })];
+  }
 }
 
 // ────────── MatMul (2-D only) ──────────
@@ -372,38 +465,87 @@ export class MatMulOp extends Function {
       throw new RangeError(`matmul shape mismatch: [${a.shape.join(", ")}] @ [${b.shape.join(", ")}]`);
     }
 
+    this.savedForBackward.a = a;
+    this.savedForBackward.b = b;
+
     if (a.numel >= DISPATCH_THRESHOLD || b.numel >= DISPATCH_THRESHOLD) {
       const envelope = matmulEnvelope(a, b);
       const out = runEnvelope(envelope, m * n);
       return new Tensor(Array.from(out), { shape: [m, n] });
     }
 
-    // Pure-TS triple-loop matmul.  O(m*k*n).
+    return new Tensor(MatMulOp._matmulNaive(a.data, b.data, m, k1, n), { shape: [m, n] });
+  }
+
+  // Backward for C = A @ B (2-D):
+  //   dL/dA = grad @ B^T
+  //   dL/dB = A^T @ grad
+  // Use internal helpers (not MatMulOp.apply) so backward stays a leaf
+  // math operation — no extra autograd subgraph.
+  backward(grad: Tensor): (Tensor | null)[] {
+    const a = this.savedForBackward.a as Tensor;
+    const b = this.savedForBackward.b as Tensor;
+    const [m, k] = a.shape as [number, number];
+    const [, n] = b.shape as [number, number];
+
+    const bT = MatMulOp._transpose2D(b.data, k, n);             // (n, k)
+    const gradAData = MatMulOp._matmulNaive(grad.data, bT, m, n, k);  // (m, k)
+
+    const aT = MatMulOp._transpose2D(a.data, m, k);             // (k, m)
+    const gradBData = MatMulOp._matmulNaive(aT, grad.data, k, m, n);  // (k, n)
+
+    return [
+      new Tensor(gradAData, { shape: [m, k] }),
+      new Tensor(gradBData, { shape: [k, n] }),
+    ];
+  }
+
+  /** O(m*k*n) naive matmul on raw Float32Array data. */
+  static _matmulNaive(aData: ArrayLike<number>, bData: ArrayLike<number>, m: number, k: number, n: number): number[] {
     const out = new Array(m * n).fill(0);
     for (let i = 0; i < m; i++) {
       for (let j = 0; j < n; j++) {
         let acc = 0;
-        for (let kk = 0; kk < k1; kk++) {
-          acc += a.data[i * k1 + kk]! * b.data[kk * n + j]!;
+        for (let kk = 0; kk < k; kk++) {
+          acc += aData[i * k + kk]! * bData[kk * n + j]!;
         }
         out[i * n + j] = acc;
       }
     }
-    return new Tensor(out, { shape: [m, n] });
+    return out;
   }
-  backward(): (Tensor | null)[] { return notImplementedBackward(); }
+
+  /** Transpose a flat (rows × cols) row-major matrix.  Returns a new Array. */
+  static _transpose2D(data: ArrayLike<number>, rows: number, cols: number): number[] {
+    const out = new Array(rows * cols);
+    for (let r = 0; r < rows; r++) {
+      for (let c = 0; c < cols; c++) {
+        out[c * rows + r] = data[r * cols + c]!;
+      }
+    }
+    return out;
+  }
 }
 
-// ────────── ReLU / Sigmoid / GELU / Softmax — pure TS for v0.3.0 ──────────
+// ────────── ReLU / Sigmoid / GELU / Softmax — pure TS ──────────
 
 export class ReLUOp extends Function {
   forward(...inputs: unknown[]): Tensor {
     const a = inputs[0] as Tensor;
+    this.savedForBackward.a = a;
     const out = new Array(a.numel);
     for (let i = 0; i < a.numel; i++) out[i] = a.data[i]! > 0 ? a.data[i]! : 0;
     return new Tensor(out, { shape: a.shape.slice() });
   }
-  backward(): (Tensor | null)[] { return notImplementedBackward(); }
+  // d/dx ReLU(x) = 1 if x > 0 else 0.  x == 0 → 0 (PyTorch).
+  backward(grad: Tensor): (Tensor | null)[] {
+    const a = this.savedForBackward.a as Tensor;
+    const out = new Array(a.numel);
+    for (let i = 0; i < a.numel; i++) {
+      out[i] = a.data[i]! > 0 ? grad.data[i]! : 0;
+    }
+    return [new Tensor(out, { shape: a.shape.slice() })];
+  }
 }
 
 export class SigmoidOp extends Function {
@@ -411,9 +553,21 @@ export class SigmoidOp extends Function {
     const a = inputs[0] as Tensor;
     const out = new Array(a.numel);
     for (let i = 0; i < a.numel; i++) out[i] = 1 / (1 + Math.exp(-a.data[i]!));
-    return new Tensor(out, { shape: a.shape.slice() });
+    const result = new Tensor(out, { shape: a.shape.slice() });
+    // Save the OUTPUT y — sigmoid backward is y * (1 - y).
+    this.savedForBackward.output = result;
+    return result;
   }
-  backward(): (Tensor | null)[] { return notImplementedBackward(); }
+  // d/dx σ(x) = σ(x) * (1 - σ(x)) = y * (1 - y).
+  backward(grad: Tensor): (Tensor | null)[] {
+    const y = this.savedForBackward.output as Tensor;
+    const out = new Array(y.numel);
+    for (let i = 0; i < y.numel; i++) {
+      const yv = y.data[i]!;
+      out[i] = grad.data[i]! * yv * (1 - yv);
+    }
+    return [new Tensor(out, { shape: y.shape.slice() })];
+  }
 }
 
 export class GELUOp extends Function {
@@ -424,6 +578,7 @@ export class GELUOp extends Function {
 
   forward(...inputs: unknown[]): Tensor {
     const a = inputs[0] as Tensor;
+    this.savedForBackward.a = a;
     const c = GELUOp.SQRT_2_OVER_PI;
     const k = GELUOp.COEFF;
     const out = new Array(a.numel);
@@ -433,7 +588,27 @@ export class GELUOp extends Function {
     }
     return new Tensor(out, { shape: a.shape.slice() });
   }
-  backward(): (Tensor | null)[] { return notImplementedBackward(); }
+  // GELU backward (tanh-approximation form):
+  //   inner   = √(2/π) * (x + 0.044715 * x³)
+  //   tanh_v  = tanh(inner)
+  //   sech²   = 1 - tanh_v²
+  //   d_inner = √(2/π) * (1 + 3 * 0.044715 * x²)
+  //   dy/dx   = 0.5 * (1 + tanh_v) + 0.5 * x * sech² * d_inner
+  backward(grad: Tensor): (Tensor | null)[] {
+    const a = this.savedForBackward.a as Tensor;
+    const c = GELUOp.SQRT_2_OVER_PI;
+    const k = GELUOp.COEFF;
+    const out = new Array(a.numel);
+    for (let i = 0; i < a.numel; i++) {
+      const x = a.data[i]!;
+      const inner = c * (x + k * x * x * x);
+      const tanhV = Math.tanh(inner);
+      const sech2 = 1 - tanhV * tanhV;
+      const dInner = c * (1 + 3 * k * x * x);
+      out[i] = grad.data[i]! * (0.5 * (1 + tanhV) + 0.5 * x * sech2 * dInner);
+    }
+    return [new Tensor(out, { shape: a.shape.slice() })];
+  }
 }
 
 export class SoftmaxOp extends Function {
@@ -464,9 +639,34 @@ export class SoftmaxOp extends Function {
         out[rowStart + k] = tmp[k] / sum;
       }
     }
-    return new Tensor(out, { shape: a.shape.slice() });
+    const result = new Tensor(out, { shape: a.shape.slice() });
+    this.savedForBackward.output = result;
+    this.savedForBackward.lastAxisSize = lastAxisSize;
+    return result;
   }
-  backward(): (Tensor | null)[] { return notImplementedBackward(); }
+
+  // Softmax backward (per-row over the last axis):
+  //   dL/dx_i = y_i * (g_i - Σ_j (g_j * y_j))
+  // The dot product is per-row; each row is independent.
+  backward(grad: Tensor): (Tensor | null)[] {
+    const y = this.savedForBackward.output as Tensor;
+    const lastAxisSize = this.savedForBackward.lastAxisSize as number;
+    const numel = y.numel;
+    const outer = numel / lastAxisSize;
+    const out = new Array(numel);
+    for (let o = 0; o < outer; o++) {
+      const rowStart = o * lastAxisSize;
+      let dot = 0;
+      for (let k = 0; k < lastAxisSize; k++) {
+        dot += grad.data[rowStart + k]! * y.data[rowStart + k]!;
+      }
+      for (let k = 0; k < lastAxisSize; k++) {
+        const idx = rowStart + k;
+        out[idx] = y.data[idx]! * (grad.data[idx]! - dot);
+      }
+    }
+    return [new Tensor(out, { shape: y.shape.slice() })];
+  }
 }
 
 // ────────── Reductions: Sum / Mean (reduce-all) ──────────
@@ -474,6 +674,7 @@ export class SoftmaxOp extends Function {
 export class SumOp extends Function {
   forward(...inputs: unknown[]): Tensor {
     const a = inputs[0] as Tensor;
+    this.savedForBackward.inputShape = a.shape.slice();
     if (a.numel >= DISPATCH_THRESHOLD) {
       const envelope = reduceAllEnvelope("ReduceSum", a);
       const out = runEnvelope(envelope, 1);
@@ -483,12 +684,21 @@ export class SumOp extends Function {
     for (let i = 0; i < a.numel; i++) sum += a.data[i]!;
     return new Tensor([sum], { shape: [1] });
   }
-  backward(): (Tensor | null)[] { return notImplementedBackward(); }
+  // d/dx_i (Σ x_j) = 1.  Broadcast the scalar gradient (shape [1]) to
+  // a full tensor of the input shape.
+  backward(grad: Tensor): (Tensor | null)[] {
+    const inputShape = this.savedForBackward.inputShape as number[];
+    const g = grad.data[0]!;
+    const numel = inputShape.length === 0 ? 1 : inputShape.reduce((a, b) => a * b, 1);
+    return [new Tensor(new Array(numel).fill(g), { shape: inputShape.slice() })];
+  }
 }
 
 export class MeanOp extends Function {
   forward(...inputs: unknown[]): Tensor {
     const a = inputs[0] as Tensor;
+    this.savedForBackward.inputShape = a.shape.slice();
+    this.savedForBackward.numel = a.numel;
     if (a.numel >= DISPATCH_THRESHOLD) {
       const envelope = reduceAllEnvelope("ReduceMean", a);
       const out = runEnvelope(envelope, 1);
@@ -498,5 +708,12 @@ export class MeanOp extends Function {
     for (let i = 0; i < a.numel; i++) sum += a.data[i]!;
     return new Tensor([sum / a.numel], { shape: [1] });
   }
-  backward(): (Tensor | null)[] { return notImplementedBackward(); }
+  // d/dx_i ((1/N) Σ x_j) = 1/N.  Broadcast g/N to the input shape.
+  backward(grad: Tensor): (Tensor | null)[] {
+    const inputShape = this.savedForBackward.inputShape as number[];
+    const n = this.savedForBackward.numel as number;
+    const g = grad.data[0]! / n;
+    const numel = inputShape.length === 0 ? 1 : inputShape.reduce((a, b) => a * b, 1);
+    return [new Tensor(new Array(numel).fill(g), { shape: inputShape.slice() })];
+  }
 }

--- a/code/packages/typescript/ml-framework-core/src/version.ts
+++ b/code/packages/typescript/ml-framework-core/src/version.ts
@@ -4,4 +4,4 @@
  * Kept in sync with package.json's `version` field by hand — there's no
  * build step that injects it.  When bumping, update both files.
  */
-export const VERSION = "0.3.0" as const;
+export const VERSION = "0.4.0" as const;

--- a/code/packages/typescript/ml-framework-core/tests/end-to-end-training.test.ts
+++ b/code/packages/typescript/ml-framework-core/tests/end-to-end-training.test.ts
@@ -1,0 +1,114 @@
+/**
+ * end-to-end-training.test.ts — proves the autograd stack actually trains.
+ * ============================================================================
+ *
+ * All the unit tests so far prove individual op correctness and graph
+ * wiring; this test runs a real (if tiny) training loop and asserts that
+ * loss decreases monotonically over the steps.
+ *
+ * Mirrors `code/packages/ruby/ml_framework_core/test/end_to_end_training_test.rb`
+ * adapted to TS / vitest idiom.
+ *
+ *   - 2-layer MLP: x → linear(W₁) → ReLU → linear(W₂) → MSE loss
+ *   - 30 SGD steps at lr=0.01
+ *   - Assert final loss < initial loss / 4 (75%+ drop)
+ *
+ * We use a tiny problem (4 samples, 2 hidden units) so the test runs in
+ * milliseconds.  Larger problems would exercise the Rust dispatch path
+ * which has its own tests; here we're only validating the autograd loop.
+ */
+
+import { describe, it, expect } from "vitest";
+import { Tensor } from "../src/index.js";
+
+/**
+ * SGD step.  PyTorch convention: subtract lr * grad from the param's
+ * data, then zero the gradient before the next step.
+ *
+ * Tensors are immutable from the outside (no public `.data =` setter),
+ * so "in-place update" is really "swap the underlying data array" — we
+ * build a fresh Tensor with `requiresGrad = true` and let the previous
+ * one fall out of scope.
+ */
+function sgdStep(param: Tensor, lr: number): Tensor {
+  const newData = param.toArray().map((v, i) => v - lr * param.grad!.toArray()[i]!);
+  const newParam = new Tensor(newData, { shape: param.shape.slice() });
+  newParam.requiresGrad = true;
+  return newParam;
+}
+
+describe("EndToEndTraining", () => {
+  it("two-layer MLP loss decreases substantially over 30 SGD steps", () => {
+    // Synthetic dataset: regress y = 2x + 3 over 4 samples.
+    const x = new Tensor([[0], [1], [2], [3]]);
+    const target = new Tensor([[3], [5], [7], [9]]);
+
+    // Layer 1: (1, 2) — 1-D input → 2 hidden units.
+    // Layer 2: (2, 1) — 2 hidden units → 1 output.
+    // Initialise to small values for deterministic test runs.
+    let w1 = new Tensor([[0.5, -0.3]]); w1.requiresGrad = true;
+    let w2 = new Tensor([[0.4], [0.7]]); w2.requiresGrad = true;
+
+    // lr=0.01 is conservative; with lr=0.05 the small MLP overshoots
+    // and lands in a 2-cycle around the minimum (correct gradient
+    // descent behavior but defeats the monotonicity check).
+    const lr = 0.01;
+    const steps = 30;
+    const losses: number[] = [];
+
+    for (let step = 0; step < steps; step++) {
+      // Forward: pred = ((x @ w1).relu) @ w2
+      const pred = x.matmul(w1).relu().matmul(w2);
+
+      // MSE loss: mean((pred - target)²)
+      const diff = pred.sub(target);
+      const loss = diff.mul(diff).mean();
+      losses.push(loss.toArray()[0]!);
+
+      loss.backward();
+
+      // SGD step — fresh Tensors with no gradient carry over.
+      w1 = sgdStep(w1, lr);
+      w2 = sgdStep(w2, lr);
+    }
+
+    const initial = losses[0]!;
+    const final = losses[steps - 1]!;
+
+    // Hard requirement: loss MUST decrease overall.
+    expect(final).toBeLessThan(initial);
+
+    // Stronger: loss should drop by at least 75% — proves the autograd
+    // gradients are pointing in the right direction, not just walking.
+    // The model has no bias so it can't fit y=2x+3 perfectly; it
+    // bottoms out around 3.2 (vs. initial ~36).
+    const dropRatio = (initial - final) / initial;
+    expect(dropRatio).toBeGreaterThan(0.75);
+
+    // Sanity: mostly monotonic.  Allow up to floor(steps/3) up-steps
+    // (SGD is noisy) but the trend must be down.
+    const increasingSteps = losses.slice(0, -1).filter((l, i) => losses[i + 1]! > l).length;
+    expect(increasingSteps).toBeLessThanOrEqual(Math.floor(steps / 3));
+  });
+
+  it("1-layer linear regression converges w near true value", () => {
+    // Simplest case: y = w * x. No nonlinearity, single parameter.
+    const x = new Tensor([[1], [2], [3], [4]]);
+    const target = new Tensor([[2], [4], [6], [8]]);  // y = 2x exactly
+
+    let w = new Tensor([[0.5]]);  // start far from true (2.0)
+    w.requiresGrad = true;
+
+    const lr = 0.05;
+    for (let step = 0; step < 20; step++) {
+      const pred = x.matmul(w);
+      const diff = pred.sub(target);
+      const loss = diff.mul(diff).mean();
+      loss.backward();
+      w = sgdStep(w, lr);
+    }
+
+    const finalW = w.toArray()[0]!;
+    expect(Math.abs(finalW - 2)).toBeLessThan(0.5);
+  });
+});

--- a/code/packages/typescript/ml-framework-core/tests/ops.test.ts
+++ b/code/packages/typescript/ml-framework-core/tests/ops.test.ts
@@ -172,12 +172,12 @@ describe("ForwardSmall — every op pure-TS path", () => {
     expect(out.toArray()).toEqual([2.5]);
   });
 
-  // Backward not implemented yet (PR #4)
-  it("backward throws 'not implemented' for now", () => {
-    const x = new Tensor([1]);
-    x.requiresGrad = true;
+  // Sanity check: backward now works end-to-end (PR #4 added it).
+  it("backward through a simple Add chain works", () => {
+    const x = new Tensor([1]); x.requiresGrad = true;
     const y = AddOp.apply(x, new Tensor([2]));
-    expect(() => y.backward()).toThrow(/not implemented/);
+    y.backward();
+    expect(x.grad!.toArray()).toEqual([1]);
   });
 });
 
@@ -290,6 +290,166 @@ describe("TensorMethods — sugar that dispatches to the Op classes", () => {
 
   it("unsupported operand throws TypeError", () => {
     expect(() => new Tensor([1]).add("oops" as never)).toThrow(TypeError);
+  });
+});
+
+describe("BackwardCorrectness — analytical gradient formulas", () => {
+  // Each test follows the Ruby PR #7 pattern: build a leaf with
+  // requiresGrad, run forward, seed backward, assert x.grad matches the
+  // analytical formula for that op.
+
+  it("Add backward writes ones to both parents", () => {
+    const a = new Tensor([1, 2, 3]); a.requiresGrad = true;
+    const b = new Tensor([10, 20, 30]); b.requiresGrad = true;
+    AddOp.apply(a, b).backward();
+    expect(a.grad!.toArray()).toEqual([1, 1, 1]);
+    expect(b.grad!.toArray()).toEqual([1, 1, 1]);
+  });
+
+  it("Sub backward gives +1 to a, -1 to b", () => {
+    const a = new Tensor([5, 5]); a.requiresGrad = true;
+    const b = new Tensor([1, 1]); b.requiresGrad = true;
+    SubOp.apply(a, b).backward();
+    expect(a.grad!.toArray()).toEqual([1, 1]);
+    expect(b.grad!.toArray()).toEqual([-1, -1]);
+  });
+
+  it("Mul backward gives b to a and a to b", () => {
+    const a = new Tensor([2, 3]); a.requiresGrad = true;
+    const b = new Tensor([4, 5]); b.requiresGrad = true;
+    MulOp.apply(a, b).backward();
+    expect(a.grad!.toArray()).toEqual([4, 5]);
+    expect(b.grad!.toArray()).toEqual([2, 3]);
+  });
+
+  it("Div backward: 1/b and -a/b²", () => {
+    const a = new Tensor([10, 20]); a.requiresGrad = true;
+    const b = new Tensor([2, 4]); b.requiresGrad = true;
+    DivOp.apply(a, b).backward();
+    expect(a.grad!.toArray()).toEqual([0.5, 0.25]);
+    expect(b.grad!.toArray()).toEqual([-2.5, -1.25]);
+  });
+
+  it("Neg backward flips signs of the gradient", () => {
+    const a = new Tensor([1, -2]); a.requiresGrad = true;
+    NegOp.apply(a).backward();
+    expect(a.grad!.toArray()).toEqual([-1, -1]);
+  });
+
+  it("Abs backward: sign(x), with sign(0) = 0", () => {
+    const a = new Tensor([-2, 0, 3]); a.requiresGrad = true;
+    AbsOp.apply(a).backward();
+    expect(a.grad!.toArray()).toEqual([-1, 0, 1]);
+  });
+
+  it("Pow backward: e * x^(e-1)", () => {
+    const a = new Tensor([2, 3]); a.requiresGrad = true;
+    PowOp.apply(a, 3).backward();
+    // d(x^3)/dx = 3x²; at x=2 → 12; at x=3 → 27.
+    expect(a.grad!.toArray()).toEqual([12, 27]);
+  });
+
+  it("MatMul backward: dL/dA = g @ B^T, dL/dB = A^T @ g", () => {
+    // A: (2, 3), B: (3, 2), C: (2, 2), seed grad = ones(2, 2).
+    const a = new Tensor([[1, 2, 3], [4, 5, 6]]); a.requiresGrad = true;
+    const b = new Tensor([[7, 8], [9, 10], [11, 12]]); b.requiresGrad = true;
+    MatMulOp.apply(a, b).backward();
+    expect(a.grad!.shape).toEqual([2, 3]);
+    expect(b.grad!.shape).toEqual([3, 2]);
+    // Spot-check: dL/dA[0,0] = sum_j (1 * B[0,j]) = 7+8 = 15
+    expect(a.grad!.toArray()[0]).toBe(15);
+    // dL/dB[0,0] = sum_i (A[i,0] * 1) = 1+4 = 5
+    expect(b.grad!.toArray()[0]).toBe(5);
+  });
+
+  it("ReLU backward: g if a>0 else 0", () => {
+    const a = new Tensor([-1, 0, 2, -3, 4]); a.requiresGrad = true;
+    ReLUOp.apply(a).backward();
+    expect(a.grad!.toArray()).toEqual([0, 0, 1, 0, 1]);
+  });
+
+  it("Sigmoid backward at 0: σ'(0) = 0.5 * 0.5 = 0.25", () => {
+    const a = new Tensor([0]); a.requiresGrad = true;
+    SigmoidOp.apply(a).backward();
+    expect(a.grad!.toArray()[0]).toBeCloseTo(0.25, 12);
+  });
+
+  it("Tanh backward at 0: tanh'(0) = 1 - 0² = 1", () => {
+    const a = new Tensor([0]); a.requiresGrad = true;
+    TanhOp.apply(a).backward();
+    expect(a.grad!.toArray()[0]).toBeCloseTo(1, 12);
+  });
+
+  it("GELU backward at 0: 0.5 * (1 + tanh(0)) + 0 = 0.5", () => {
+    const a = new Tensor([0]); a.requiresGrad = true;
+    GELUOp.apply(a).backward();
+    expect(a.grad!.toArray()[0]).toBeCloseTo(0.5, 6);
+  });
+
+  it("GELU backward matches finite differences at x=1", () => {
+    // Spot-check the analytical formula against a finite-difference estimate.
+    const eps = 1e-4;
+    const hi = GELUOp.apply(new Tensor([1 + eps])).toArray()[0]!;
+    const lo = GELUOp.apply(new Tensor([1 - eps])).toArray()[0]!;
+    const finiteDiff = (hi - lo) / (2 * eps);
+
+    const a = new Tensor([1]); a.requiresGrad = true;
+    GELUOp.apply(a).backward();
+    expect(a.grad!.toArray()[0]).toBeCloseTo(finiteDiff, 3);
+  });
+
+  it("Softmax backward at uniform input cancels to zero", () => {
+    // Uniform input → uniform output → backward with grad=ones cancels
+    // (each row's dot product equals each individual product).
+    const a = new Tensor([1, 1, 1]); a.requiresGrad = true;
+    SoftmaxOp.apply(a).backward();
+    for (const v of a.grad!.toArray()) {
+      // f32 round-tripping (Float32Array storage) introduces ~1e-8 noise
+      // even on values that are algebraically zero — 6 digits is safe.
+      expect(v).toBeCloseTo(0, 6);
+    }
+  });
+
+  it("Softmax backward matches finite differences", () => {
+    const eps = 1e-4;
+    const seed = new Tensor([1, 0, 0]);
+    // Compute ∂y_0/∂x_i via finite differences
+    const grads_fd = [0, 1, 2].map((i) => {
+      const shiftHi = [1, 2, 3]; shiftHi[i] += eps;
+      const shiftLo = [1, 2, 3]; shiftLo[i] -= eps;
+      const yHi = SoftmaxOp.apply(new Tensor(shiftHi)).toArray()[0]!;
+      const yLo = SoftmaxOp.apply(new Tensor(shiftLo)).toArray()[0]!;
+      return (yHi - yLo) / (2 * eps);
+    });
+    const x = new Tensor([1, 2, 3]); x.requiresGrad = true;
+    SoftmaxOp.apply(x).backward(seed);
+    for (let i = 0; i < 3; i++) {
+      expect(x.grad!.toArray()[i]).toBeCloseTo(grads_fd[i]!, 3);
+    }
+  });
+
+  it("Sum backward broadcasts the scalar grad to input shape", () => {
+    const a = new Tensor([1, 2, 3, 4]); a.requiresGrad = true;
+    SumOp.apply(a).backward();
+    expect(a.grad!.toArray()).toEqual([1, 1, 1, 1]);
+  });
+
+  it("Mean backward distributes 1/N evenly", () => {
+    const a = new Tensor([1, 2, 3, 4]); a.requiresGrad = true;
+    MeanOp.apply(a).backward();
+    for (const v of a.grad!.toArray()) {
+      expect(v).toBeCloseTo(0.25, 12);
+    }
+  });
+
+  it("Chained op backward: x → x*2 → +1 → sum, gradient = 2", () => {
+    const x = new Tensor([1, 2, 3]); x.requiresGrad = true;
+    const two = new Tensor([2, 2, 2]);
+    const one = new Tensor([1, 1, 1]);
+    const y = MulOp.apply(x, two);
+    const z = AddOp.apply(y, one);
+    SumOp.apply(z).backward();
+    expect(x.grad!.toArray()).toEqual([2, 2, 2]);
   });
 });
 


### PR DESCRIPTION
## Summary

- `backward(outputGrad)` added to all 15 Function subclasses (Add/Sub/Mul/Div/Neg/Abs/Pow/MatMul/ReLU/Sigmoid/Tanh/GELU/Softmax/Sum/Mean) using analytical gradient formulas mirroring Ruby PR #7 + Python autograd.py exactly.
- New end-to-end test trains a 2-layer MLP via SGD; loss drops 75%+ from initial over 30 steps.
- 19 new tests; 148 tests total across the package, all passing.

## What works now (end-to-end!)

```ts
import { Tensor } from "@coding-adventures/ml-framework-core";

let w1 = new Tensor([[0.5, -0.3]]); w1.requiresGrad = true;
let w2 = new Tensor([[0.4], [0.7]]); w2.requiresGrad = true;

for (let step = 0; step < 30; step++) {
  const pred = x.matmul(w1).relu().matmul(w2);
  const loss = pred.sub(target).mul(pred.sub(target)).mean();
  loss.backward();
  w1 = sgdStep(w1, 0.01);
  w2 = sgdStep(w2, 0.01);
}
// Loss drops 75%+ from initial.
```

## Architecture choices

- **All backward in pure TS** (same decision as Ruby PR #7) — backward formulas are mostly element-wise muls + reductions; routing through Rust would require new envelope shapes per backward op, deferred
- **MatMul backward uses internal `_matmulNaive` + `_transpose2D` static helpers** — not `MatMulOp.apply` — so backward stays a leaf op (no extra autograd subgraph)
- **`savedForBackward` Record** — each subclass writes its own hardcoded keys (a, b, output, inputShape, etc.); casts are compile-time only

## Test plan

- [x] `npx tsc --noEmit`: 0 errors
- [x] `tests/tensor.test.ts`: 61/61 (no regressions)
- [x] `tests/autograd.test.ts`: 18/18 (no regressions)
- [x] `tests/ops.test.ts`: 67/67 (49 forward + 17 new backward + 1 chained)
- [x] `tests/end-to-end-training.test.ts`: 2/2 (NEW — real MLP training)
- [x] Security review passed
- [ ] CI: build (ubuntu/macos/windows) — pending
- [ ] CI: CodeQL js-ts Analyze — pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)