### PR TITLE
Track browser form file control descriptors

### DIFF
--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -1620,6 +1620,7 @@ pub struct BrowserForm {
     pub buttons: Vec<BrowserFormButton>,
     pub text_entries: Vec<BrowserFormTextEntry>,
     pub choice_controls: Vec<BrowserFormChoiceControl>,
+    pub file_controls: Vec<BrowserFormFileControl>,
     pub controls: Vec<BrowserFormControl>,
     pub submitters: Vec<BrowserFormSubmitter>,
 }
@@ -1796,6 +1797,26 @@ pub struct BrowserFormChoiceControl {
     pub group_name: Option<String>,
     pub group_checked_ids: Vec<String>,
     pub group_checked_values: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserFormFileControl {
+    pub id: Option<String>,
+    pub name: Option<String>,
+    pub form_owner: Option<String>,
+    pub labels: Vec<String>,
+    pub accessible_name: Option<String>,
+    pub accept: Option<String>,
+    pub accept_tokens: Vec<String>,
+    pub capture: Option<String>,
+    pub multiple: bool,
+    pub disabled: bool,
+    pub required: bool,
+    pub successful: bool,
+    pub submission_values: Vec<String>,
+    pub will_validate: bool,
+    pub validation_attributes: Vec<String>,
+    pub validation_barred_reason: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -12864,6 +12885,7 @@ fn browser_form(
     );
     let text_entries = browser_form_text_entries(&controls);
     let choice_controls = browser_form_choice_controls(&controls, element.attribute("id"));
+    let file_controls = browser_form_file_controls(&controls);
     let submitters = browser_form_submitters(
         &controls,
         action.as_deref(),
@@ -12910,6 +12932,7 @@ fn browser_form(
         buttons,
         text_entries,
         choice_controls,
+        file_controls,
         controls,
         submitters,
     }
@@ -13514,6 +13537,31 @@ fn browser_choice_group_form_owner<'a>(
     form_id: Option<&'a str>,
 ) -> Option<&'a str> {
     control.form_owner.as_deref().or(form_id)
+}
+
+fn browser_form_file_controls(controls: &[BrowserFormControl]) -> Vec<BrowserFormFileControl> {
+    controls
+        .iter()
+        .filter(|control| control.control_type == "file")
+        .map(|control| BrowserFormFileControl {
+            id: control.id.clone(),
+            name: control.name.clone(),
+            form_owner: control.form_owner.clone(),
+            labels: control.labels.clone(),
+            accessible_name: control.accessible_name.clone(),
+            accept: control.accept.clone(),
+            accept_tokens: control.accept_tokens.clone(),
+            capture: control.capture.clone(),
+            multiple: control.multiple,
+            disabled: control.disabled,
+            required: control.required,
+            successful: control.successful,
+            submission_values: control.submission_values.clone(),
+            will_validate: control.will_validate,
+            validation_attributes: control.validation_attributes.clone(),
+            validation_barred_reason: control.validation_barred_reason.clone(),
+        })
+        .collect()
 }
 
 fn collect_form_controls_for_form_into(

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -2,13 +2,13 @@ use coding_adventures_html_parser::{
     parse_browser_document, BrowserAnchor, BrowserComponentHydrationTarget, BrowserDataAttribute,
     BrowserDatalistOption, BrowserDocument, BrowserDocumentMetadata, BrowserEmbeddedContext,
     BrowserForm, BrowserFormButton, BrowserFormChoiceControl, BrowserFormControl,
-    BrowserFormDatalist, BrowserFormFieldset, BrowserFormLabel, BrowserFormOutput,
-    BrowserFormSelect, BrowserFormSubmitter, BrowserFormSuccessfulControl, BrowserFormTextEntry,
-    BrowserFormValidationControl, BrowserHeading, BrowserHttpEquivHint, BrowserImage,
-    BrowserImageSource, BrowserInteractiveElement, BrowserLink, BrowserMedia, BrowserMeta,
-    BrowserMetadataDirective, BrowserRefresh, BrowserResource, BrowserResourceHint, BrowserScript,
-    BrowserSelectOption, BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet,
-    BrowserTable, BrowserTemplate, BrowserThemeColor,
+    BrowserFormDatalist, BrowserFormFieldset, BrowserFormFileControl, BrowserFormLabel,
+    BrowserFormOutput, BrowserFormSelect, BrowserFormSubmitter, BrowserFormSuccessfulControl,
+    BrowserFormTextEntry, BrowserFormValidationControl, BrowserHeading, BrowserHttpEquivHint,
+    BrowserImage, BrowserImageSource, BrowserInteractiveElement, BrowserLink, BrowserMedia,
+    BrowserMeta, BrowserMetadataDirective, BrowserRefresh, BrowserResource, BrowserResourceHint,
+    BrowserScript, BrowserSelectOption, BrowserStructuredItem, BrowserStructuredProperty,
+    BrowserStylesheet, BrowserTable, BrowserTemplate, BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -736,6 +736,8 @@ struct ExpectedForm {
     text_entries: Vec<ExpectedFormTextEntry>,
     #[serde(default)]
     choice_controls: Vec<ExpectedFormChoiceControl>,
+    #[serde(default)]
+    file_controls: Vec<ExpectedFormFileControl>,
     controls: Vec<ExpectedFormControl>,
     #[serde(default)]
     submitters: Vec<ExpectedFormSubmitter>,
@@ -979,6 +981,41 @@ struct ExpectedFormChoiceControl {
     group_checked_ids: Vec<String>,
     #[serde(default)]
     group_checked_values: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedFormFileControl {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    form_owner: Option<String>,
+    #[serde(default)]
+    labels: Vec<String>,
+    #[serde(default)]
+    accessible_name: Option<String>,
+    #[serde(default)]
+    accept: Option<String>,
+    #[serde(default)]
+    accept_tokens: Vec<String>,
+    #[serde(default)]
+    capture: Option<String>,
+    #[serde(default)]
+    multiple: bool,
+    disabled: bool,
+    #[serde(default)]
+    required: bool,
+    #[serde(default)]
+    successful: bool,
+    #[serde(default)]
+    submission_values: Vec<String>,
+    #[serde(default)]
+    will_validate: bool,
+    #[serde(default)]
+    validation_attributes: Vec<String>,
+    #[serde(default)]
+    validation_barred_reason: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1819,6 +1856,66 @@ fn browser_form_choice_descriptor_metadata_tracks_checkbox_radio_state_and_group
     assert_eq!(external.group_name.as_deref(), Some("plan"));
     assert_eq!(external.group_checked_ids, vec!["plan-basic"]);
     assert_eq!(external.group_checked_values, vec!["basic"]);
+}
+
+#[test]
+fn browser_form_file_descriptor_metadata_tracks_upload_controls_and_hints() {
+    let document = parse_browser_document(
+        "<form id=uploads enctype=multipart/form-data>\
+         <label for=avatar>Avatar</label>\
+         <input id=avatar type=file name=avatar accept=\"image/png, image/jpeg, .webp\" capture=user multiple required>\
+         <label>Attachment<input id=attachment type=file name=attachment disabled></label>\
+         </form>\
+         <input id=external type=file form=uploads name=outside accept=\"application/pdf\">",
+    )
+    .expect("form file descriptor fixture should parse");
+
+    let form = document
+        .forms
+        .first()
+        .expect("uploads form should be summarized");
+    let ids: Vec<&str> = form
+        .file_controls
+        .iter()
+        .filter_map(|file| file.id.as_deref())
+        .collect();
+    assert_eq!(ids, vec!["avatar", "attachment", "external"]);
+
+    let avatar = &form.file_controls[0];
+    assert_eq!(avatar.name.as_deref(), Some("avatar"));
+    assert_eq!(avatar.labels, vec!["Avatar"]);
+    assert_eq!(avatar.accessible_name.as_deref(), Some("Avatar"));
+    assert_eq!(
+        avatar.accept.as_deref(),
+        Some("image/png, image/jpeg, .webp")
+    );
+    assert_eq!(
+        avatar.accept_tokens,
+        vec!["image/png", "image/jpeg", ".webp"]
+    );
+    assert_eq!(avatar.capture.as_deref(), Some("user"));
+    assert!(avatar.multiple);
+    assert!(avatar.required);
+    assert!(avatar.successful);
+    assert!(avatar.submission_values.is_empty());
+    assert!(avatar.will_validate);
+    assert_eq!(avatar.validation_attributes, vec!["required"]);
+
+    let attachment = &form.file_controls[1];
+    assert_eq!(attachment.labels, vec!["Attachment"]);
+    assert!(attachment.disabled);
+    assert!(!attachment.successful);
+    assert!(!attachment.will_validate);
+    assert_eq!(
+        attachment.validation_barred_reason.as_deref(),
+        Some("disabled")
+    );
+
+    let external = &form.file_controls[2];
+    assert_eq!(external.form_owner.as_deref(), Some("uploads"));
+    assert_eq!(external.accept.as_deref(), Some("application/pdf"));
+    assert_eq!(external.accept_tokens, vec!["application/pdf"]);
+    assert!(external.successful);
 }
 
 #[test]
@@ -2754,6 +2851,11 @@ impl ExpectedForm {
                 .into_iter()
                 .map(ExpectedFormChoiceControl::into_browser_form_choice_control)
                 .collect(),
+            file_controls: self
+                .file_controls
+                .into_iter()
+                .map(ExpectedFormFileControl::into_browser_form_file_control)
+                .collect(),
             controls: self
                 .controls
                 .into_iter()
@@ -2950,6 +3052,29 @@ impl ExpectedFormChoiceControl {
             group_name: self.group_name,
             group_checked_ids: self.group_checked_ids,
             group_checked_values: self.group_checked_values,
+        }
+    }
+}
+
+impl ExpectedFormFileControl {
+    fn into_browser_form_file_control(self) -> BrowserFormFileControl {
+        BrowserFormFileControl {
+            id: self.id,
+            name: self.name,
+            form_owner: self.form_owner,
+            labels: self.labels,
+            accessible_name: self.accessible_name,
+            accept: self.accept,
+            accept_tokens: self.accept_tokens,
+            capture: self.capture,
+            multiple: self.multiple,
+            disabled: self.disabled,
+            required: self.required,
+            successful: self.successful,
+            submission_values: self.submission_values,
+            will_validate: self.will_validate,
+            validation_attributes: self.validation_attributes,
+            validation_barred_reason: self.validation_barred_reason,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -271,6 +271,9 @@
             "choice_controls": [
               { "id": "fast", "control_type": "checkbox", "name": "fast", "labels": ["Fast"], "accessible_name": "Fast", "value": "on", "checked": true, "disabled": true, "validation_barred_reason": "disabled", "group_name": "fast", "group_checked_ids": ["fast"], "group_checked_values": ["on"] }
             ],
+            "file_controls": [
+              { "id": "upload", "name": "upload", "accept": "image/png, image/jpeg, .webp", "accept_tokens": ["image/png", "image/jpeg", ".webp"], "capture": "environment", "multiple": false, "disabled": false, "successful": true, "submission_values": [], "will_validate": true }
+            ],
             "controls": [
               { "id": "q", "control_type": "text", "name": "q", "labels": ["Query"], "accessible_name": "Query", "accessible_description": "Query", "placeholder": "Search terms", "autocomplete": "section-primary shipping search", "autocomplete_tokens": ["section-primary", "shipping", "search"], "autocapitalize": "words", "enterkeyhint": "search", "dirname": "q.dir", "spellcheck": "false", "autocorrect": "off", "inputmode": "search", "pattern": "[A-Za-z ]+", "minlength": "2", "maxlength": "80", "size": "40", "list": "query-suggestions", "datalist_options": ["Rust", "HTML", "Browser APIs"], "value": null, "successful": true, "submission_values": [""], "autofocus": true, "disabled": false, "required": true, "will_validate": true, "validation_attributes": ["required", "pattern", "minlength", "maxlength"], "checked": false, "text": "", "options": [] },
               { "id": "count", "control_type": "number", "name": "count", "labels": ["Count"], "accessible_name": "Count", "min": "1", "max": "10", "step": "0.5", "value": "2", "successful": true, "submission_values": ["2"], "disabled": false, "required": true, "will_validate": true, "validation_attributes": ["required", "min", "max", "step"], "checked": false, "text": "", "options": [] },


### PR DESCRIPTION
## Summary
- add dedicated BrowserForm file-control descriptors for upload inputs
- expose accept tokens, capture, multiple, label/accessibility, success, and validation metadata
- cover the descriptor in the browser-readiness fixture and a focused parser test

## Tests
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- cargo test -p coding-adventures-html-parser browser_form_file_descriptor_metadata_tracks_upload_controls_and_hints
- cargo test -p coding-adventures-html-parser browser_form_
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser