### PR TITLE
Track browser form choice control descriptors

### DIFF
--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -1619,6 +1619,7 @@ pub struct BrowserForm {
     pub validation_controls: Vec<BrowserFormValidationControl>,
     pub buttons: Vec<BrowserFormButton>,
     pub text_entries: Vec<BrowserFormTextEntry>,
+    pub choice_controls: Vec<BrowserFormChoiceControl>,
     pub controls: Vec<BrowserFormControl>,
     pub submitters: Vec<BrowserFormSubmitter>,
 }
@@ -1772,6 +1773,29 @@ pub struct BrowserFormTextEntry {
     pub will_validate: bool,
     pub validation_attributes: Vec<String>,
     pub validation_barred_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserFormChoiceControl {
+    pub id: Option<String>,
+    pub control_type: String,
+    pub name: Option<String>,
+    pub form_owner: Option<String>,
+    pub labels: Vec<String>,
+    pub accessible_name: Option<String>,
+    pub value: Option<String>,
+    pub checked: bool,
+    pub disabled: bool,
+    pub required: bool,
+    pub group_required: bool,
+    pub successful: bool,
+    pub submission_values: Vec<String>,
+    pub will_validate: bool,
+    pub validation_attributes: Vec<String>,
+    pub validation_barred_reason: Option<String>,
+    pub group_name: Option<String>,
+    pub group_checked_ids: Vec<String>,
+    pub group_checked_values: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -12839,6 +12863,7 @@ fn browser_form(
         novalidate,
     );
     let text_entries = browser_form_text_entries(&controls);
+    let choice_controls = browser_form_choice_controls(&controls, element.attribute("id"));
     let submitters = browser_form_submitters(
         &controls,
         action.as_deref(),
@@ -12884,6 +12909,7 @@ fn browser_form(
         validation_controls,
         buttons,
         text_entries,
+        choice_controls,
         controls,
         submitters,
     }
@@ -13399,6 +13425,95 @@ fn is_browser_form_text_entry(control: &BrowserFormControl) -> bool {
         control.control_type.as_str(),
         "text" | "search" | "url" | "tel" | "email" | "password" | "number" | "textarea"
     )
+}
+
+fn browser_form_choice_controls(
+    controls: &[BrowserFormControl],
+    form_id: Option<&str>,
+) -> Vec<BrowserFormChoiceControl> {
+    controls
+        .iter()
+        .filter(|control| is_browser_form_choice_control(control))
+        .map(|control| BrowserFormChoiceControl {
+            id: control.id.clone(),
+            control_type: control.control_type.clone(),
+            name: control.name.clone(),
+            form_owner: control.form_owner.clone(),
+            labels: control.labels.clone(),
+            accessible_name: control.accessible_name.clone(),
+            value: control.value.clone(),
+            checked: control.checked,
+            disabled: control.disabled,
+            required: control.required,
+            group_required: browser_choice_group_required(controls, control, form_id),
+            successful: control.successful,
+            submission_values: control.submission_values.clone(),
+            will_validate: control.will_validate,
+            validation_attributes: control.validation_attributes.clone(),
+            validation_barred_reason: control.validation_barred_reason.clone(),
+            group_name: control.name.clone(),
+            group_checked_ids: browser_choice_group_checked_ids(controls, control, form_id),
+            group_checked_values: browser_choice_group_checked_values(controls, control, form_id),
+        })
+        .collect()
+}
+
+fn is_browser_form_choice_control(control: &BrowserFormControl) -> bool {
+    matches!(control.control_type.as_str(), "checkbox" | "radio")
+}
+
+fn browser_choice_group_required(
+    controls: &[BrowserFormControl],
+    target: &BrowserFormControl,
+    form_id: Option<&str>,
+) -> bool {
+    controls
+        .iter()
+        .filter(|control| browser_choice_group_peer(control, target, form_id))
+        .any(|control| control.required)
+}
+
+fn browser_choice_group_checked_ids(
+    controls: &[BrowserFormControl],
+    target: &BrowserFormControl,
+    form_id: Option<&str>,
+) -> Vec<String> {
+    controls
+        .iter()
+        .filter(|control| browser_choice_group_peer(control, target, form_id) && control.checked)
+        .filter_map(|control| control.id.clone())
+        .collect()
+}
+
+fn browser_choice_group_checked_values(
+    controls: &[BrowserFormControl],
+    target: &BrowserFormControl,
+    form_id: Option<&str>,
+) -> Vec<String> {
+    controls
+        .iter()
+        .filter(|control| browser_choice_group_peer(control, target, form_id) && control.checked)
+        .filter_map(|control| control.value.clone())
+        .collect()
+}
+
+fn browser_choice_group_peer(
+    control: &BrowserFormControl,
+    target: &BrowserFormControl,
+    form_id: Option<&str>,
+) -> bool {
+    target.name.is_some()
+        && control.control_type == target.control_type
+        && control.name == target.name
+        && browser_choice_group_form_owner(control, form_id)
+            == browser_choice_group_form_owner(target, form_id)
+}
+
+fn browser_choice_group_form_owner<'a>(
+    control: &'a BrowserFormControl,
+    form_id: Option<&'a str>,
+) -> Option<&'a str> {
+    control.form_owner.as_deref().or(form_id)
 }
 
 fn collect_form_controls_for_form_into(

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -1,14 +1,14 @@
 use coding_adventures_html_parser::{
     parse_browser_document, BrowserAnchor, BrowserComponentHydrationTarget, BrowserDataAttribute,
     BrowserDatalistOption, BrowserDocument, BrowserDocumentMetadata, BrowserEmbeddedContext,
-    BrowserForm, BrowserFormButton, BrowserFormControl, BrowserFormDatalist, BrowserFormFieldset,
-    BrowserFormLabel, BrowserFormOutput, BrowserFormSelect, BrowserFormSubmitter,
-    BrowserFormSuccessfulControl, BrowserFormTextEntry, BrowserFormValidationControl,
-    BrowserHeading, BrowserHttpEquivHint, BrowserImage, BrowserImageSource,
-    BrowserInteractiveElement, BrowserLink, BrowserMedia, BrowserMeta, BrowserMetadataDirective,
-    BrowserRefresh, BrowserResource, BrowserResourceHint, BrowserScript, BrowserSelectOption,
-    BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet, BrowserTable,
-    BrowserTemplate, BrowserThemeColor,
+    BrowserForm, BrowserFormButton, BrowserFormChoiceControl, BrowserFormControl,
+    BrowserFormDatalist, BrowserFormFieldset, BrowserFormLabel, BrowserFormOutput,
+    BrowserFormSelect, BrowserFormSubmitter, BrowserFormSuccessfulControl, BrowserFormTextEntry,
+    BrowserFormValidationControl, BrowserHeading, BrowserHttpEquivHint, BrowserImage,
+    BrowserImageSource, BrowserInteractiveElement, BrowserLink, BrowserMedia, BrowserMeta,
+    BrowserMetadataDirective, BrowserRefresh, BrowserResource, BrowserResourceHint, BrowserScript,
+    BrowserSelectOption, BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet,
+    BrowserTable, BrowserTemplate, BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -734,6 +734,8 @@ struct ExpectedForm {
     buttons: Vec<ExpectedFormButton>,
     #[serde(default)]
     text_entries: Vec<ExpectedFormTextEntry>,
+    #[serde(default)]
+    choice_controls: Vec<ExpectedFormChoiceControl>,
     controls: Vec<ExpectedFormControl>,
     #[serde(default)]
     submitters: Vec<ExpectedFormSubmitter>,
@@ -938,6 +940,45 @@ struct ExpectedFormTextEntry {
     validation_attributes: Vec<String>,
     #[serde(default)]
     validation_barred_reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedFormChoiceControl {
+    #[serde(default)]
+    id: Option<String>,
+    control_type: String,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    form_owner: Option<String>,
+    #[serde(default)]
+    labels: Vec<String>,
+    #[serde(default)]
+    accessible_name: Option<String>,
+    #[serde(default)]
+    value: Option<String>,
+    checked: bool,
+    disabled: bool,
+    #[serde(default)]
+    required: bool,
+    #[serde(default)]
+    group_required: bool,
+    #[serde(default)]
+    successful: bool,
+    #[serde(default)]
+    submission_values: Vec<String>,
+    #[serde(default)]
+    will_validate: bool,
+    #[serde(default)]
+    validation_attributes: Vec<String>,
+    #[serde(default)]
+    validation_barred_reason: Option<String>,
+    #[serde(default)]
+    group_name: Option<String>,
+    #[serde(default)]
+    group_checked_ids: Vec<String>,
+    #[serde(default)]
+    group_checked_values: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1686,6 +1727,98 @@ fn browser_form_text_entry_descriptor_metadata_tracks_textual_controls_and_editi
     assert_eq!(external.name.as_deref(), Some("outside"));
     assert_eq!(external.placeholder.as_deref(), Some("Outside"));
     assert_eq!(external.text, "External note");
+}
+
+#[test]
+fn browser_form_choice_descriptor_metadata_tracks_checkbox_radio_state_and_groups() {
+    let document = parse_browser_document(
+        "<form id=prefs>\
+         <label><input id=news type=checkbox name=news value=yes checked required>Newsletter</label>\
+         <input id=updates type=checkbox name=updates>\
+         <label for=plan-basic>Basic</label>\
+         <input id=plan-basic type=radio name=plan value=basic checked required>\
+         <input id=plan-pro type=radio name=plan value=pro>\
+         <fieldset disabled><label><input id=legacy type=radio name=legacy value=old checked>Legacy</label></fieldset>\
+         </form>\
+         <input id=external type=radio form=prefs name=plan value=outside>",
+    )
+    .expect("form choice descriptor fixture should parse");
+
+    let form = document
+        .forms
+        .first()
+        .expect("prefs form should be summarized");
+    let ids: Vec<&str> = form
+        .choice_controls
+        .iter()
+        .filter_map(|choice| choice.id.as_deref())
+        .collect();
+    assert_eq!(
+        ids,
+        vec![
+            "news",
+            "updates",
+            "plan-basic",
+            "plan-pro",
+            "legacy",
+            "external"
+        ]
+    );
+
+    let news = &form.choice_controls[0];
+    assert_eq!(news.control_type, "checkbox");
+    assert_eq!(news.labels, vec!["Newsletter"]);
+    assert_eq!(news.accessible_name.as_deref(), Some("Newsletter"));
+    assert_eq!(news.value.as_deref(), Some("yes"));
+    assert!(news.checked);
+    assert!(news.required);
+    assert!(news.group_required);
+    assert!(news.successful);
+    assert_eq!(news.submission_values, vec!["yes"]);
+    assert_eq!(news.group_checked_ids, vec!["news"]);
+    assert_eq!(news.group_checked_values, vec!["yes"]);
+    assert_eq!(news.validation_attributes, vec!["required"]);
+
+    let updates = &form.choice_controls[1];
+    assert_eq!(updates.control_type, "checkbox");
+    assert_eq!(updates.value.as_deref(), Some("on"));
+    assert!(!updates.checked);
+    assert!(!updates.successful);
+    assert!(updates.submission_values.is_empty());
+    assert!(updates.group_checked_ids.is_empty());
+    assert!(updates.group_checked_values.is_empty());
+
+    let plan_basic = &form.choice_controls[2];
+    assert_eq!(plan_basic.control_type, "radio");
+    assert_eq!(plan_basic.labels, vec!["Basic"]);
+    assert_eq!(plan_basic.group_name.as_deref(), Some("plan"));
+    assert!(plan_basic.checked);
+    assert!(plan_basic.required);
+    assert!(plan_basic.group_required);
+    assert_eq!(plan_basic.group_checked_ids, vec!["plan-basic"]);
+    assert_eq!(plan_basic.group_checked_values, vec!["basic"]);
+
+    let plan_pro = &form.choice_controls[3];
+    assert_eq!(plan_pro.control_type, "radio");
+    assert_eq!(plan_pro.group_name.as_deref(), Some("plan"));
+    assert!(!plan_pro.required);
+    assert!(plan_pro.group_required);
+    assert_eq!(plan_pro.group_checked_ids, vec!["plan-basic"]);
+    assert_eq!(plan_pro.group_checked_values, vec!["basic"]);
+
+    let legacy = &form.choice_controls[4];
+    assert_eq!(legacy.control_type, "radio");
+    assert!(legacy.checked);
+    assert!(legacy.disabled);
+    assert!(!legacy.successful);
+    assert_eq!(legacy.validation_barred_reason.as_deref(), Some("disabled"));
+    assert_eq!(legacy.group_checked_values, vec!["old"]);
+
+    let external = &form.choice_controls[5];
+    assert_eq!(external.form_owner.as_deref(), Some("prefs"));
+    assert_eq!(external.group_name.as_deref(), Some("plan"));
+    assert_eq!(external.group_checked_ids, vec!["plan-basic"]);
+    assert_eq!(external.group_checked_values, vec!["basic"]);
 }
 
 #[test]
@@ -2616,6 +2749,11 @@ impl ExpectedForm {
                 .into_iter()
                 .map(ExpectedFormTextEntry::into_browser_form_text_entry)
                 .collect(),
+            choice_controls: self
+                .choice_controls
+                .into_iter()
+                .map(ExpectedFormChoiceControl::into_browser_form_choice_control)
+                .collect(),
             controls: self
                 .controls
                 .into_iter()
@@ -2786,6 +2924,32 @@ impl ExpectedFormTextEntry {
             will_validate: self.will_validate,
             validation_attributes: self.validation_attributes,
             validation_barred_reason: self.validation_barred_reason,
+        }
+    }
+}
+
+impl ExpectedFormChoiceControl {
+    fn into_browser_form_choice_control(self) -> BrowserFormChoiceControl {
+        BrowserFormChoiceControl {
+            id: self.id,
+            control_type: self.control_type,
+            name: self.name,
+            form_owner: self.form_owner,
+            labels: self.labels,
+            accessible_name: self.accessible_name,
+            value: self.value,
+            checked: self.checked,
+            disabled: self.disabled,
+            required: self.required,
+            group_required: self.group_required,
+            successful: self.successful,
+            submission_values: self.submission_values,
+            will_validate: self.will_validate,
+            validation_attributes: self.validation_attributes,
+            validation_barred_reason: self.validation_barred_reason,
+            group_name: self.group_name,
+            group_checked_ids: self.group_checked_ids,
+            group_checked_values: self.group_checked_values,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -101,6 +101,9 @@
               { "control_type": "text", "name": "disabled", "value": "no", "text": "", "disabled": true, "validation_barred_reason": "disabled" },
               { "control_type": "textarea", "name": "notes", "value": "Line one Line two", "text": "Line one Line two", "disabled": false, "will_validate": true }
             ],
+            "choice_controls": [
+              { "control_type": "checkbox", "name": "in_stock", "value": "yes", "checked": true, "disabled": false, "successful": true, "submission_values": ["yes"], "will_validate": true, "group_name": "in_stock", "group_checked_values": ["yes"] }
+            ],
             "controls": [
               { "control_type": "text", "name": "q", "value": "rust html", "successful": true, "submission_values": ["rust html"], "disabled": false, "will_validate": true, "checked": false, "text": "", "options": [] },
               { "control_type": "hidden", "name": "page", "value": "1", "successful": true, "submission_values": ["1"], "disabled": false, "validation_barred_reason": "input-type-hidden", "checked": false, "text": "", "options": [] },
@@ -264,6 +267,9 @@
               { "id": "count", "control_type": "number", "name": "count", "labels": ["Count"], "accessible_name": "Count", "value": "2", "text": "", "min": "1", "max": "10", "step": "0.5", "disabled": false, "required": true, "will_validate": true, "validation_attributes": ["required", "min", "max", "step"] },
               { "id": "notes", "control_type": "textarea", "name": "notes", "labels": ["NotesKeep me"], "accessible_name": "NotesKeep me", "placeholder": "Details", "value": "Keep me", "text": "Keep me", "autocapitalize": "sentences", "enterkeyhint": "done", "dirname": "notes.dir", "spellcheck": "true", "autocorrect": "on", "maxlength": "500", "rows": "4", "cols": "40", "wrap": "hard", "disabled": false, "readonly": true, "validation_attributes": ["readonly", "maxlength"], "validation_barred_reason": "readonly" },
               { "id": "external", "control_type": "text", "name": "outside", "form_owner": "search", "accessible_name": "Outside", "placeholder": "Outside", "value": null, "text": "", "disabled": false, "will_validate": true }
+            ],
+            "choice_controls": [
+              { "id": "fast", "control_type": "checkbox", "name": "fast", "labels": ["Fast"], "accessible_name": "Fast", "value": "on", "checked": true, "disabled": true, "validation_barred_reason": "disabled", "group_name": "fast", "group_checked_ids": ["fast"], "group_checked_values": ["on"] }
             ],
             "controls": [
               { "id": "q", "control_type": "text", "name": "q", "labels": ["Query"], "accessible_name": "Query", "accessible_description": "Query", "placeholder": "Search terms", "autocomplete": "section-primary shipping search", "autocomplete_tokens": ["section-primary", "shipping", "search"], "autocapitalize": "words", "enterkeyhint": "search", "dirname": "q.dir", "spellcheck": "false", "autocorrect": "off", "inputmode": "search", "pattern": "[A-Za-z ]+", "minlength": "2", "maxlength": "80", "size": "40", "list": "query-suggestions", "datalist_options": ["Rust", "HTML", "Browser APIs"], "value": null, "successful": true, "submission_values": [""], "autofocus": true, "disabled": false, "required": true, "will_validate": true, "validation_attributes": ["required", "pattern", "minlength", "maxlength"], "checked": false, "text": "", "options": [] },


### PR DESCRIPTION
## Summary
- add BrowserFormChoiceControl descriptors for checkbox and radio controls
- expose checked/default value, labels, submission, validation, and same-form group state
- update browser readiness fixture expectations and targeted coverage for checkbox/radio groups, disabled fieldsets, and external form-owned radios

## Validation
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- cargo test -p coding-adventures-html-parser browser_form_choice_descriptor_metadata_tracks_checkbox_radio_state_and_groups
- cargo test -p coding-adventures-html-parser browser_form_
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser