### PR TITLE
feat(ml-framework-core-ts): v1.0.0 — benchmark + RubyGems polish (JS/TS pilot PR #5/5) 🎉

### DIFF
--- a/code/packages/typescript/ml-framework-core/CHANGELOG.md
+++ b/code/packages/typescript/ml-framework-core/CHANGELOG.md
@@ -2,6 +2,91 @@
 
 ## Unreleased
 
+### Added — v1.0.0: complete TypeScript ML framework on the Rust matrix-cpu engine
+
+PR #5 of 5 (FINAL) in the JS/TS pilot.  v1.0.0 marks the completion of
+the multi-PR plan: a PyTorch-shaped TypeScript ML framework with all 15
+ops (forward + backward), autograd engine, end-to-end MLP training, and
+a benchmark script for performance characterization.
+
+#### What v1.0.0 means
+
+The complete stack works:
+
+```ts
+import { Tensor } from "@coding-adventures/ml-framework-core";
+
+// Build a model
+let w1 = new Tensor([[0.5, -0.3]]); w1.requiresGrad = true;
+let w2 = new Tensor([[0.4], [0.7]]); w2.requiresGrad = true;
+
+// Train (loss drops 75%+ in 30 SGD steps on the test suite's data)
+for (let step = 0; step < 30; step++) {
+  const pred = x.matmul(w1).relu().matmul(w2);
+  const loss = pred.sub(target).mul(pred.sub(target)).mean();
+  loss.backward();
+  w1 = sgdStep(w1, 0.01);
+  w2 = sgdStep(w2, 0.01);
+}
+```
+
+All math is pure TypeScript for tensors under 10k cells.  At 10k+ cells
+the ops auto-dispatch through `@coding-adventures/matrix-rust-napi` to
+the Rust matrix-cpu executor (SIMD-accelerated f32).  No Rust toolchain
+is required to use the package at small/medium sizes.
+
+#### New in v1.0.0
+
+- **`scripts/benchmark.ts`** — performance characterization.  Runs
+  forward + backward on a 2-layer MLP at batch sizes 100, 1000, 5000,
+  10_000, 50_000 and prints a markdown table of median timings.
+  Gracefully handles the case where matrix-rust-napi isn't built
+  (skips Rust-only rows with a clear "Rust needed" label).  Run via
+  `npm run benchmark`.
+
+- **Package.json polish**:
+  - Tightened description to highlight v1.0.0 scope (15 ops, autograd,
+    auto-dispatch, end-to-end training verified)
+  - Added `tsx` as a devDependency for the benchmark script
+  - Added `"benchmark"` npm script
+
+- **README polish**: Quick-start section with the end-to-end MLP
+  example at the top; Benchmark section with example output table;
+  Test coverage section; "Future work" table.
+
+#### Layered architecture (now complete)
+
+```
+@coding-adventures/ml-framework-core (THIS PACKAGE, v1.0.0)
+  Tensor + autograd + 15 differentiable ops (forward + backward)
+  ↓ dispatch large tensors through ↓
+@coding-adventures/matrix-rust-napi (v0.4.0)
+  TypeScript wrapper for the Rust N-API addon
+  ↓
+matrix-rust-napi (Rust cdylib, v0.3.0)
+  Exposes runGraphOnCpu via N-API
+  ↓
+node-bridge (Rust workspace crate, v0.1.0)
+  Zero-dep N-API wrapper
+  ↓
+matrix-ir-json → matrix-ir → matrix-runtime → matrix-cpu
+```
+
+#### Test coverage (unchanged from v0.4.0 — all still passing)
+
+- `tests/tensor.test.ts`             61 tests
+- `tests/autograd.test.ts`           18 tests
+- `tests/ops.test.ts`                67 tests
+- `tests/end-to-end-training.test.ts` 2 tests
+- Total: 148 tests, 0 failures
+
+#### What's next (for the project, not the package)
+
+The user will pick the next language pilot — Lua, Go, or Swift.  The
+architecture pattern established by both the Ruby pilot (8 PRs) and
+this JS/TS pilot (5 PRs because the bottom three layers already
+existed) transfers directly.
+
 ### Added — v0.4.0: backward dispatch + end-to-end MLP training test
 
 PR #4 of 5 in the JS/TS pilot.  Adds `backward(outputGrad)` to all 15

--- a/code/packages/typescript/ml-framework-core/README.md
+++ b/code/packages/typescript/ml-framework-core/README.md
@@ -1,50 +1,85 @@
 # `@coding-adventures/ml-framework-core`
 
-Idiomatic TypeScript Tensor + autograd on top of the Rust matrix-cpu
-execution engine.  v0.1.0 ships the Tensor layer in pure TypeScript;
-autograd, op dispatch through Rust, and an end-to-end MLP land in
-PRs #2–#5.
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Node](https://img.shields.io/badge/Node-%3E%3D%2020-green)](https://nodejs.org/)
+[![TypeScript](https://img.shields.io/badge/TypeScript-%3E%3D%205-blue)](https://www.typescriptlang.org/)
+[![Tests](https://img.shields.io/badge/tests-148%20passing-brightgreen)]()
 
-## Install
+A small, PyTorch-shaped TypeScript ML library.  All 15 differentiable
+ops, full autograd, end-to-end MLP training — all in idiomatic
+TypeScript.  Tensors under 10k cells stay in pure TS; tensors above
+auto-dispatch through `@coding-adventures/matrix-rust-napi` to the Rust
+`matrix-cpu` executor for SIMD-accelerated f32 math.
 
-```bash
-npm install @coding-adventures/ml-framework-core
-```
-
-(Not yet published; in-repo path-resolution works today via the workspace.)
-
-## Quick start (v0.1.0)
+## Quick start
 
 ```ts
 import { Tensor } from "@coding-adventures/ml-framework-core";
 
+// A 2-layer MLP, no bias: 1 input → 2 hidden ReLU → 1 output
+let w1 = new Tensor([[0.5, -0.3]]); w1.requiresGrad = true;
+let w2 = new Tensor([[0.4], [0.7]]); w2.requiresGrad = true;
+
+// Synthetic data: regress y = 2x + 3 over 4 samples
+const x = new Tensor([[0], [1], [2], [3]]);
+const target = new Tensor([[3], [5], [7], [9]]);
+
+function sgdStep(p: Tensor, lr: number): Tensor {
+  const newData = p.toArray().map((v, i) => v - lr * p.grad!.toArray()[i]!);
+  const np = new Tensor(newData, { shape: p.shape.slice() });
+  np.requiresGrad = true;
+  return np;
+}
+
+for (let step = 0; step < 30; step++) {
+  const pred = x.matmul(w1).relu().matmul(w2);
+  const diff = pred.sub(target);
+  const loss = diff.mul(diff).mean();
+  loss.backward();
+  w1 = sgdStep(w1, 0.01);
+  w2 = sgdStep(w2, 0.01);
+}
+
+// Loss drops 75%+ from initial in 30 SGD steps.
+```
+
+That snippet runs in pure TypeScript today (no native addon required).
+The test suite exercises this exact training loop in
+`tests/end-to-end-training.test.ts`.
+
+## What's in the box
+
+### `Tensor`
+
+```ts
 // Construction
-const a = new Tensor([[1, 2, 3], [4, 5, 6]]);  // shape inferred → [2, 3]
-const b = new Tensor([1, 2, 3], { shape: [3] });
+new Tensor(nestedOrFlat, { shape?, dtype? })
 
 // Factories
-Tensor.zeros(2, 3);
-Tensor.ones(3);
-Tensor.full([2, 2], 7.5);
-Tensor.eye(3);                  // 3×3 identity
-Tensor.eye(2, 3);               // rectangular
-Tensor.arange(5);               // 0, 1, 2, 3, 4
-Tensor.arange(0, 10, 2);        // 0, 2, 4, 6, 8
-Tensor.randn([3, 4], 42);       // standard-normal with seed
+Tensor.zeros(2, 3);   Tensor.ones(3);    Tensor.full([2, 2], 7.5);
+Tensor.eye(3);        Tensor.eye(2, 3);   // rectangular
+Tensor.arange(5);     Tensor.arange(0, 10, 2);   Tensor.arange(5, 0, -1);
+Tensor.randn([3, 4], 42);                  // standard-normal with seed
 Tensor.fromArray([[1, 2], [3, 4]]);
+Tensor.onesLike(t);   Tensor.zerosLike(t);
 
 // Shape ops
-a.reshape([3, 2]);
-a.transpose();                  // 2-D only in v0.1
-a.flatten();
-a.squeeze();
-a.unsqueeze(0);
+t.reshape([3, 2]);   t.transpose();   t.flatten();
+t.squeeze();         t.unsqueeze(0);
 
-// Element-wise math (TypeScript has no operator overloading;
-// chain methods instead — PyTorch-from-JS convention)
+// Element-wise math methods (TypeScript has no operator overloading)
 a.add(b)   a.sub(b)   a.mul(b)   a.div(b)
 a.pow(2)   a.neg()
-a.add(5)                        // scalar broadcasts
+a.add(5)                                   // scalar broadcasts
+
+// Named ops
+a.matmul(b)
+a.relu()   a.sigmoid()   a.tanh()   a.gelu()   a.softmax()
+a.sum()    a.mean()      a.abs()
+
+// Autograd
+x.requiresGrad = true;
+y.backward(grad?);
 
 // Introspection
 a.shape;        // → [2, 3]
@@ -57,16 +92,119 @@ a.equals(b);    // structural element-wise equality
 a.equalsClose(b, 1e-6);
 ```
 
-## What's intentionally NOT in v0.1.0
+### `Function` (autograd)
 
-| Feature                | Lands in | Why deferred                              |
-|------------------------|----------|-------------------------------------------|
-| Autograd (`backward`)  | PR #2    | Needs its own focused PR                  |
-| Rust dispatch          | PR #3    | Needs autograd graph first                |
-| Broadcasting           | PR #3    | Couples Tensor to shape algebra           |
-| Indexing/slicing       | post-#5  | 50+ lines of arg-shape handling           |
-| Reductions (sum/mean)  | PR #3    | These become Function subclasses          |
-| Higher-rank transpose  | post-#5  | Generic strided index math not needed yet |
+```ts
+// Define a new differentiable op:
+import { Function, Tensor } from "@coding-adventures/ml-framework-core";
+
+class MyOp extends Function {
+  forward(...inputs: unknown[]): Tensor {
+    const x = inputs[0] as Tensor;
+    this.savedForBackward.x = x;
+    // ... return a Tensor ...
+  }
+
+  backward(grad: Tensor): (Tensor | null)[] {
+    const x = this.savedForBackward.x as Tensor;
+    // ... return [Tensor or null per parent] ...
+  }
+}
+
+// Use it:
+const y = MyOp.apply(x);
+y.backward();
+// x.grad now populated.
+```
+
+## Op dispatch matrix
+
+| Op       | Rust dispatch (≥10k cells)? | Notes                            |
+|----------|-----------------------------|----------------------------------|
+| Add/Sub  | yes                         | Elementwise                      |
+| Mul/Div  | yes                         | Elementwise                      |
+| Neg/Abs  | yes                         | Elementwise                      |
+| Tanh     | yes                         | Elementwise activation           |
+| MatMul   | yes (2-D only)              | (m,k) @ (k,n) → (m,n)            |
+| Sum/Mean | yes (reduce-all)            | Output shape `[1]`               |
+| Pow      | pure TS                     | Scalar exponent                  |
+| ReLU     | pure TS                     | Would use Max + zero-tensor const|
+| Sigmoid  | pure TS                     | 4-op multi-graph                 |
+| GELU     | pure TS                     | Large multi-op graph             |
+| Softmax  | pure TS                     | Multi-op; numerically stable     |
+
+## Installation
+
+```bash
+npm install @coding-adventures/ml-framework-core
+```
+
+The package itself is pure TypeScript.  To enable Rust dispatch above
+the 10k-cell threshold, also install
+`@coding-adventures/matrix-rust-napi` (ships an N-API addon built from
+the workspace Rust crate).
+
+## Benchmark
+
+```bash
+cd code/packages/typescript/ml-framework-core
+npm install
+npm run benchmark
+```
+
+Example output (Apple M-series, Node 20, pure-TS fallback only):
+
+```
+| batch  | forward (ms) | backward (ms) | total (ms) | dispatch       |
+|--------|--------------|---------------|------------|----------------|
+|    100 |         0.11 |          0.23 |       0.33 | TS (no Rust)   |
+|   1000 |         0.32 |          0.47 |       0.79 | TS (no Rust)   |
+|   5000 |    (skipped) |     (skipped) |  (skipped) | Rust needed    |
+|  10000 |    (skipped) |     (skipped) |  (skipped) | Rust needed    |
+|  50000 |    (skipped) |     (skipped) |  (skipped) | Rust needed    |
+```
+
+Build the matrix-rust-napi native addon (`cd ../matrix-rust-napi && npm
+run build`) to see the Rust-dispatch numbers.
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  @coding-adventures/ml-framework-core (THIS PACKAGE, v1.0.0)         │
+│    Tensor + autograd + 15 differentiable ops (forward + backward)    │
+│    ↓ dispatch large tensors through ↓                                │
+│  @coding-adventures/matrix-rust-napi (v0.4.0, exists)                │
+│    TypeScript wrapper for the Rust N-API addon                       │
+│    ↓                                                                  │
+│  matrix-rust-napi (Rust cdylib, v0.3.0, exists)                      │
+│    Exposes runGraphOnCpu via N-API                                   │
+│    ↓                                                                  │
+│  node-bridge (Rust workspace crate, v0.1.0, exists)                  │
+│    Zero-dep N-API wrapper                                            │
+│    ↓                                                                  │
+│  matrix-ir-json → matrix-ir → matrix-runtime → matrix-cpu            │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+This stack — `node-bridge` → `matrix-rust-napi` → `@coding-adventures/matrix-rust-napi`
+→ `@coding-adventures/ml-framework-core` — is the **JS/TS pilot** for a
+multi-language plan.  Sister stack: `c-bridge` →
+`matrix_rust_ruby_native` → `matrix_rust_ruby` →
+`coding_adventures_ml_framework_core` (Ruby).
+
+## Test coverage
+
+148 vitest cases, 0 failures across 4 files:
+
+```bash
+npm test                   # runs all four
+# Or individually:
+npx vitest run tests/tensor.test.ts                # 61 tests
+npx vitest run tests/autograd.test.ts              # 18 tests
+npx vitest run tests/ops.test.ts                   # 67 tests
+npx vitest run tests/end-to-end-training.test.ts   #  2 tests
+```
 
 ## Storage model
 
@@ -76,40 +214,22 @@ a.equalsClose(b, 1e-6);
 
 Using `Float32Array` instead of `number[]`:
 
-- **No lossy conversion at the dispatch boundary** — the bytes we'd send
-  to matrix-cpu are already f32 in memory.  No round-trip through f64.
+- **No lossy conversion at the dispatch boundary** — the bytes we'd
+  send to matrix-cpu are already f32 in memory.  No round-trip through
+  f64.
 - **Roughly 2-3× faster** for tight inner loops (V8 specializes the
   contiguous-Float32 path).
 - **Row-major contiguous layout** — matches matrix-cpu's expectation.
 
-## Architecture (will be filled out by PRs #2–#5)
+## Future work
 
-```
-@coding-adventures/ml-framework-core   ← this package (v0.1.0)
-       ↓ (PR #2 adds autograd)
-       ↓ (PR #3 adds Rust dispatch above 10k cells)
-@coding-adventures/matrix-rust-napi    ← TS wrapper (v0.4.0, exists)
-       ↓
-matrix-rust-napi (Rust cdylib)         ← N-API addon (v0.3.0, exists)
-       ↓
-node-bridge (Rust workspace crate)     ← zero-dep N-API wrapper (v0.1.0, exists)
-       ↓
-matrix-ir-json → matrix-ir → matrix-runtime → matrix-cpu
-```
-
-The bottom three layers already exist — this package is the top of the
-TS stack we're building.
-
-## Testing
-
-```bash
-npm install
-npm test
-```
-
-The v0.1.0 suite runs ~50 vitest cases covering construction,
-factories, shape ops, element-wise math, equality, and round-trip
-properties.
+| Feature                | Status                                |
+|------------------------|---------------------------------------|
+| Broadcasting           | Deferred — couples Tensor to shape algebra |
+| Indexing/slicing       | Deferred — 50+ lines of arg-shape handling |
+| Higher-rank transpose  | Deferred — generic strided index math not needed yet |
+| Rust dispatch for Pow/ReLU/Sigmoid/GELU/Softmax | Deferred — multi-op graphs / constants would double PR size |
+| Backward dispatch through Rust | Deferred — same envelope-shape investment as forward |
 
 ## License
 

--- a/code/packages/typescript/ml-framework-core/package-lock.json
+++ b/code/packages/typescript/ml-framework-core/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "@coding-adventures/ml-framework-core",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coding-adventures/ml-framework-core",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",
         "@vitest/coverage-v8": "^3.0.0",
+        "tsx": "^4.0.0",
         "typescript": "^5.0.0",
         "vitest": "^3.0.0"
       }
@@ -1996,6 +1997,481 @@
       "dev": true,
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
       }
     },
     "node_modules/typescript": {

--- a/code/packages/typescript/ml-framework-core/package.json
+++ b/code/packages/typescript/ml-framework-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coding-adventures/ml-framework-core",
-  "version": "0.4.0",
-  "description": "Idiomatic TypeScript Tensor + autograd on top of the Rust matrix-cpu engine.  v0.1.0 ships the Tensor layer (factories, shape ops, named element-wise methods); autograd + 15 op dispatch + end-to-end MLP land in PRs #2–#5.",
+  "version": "1.0.0",
+  "description": "Complete PyTorch-shaped TypeScript ML framework on the Rust matrix-cpu engine.  Tensor + autograd + 15 differentiable ops (Add/Sub/Mul/Div/Neg/Abs/Pow/MatMul/ReLU/Sigmoid/Tanh/GELU/Softmax/Sum/Mean) with full forward and backward.  Small tensors use a pure-TypeScript fast path; tensors of 10k+ cells auto-dispatch through @coding-adventures/matrix-rust-napi to the Rust matrix-cpu executor for SIMD-accelerated f32 math.  End-to-end MLP training verified by the test suite.",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",
@@ -13,7 +13,8 @@
   "scripts": {
     "build": "tsc",
     "test": "vitest run",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "benchmark": "tsx scripts/benchmark.ts"
   },
   "author": "Adhithya Rajasekaran",
   "license": "MIT",
@@ -37,6 +38,7 @@
     "typescript": "^5.0.0",
     "vitest": "^3.0.0",
     "@vitest/coverage-v8": "^3.0.0",
-    "@types/node": "^20.0.0"
+    "@types/node": "^20.0.0",
+    "tsx": "^4.0.0"
   }
 }

--- a/code/packages/typescript/ml-framework-core/scripts/benchmark.ts
+++ b/code/packages/typescript/ml-framework-core/scripts/benchmark.ts
@@ -1,0 +1,183 @@
+/**
+ * scripts/benchmark.ts — performance characterization for ml-framework-core
+ * ============================================================================
+ *
+ * Runs the same 2-layer MLP from tests/end-to-end-training.test.ts at
+ * increasing batch sizes and prints a markdown table of forward +
+ * backward timings.
+ *
+ * Two intended uses:
+ *
+ *   1. **Find the TS-vs-Rust crossover** — at small batch sizes the
+ *      pure-TS fallback wins because the JSON+hex+FFI dispatch
+ *      overhead dominates.  As batches grow, Rust's f32 SIMD pulls
+ *      ahead.  The table makes the crossover visible at a glance.
+ *
+ *   2. **Spot regressions** — re-run after any change to ops.ts /
+ *      autograd.ts and compare with prior runs.  A 2-3× slowdown
+ *      anywhere should be investigated.
+ *
+ * Usage:
+ *
+ *   cd code/packages/typescript/ml-framework-core
+ *   npm install
+ *   npm run benchmark    # or: npx tsx scripts/benchmark.ts
+ *
+ * No CLI arguments.  No file output.  Stdout-only.  Mirrors the Ruby
+ * benchmark.rb structure 1-for-1.
+ */
+
+import { Tensor } from "../src/index.js";
+import { performance } from "node:perf_hooks";
+
+// Configurable batch sizes — picked to bracket the 10_000-cell dispatch
+// threshold (the matmul intermediate is batch * 2 = 2*batch cells, so
+// batch >= 5000 triggers Rust dispatch when matrix-rust-napi is built).
+const BATCH_SIZES = [100, 1000, 5000, 10_000, 50_000];
+const WARMUP_RUNS = 2;
+const TIMED_RUNS = 5;
+
+/**
+ * Lazy-detect whether the Rust dispatch path is available.  Tries to
+ * resolve `@coding-adventures/matrix-rust-napi`; if the .node addon
+ * isn't built we surface that as a header note rather than crashing.
+ */
+function rustAvailable(): boolean {
+  try {
+    // Dynamic require via createRequire so this ESM script can probe a
+    // CJS addon.  We don't actually call the addon — just confirm it
+    // resolves and loads without throwing.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { createRequire } = require("node:module") as typeof import("node:module");
+    const requireFn = createRequire(import.meta.url);
+    requireFn("@coding-adventures/matrix-rust-napi");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * A single forward + backward pass at the given batch size.
+ * Returns [forwardMs, backwardMs].
+ */
+function timeStep(batchSize: number): [number, number] {
+  // Build inputs: x is (batch, 1), target is (batch, 1).  Values don't
+  // matter — we're measuring time, not loss.
+  const xData = Array.from({ length: batchSize }, (_, i) => [i / batchSize]);
+  const yData = Array.from({ length: batchSize }, (_, i) => [2 * (i / batchSize) + 3]);
+  const x = new Tensor(xData);
+  const target = new Tensor(yData);
+
+  // 2-hidden-unit MLP — minimal layer count to focus on per-cell cost
+  // rather than per-op orchestration overhead.
+  const w1 = new Tensor([[0.5, -0.3]]);
+  w1.requiresGrad = true;
+  const w2 = new Tensor([[0.4], [0.7]]);
+  w2.requiresGrad = true;
+
+  // --- forward ---
+  const fwdStart = performance.now();
+  const pred = x.matmul(w1).relu().matmul(w2);
+  const diff = pred.sub(target);
+  const loss = diff.mul(diff).mean();
+  const fwdEnd = performance.now();
+
+  // --- backward ---
+  const bwdStart = performance.now();
+  loss.backward();
+  const bwdEnd = performance.now();
+
+  return [fwdEnd - fwdStart, bwdEnd - bwdStart];
+}
+
+/**
+ * Pick the dispatch label for a given batch size.  The (batch × hidden)
+ * intermediate of `x.matmul(w1).relu` is batch * 2, so 5000 batch →
+ * 10000-cell intermediate → Rust kicks in.  Crude but useful enough as
+ * a column label.
+ */
+function dispatchLabel(batchSize: number, rustOk: boolean): string {
+  if (!rustOk) return "TS (no Rust)";
+  return batchSize < 5_000 ? "TS" : "Rust";
+}
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted[Math.floor(sorted.length / 2)]!;
+}
+
+function runBenchmark(): void {
+  const rustOk = rustAvailable();
+
+  console.log("# ml-framework-core benchmark\n");
+  console.log("Forward + backward pass on a 2-layer MLP (1 input → 2 hidden ReLU → 1 output)");
+  console.log(`at increasing batch sizes.  Each timing is the median of ${TIMED_RUNS} runs`);
+  console.log(`after ${WARMUP_RUNS} warmup runs.\n`);
+  console.log(`- Node version:        ${process.version} (${process.platform}/${process.arch})`);
+  console.log(`- matrix-rust-napi:    ${rustOk ? "available" : "NOT BUILT — TS fallback only"}\n`);
+  console.log("| batch  | forward (ms) | backward (ms) | total (ms) | dispatch       |");
+  console.log("|--------|--------------|---------------|------------|----------------|");
+
+  type Row = {
+    batch: number;
+    fwdMs: number | null;
+    bwdMs: number | null;
+    totalMs: number | null;
+    dispatch: string;
+  };
+  const results: Row[] = [];
+
+  for (const batchSize of BATCH_SIZES) {
+    // If matrix-rust-napi isn't available AND this batch would trigger
+    // a Rust dispatch (matmul intermediate ≥ 10k cells), skip the row
+    // rather than crashing with LoadError.  Same logic as Ruby
+    // benchmark.rb.
+    if (!rustOk && batchSize >= 5_000) {
+      const dispatch = "Rust needed";
+      console.log(
+        `| ${String(batchSize).padStart(6)} | ${"(skipped)".padStart(12)} | ${"(skipped)".padStart(13)} | ${"(skipped)".padStart(10)} | ${dispatch.padEnd(14)} |`,
+      );
+      results.push({ batch: batchSize, fwdMs: null, bwdMs: null, totalMs: null, dispatch });
+      continue;
+    }
+
+    // Warmup runs — let any lazy requires fire and the JIT settle.
+    for (let i = 0; i < WARMUP_RUNS; i++) timeStep(batchSize);
+
+    // Timed runs — collect all and take the median for stability.  Mean
+    // is dominated by GC pauses in V8.
+    const samples = Array.from({ length: TIMED_RUNS }, () => timeStep(batchSize));
+    const fwdMs = median(samples.map(([f]) => f));
+    const bwdMs = median(samples.map(([, b]) => b));
+    const totalMs = fwdMs + bwdMs;
+    const dispatch = dispatchLabel(batchSize, rustOk);
+
+    console.log(
+      `| ${String(batchSize).padStart(6)} | ${fwdMs.toFixed(2).padStart(12)} | ${bwdMs.toFixed(2).padStart(13)} | ${totalMs.toFixed(2).padStart(10)} | ${dispatch.padEnd(14)} |`,
+    );
+    results.push({ batch: batchSize, fwdMs, bwdMs, totalMs, dispatch });
+  }
+
+  console.log("\n## Notes\n");
+  if (rustOk) {
+    const rustRow = results.find((r) => r.dispatch === "Rust");
+    if (rustRow) {
+      console.log(`- Rust dispatch crossed in around batch=${rustRow.batch} cells per intermediate.`);
+      console.log("  Below that, the pure-TS element-wise loop is faster than the");
+      console.log("  JSON+hex+FFI envelope round-trip.");
+    } else {
+      console.log("- All batches stayed in the pure-TS path.");
+    }
+  } else {
+    console.log("- All timings reflect the pure-TS fallback path.");
+    console.log("  Build the matrix-rust-napi native addon (`cd ../matrix-rust-napi && npm run build`)");
+    console.log("  to compare against Rust dispatch.");
+  }
+  console.log("\n## Reproducing\n");
+  console.log("    cd code/packages/typescript/ml-framework-core");
+  console.log("    npm install");
+  console.log("    npm run benchmark");
+}
+
+runBenchmark();

--- a/code/packages/typescript/ml-framework-core/src/version.ts
+++ b/code/packages/typescript/ml-framework-core/src/version.ts
@@ -4,4 +4,4 @@
  * Kept in sync with package.json's `version` field by hand — there's no
  * build step that injects it.  When bumping, update both files.
  */
-export const VERSION = "0.4.0" as const;
+export const VERSION = "1.0.0" as const;


### PR DESCRIPTION
## Summary — THE FINAL JS/TS PILOT PR

v1.0.0 marks the **completion** of the 5-PR JS/TS pilot for the multi-language ML framework plan. With this PR merged:

- 15 differentiable ops with full forward + backward (Add, Sub, Mul, Div, Neg, Abs, Pow, MatMul, ReLU, Sigmoid, Tanh, GELU, Softmax, Sum, Mean)
- Pure-TypeScript autograd engine (Function.apply + Tensor#backward via topological sort + reverse walk)
- Automatic Rust dispatch above 10k cells through `@coding-adventures/matrix-rust-napi` → `matrix-rust-napi` (N-API) → `node-bridge` → `matrix-cpu`
- End-to-end MLP training verified (loss drops 75%+ over 30 SGD steps)
- 148 tests passing across 4 files

## What's new in v1.0.0

- **`scripts/benchmark.ts`**: forward + backward MLP timing at batch sizes 100/1000/5000/10k/50k. Markdown table output. Gracefully handles missing native addon.
- **Package.json polish**: tightened description, added `tsx` devDep + `npm run benchmark`
- **README polish**: Quick-start with end-to-end MLP at top, Benchmark section, Test coverage section, Future work table
- **Version**: 0.4.0 → 1.0.0

## The 5 JS/TS pilot PRs

| #  | Title                                  | Status |
|----|----------------------------------------|--------|
| 1  | ml-framework-core Tensor               | merged (#4829) |
| 2  | ml-framework-core autograd             | merged (#4837) |
| 3  | ml-framework-core forward op dispatch  | merged (#4852) |
| 4  | ml-framework-core backward + MLP test  | merged (#4878) |
| 5  | v1.0.0 — benchmark + polish (THIS PR)  | open   |

## Test plan

- [x] `npx tsc --noEmit`: 0 errors
- [x] All 4 test files pass: 148/148 (no regressions)
- [x] `npx tsx scripts/benchmark.ts` runs end-to-end locally
- [x] Security review: passed
- [ ] CI: build (ubuntu/macos/windows) — pending
- [ ] CI: CodeQL js-ts Analyze — pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)