### PR TITLE
feat(iir-to-armv7): label + jmp + jmp_if_true/false via Bcond — A3++.5.5 fifth slice

### DIFF
--- a/code/packages/rust/iir-to-armv7/CHANGELOG.md
+++ b/code/packages/rust/iir-to-armv7/CHANGELOG.md
@@ -3,6 +3,97 @@
 All notable changes to this crate are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.5] — 2026-06-02 (A3++.5.5 fifth slice — `label` + `jmp` + `jmp_if_true`/`jmp_if_false`)
+
+### Added — control flow via Bcond + two-pass backpatching
+
+Wires the first control-flow primitives.  Four new IIR ops:
+
+| IIR op | A32 lowering |
+|--------|--------------|
+| `label "<name>"` | zero words; records `(name → current_word_index)` |
+| `jmp "<name>"` | `B target` (1 word; cond = AL = `0xEA00_0000`) |
+| `jmp_if_true cond, "<name>"` | `CMP cond_reg, #0; BNE target` (2 words) |
+| `jmp_if_false cond, "<name>"` | `CMP cond_reg, #0; BEQ target` (2 words) |
+
+#### Why the CMP + Bcond pattern for boolean branches?
+
+ARMv7 has no branch-on-register.  But unlike the 8008 (which needed
+ANA A as the TEST idiom), ARMv7 ships a dedicated **CMP Rn, #0**
+form on the data-processing-immediate family — it sets the Z flag
+from `Rn - 0 == 0` and discards the difference.  Pair it with BNE
+(branch if Z clear) or BEQ (branch if Z set) and you've got
+2-word boolean branches.
+
+#### Two-pass backpatching, ARMv7-style
+
+ARMv7's B carries a **24-bit signed PC-relative offset in WORDS**
+(the silicon shifts left 2 to get bytes).  Pass 1 emits each branch
+with a placeholder 0 offset and records `(slot, target_label,
+cond_base)` in `pending_branches`.  Pass 2 computes:
+
+```rust
+imm24 = target_word_index - slot - 2
+```
+
+The `- 2` accounts for ARM's classic 2-stage pipeline prefetch:
+at execute time PC = current_instruction_address + 8 bytes = +2 words.
+The branch silicon then computes `target = current + 8 + imm24*4`,
+giving us back the intended target word index.
+
+Range check: imm24 must fit in signed 24 bits (±2^23 words = ±32 MiB
+of code).  Practical functions are far below this; the
+`BranchOutOfRange` error variant is forward-compat with much larger
+modules.
+
+#### New constants
+
+* `pub const B_BASE: u32 = 0xEA00_0000;` — B with cond=AL
+* `pub const B_NE_BASE: u32 = 0x1A00_0000;` — BNE
+* `pub const B_EQ_BASE: u32 = 0x0A00_0000;` — BEQ
+* `pub const CMP_IMM_ZERO_BASE: u32 = 0xE350_0000;` — CMP Rn, #0
+
+The condition nibble pattern continues from v0.4.4: each
+conditional branch base is just `(cond << 28) | 0x0A00_0000`.
+
+#### New encoder helpers
+
+* `encode_cmp_imm_zero(rn: u8) -> u32`
+* `encode_branch(cond_base: u32, imm24: i32) -> u32` — masks the
+  signed 24-bit imm and ORs it with the base.
+
+#### New error variants
+
+* `IIRArmv7Error::UndefinedLabel { function, label }`
+* `IIRArmv7Error::BranchOutOfRange { function, target, current }`
+
+#### Tests added (61 total, was 51)
+
+* 4 constant-pinning tests (`B_BASE`, `B_NE_BASE`, `B_EQ_BASE`,
+  `CMP_IMM_ZERO_BASE`).
+* `jmp_to_forward_label_backpatches_correct_offset` — pinned
+  `B target = 0xEA00_0000 | 0` for a forward jump to imm24=0.
+* `jmp_to_backward_label_emits_negative_offset` — pinned
+  `0xEAFFFFFD` for an imm24 of -3 (showing the two's-complement
+  24-bit masking).
+* `jmp_to_undefined_label_is_rejected` — confirms the
+  `UndefinedLabel` error path.
+* `jmp_if_true_emits_cmp_zero_then_bne` — pinned
+  `0xE3A0_0001 / 0xE350_0000 / 0x1A00_0000 / 0xE3A0_1000 / BX_LR`.
+* `jmp_if_false_emits_cmp_zero_then_beq` — same shape with
+  `0x0A00_0000` (BEQ).
+* `errors_for_branch_variants_display_without_panic`.
+
+### What is NOT in v0.4.5 (deferred to v0.4.6 / A3++.6 / A3+++)
+
+* `call <fn_name>` — `BL` instruction (B with link, opcode 1
+  instead of 0) + return-value-from-r0 capture.
+* `ret` for non-entry functions emits BX LR — that already works
+  from v0.3.0.  Real RET via the AAPCS frame-pointer dance lands
+  in A3++.6.
+* Stack spilling once the 13-register pool exhausts.
+* `lang-aot --emit=armv7` wiring — A3+++ (v0.5.0).
+
 ## [0.4.4] — 2026-06-02 (A3++.5.5 fourth slice — `cmp_ne`/`cmp_lt`/`cmp_gt`/`cmp_gte`/`cmp_lte` via condition prefixes)
 
 ### Added — full boolean comparison family

--- a/code/packages/rust/iir-to-armv7/Cargo.toml
+++ b/code/packages/rust/iir-to-armv7/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iir-to-armv7"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2021"
-description = "IIR → ARMv7 (A32) machine code backend — lowers IIRModule to a Vec<u32> of encoded 32-bit ARMv7-A instructions.  v0.4.4 (A3++.5.5 fourth slice): completes the boolean comparison family with `cmp_ne` (NE = 0x13A0..), `cmp_lt` (CC = 0x33A0..), `cmp_gt` (HI = 0x83A0..), `cmp_gte` (CS = 0x23A0..), `cmp_lte` (LS = 0x93A0..).  All six comparisons share the CMP + MOV + MOV<cond> capture skeleton; only the trailing MOV's condition prefix nibble changes.  ARMv7's HI condition handles unsigned > natively — no operand-swap trick like 8008/RV32I.  A new `encode_mov_imm_cond(base, rd, imm8)` helper avoids cluttering the API with 6 nearly-identical encoders."
+description = "IIR → ARMv7 (A32) machine code backend — lowers IIRModule to a Vec<u32> of encoded 32-bit ARMv7-A instructions.  v0.4.5 (A3++.5.5 fifth slice): adds control flow via `label`, `jmp` (B with cond=AL = 0xEA00_0000), `jmp_if_true` (CMP rn,#0 + BNE 0x1A00_0000), `jmp_if_false` (CMP + BEQ 0x0A00_0000).  Per-function two-pass backpatching mirrors the 8008's v0.3.4.  ARMv7 branches carry a 24-bit signed PC-relative offset in WORDS — silicon shifts left 2 to bytes and adds the +8 PC prefetch quirk.  New errors: UndefinedLabel and BranchOutOfRange."
 
 [lib]
 name = "iir_to_armv7"

--- a/code/packages/rust/iir-to-armv7/src/lib.rs
+++ b/code/packages/rust/iir-to-armv7/src/lib.rs
@@ -479,6 +479,81 @@ pub(crate) fn encode_mov_imm_cond(cond_base: u32, rd: u8, imm8: u8) -> u32 {
     cond_base | ((rd as u32) << 12) | (imm8 as u32)
 }
 
+/// ARMv7-A `B addr` (unconditional branch) base — `0xEA00_0000`.
+///
+/// Bit layout (cond=AL):
+///
+/// ```text
+/// 31..28  cond     = 0xE = 1110            (always — unconditional)
+/// 27..25           = 101                    (branch family)
+/// 24               = 0                      (B; 1 = BL with link)
+/// 23.. 0  imm24    = (signed PC-relative offset in WORDS)
+/// ```
+///
+/// At execute time the PC reads `instruction_address + 8` (the
+/// classic ARM 2-stage pipeline prefetch offset).  So for a branch
+/// at byte offset `A` targeting byte offset `T`:
+///
+/// ```text
+/// imm24 = (T - A - 8) / 4    ; sign-extended 24 bits
+/// ```
+///
+/// OR this base with `imm24 & 0x00FF_FFFF` to form the full word.
+pub const B_BASE: u32 = 0xEA00_0000;
+
+/// ARMv7-A `BNE addr` (branch if Z flag CLEAR) base — `0x1A00_0000`.
+///
+/// Same shape as `B_BASE` but with cond = NE = `0001`.  After
+/// CMP/TST that sets the Z flag, BNE branches when the comparison
+/// was non-equal / non-zero — which `jmp_if_true cond_var, label`
+/// lowers to after CMP cond_var, #0.
+pub const B_NE_BASE: u32 = 0x1A00_0000;
+
+/// ARMv7-A `BEQ addr` (branch if Z flag SET) base — `0x0A00_0000`.
+///
+/// Same shape as `B_BASE` but with cond = EQ = `0000`.  Pairs with
+/// `jmp_if_false cond_var, label` after CMP cond_var, #0.
+pub const B_EQ_BASE: u32 = 0x0A00_0000;
+
+/// ARMv7-A `CMP Rn, #0` base — `0xE350_0000`.
+///
+/// Data-processing-immediate form of CMP.  Compares `Rn` against the
+/// 8-bit immediate `0` and sets Z if equal (i.e. Rn == 0).  The
+/// canonical "test whether a boolean register is zero" idiom.
+///
+/// Bit layout (cond=AL, S=1, Rn=0, imm=0):
+///
+/// ```text
+/// 31..28  cond     = 0xE = 1110            (always — unconditional)
+/// 27..25           = 001                    (data-processing immediate)
+/// 24..21  opcode   = 1010                   (CMP)
+/// 20      S        = 1                      (CMP always sets flags)
+/// 19..16  Rn       = (in this base, 0)     (the register to compare)
+/// 15..12           = 0000                   (Rd unused for CMP)
+/// 11.. 8  rotate   = 0000
+///  7.. 0  imm8     = 0                      (we compare against 0)
+/// ```
+///
+/// For `CMP Rn, #0`: OR in `(Rn << 16)`.
+pub const CMP_IMM_ZERO_BASE: u32 = 0xE350_0000;
+
+/// Encode an ARMv7-A `CMP Rn, #0` instruction.
+pub(crate) fn encode_cmp_imm_zero(rn: u8) -> u32 {
+    debug_assert!(rn <= 15, "rn out of 4-bit range: {rn}");
+    CMP_IMM_ZERO_BASE | ((rn as u32) << 16)
+}
+
+/// Encode an ARMv7-A branch instruction (`B`/`BEQ`/`BNE`/...).
+///
+/// `cond_base` is one of `B_BASE`/`B_EQ_BASE`/`B_NE_BASE`/...  The
+/// `imm24` argument is the signed 24-bit word offset; the encoder
+/// masks it to 24 bits and ORs it with the base.  Range check is
+/// the caller's responsibility — `lower_iir_to_armv7` returns
+/// `BranchOutOfRange` if the offset doesn't fit.
+pub(crate) fn encode_branch(cond_base: u32, imm24: i32) -> u32 {
+    cond_base | ((imm24 as u32) & 0x00FF_FFFF)
+}
+
 // ===========================================================================
 // IIRArmv7Config
 // ===========================================================================
@@ -535,6 +610,13 @@ pub enum IIRArmv7Error {
     /// lands in a future increment (A3++.5 or later).  r13 (sp),
     /// r14 (lr), and r15 (pc) are not part of the pool.
     OutOfRegisters { function: String, name: String },
+    /// A `jmp`/`jmp_if_*` referenced a label name not defined in
+    /// the same function.
+    UndefinedLabel { function: String, label: String },
+    /// A computed branch offset doesn't fit in ARM's signed 24-bit
+    /// immediate (range ±32 MiB, more than enough for any practical
+    /// function).
+    BranchOutOfRange { function: String, target: usize, current: usize },
 }
 
 impl fmt::Display for IIRArmv7Error {
@@ -557,6 +639,12 @@ impl fmt::Display for IIRArmv7Error {
             }
             Self::OutOfRegisters { function, name } => {
                 write!(f, "out of ARMv7 registers (r0..r12) while binding {name:?} in function {function:?}; stack spilling not yet supported")
+            }
+            Self::UndefinedLabel { function, label } => {
+                write!(f, "undefined label {label:?} referenced by jmp/jmp_if in function {function:?}")
+            }
+            Self::BranchOutOfRange { function, target, current } => {
+                write!(f, "branch in function {function:?} from word offset {current} to word offset {target} doesn't fit in ARM's signed 24-bit imm")
             }
         }
     }
@@ -625,6 +713,9 @@ const SUPPORTED_OPS: &[&str] = &[
     // A3++.5.5 fourth slice — remaining 5 comparison ops using
     // distinct condition prefixes on the trailing MOV.
     "cmp_ne", "cmp_lt", "cmp_gt", "cmp_gte", "cmp_lte",
+    // A3++.5.5 fifth slice — labels + branches.  Two-pass per-function
+    // backpatching for PC-relative offsets.
+    "label", "jmp", "jmp_if_true", "jmp_if_false",
 ];
 
 /// Lower an [`IIRModule`] to a `Vec<u32>` of ARMv7 (A32) opcode words.
@@ -675,6 +766,24 @@ pub fn lower_iir_to_armv7(
         // shape as v0.2.0 (no redundant `MOV r0, X` round-trip).
         let mut env: HashMap<String, u8> = HashMap::new();
         let mut next_reg: usize = 0;
+
+        // ── Per-function label-resolution state (v0.4.5) ──────────────
+        //
+        // ARMv7's branch instructions carry a 24-bit signed PC-relative
+        // offset (in words; the silicon shifts left 2 to convert to
+        // bytes).  Pass 1 emits each branch with a placeholder zero
+        // offset and records `(word_index_of_branch, target_label,
+        // cond_base)` in `pending_branches`.  After all instructions in
+        // the function are emitted, pass 2 looks up each pending
+        // branch's label in `labels`, computes the PC-relative offset
+        // (accounting for ARM's +8 PC prefetch quirk), range-checks it
+        // against signed 24-bit, and ORs it into the placeholder word.
+        //
+        // Labels are keyed by name → word index (not byte index — every
+        // A32 instruction is a fixed 4 bytes, and the branch offset is
+        // already in word units).
+        let mut labels: HashMap<String, usize> = HashMap::new();
+        let mut pending_branches: Vec<(usize, String, u32)> = Vec::new();
 
         for instr in &f.instructions {
             if !SUPPORTED_OPS.contains(&instr.op.as_str()) {
@@ -852,8 +961,100 @@ pub fn lower_iir_to_armv7(
                     words.push(word);
                 }
 
+                // ── label "<name>": record current word index ──────────
+                "label" => {
+                    let name = match instr.srcs.first() {
+                        Some(Operand::Var(s)) => s.clone(),
+                        _ => return Err(IIRArmv7Error::InvalidOperand {
+                            function: f.name.clone(),
+                            detail: "label requires srcs[0] = Operand::Var(name)".into(),
+                        }),
+                    };
+                    labels.insert(name, words.len());
+                }
+
+                // ── jmp "<name>": B with cond=AL ───────────────────────
+                "jmp" => {
+                    let target = match instr.srcs.first() {
+                        Some(Operand::Var(s)) => s.clone(),
+                        _ => return Err(IIRArmv7Error::InvalidOperand {
+                            function: f.name.clone(),
+                            detail: "jmp requires srcs[0] = Operand::Var(target_label)".into(),
+                        }),
+                    };
+                    pending_branches.push((words.len(), target, B_BASE));
+                    words.push(0); // placeholder — pass 2 overwrites
+                }
+
+                // ── jmp_if_true / jmp_if_false ─────────────────────────
+                //
+                // ARMv7 has no "branch on register"; we provoke the Z
+                // flag via `CMP cond_reg, #0` and use BNE / BEQ:
+                //
+                //   CMP   cond_reg, #0    ; sets Z if cond == 0
+                //   BNE   target          ; jmp_if_true  — branch if cond != 0
+                //   BEQ   target          ; jmp_if_false — branch if cond == 0
+                //
+                // The CMP-imm-zero idiom is one word; the conditional
+                // branch is another.  2 words total — neat parallel to
+                // the 8008's MOV A, r; ANA A; JFZ/JTZ sequence.
+                "jmp_if_true" | "jmp_if_false" => {
+                    let cond_name = match instr.srcs.first() {
+                        Some(Operand::Var(s)) => s.clone(),
+                        _ => return Err(IIRArmv7Error::InvalidOperand {
+                            function: f.name.clone(),
+                            detail: format!("{} requires srcs[0] = Operand::Var(cond)", instr.op),
+                        }),
+                    };
+                    let target = match instr.srcs.get(1) {
+                        Some(Operand::Var(s)) => s.clone(),
+                        _ => return Err(IIRArmv7Error::InvalidOperand {
+                            function: f.name.clone(),
+                            detail: format!("{} requires srcs[1] = Operand::Var(target_label)", instr.op),
+                        }),
+                    };
+                    let cond_reg = lookup_register(&env, &cond_name, &f.name)?;
+                    words.push(encode_cmp_imm_zero(cond_reg));
+                    let branch_base = if instr.op == "jmp_if_true" {
+                        B_NE_BASE
+                    } else {
+                        B_EQ_BASE
+                    };
+                    pending_branches.push((words.len(), target, branch_base));
+                    words.push(0); // placeholder
+                }
+
                 _ => unreachable!("SUPPORTED_OPS guard above prevents this"),
             }
+        }
+
+        // ── Pass 2: backpatch pending branches ─────────────────────────
+        //
+        // For each pending entry (slot, target_label, cond_base):
+        //   1. Resolve target_label → target_word_index via `labels`.
+        //   2. Compute the signed 24-bit word offset:
+        //        imm24 = target - slot - 2
+        //      (the `- 2` accounts for ARM's PC = current_instruction + 8
+        //      = current_instruction + 2 words; the branch's "current"
+        //      address is `slot * 4` bytes, and the silicon adds 8.)
+        //   3. Range-check imm24 against signed 24-bit (±2^23 words).
+        //   4. OR the encoded imm24 into the placeholder word.
+        for (slot, label, cond_base) in &pending_branches {
+            let target = *labels.get(label).ok_or_else(|| {
+                IIRArmv7Error::UndefinedLabel {
+                    function: f.name.clone(),
+                    label: label.clone(),
+                }
+            })?;
+            let imm24: i32 = (target as i32) - (*slot as i32) - 2;
+            if !(-(1 << 23)..(1 << 23)).contains(&imm24) {
+                return Err(IIRArmv7Error::BranchOutOfRange {
+                    function: f.name.clone(),
+                    target,
+                    current: *slot,
+                });
+            }
+            words[*slot] = encode_branch(*cond_base, imm24);
         }
     }
 

--- a/code/packages/rust/iir-to-armv7/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-armv7/tests/test_backend.rs
@@ -7,8 +7,8 @@ use interpreter_ir::{IIRFunction, IIRInstr, IIRModule, Operand};
 use iir_to_armv7::{
     lower_iir_to_armv7, validate_for_armv7,
     IIRArmv7Config, IIRArmv7Error,
-    ADC_REG_BASE, ADD_REG_BASE, AND_REG_BASE, BKPT, BX_LR, CMP_REG_BASE,
-    EOR_REG_BASE,
+    ADC_REG_BASE, ADD_REG_BASE, AND_REG_BASE, B_BASE, B_EQ_BASE, B_NE_BASE,
+    BKPT, BX_LR, CMP_IMM_ZERO_BASE, CMP_REG_BASE, EOR_REG_BASE,
     MOV_IMM_CC_BASE, MOV_IMM_CS_BASE, MOV_IMM_EQ_BASE, MOV_IMM_HI_BASE,
     MOV_IMM_LS_BASE, MOV_IMM_NE_BASE, MOV_IMM_R0_BASE, MOV_REG_BASE,
     ORR_REG_BASE, SBC_REG_BASE, SUB_REG_BASE,
@@ -851,6 +851,184 @@ fn cmp_gte_uses_movcs_for_set_true() {
 fn cmp_lte_uses_movls_for_set_true() {
     // MOVLS r2, #1 = 0x93A0_0000 | (2<<12) | 1 = 0x93A0_2001
     assert_cmp_variant("cmp_lte", 0x93A0_2001);
+}
+
+// ===========================================================================
+// 12. A3++.5.5 fifth slice — branches (`label` + `jmp` + `jmp_if_*`)
+// ===========================================================================
+//
+// ARMv7's B instruction carries a 24-bit signed PC-relative offset
+// in WORDS (shifted left 2 to convert to bytes by the silicon).
+// PC at execute time = current_instruction_address + 8 (the classic
+// ARM 2-stage pipeline prefetch offset).
+//
+// For a branch at word index `S` targeting word index `T`:
+//   imm24 = T - S - 2     (the -2 = 8 bytes / 4 = 2 words for the
+//                          PC prefetch quirk)
+//
+// The boolean-branch idiom adds a CMP cond_reg, #0 in front to
+// provoke the Z flag from the cond register, then uses BNE/BEQ.
+
+#[test]
+fn b_base_pinned_to_0xea000000() {
+    assert_eq!(B_BASE, 0xEA00_0000,
+        "B (cond=AL) base should be 0xEA000000; got 0x{:08x}", B_BASE);
+}
+
+#[test]
+fn b_ne_base_pinned_to_0x1a000000() {
+    assert_eq!(B_NE_BASE, 0x1A00_0000);
+}
+
+#[test]
+fn b_eq_base_pinned_to_0x0a000000() {
+    assert_eq!(B_EQ_BASE, 0x0A00_0000);
+}
+
+#[test]
+fn cmp_imm_zero_base_pinned_to_0xe3500000() {
+    assert_eq!(CMP_IMM_ZERO_BASE, 0xE350_0000,
+        "CMP Rn, #0 base should be 0xE3500000; got 0x{:08x}", CMP_IMM_ZERO_BASE);
+}
+
+#[test]
+fn jmp_to_forward_label_backpatches_correct_offset() {
+    // const v=42; jmp end; const w=99; label end; ret v
+    //
+    // Layout (word indices):
+    //   0: MOV r0, #42       (3E A0 002A — wait, 0xE3A0_002A)
+    //   1: B end             (0xEA00_???? — backpatched)
+    //   2: MOV r1, #99       (0xE3A0_1063)
+    //   <-- label "end" at word index 3 -->
+    //   3: BX LR             (0xE12F_FF1E)
+    //
+    // For B at slot 1 targeting word index 3:
+    //   imm24 = 3 - 1 - 2 = 0
+    // So the B word = 0xEA00_0000 | 0 = 0xEA00_0000.
+    let f = IIRFunction::new("fwd", vec![], "u8", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(42)], "u8"),
+        IIRInstr::new("jmp",   None,             vec![Operand::Var("end".into())], "void"),
+        IIRInstr::new("const", Some("w".into()), vec![Operand::Int(99)], "u8"),
+        IIRInstr::new("label", None,             vec![Operand::Var("end".into())], "void"),
+        IIRInstr::new("ret",   None,             vec![Operand::Var("v".into())], "u8"),
+    ]);
+    let words = lower_iir_to_armv7(&module_with(f), &IIRArmv7Config::default())
+        .expect("lowering");
+    assert_eq!(words, vec![
+        0xE3A0_002A,    // 0: MOV r0, #42  (v)
+        B_BASE | 0,     // 1: B 0 (target = current + 8 = +0 words past prefetch)
+        0xE3A0_1063,    // 2: MOV r1, #99 (w, unreachable)
+        // label "end" at word index 3
+        BX_LR,          // 3: BX LR (ret v — v is already in r0)
+    ], "forward jmp expected; got: {words:08x?}");
+}
+
+#[test]
+fn jmp_to_backward_label_emits_negative_offset() {
+    // label loop; const v=1; jmp loop; ret_void
+    //
+    //   <-- label "loop" at word index 0 -->
+    //   0: MOV r0, #1
+    //   1: B loop  (target = 0; imm24 = 0 - 1 - 2 = -3)
+    //   2: BX LR
+    //
+    // imm24 = -3 = 0xFFFFFD in signed 24-bit.  Masked to 24 bits and
+    // OR'd into B_BASE: 0xEA00_0000 | 0xFFFFFD = 0xEAFFFFFD.
+    let f = IIRFunction::new("backward", vec![], "void", vec![
+        IIRInstr::new("label", None,             vec![Operand::Var("loop".into())], "void"),
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(1)], "u8"),
+        IIRInstr::new("jmp",   None,             vec![Operand::Var("loop".into())], "void"),
+        IIRInstr::new("ret_void", None,          vec![], "void"),
+    ]);
+    let words = lower_iir_to_armv7(&module_with(f), &IIRArmv7Config::default())
+        .expect("lowering");
+    assert_eq!(words, vec![
+        0xE3A0_0001,    // 0: MOV r0, #1
+        0xEAFF_FFFD,    // 1: B loop (imm24 = -3)
+        BX_LR,          // 2: BX LR
+    ], "backward jmp expected; got: {words:08x?}");
+}
+
+#[test]
+fn jmp_to_undefined_label_is_rejected() {
+    let f = IIRFunction::new("dangling", vec![], "void", vec![
+        IIRInstr::new("jmp", None, vec![Operand::Var("nowhere".into())], "void"),
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ]);
+    let err = lower_iir_to_armv7(&module_with(f), &IIRArmv7Config::default())
+        .expect_err("jmp to nonexistent label should fail");
+    match err {
+        IIRArmv7Error::UndefinedLabel { function, label } => {
+            assert_eq!(function, "dangling");
+            assert_eq!(label, "nowhere");
+        }
+        other => panic!("expected UndefinedLabel, got: {other:?}"),
+    }
+}
+
+#[test]
+fn jmp_if_true_emits_cmp_zero_then_bne() {
+    // const cond=1; jmp_if_true cond, end; const x=0; label end; ret_void
+    //
+    //   0: MOV r0, #1         (cond → r0)
+    //   1: CMP r0, #0         (0xE350_0000 | (0<<16) = 0xE350_0000)
+    //   2: BNE end            (target = word 5; imm24 = 5-2-2 = 1)
+    //   3: MOV r1, #0         (x — unreachable)
+    //   <-- label end at word 4 -->
+    //   4: BX LR
+    //
+    // Wait, the count: words[0]=MOV r0, words[1]=CMP, words[2]=BNE, words[3]=MOV r1.
+    // Then label "end" at word index 4. Then BX LR at word 4.
+    // imm24 = target - slot - 2 = 4 - 2 - 2 = 0.
+    let f = IIRFunction::new("if_true", vec![], "void", vec![
+        IIRInstr::new("const", Some("cond".into()), vec![Operand::Int(1)], "bool"),
+        IIRInstr::new("jmp_if_true", None,
+            vec![Operand::Var("cond".into()), Operand::Var("end".into())], "void"),
+        IIRInstr::new("const", Some("x".into()), vec![Operand::Int(0)], "u8"),
+        IIRInstr::new("label", None, vec![Operand::Var("end".into())], "void"),
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ]);
+    let words = lower_iir_to_armv7(&module_with(f), &IIRArmv7Config::default())
+        .expect("lowering");
+    assert_eq!(words, vec![
+        0xE3A0_0001,    // 0: MOV r0, #1 (cond)
+        0xE350_0000,    // 1: CMP r0, #0
+        B_NE_BASE | 0,  // 2: BNE end (imm24 = 4 - 2 - 2 = 0)
+        0xE3A0_1000,    // 3: MOV r1, #0 (x — unreachable)
+        BX_LR,          // 4: BX LR
+    ], "jmp_if_true expected; got: {words:08x?}");
+}
+
+#[test]
+fn jmp_if_false_emits_cmp_zero_then_beq() {
+    // Same layout as jmp_if_true but with BEQ.
+    let f = IIRFunction::new("if_false", vec![], "void", vec![
+        IIRInstr::new("const", Some("cond".into()), vec![Operand::Int(0)], "bool"),
+        IIRInstr::new("jmp_if_false", None,
+            vec![Operand::Var("cond".into()), Operand::Var("end".into())], "void"),
+        IIRInstr::new("const", Some("x".into()), vec![Operand::Int(99)], "u8"),
+        IIRInstr::new("label", None, vec![Operand::Var("end".into())], "void"),
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ]);
+    let words = lower_iir_to_armv7(&module_with(f), &IIRArmv7Config::default())
+        .expect("lowering");
+    assert_eq!(words, vec![
+        0xE3A0_0000,    // 0: MOV r0, #0 (cond)
+        0xE350_0000,    // 1: CMP r0, #0
+        B_EQ_BASE | 0,  // 2: BEQ end
+        0xE3A0_1063,    // 3: MOV r1, #99 (unreachable)
+        BX_LR,          // 4: BX LR
+    ], "jmp_if_false expected; got: {words:08x?}");
+}
+
+#[test]
+fn errors_for_branch_variants_display_without_panic() {
+    let _ = format!("{}", IIRArmv7Error::UndefinedLabel {
+        function: "f".into(), label: "ghost".into(),
+    });
+    let _ = format!("{}", IIRArmv7Error::BranchOutOfRange {
+        function: "huge".into(), target: 10_000_000, current: 0,
+    });
 }
 
 #[test]

--- a/code/specs/iir-to-armv7.md
+++ b/code/specs/iir-to-armv7.md
@@ -74,7 +74,8 @@ IIRModule
 | v0.4.1 (A3++.5.5 first slice) | Bitwise DP-register ops `and` (AND `0xE000_0000`), `or` (ORR `0xE180_0000`), `xor` (EOR `0xE020_0000`) | **merged** |
 | v0.4.2 (A3++.5.5 second slice) | Carry-chained DP-register ops `adc` (`0xE0A0_0000`) and `sbb` (`0xE0C0_0000`) | **merged** |
 | v0.4.3 (A3++.5.5 third slice) | `cmp` equality with flag-to-bool capture via `MOVEQ` (`0x03A0_0000`) | **merged** |
-| **v0.4.4 (A3++.5.5 fourth slice — this PR)** | Full comparison family: `cmp_ne` (NE `0x13A0..`), `cmp_lt` (CC `0x33A0..`), `cmp_gt` (HI `0x83A0..` — handles unsigned > natively), `cmp_gte` (CS `0x23A0..`), `cmp_lte` (LS `0x93A0..`).  Shared `encode_mov_imm_cond(base, rd, imm8)` helper covers all six. | this PR |
+| v0.4.4 (A3++.5.5 fourth slice) | Full comparison family `cmp_ne`/`cmp_lt`/`cmp_gt`/`cmp_gte`/`cmp_lte` via condition prefixes | **merged** |
+| **v0.4.5 (A3++.5.5 fifth slice — this PR)** | Control flow: `label` + `jmp` (B `0xEA00_0000`) + `jmp_if_true` (CMP rn,#0 + BNE `0x1A00_0000`) + `jmp_if_false` (CMP + BEQ `0x0A00_0000`).  Per-function two-pass backpatching of 24-bit signed PC-relative word offsets (with the ARM +8 prefetch quirk). | this PR |
 | v0.3.x (A3++.5.5) | Comparisons + conditional branches via the cond-field on every A32 instruction (a stronger version of the 8008's flag-based jumps) | future |
 | v0.3.x (A3++.6) | Function calls via `bl` with PC-relative offsets + stack spilling | future |
 | v0.4.0 (A3+++) | `lang-aot --emit=armv7` wiring | future |


### PR DESCRIPTION
## Summary

Wires the first control-flow primitives with per-function two-pass backpatching (mirroring the 8008's v0.3.4):

| IIR op                | A32 lowering                              |
| --------------------- | ----------------------------------------- |
| \`label "<name>"\`      | zero words; records (name → word index)   |
| \`jmp "<name>"\`        | \`B target\` (1 word; cond=AL)            |
| \`jmp_if_true cond, L\` | \`CMP cond_reg, #0; BNE target\` (2 words) |
| \`jmp_if_false cond, L\`| \`CMP cond_reg, #0; BEQ target\` (2 words) |

### Why CMP + Bcond for boolean branches?

ARMv7 has no branch-on-register.  But unlike the 8008 (which needed \`ANA A\` as the TEST idiom), ARMv7 ships a dedicated **CMP Rn, #0** form on the data-processing-immediate family — sets Z from \`Rn - 0 == 0\` and discards the difference.  Pair it with BNE/BEQ and you've got **2-word boolean branches**.

### Two-pass backpatching, ARMv7-style

ARMv7's B carries a **24-bit signed PC-relative offset in WORDS** (silicon shifts left 2 to bytes).  Pass 1 emits each branch with a placeholder 0 offset; pass 2 computes:

\`\`\`text
imm24 = target_word_index - slot - 2
\`\`\`

The \`- 2\` accounts for ARM's classic 2-stage pipeline prefetch: at execute time PC = current_instruction + 8 bytes = +2 words.

### New public constants

- \`B_BASE = 0xEA00_0000\` (cond=AL)
- \`B_NE_BASE = 0x1A00_0000\` (cond=NE)
- \`B_EQ_BASE = 0x0A00_0000\` (cond=EQ)
- \`CMP_IMM_ZERO_BASE = 0xE350_0000\` (CMP Rn, #0)

The cond nibble pattern from v0.4.4 continues — each conditional branch base is just \`(cond << 28) | 0x0A00_0000\`.

### New error variants

- \`UndefinedLabel { function, label }\`
- \`BranchOutOfRange { function, target, current }\` (range ±32 MiB of code)

### Deferred to follow-up slices

- **A3++.6** — \`call <fn_name>\` via \`BL\` (B with link) + stack spilling
- **A3+++ (v0.5.0)** — \`lang-aot --emit=armv7\` wiring

## Test plan

- [x] \`cargo test -p iir-to-armv7\` — 61/61 backend tests pass, 1/1 doctest passes
- [x] All 4 new constants pinned
- [x] Forward jump pinned (\`B target = 0xEA00_0000 | 0\` for imm24=0)
- [x] Backward jump pinned (\`0xEAFFFFFD\` for imm24=-3 — two's-complement 24-bit masking)
- [x] Undefined label rejected
- [x] jmp_if_true / jmp_if_false sequences pinned with correct BNE/BEQ
- [x] Security review passed (no vulnerabilities found)
- [ ] CI green
- [ ] No merge conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)