### PR TITLE
feat(iir-to-intel4004): crate skeleton — A4 fourth architecture backend

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -657,6 +657,7 @@ members = [
     "iir-to-riscv",
     "iir-to-intel8008",
     "iir-to-armv7",
+    "iir-to-intel4004",
     "aot-debug",
     "twig-to-beam",
     "twig-to-wasm",

--- a/code/packages/rust/iir-to-intel4004/BUILD
+++ b/code/packages/rust/iir-to-intel4004/BUILD
@@ -1,0 +1,1 @@
+cargo test -p iir-to-intel4004

--- a/code/packages/rust/iir-to-intel4004/CHANGELOG.md
+++ b/code/packages/rust/iir-to-intel4004/CHANGELOG.md
@@ -1,0 +1,106 @@
+# Changelog — iir-to-intel4004
+
+All notable changes to this crate are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [0.1.0] — 2026-06-02 (A4 — crate skeleton)
+
+### Added — `JUN 0x000`-only emission
+
+First release.  Implements item A4 of the
+[multi-language architecture backends plan][plan]: a crate skeleton
+that lowers any IIR module to the canonical 2-byte 4004-ROM halt
+sentinel `JUN 0x000` (bytes `0x40 0x00`).
+
+#### Public surface
+
+```rust
+pub struct IIRIntel4004Config { pub module_name: String }
+impl IIRIntel4004Config {
+    pub fn new(module_name: impl Into<String>) -> Self;
+}
+
+pub enum IIRIntel4004Error {
+    ValidationFailed(Vec<String>),
+    UnsupportedOp     { function: String, op: String },
+    UnsupportedType   { function: String, type_hint: String },
+    InvalidOperand    { function: String, detail: String },
+}
+
+pub fn validate_for_intel4004(module: &IIRModule) -> Vec<String>;
+pub fn lower_iir_to_intel4004(
+    module: &IIRModule,
+    cfg: &IIRIntel4004Config,
+) -> Result<Vec<u8>, IIRIntel4004Error>;
+
+pub const HALT_LOOP: [u8; 2] = [0x40, 0x00];
+```
+
+#### Why an Intel 4004 backend?
+
+The Intel 4004 (1971) was the **world's first commercial
+microprocessor**.  Tiny ISA, 4-bit data, 12-bit ROM addresses,
+single 4-bit accumulator, 16 4-bit registers organised as 8 register
+pairs, tiny ROM (4 KiB max) and RAM (640 bits max).
+
+In this codebase the 4004 is primarily a Brainfuck fit per
+MULTILANG-ARCHITECTURE-BACKENDS.md §A4.
+
+A4 establishes the fourth architecture backend alongside RV32I
+(A1), Intel 8008 (A2), and ARMv7 (A3).  The 4004 is the most
+constrained target in the lane by a wide margin — 4-bit data, 4 KiB
+ROM, single accumulator, no formal HLT.
+
+#### Why `Vec<u8>` output, not textual asm?
+
+* **Round-trips with the in-tree intel-4004-assembler and any
+  4004 simulator** — both consume raw byte streams.
+* **Deterministic test surface** — 4004 mnemonics have multiple
+  historical spellings (Intel MCS-4 manual vs modern reverse-
+  engineered docs).  Bytes are unambiguous.
+* **Trivial output size** — 4004 instructions are 1 or 2 bytes;
+  emitting bytes directly skips a textual-assembly round-trip.
+
+#### The `JUN 0x000` halt encoding
+
+The 4004 has no formal `HLT` instruction.  The canonical "halt"
+idiom in 4004 ROM development is `JUN 0x000` — an unconditional
+jump back to ROM address 0, which (when this instruction is itself
+at address 0) loops forever, simulating halt.
+
+`0x40 0x00`.  Bit layout:
+
+```text
+byte 1: 0100 0000 = 0x40   (JUN opcode + high nibble of 12-bit addr = 0)
+byte 2: 0000 0000 = 0x00   (low byte of address = 0)
+```
+
+#### Why JUN-self over NOP-cycle or unimplemented-opcode?
+
+| Candidate | Pros | Cons |
+|-----------|------|------|
+| `JUN 0x000` | Self-documenting; portable across all 4004 implementations | None for skeleton purposes |
+| `NOP NOP NOP ...` (0x00 cycle) | Even simpler bytes | Doesn't halt — keeps running into whatever follows |
+| Unimplemented opcode | Forces a trap | 4004 silicon executes most "unused" bit patterns as NOPs; not portable |
+
+`JUN 0x000` wins on portability + clarity.
+
+#### What is NOT in v0.1.0
+
+* **No instruction lowering.**  Function bodies in the input
+  `IIRModule` are ignored.  v0.2.0 (A4+) lowers `LDM` (load
+  immediate) + `ret`/`ret_void`.
+* **No `lang-aot --emit=intel4004`.**  Deferred to v0.4.0 (A4+++).
+* **No external assembler / linker integration.**
+
+#### Tests added (7 total)
+
+* `validate_returns_empty_for_empty_module`
+* `lower_emits_exactly_two_bytes`
+* `lower_emits_the_canonical_jun_self_bytes` (exact `[0x40, 0x00]`)
+* `halt_loop_constant_pinned_to_40_00`
+* `default_config_has_nonempty_module_name`
+* `new_sets_module_name`
+* `errors_display_without_panic`
+
+[plan]: ../../../specs/MULTILANG-ARCHITECTURE-BACKENDS.md

--- a/code/packages/rust/iir-to-intel4004/Cargo.toml
+++ b/code/packages/rust/iir-to-intel4004/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "iir-to-intel4004"
+version = "0.1.0"
+edition = "2021"
+description = "IIR → Intel 4004 machine code backend — lowers IIRModule to a Vec<u8> of encoded 4-bit-data, 8-bit-instruction Intel 4004 opcodes.  v0.1.0 (A4): crate skeleton that lowers any module to a single `JUN 0x000` (0x40 0x00) infinite-loop halt sentinel — the canonical 4004-ROM halt idiom (the chip has no formal HLT instruction).  Real lowering (LDM/ADD/SUB/conditional jumps) lands in A4+ through A4++.  The 4004 (1971) is the world's first commercial microprocessor — the most constrained target in the LANG VM architecture-backend lane, primarily a Brainfuck fit per MULTILANG-ARCHITECTURE-BACKENDS.md §A4."
+
+[lib]
+name = "iir_to_intel4004"
+path = "src/lib.rs"
+
+[dependencies]
+interpreter-ir = { path = "../interpreter-ir" }
+
+[[test]]
+name = "test_backend"
+path = "tests/test_backend.rs"

--- a/code/packages/rust/iir-to-intel4004/README.md
+++ b/code/packages/rust/iir-to-intel4004/README.md
@@ -1,0 +1,132 @@
+# iir-to-intel4004
+
+**IIR → Intel 4004 machine code backend.**
+
+Lowers an `IIRModule` from the [interpreter-ir](../interpreter-ir/)
+shared IR to a `Vec<u8>` of encoded 8-bit Intel 4004 opcodes.
+
+| | |
+|---|---|
+| **Version** | 0.1.0 — skeleton (A4) |
+| **Plan** | [`MULTILANG-ARCHITECTURE-BACKENDS.md`](../../../specs/MULTILANG-ARCHITECTURE-BACKENDS.md) §A4 |
+| **Spec** | [`iir-to-intel4004.md`](../../../specs/iir-to-intel4004.md) |
+| **Sibling backends** | [`iir-to-intel8008`](../iir-to-intel8008/), [`iir-to-riscv`](../iir-to-riscv/), [`iir-to-armv7`](../iir-to-armv7/), [`iir-to-llvm`](../iir-to-llvm/), [`iir-to-wasm`](../iir-to-wasm/) |
+| **Downstream consumers** | Any in-tree 4004 simulator, `intel-4004-assembler` for round-trip, EPROM burners |
+
+## Why an Intel 4004 backend?
+
+The Intel 4004 (1971) was the **world's first commercial
+microprocessor**.  Tiny ISA, 4-bit data, 12-bit ROM addresses,
+single 4-bit accumulator, 16 4-bit registers organised as 8 register
+pairs, tiny ROM (4 KiB max) and RAM (640 bits max).
+
+In this codebase the 4004 is primarily a **Brainfuck fit** — BF's
+minimal needs map cleanly to a 4004's accumulator-and-loop programming
+model.
+
+Adding the 4004 gives the LANG VM backend matrix a fourth
+architecture:
+
+| | RV32I (A1) | Intel 8008 (A2) | ARMv7 (A3) | **Intel 4004 (A4)** |
+|---|---|---|---|---|
+| Width | 32-bit | 8-bit | 32-bit | **4-bit** |
+| ROM size | huge | 16 KiB | huge | **4 KiB** |
+| Registers | 31 GP | 7 GP | 13 GP | **8 register pairs** |
+| Mnemonic style | Modern RISC | Irregular CISC | RISC + cond prefixes | Tiny MCS-4 |
+| Year first shipped | 2015 | 1972 | 2005 | **1971** |
+
+The 4004 is the most constrained target in the lane by a wide margin.
+
+## Quick start
+
+```rust
+use interpreter_ir::IIRModule;
+use iir_to_intel4004::{validate_for_intel4004, lower_iir_to_intel4004, IIRIntel4004Config};
+
+let module = IIRModule {
+    name: "demo".into(),
+    functions: vec![],
+    entry_point: None,
+    language: "demo".into(),
+    exports: vec![],
+    imports: vec![],
+};
+
+assert!(validate_for_intel4004(&module).is_empty());
+
+let bytes = lower_iir_to_intel4004(&module, &IIRIntel4004Config::default())
+    .expect("lowering should succeed");
+
+// v0.1.0 emits the canonical 2-byte halt sentinel.
+assert_eq!(bytes, vec![0x40, 0x00]);
+```
+
+## Public API (v0.1.0)
+
+```rust
+pub struct IIRIntel4004Config { pub module_name: String }
+impl IIRIntel4004Config {
+    pub fn new(module_name: impl Into<String>) -> Self;
+}
+
+pub enum IIRIntel4004Error {
+    ValidationFailed(Vec<String>),
+    UnsupportedOp     { function: String, op: String },
+    UnsupportedType   { function: String, type_hint: String },
+    InvalidOperand    { function: String, detail: String },
+}
+
+pub fn validate_for_intel4004(module: &IIRModule) -> Vec<String>;
+pub fn lower_iir_to_intel4004(
+    module: &IIRModule,
+    cfg: &IIRIntel4004Config,
+) -> Result<Vec<u8>, IIRIntel4004Error>;
+
+pub const HALT_LOOP: [u8; 2] = [0x40, 0x00];
+```
+
+## The halt sentinel: `JUN 0x000`
+
+The 4004 has no formal `HLT` instruction.  The canonical "halt"
+idiom in 4004 ROM development is `JUN 0x000` — an unconditional
+jump back to ROM address 0, which (when this instruction is itself
+at address 0) loops forever, simulating halt.
+
+Bit layout (JUN = `0100 aaaa aaaaaaaa`):
+
+```text
+byte 1: 0100 0000 = 0x40   (JUN opcode + high nibble of 12-bit addr = 0)
+byte 2: 0000 0000 = 0x00   (low byte of address = 0)
+```
+
+### Why JUN-self over NOP-cycle or unimplemented-opcode?
+
+| Candidate | Pros | Cons |
+|-----------|------|------|
+| `JUN 0x000` (this) | Self-documenting; portable across all 4004 implementations | None for skeleton purposes |
+| `NOP NOP NOP ...` (0x00 cycle) | Even simpler bytes | Doesn't halt — keeps running into whatever follows |
+| Unimplemented opcode | Forces a trap | 4004 silicon executes most "unused" bit patterns as NOPs; not portable |
+
+## What is NOT in v0.1.0
+
+* **No instruction lowering.**  Function bodies in the input
+  `IIRModule` are ignored.  v0.2.0 (A4+) lowers `LDM` (load
+  immediate) + `ret`/`ret_void`.
+* **No `lang-aot --emit=intel4004`.**  Deferred to A4+++.
+* **No external assembler / linker integration.**
+
+## Tests
+
+* `validate_returns_empty_for_empty_module`
+* `lower_emits_exactly_two_bytes`
+* `lower_emits_the_canonical_jun_self_bytes` (exact `[0x40, 0x00]`)
+* `halt_loop_constant_pinned_to_40_00`
+* `default_config_has_nonempty_module_name`
+* `new_sets_module_name`
+* `errors_display_without_panic`
+
+Run with `cargo test -p iir-to-intel4004`.
+
+## License
+
+Same as the parent repository.

--- a/code/packages/rust/iir-to-intel4004/src/lib.rs
+++ b/code/packages/rust/iir-to-intel4004/src/lib.rs
@@ -1,0 +1,228 @@
+//! # iir-to-intel4004 — IIR → Intel 4004 machine code backend (v0.1.0 skeleton).
+//!
+//! Lowers an [`interpreter_ir::IIRModule`] to a `Vec<u8>` of encoded
+//! 8-bit Intel 4004 opcodes, suitable to drop into any 4004
+//! simulator or to write out as a flat `.bin` for burning to a
+//! 1702/2708 EPROM and plugging into a 4004 dev board.
+//!
+//! ## Why an Intel 4004 backend?
+//!
+//! The Intel 4004 (1971) was the **world's first commercial
+//! microprocessor**.  Tiny ISA, 4-bit data, 12-bit ROM addresses,
+//! single 4-bit accumulator, 16 4-bit registers organised as 8
+//! register pairs, tiny ROM (4 KiB max) and RAM (640 bits max).
+//!
+//! In this codebase the 4004 is primarily a **Brainfuck fit** —
+//! BF's minimal needs (single tape pointer, ±1 increment ops,
+//! conditional jump on zero) actually do map cleanly to a 4004's
+//! accumulator-and-loop programming model.
+//!
+//! Adding the 4004 gives us:
+//!
+//! 1. **Historical fidelity.**  The 4004 is where the entire
+//!    modern-microprocessor lineage began.
+//! 2. **A fourth architecture backend** alongside RV32I (A1),
+//!    Intel 8008 (A2), and ARMv7 (A3).  The most constrained
+//!    target in the lane by a wide margin.
+//! 3. **Stress-tests the IIR's neutrality.**  If a 4-bit-data,
+//!    4 KiB-ROM target can swallow the IIR's 64-bit `Operand::Int`
+//!    shape (via truncation + range-rejection), every other
+//!    backend can too.
+//!
+//! ## Scope of v0.1.0 (A4)
+//!
+//! This release is a **skeleton**: any IIR module lowers to a
+//! single `JUN 0x000` (jump-unconditional to address 0) infinite-
+//! loop halt sentinel, encoded as the two bytes `0x40 0x00`.  No
+//! instruction selection yet; that arrives in A4+ and beyond.
+//!
+//! ## Why `Vec<u8>` output, not textual asm?
+//!
+//! - **Round-trips with the in-tree intel-4004-assembler and any
+//!   4004 simulator** — both consume raw byte streams.
+//! - **Deterministic test surface** — 4004 mnemonics have multiple
+//!   historical spellings (Intel MCS-4 manual vs modern reverse-
+//!   engineered docs).  Bytes are unambiguous.
+//! - **Trivial output size** — 4004 instructions are 1 or 2
+//!   bytes; emitting bytes directly skips a textual-assembly
+//!   round-trip.
+//!
+//! ## Quick start
+//!
+//! ```
+//! use interpreter_ir::IIRModule;
+//! use iir_to_intel4004::{validate_for_intel4004, lower_iir_to_intel4004, IIRIntel4004Config};
+//!
+//! let module = IIRModule {
+//!     name: "demo".into(),
+//!     functions: vec![],
+//!     entry_point: None,
+//!     language: "demo".into(),
+//!     exports: vec![],
+//!     imports: vec![],
+//! };
+//!
+//! assert!(validate_for_intel4004(&module).is_empty());
+//!
+//! let bytes = lower_iir_to_intel4004(&module, &IIRIntel4004Config::default())
+//!     .expect("lowering should succeed");
+//! // JUN 0x000 = 0x40 0x00 = the canonical 4004-ROM halt idiom.
+//! assert_eq!(bytes, vec![0x40, 0x00]);
+//! ```
+
+use interpreter_ir::IIRModule;
+use std::fmt;
+
+// ===========================================================================
+// Intel 4004 opcode constants
+// ===========================================================================
+//
+// The 4004 has no formal HLT.  The canonical "halt" idiom is `JUN
+// 0x000` — an unconditional jump back to ROM address 0, which
+// (when itself at address 0) loops forever, simulating halt.
+
+/// Canonical "halt" sentinel for the Intel 4004 — two bytes:
+/// `0x40 0x00` (= `JUN 0x000`, jump-unconditional to ROM address 0).
+///
+/// Bit layout:
+///
+/// ```text
+/// byte 1: 0100 0000 = 0x40   (JUN opcode + high nibble of 12-bit addr = 0)
+/// byte 2: 0000 0000 = 0x00   (low byte of address = 0)
+/// ```
+///
+/// JUN's encoding is `0100 aaaa aaaaaaaa` — the high 4 bits of
+/// byte 1 are the JUN opcode (`0100`), the low 4 bits hold the
+/// high 4 bits of the 12-bit address, and byte 2 holds the low 8
+/// bits.
+///
+/// When emitted at ROM address 0 (where lowering starts), this
+/// instruction's address is 0 and its target is also 0, so the CPU
+/// infinitely re-executes it.  Every 4004 simulator and any
+/// oscilloscope hooked to the program counter recognises this
+/// pattern as "the chip is stuck at address 0".
+///
+/// ## Why JUN-self over NOP-cycle or unimplemented-opcode?
+///
+/// | Candidate | Pros | Cons |
+/// |-----------|------|------|
+/// | `JUN 0x000` (this) | Self-documenting; portable across all 4004 implementations | None for skeleton purposes |
+/// | `NOP NOP NOP ...` (0x00 cycle) | Even simpler bytes | Doesn't halt — keeps running into whatever follows |
+/// | Unimplemented opcode | Forces a trap | 4004 silicon executes most "unused" bit patterns as NOPs; not portable |
+///
+/// `JUN 0x000` wins on portability + clarity.
+pub const HALT_LOOP: [u8; 2] = [0x40, 0x00];
+
+// ===========================================================================
+// IIRIntel4004Config
+// ===========================================================================
+
+/// Configuration for the IIR → Intel 4004 lowering pass.
+///
+/// Currently only the module name is configurable, reserved for
+/// future symbol-table / ROM-image emission.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IIRIntel4004Config {
+    /// Module name — reserved for future symbol-table / `.bin`
+    /// header use.
+    pub module_name: String,
+}
+
+impl IIRIntel4004Config {
+    /// Build a config with a custom module name.
+    pub fn new(module_name: impl Into<String>) -> Self {
+        Self {
+            module_name: module_name.into(),
+        }
+    }
+}
+
+impl Default for IIRIntel4004Config {
+    fn default() -> Self {
+        Self {
+            module_name: "iir_module".into(),
+        }
+    }
+}
+
+// ===========================================================================
+// IIRIntel4004Error
+// ===========================================================================
+
+/// Errors that can occur during IIR → Intel 4004 lowering.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IIRIntel4004Error {
+    /// The module failed pre-flight validation.
+    ValidationFailed(Vec<String>),
+    /// An IIR opcode not yet supported by this backend.  v0.1.0
+    /// doesn't lower any instructions, so a non-empty function
+    /// body would surface this in a future version.
+    UnsupportedOp { function: String, op: String },
+    /// A type hint that does not map to any Intel 4004
+    /// representation.
+    UnsupportedType { function: String, type_hint: String },
+    /// An operand has an unexpected shape.
+    InvalidOperand { function: String, detail: String },
+}
+
+impl fmt::Display for IIRIntel4004Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ValidationFailed(errs) => {
+                write!(f, "validation failed:\n  {}", errs.join("\n  "))
+            }
+            Self::UnsupportedOp { function, op } => {
+                write!(f, "unsupported op in function {function:?}: {op}")
+            }
+            Self::UnsupportedType { function, type_hint } => {
+                write!(f, "unsupported type in function {function:?}: {type_hint}")
+            }
+            Self::InvalidOperand { function, detail } => {
+                write!(f, "invalid operand in function {function:?}: {detail}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for IIRIntel4004Error {}
+
+// ===========================================================================
+// validate_for_intel4004
+// ===========================================================================
+
+/// Pre-flight validation for IIR → Intel 4004 lowering.
+///
+/// **v0.1.0 stub**: always returns an empty `Vec` — there are no
+/// validation rules yet because no instructions are lowered.
+/// Future versions will add rules as opcodes come online (see
+/// `MULTILANG-ARCHITECTURE-BACKENDS.md` §A4).
+///
+/// Mirrors the shape of the other IIR backends'
+/// `validate_for_{wasm,jvm,clr,beam,llvm,riscv,intel8008,armv7}`
+/// so callers can switch backends without changing their pre-
+/// flight logic.
+pub fn validate_for_intel4004(_module: &IIRModule) -> Vec<String> {
+    Vec::new()
+}
+
+// ===========================================================================
+// lower_iir_to_intel4004
+// ===========================================================================
+
+/// Lower an [`IIRModule`] to a `Vec<u8>` of Intel 4004 opcode bytes.
+///
+/// **v0.1.0 scope**: emits the canonical 2-byte halt sentinel `JUN
+/// 0x000` (`0x40 0x00`) regardless of the input.  This is the
+/// smallest "valid Intel 4004 program" we can produce — enough to
+/// load into a simulator, step once, and confirm the CPU is stuck
+/// at address 0.  Real lowering arrives in v0.2.0+ (A4+).
+pub fn lower_iir_to_intel4004(
+    module: &IIRModule,
+    _cfg: &IIRIntel4004Config,
+) -> Result<Vec<u8>, IIRIntel4004Error> {
+    let errors = validate_for_intel4004(module);
+    if !errors.is_empty() {
+        return Err(IIRIntel4004Error::ValidationFailed(errors));
+    }
+    Ok(HALT_LOOP.to_vec())
+}

--- a/code/packages/rust/iir-to-intel4004/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-intel4004/tests/test_backend.rs
@@ -1,0 +1,110 @@
+//! Integration tests for `iir-to-intel4004` v0.1.0 (A4 skeleton).
+//!
+//! Smoke-level — confirms the validator stub, the emitter shape,
+//! and the exact encoded `JUN 0x000` byte pair (`0x40 0x00`).
+
+use interpreter_ir::IIRModule;
+use iir_to_intel4004::{
+    lower_iir_to_intel4004, validate_for_intel4004,
+    IIRIntel4004Config, IIRIntel4004Error, HALT_LOOP,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn empty_module() -> IIRModule {
+    IIRModule {
+        name: "demo".into(),
+        functions: vec![],
+        entry_point: None,
+        language: "test".into(),
+        exports: vec![],
+        imports: vec![],
+    }
+}
+
+// ===========================================================================
+// 1. Validator stub
+// ===========================================================================
+
+#[test]
+fn validate_returns_empty_for_empty_module() {
+    assert!(validate_for_intel4004(&empty_module()).is_empty());
+}
+
+// ===========================================================================
+// 2. Lowering shape and the exact `JUN 0x000` encoding
+// ===========================================================================
+
+#[test]
+fn lower_emits_exactly_two_bytes() {
+    let bytes = lower_iir_to_intel4004(&empty_module(), &IIRIntel4004Config::default())
+        .expect("lowering");
+    assert_eq!(bytes.len(), 2,
+        "v0.1.0 must emit exactly two bytes (the JUN 0x000 sentinel); got: {bytes:02x?}");
+}
+
+/// The emitted bytes are `0x40 0x00` — the canonical 4004-ROM
+/// `JUN 0x000` halt idiom.
+///
+/// Bit layout (JUN = `0100 aaaa aaaaaaaa`):
+///
+/// ```text
+/// byte 1: 0100 0000 = 0x40   (JUN opcode + high nibble of 12-bit addr = 0)
+/// byte 2: 0000 0000 = 0x00   (low byte of address = 0)
+/// ```
+///
+/// Pinning the exact constant guards against any future change in
+/// 4004 simulator decoders that would break the encoding.
+#[test]
+fn lower_emits_the_canonical_jun_self_bytes() {
+    let bytes = lower_iir_to_intel4004(&empty_module(), &IIRIntel4004Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![0x40, 0x00],
+        "expected canonical JUN 0x000 encoding [0x40, 0x00]; got: {bytes:02x?}");
+    assert_eq!(bytes.as_slice(), &HALT_LOOP,
+        "the emitted bytes should equal the exported HALT_LOOP constant");
+}
+
+#[test]
+fn halt_loop_constant_pinned_to_40_00() {
+    // Sanity: the HALT_LOOP constant matches the canonical 4004
+    // JUN-0x000 documented encoding.
+    assert_eq!(HALT_LOOP, [0x40, 0x00],
+        "JUN 0x000 should be [0x40, 0x00] (opcode 0100, addr 0x000)");
+}
+
+// ===========================================================================
+// 3. Config defaults
+// ===========================================================================
+
+#[test]
+fn default_config_has_nonempty_module_name() {
+    let cfg = IIRIntel4004Config::default();
+    assert!(!cfg.module_name.is_empty());
+}
+
+#[test]
+fn new_sets_module_name() {
+    let cfg = IIRIntel4004Config::new("custom");
+    assert_eq!(cfg.module_name, "custom");
+}
+
+// ===========================================================================
+// 4. Error display
+// ===========================================================================
+
+#[test]
+fn errors_display_without_panic() {
+    let _ = format!("{}", IIRIntel4004Error::ValidationFailed(vec!["x".into()]));
+    let _ = format!("{}", IIRIntel4004Error::UnsupportedOp {
+        function: "f".into(), op: "weird".into(),
+    });
+    let _ = format!("{}", IIRIntel4004Error::UnsupportedType {
+        function: "f".into(), type_hint: "weird".into(),
+    });
+    let _ = format!("{}", IIRIntel4004Error::InvalidOperand {
+        function: "f".into(), detail: "bad".into(),
+    });
+}

--- a/code/specs/iir-to-intel4004.md
+++ b/code/specs/iir-to-intel4004.md
@@ -1,0 +1,147 @@
+# iir-to-intel4004 — IIR → Intel 4004 machine code backend
+
+**Status:** v0.1.0 — skeleton (A4)
+**Plan:** [`MULTILANG-ARCHITECTURE-BACKENDS.md`](MULTILANG-ARCHITECTURE-BACKENDS.md) §A4
+**Related:** [`iir-to-intel8008`][i8008], [`iir-to-riscv`][rv], [`iir-to-armv7`][arm]
+
+[i8008]: ../packages/rust/iir-to-intel8008/
+[rv]: ../packages/rust/iir-to-riscv/
+[arm]: ../packages/rust/iir-to-armv7/
+
+## Why a new crate?
+
+The Intel 4004 (1971) was the **world's first commercial
+microprocessor**.  Tiny ISA, 4-bit data, 12-bit ROM addresses,
+single 4-bit accumulator, 16 4-bit registers organized as 8 register
+pairs, tiny ROM (4 KiB max) and RAM (640 bits max).
+
+In this codebase the 4004 is primarily a **Brainfuck fit** — BF's
+minimal needs (single tape pointer, ±1 increment ops, conditional
+jump on zero) actually do map cleanly to a 4004's accumulator-and-
+loop programming model.
+
+Adding the 4004 as a backend gives us:
+
+1. **Historical fidelity.**  The 4004 is where the entire
+   modern-microprocessor lineage began.  Compiling LANG VM
+   programs to 4004 silicon is a small piece of computing
+   history made queryable.
+2. **A fourth architecture backend** alongside RV32I (A1),
+   Intel 8008 (A2), and ARMv7 (A3).  The four sit at very
+   different points in the design space:
+   - RV32I: clean modern 32-bit RISC.
+   - Intel 8008: irregular 8-bit accumulator CISC (Oct's native).
+   - ARMv7: 32-bit RISC + cond-field on every instruction.
+   - **Intel 4004**: 4-bit data, 12-bit ROM addresses, single
+     accumulator, register pairs.  The most constrained target
+     in the lane by a wide margin.
+3. **Stress-tests the IIR's neutrality.**  If a 4-bit-data,
+   4 KiB-ROM target can swallow the IIR's 64-bit Operand::Int
+   shape (via truncation + range-rejection), every other backend
+   can too.
+
+## Why `Vec<u8>` output, not textual asm?
+
+* **Round-trips with `intel-4004-assembler` and any in-tree
+  4004 simulator.**  Both consume raw byte streams.
+* **Deterministic test surface** — 4004 mnemonics have multiple
+  historical spellings (Intel's original MCS-4 manual vs modern
+  reverse-engineered docs).  Bytes are unambiguous.
+* **Trivial output size** — 4004 instructions are 1 or 2 bytes;
+  emitting bytes directly skips a textual-assembly round-trip.
+
+## Pipeline
+
+```text
+IIRModule
+  → validate_for_intel4004()      pre-flight, returns Vec<String>
+  → lower_iir_to_intel4004()      returns Vec<u8> of 4004 opcodes
+  → (optional)
+      • intel-4004-assembler: round-trip via its decoder
+      • write to .bin + a 4004 simulator for in-process testing
+      • burn to a 1702/2708 EPROM + plug into a 4004 dev board
+```
+
+## Scope by version
+
+| Version | Scope | Status |
+|---------|-------|--------|
+| **v0.1.0 (A4 — this PR)** | crate skeleton: any module → single `JUN 0x000` (`0x40 0x00`) infinite-loop halt sentinel | this PR |
+| v0.2.0 (A4+) | `const dest, Int(n)` → `LDM n` (load immediate to accumulator, 4-bit n) + `ret`/`ret_void` → JUN-self | future |
+| v0.3.0 (A4++) | Register-pair allocator over `r0r1..r14r15` + arithmetic via accumulator (`ADD`, `SUB` family) | future |
+| v0.4.0 (A4+++) | `lang-aot --emit=intel4004` wiring + Brainfuck end-to-end | future |
+
+## Public surface (v0.1.0)
+
+```rust
+pub struct IIRIntel4004Config { pub module_name: String }
+impl IIRIntel4004Config {
+    pub fn new(module_name: impl Into<String>) -> Self;
+}
+
+pub enum IIRIntel4004Error {
+    ValidationFailed(Vec<String>),
+    UnsupportedOp     { function: String, op: String },
+    UnsupportedType   { function: String, type_hint: String },
+    InvalidOperand    { function: String, detail: String },
+}
+
+pub fn validate_for_intel4004(module: &IIRModule) -> Vec<String>;
+pub fn lower_iir_to_intel4004(
+    module: &IIRModule,
+    cfg: &IIRIntel4004Config,
+) -> Result<Vec<u8>, IIRIntel4004Error>;
+
+pub const HALT_LOOP: [u8; 2] = [0x40, 0x00];
+```
+
+## The `JUN 0x000` halt encoding (v0.1.0 acceptance criterion)
+
+The 4004 has no formal `HLT` instruction.  The canonical "halt"
+idiom in 4004 ROM development is `JUN 0x000` — an unconditional
+jump back to ROM address 0, which (when this instruction is
+itself at address 0) loops on itself forever, simulating halt.
+
+Bit layout: `0100 aaaa aaaaaaaa` — the high 4 bits of byte 1 are
+the JUN opcode (`0100`), the low 4 bits hold the high 4 bits of
+the 12-bit address, and byte 2 holds the low 8 bits.
+
+For `JUN 0x000`:
+
+```text
+byte 1: 0100 0000 = 0x40   (JUN opcode + high addr nibble = 0)
+byte 2: 0000 0000 = 0x00   (low addr byte = 0)
+```
+
+When emitted at ROM address 0 (where lowering starts), this
+instruction's address is 0 and its target is 0, so the CPU
+infinitely re-executes it.  Every 4004 simulator and any
+oscilloscope hooked to the program counter recognises this
+pattern as "the chip is stuck at address 0".
+
+### Why JUN-self over NOP-cycle or unimplemented-opcode?
+
+| Candidate | Pros | Cons |
+|-----------|------|------|
+| `JUN 0x000` (this) | Self-documenting; portable across all 4004 implementations | None for skeleton purposes |
+| `NOP NOP NOP ...` (0x00 cycle) | Even simpler bytes | Doesn't halt — keeps running into whatever follows |
+| Unimplemented opcode | Forces a trap | 4004 silicon executes most "unused" bit patterns as NOPs; not portable |
+
+`JUN 0x000` wins on portability + clarity.
+
+## Non-goals (v0.1.0)
+
+* No instruction lowering — deferred to A4+.
+* No `lang-aot --emit=intel4004` wiring — deferred to A4+++.
+* No external assembler / linker integration.  Output is raw
+  bytes; downstream loaders are the caller's responsibility.
+
+## Tests (v0.1.0)
+
+* `validate_returns_empty_for_empty_module` — stub validator behaves.
+* `lower_emits_exactly_two_bytes` — output shape.
+* `lower_emits_the_canonical_jun_self_bytes` — exact `0x40 0x00`.
+* `halt_loop_constant_pinned_to_40_00` — guards the constant.
+* `default_config_has_nonempty_module_name` — config invariant.
+* `new_sets_module_name` — builder contract.
+* `errors_display_without_panic` — error formatting smoke.


### PR DESCRIPTION
## Summary

Adds a new crate \`iir-to-intel4004\` at v0.1.0 — the **A4 skeleton** in the LANG VM architecture-backend matrix, mirroring iir-to-riscv (A1), iir-to-intel8008 (A2), and iir-to-armv7 (A3).

The Intel 4004 (1971) was the **world's first commercial microprocessor**.  Tiny ISA, 4-bit data, 12-bit ROM addresses, single 4-bit accumulator, 16 4-bit registers organised as 8 register pairs, tiny ROM (4 KiB max) and RAM (640 bits max).

In this codebase the 4004 is primarily a **Brainfuck fit** per MULTILANG-ARCHITECTURE-BACKENDS.md §A4.

### Design-space positioning across the four lanes

|              | RV32I (A1) | 8008 (A2)  | ARMv7 (A3) | **4004 (A4)** |
|--------------|------------|------------|------------|---------------|
| Width        | 32-bit     | 8-bit      | 32-bit     | **4-bit**     |
| ROM size     | huge       | 16 KiB     | huge       | **4 KiB**     |
| Registers    | 31 GP      | 7 GP       | 13 GP      | **8 pairs**   |
| Year shipped | 2015       | 1972       | 2005       | **1971**      |

The 4004 is the **most constrained target in the lane by a wide margin**.

### v0.1.0 surface

\`\`\`rust
pub struct IIRIntel4004Config { pub module_name: String }
pub enum IIRIntel4004Error { ValidationFailed, UnsupportedOp, UnsupportedType, InvalidOperand }
pub fn validate_for_intel4004(module: &IIRModule) -> Vec<String>;
pub fn lower_iir_to_intel4004(module, cfg) -> Result<Vec<u8>, IIRIntel4004Error>;
pub const HALT_LOOP: [u8; 2] = [0x40, 0x00];
\`\`\`

### Why JUN 0x000 as the halt sentinel?

The 4004 has **no formal HLT instruction**.  The canonical "halt" idiom is \`JUN 0x000\` — an unconditional jump back to ROM address 0, which (when itself at address 0) loops forever, simulating halt.

\`\`\`text
byte 1: 0100 0000 = 0x40   (JUN opcode + high nibble of 12-bit addr = 0)
byte 2: 0000 0000 = 0x00   (low byte of address = 0)
\`\`\`

Why JUN-self over NOP-cycle or unimplemented-opcode?

| Candidate | Pros | Cons |
|-----------|------|------|
| \`JUN 0x000\` (this) | Self-documenting; portable across all 4004 implementations | None for skeleton purposes |
| \`NOP NOP NOP ...\` (0x00 cycle) | Even simpler bytes | Doesn't halt — keeps running into whatever follows |
| Unimplemented opcode | Forces a trap | 4004 silicon executes most "unused" bit patterns as NOPs; not portable |

### Future slices

- **v0.2.0 (A4+)**   — \`const\` → \`LDM\` (load immediate to accumulator); \`ret\` → JUN-self
- **v0.3.0 (A4++)**  — register-pair allocator over r0r1..r14r15 + arithmetic via accumulator
- **v0.4.0 (A4+++)** — \`lang-aot --emit=intel4004\` wiring + Brainfuck end-to-end

## Test plan

- [x] \`cargo test -p iir-to-intel4004\` — 7/7 backend tests pass, 1/1 doctest passes
- [x] HALT_LOOP pinned to \`[0x40, 0x00]\`
- [x] Lower emits exactly two bytes
- [x] Lower emits the canonical \`JUN 0x000\` byte pair
- [x] Config defaults + builder + error Display smoke
- [x] Workspace Cargo.toml updated
- [x] Spec + README + CHANGELOG + BUILD created
- [x] Security review passed (no vulnerabilities found)
- [ ] CI green
- [ ] No merge conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)