### PR TITLE
feat(lang-aot): --emit=armv7 wiring (A3+++) — source → IIR → ARMv7 .bin

### DIFF
--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "lang-aot"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
-description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, and Oct to native executables through the shared IIR pipeline.  v0.8.0 (A2+++): adds `--emit=intel8008` flag (aliases `i8008`, `8008`) that routes source → IIR → Intel 8008 machine code (.bin) via iir-to-intel8008, cross-platform.  Downstream consumers: the in-tree intel8008-simulator, a 1702 EPROM burner, or any 8008 emulator that consumes raw byte streams.  Previous v0.7.0 (A1+++) adds `--emit=riscv32` for RV32I."
+description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, and Oct to native executables through the shared IIR pipeline.  v0.9.0 (A3+++): adds `--emit=armv7` flag (aliases `arm`, `arm32`) that routes source → IIR → ARMv7 (A32) machine code (.bin) via iir-to-armv7, cross-platform.  Downstream consumers: the in-tree arm-simulator, qemu-arm, objcopy + a phone-class Linux linker, or a Cortex-A7/A8/A9-era SoC flash loader.  Previous targets: v0.8.0 (A2+++ intel8008), v0.7.0 (A1+++ riscv32)."
 
 [dependencies]
 twig-aot              = { path = "../twig-aot" }
@@ -16,6 +16,7 @@ cli-builder           = { path = "../cli-builder" }
 iir-to-llvm           = { path = "../iir-to-llvm" }
 iir-to-riscv          = { path = "../iir-to-riscv" }
 iir-to-intel8008      = { path = "../iir-to-intel8008" }
+iir-to-armv7          = { path = "../iir-to-armv7" }
 
 [[bin]]
 name = "lang-aot"

--- a/code/packages/rust/lang-aot/bin/lang_aot.rs
+++ b/code/packages/rust/lang-aot/bin/lang_aot.rs
@@ -44,11 +44,13 @@ fn main() -> ExitCode {
     //   * LlvmIr       → .ll  (foo.bas → foo.ll),  matching `llc` input convention
     //   * Riscv32Bin   → .bin (foo.bas → foo.bin), the conventional flat ELF-less name
     //   * Intel8008Bin → .bin (foo.oct → foo.bin), shares the `.bin` convention with RV32I
+    //   * Armv7Bin     → .bin (foo.twig → foo.bin), shares the `.bin` convention
     let output = cmd.output.unwrap_or_else(|| match cmd.emit {
         EmitMode::Native       => input.with_extension(""),
         EmitMode::LlvmIr       => input.with_extension("ll"),
         EmitMode::Riscv32Bin   => input.with_extension("bin"),
         EmitMode::Intel8008Bin => input.with_extension("bin"),
+        EmitMode::Armv7Bin     => input.with_extension("bin"),
     });
 
     let language = match cmd.language {
@@ -89,6 +91,13 @@ enum EmitMode {
     /// or a 1702 EPROM burner.  Oct's native target — its IIR is
     /// designed to round-trip through 8008 silicon.
     Intel8008Bin,
+    /// Flat `.bin` of little-endian 32-bit ARMv7-A (A32) instruction
+    /// words via `iir-to-armv7`.  Cross-platform.  Downstream
+    /// consumers: the in-tree `arm-simulator`, `qemu-arm`,
+    /// `objcopy` + a phone-class Linux linker, or a Cortex-A7/A8/A9-
+    /// era SoC flash loader.  Phone-class target — billions of
+    /// deployed silicon units.
+    Armv7Bin,
 }
 
 struct CliArgs {
@@ -165,9 +174,10 @@ fn parse_emit_value(v: &str) -> Result<EmitMode, String> {
         "llvm-ir" | "llvm" | "ll"     => Ok(EmitMode::LlvmIr),
         "riscv32" | "rv32" | "bin"    => Ok(EmitMode::Riscv32Bin),
         "intel8008" | "i8008" | "8008" => Ok(EmitMode::Intel8008Bin),
+        "armv7" | "arm" | "arm32" => Ok(EmitMode::Armv7Bin),
         other => Err(format!(
             "unknown --emit value {other:?}; expected one of: \
-             native | llvm-ir | riscv32 | intel8008"
+             native | llvm-ir | riscv32 | intel8008 | armv7"
         )),
     }
 }
@@ -204,6 +214,13 @@ Options:
                                                 via iir-to-intel8008; cross-platform;
                                                 load into intel8008-simulator or burn
                                                 to a 1702 EPROM (Oct's native target)
+                             armv7 | arm | arm32
+                                              → flat .bin of little-endian 32-bit
+                                                ARMv7-A instruction words via
+                                                iir-to-armv7; cross-platform; load
+                                                into arm-simulator, qemu-arm, or
+                                                objcopy + a phone-class Linux linker
+                                                (Cortex-A7/A8/A9-era SoCs)
   -h, --help               Show this help.\
 ");
 }
@@ -233,6 +250,16 @@ fn dispatch(
     // instruction is a byte sequence).  Oct's native target.
     if emit == EmitMode::Intel8008Bin {
         return lang_aot::compile_file_to_intel8008_bin(input, output, language)
+            .map_err(|e| format!("{e}"));
+    }
+    // ARMv7 .bin emission is also cross-platform — flatten each
+    // 32-bit A32 word to little-endian bytes (ARM's default endian
+    // on every modern Linux/Android/qemu setup).  No linker, no
+    // host gating (an ARM Cortex-A class CPU isn't a common dev
+    // host; downstream is always arm-simulator, qemu-arm, or a
+    // phone-class Linux board).
+    if emit == EmitMode::Armv7Bin {
+        return lang_aot::compile_file_to_armv7_bin(input, output, language)
             .map_err(|e| format!("{e}"));
     }
     #[cfg(target_os = "linux")]

--- a/code/packages/rust/lang-aot/src/lib.rs
+++ b/code/packages/rust/lang-aot/src/lib.rs
@@ -142,6 +142,12 @@ pub enum LangAotError {
     /// (which already includes the failing function name and the
     /// unsupported op/type/operand).
     Intel8008BackendError(String),
+    /// The ARMv7 (A32) backend rejected the IIR.
+    ///
+    /// Carries the human-readable string from `iir-to-armv7` (which
+    /// already includes the failing function name and the
+    /// unsupported op/type/operand).
+    Armv7BackendError(String),
 }
 
 impl fmt::Display for LangAotError {
@@ -156,6 +162,7 @@ impl fmt::Display for LangAotError {
             LangAotError::LlvmBackendError(m) => write!(f, "llvm: {m}"),
             LangAotError::RiscvBackendError(m) => write!(f, "riscv32: {m}"),
             LangAotError::Intel8008BackendError(m) => write!(f, "intel8008: {m}"),
+            LangAotError::Armv7BackendError(m) => write!(f, "armv7: {m}"),
         }
     }
 }
@@ -380,6 +387,76 @@ pub fn compile_file_to_intel8008_bin(
     let bytes = iir_to_intel8008::lower_iir_to_intel8008(&module, &cfg)
         .map_err(|e| LangAotError::Intel8008BackendError(format!("{e}")))?;
 
+    std::fs::write(out, &bytes)?;
+    Ok(())
+}
+
+/// Cross-platform: source → IIR → ARMv7 (A32) machine code (`.bin`) on disk.
+///
+/// Unlike the native-executable pipelines, this one does **not** link
+/// or run any toolchain — it just writes a flat `.bin` of 32-bit
+/// ARMv7-A instruction words encoded as little-endian bytes.
+/// Downstream consumers:
+///
+/// * [`arm-simulator`](../arm-simulator) — load + execute in-process.
+/// * `qemu-arm` — `qemu-arm -kernel out.bin`.
+/// * `objcopy` + a phone-class Linux linker for an ELF executable on
+///   a Cortex-A7/A8/A9-era SoC.
+///
+/// No `cfg(target_os = ...)` gating: emitting bytes is platform-
+/// agnostic.
+///
+/// # Wire format
+///
+/// Each emitted A32 word is written as **little-endian** bytes.
+/// ARMv7 is configurable-endian but defaults to little-endian on
+/// every modern Linux / Android distribution, on QEMU, and on the
+/// in-tree `arm-simulator`.  `Vec<u32>::iter().flat_map(u32::to_le_bytes)`
+/// is the canonical Rust expression of that encoding.
+///
+/// # Why no host gating?
+///
+/// ARMv7 host execution would require an ARM Cortex-A class CPU.
+/// Most LANG VM developers don't have one as their dev host, so we
+/// never produce a "native" binary the host can execute — the
+/// downstream consumer is always a simulator (in-tree
+/// `arm-simulator`, `qemu-arm`), a phone-class Linux board, or a
+/// flash loader.  All host OSes can write a flat byte file, so the
+/// pipeline is universally available.
+///
+/// # Errors
+///
+/// * `FrontendError` — the language-specific frontend rejected the source.
+/// * `Armv7BackendError` — the IIR contained an op or type the ARMv7
+///   backend does not yet handle (the message names the function and
+///   op).
+/// * `Io` — failed to read the input or write the output.
+///
+/// # Example downstream invocation
+///
+/// ```bash
+/// lang-aot foo.twig --emit=armv7 -o foo.bin
+/// # Then load foo.bin into the simulator or QEMU:
+/// qemu-arm -kernel foo.bin
+/// ```
+pub fn compile_file_to_armv7_bin(
+    src: &Path,
+    out: &Path,
+    language: Language,
+) -> Result<(), LangAotError> {
+    let source = std::fs::read_to_string(src)?;
+    let stem = src.file_stem().and_then(|s| s.to_str()).unwrap_or("lang");
+    let module = compile_source_to_iir(language, &source, stem)?;
+
+    let cfg = iir_to_armv7::IIRArmv7Config::new(stem);
+    let words = iir_to_armv7::lower_iir_to_armv7(&module, &cfg)
+        .map_err(|e| LangAotError::Armv7BackendError(format!("{e}")))?;
+
+    // Flatten Vec<u32> → Vec<u8> via little-endian ARMv7 word encoding.
+    let mut bytes = Vec::with_capacity(words.len() * 4);
+    for w in &words {
+        bytes.extend_from_slice(&w.to_le_bytes());
+    }
     std::fs::write(out, &bytes)?;
     Ok(())
 }

--- a/code/packages/rust/lang-aot/tests/end_to_end_smoke.rs
+++ b/code/packages/rust/lang-aot/tests/end_to_end_smoke.rs
@@ -1007,3 +1007,58 @@ fn end_to_end_twig_42_emits_intel8008_bin_via_lang_aot() {
     assert_eq!(&bytes[..3.min(bytes.len())], &[0x3E, 0x2A, 0x76],
         "Twig `42` should produce `MVI A, 42; HLT`; got: {bytes:02x?}");
 }
+
+// ===========================================================================
+// A3+++ — source -> IIR -> ARMv7 (A32) machine code (.bin) via lang-aot
+// ===========================================================================
+//
+// Cross-platform: no linker, no cfg gating.  Confirms the new
+// compile_file_to_armv7_bin entry point runs the full source ->
+// IIR -> iir-to-armv7 pipeline and produces a flat .bin of
+// little-endian 32-bit A32 instruction words.
+//
+// Twig `42` lowers to the canonical 2-word `MOV r0, #42; BX LR`
+// sequence: `0xE3A0_002A 0xE12F_FF1E` stored little-endian as
+// `2A 00 A0 E3  1E FF 2F E1`.
+
+#[test]
+fn end_to_end_twig_42_emits_armv7_bin_via_lang_aot() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = dir.path().join("smoke.twig");
+    let bin = dir.path().join("smoke.bin");
+    std::fs::write(&src, b"42\n").unwrap();
+
+    if let Err(e) = lang_aot::compile_file_to_armv7_bin(&src, &bin, lang_aot::Language::Twig) {
+        // Tolerate not-yet-covered op gaps — same convention as the
+        // LLVM + RISC-V + Intel 8008 paths.  After A3++.6, ARMv7
+        // supports the full IIR core for simple programs, so Twig's
+        // `42` should always succeed here.
+        let msg = format!("{e}");
+        if msg.contains("UnsupportedOp")
+            || msg.contains("UnsupportedType")
+            || msg.contains("InvalidOperand")
+            || msg.contains("OutOfRegisters")
+        {
+            eprintln!("skipping: Twig ARMv7 lowering gap (expected): {msg}");
+            return;
+        }
+        panic!("unexpected Twig -> ARMv7 error: {e}");
+    }
+
+    let bytes = std::fs::read(&bin).expect("read .bin");
+    assert!(!bytes.is_empty(),
+        "Twig `42` should produce a non-empty .bin");
+    assert_eq!(bytes.len() % 4, 0,
+        ".bin length should be a multiple of 4 (A32 word size); got {} bytes",
+        bytes.len());
+
+    // Twig `42` lowers to `MOV r0, #42; BX LR` = `0xE3A0_002A 0xE12F_FF1E`.
+    // Stored little-endian: `2A 00 A0 E3 1E FF 2F E1`.
+    assert_eq!(&bytes[..4.min(bytes.len())], &[0x2A, 0x00, 0xA0, 0xE3],
+        "Twig `42` should produce `MOV r0, #42` (0xE3A0_002A) as the first \
+         4 bytes little-endian (2A 00 A0 E3); got: {:02x?}",
+        &bytes[..4.min(bytes.len())]);
+    assert_eq!(&bytes[4..8.min(bytes.len())], &[0x1E, 0xFF, 0x2F, 0xE1],
+        "second word should be BX LR (0xE12F_FF1E) little-endian; got: {:02x?}",
+        &bytes[4..8.min(bytes.len())]);
+}

--- a/code/specs/iir-to-armv7.md
+++ b/code/specs/iir-to-armv7.md
@@ -76,7 +76,8 @@ IIRModule
 | v0.4.3 (A3++.5.5 third slice) | `cmp` equality with flag-to-bool capture via `MOVEQ` (`0x03A0_0000`) | **merged** |
 | v0.4.4 (A3++.5.5 fourth slice) | Full comparison family `cmp_ne`/`cmp_lt`/`cmp_gt`/`cmp_gte`/`cmp_lte` via condition prefixes | **merged** |
 | v0.4.5 (A3++.5.5 fifth slice) | Control flow: `label` + `jmp` + `jmp_if_true`/`jmp_if_false` via Bcond + two-pass backpatching | **merged** |
-| **v0.4.6 (A3++.6 — this PR)** | Real `call` via `BL` (branch with link, `0xEB00_0000` — NOT `0xEA00_0000` which is B) + module-level call-backpatching (analogous to the 8008's v0.3.9).  ARMv7 backend now feature-complete for AOT. | this PR |
+| v0.4.6 (A3++.6) | Real `call` via `BL` + module-level call-backpatching.  ARMv7 backend feature-complete for AOT. | **merged** |
+| **A3+++ (this PR, in `lang-aot` v0.8.0 → v0.9.0)** | `lang-aot --emit=armv7` (aliases `arm`, `arm32`) routes source → IIR → ARMv7 (A32) `.bin` via `iir-to-armv7`; flattens `Vec<u32>` to little-endian bytes; cross-platform; no host gating; no version bump for the iir-to-armv7 crate itself | this PR |
 | v0.3.x (A3++.5.5) | Comparisons + conditional branches via the cond-field on every A32 instruction (a stronger version of the 8008's flag-based jumps) | future |
 | v0.3.x (A3++.6) | Function calls via `bl` with PC-relative offsets + stack spilling | future |
 | v0.4.0 (A3+++) | `lang-aot --emit=armv7` wiring | future |


### PR DESCRIPTION
## Summary

After 6 backend slices completing **A3++.6**, this PR wires the \`iir-to-armv7\` backend into the \`lang-aot\` AOT driver.  Mirrors the A2+++ pattern that wired \`iir-to-intel8008\` in the previous lang-aot v0.8.0 release.

- New CLI flag: \`lang-aot foo.twig --emit=armv7 -o foo.bin\` (aliases \`arm\`, \`arm32\`).
- New public API: \`lang_aot::compile_file_to_armv7_bin(src, out, language)\`.
- New error variant: \`LangAotError::Armv7BackendError(String)\`.
- E2E smoke test asserting Twig \`42\` lowers to \`2A 00 A0 E3 1E FF 2F E1\` (MOV r0, #42 + BX LR, little-endian) through the full pipeline.
- lang-aot version bump 0.8.0 → 0.9.0.

### Wire format

Each emitted A32 word is written as **little-endian** bytes.  ARMv7 is configurable-endian but defaults to little-endian on every modern Linux / Android distribution, on QEMU, and on the in-tree \`arm-simulator\`.

### Downstream consumers of the emitted .bin

- In-tree \`arm-simulator\` via load + execute
- \`qemu-arm\` for cross-platform execution
- \`objcopy\` + a phone-class Linux linker for an ELF on a Cortex-A7/A8/A9-era SoC

### Why no host gating?

An ARM Cortex-A class CPU isn't a common dev host, so we never produce a "native" binary the host can execute.  Downstream is always a simulator (in-tree arm-simulator, qemu-arm), a phone-class Linux board, or a flash loader.

### A3++.6 + A3+++ completes the third architecture-backend lane

Together with A1/A1+/A1++/A1+++ (RV32I, fully merged) and A2/A2+/A2++/A2+++ (Intel 8008, fully merged), the LANG VM backend matrix now spans three architectures:

- **RV32I** (clean 32-bit RISC)
- **Intel 8008** (irregular 8-bit accumulator CISC, Oct's native)
- **ARMv7** (32-bit RISC with cond-field on every instruction + barrel shifter — phone-class target)

A4 (Intel 4004) and A5 (GE-225) onward continue the lane in subsequent issues.

## Test plan

- [x] \`cargo test -p lang-aot\` — 22/22 tests pass (was 21 before adding the ARMv7 one)
- [x] New \`end_to_end_twig_42_emits_armv7_bin_via_lang_aot\` asserts the canonical \`2A 00 A0 E3 1E FF 2F E1\` byte sequence
- [x] Existing 21 e2e tests still pass (no regression)
- [x] \`--emit=armv7\` parsing accepts \`armv7\`, \`arm\`, \`arm32\` aliases
- [x] Default output extension \`.bin\` for Armv7Bin mode
- [x] Security review passed (no vulnerabilities found)
- [ ] CI green
- [ ] No merge conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)