### PR TITLE
[codex] board-vm: summarize ejected boot runs

### DIFF
--- a/code/packages/rust/board-vm-uno-r4-firmware/README.md
+++ b/code/packages/rust/board-vm-uno-r4-firmware/README.md
@@ -70,6 +70,9 @@ the parsed BVM module, so the boot runner uses one board-checked artifact view
 for both store-only decisions and direct execution. The checked boot-run result
 returns that plan with the optional runtime report, letting diagnostics describe
 whether startup validated-and-ran or validated-and-skipped a store-only artifact.
+Its compact summary preserves the boot plan plus run status, instruction count,
+and open-handle count when execution happened, without inventing a second
+artifact interpretation path.
 
 The ejected artifact stays board-agnostic; this firmware binary is the Uno R4
 backend that decides how to validate and execute it.

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/lib.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/lib.rs
@@ -5,7 +5,7 @@ use board_vm_ir::{
     RequiredCapabilitiesError, ValidateError, MODULE_VERSION,
 };
 use board_vm_protocol::{ProgramFormat, BOOT_RUN_AT_BOOT, BOOT_RUN_IF_NO_HOST, BOOT_STORE_ONLY};
-use board_vm_runtime::{BoardHal, RunReport, Runtime, RuntimeError};
+use board_vm_runtime::{BoardHal, RunReport, RunStatus, Runtime, RuntimeError};
 
 pub mod arduino_usb_link;
 pub mod ejected_blink;
@@ -124,6 +124,38 @@ pub struct EjectedBootPlan {
 pub struct EjectedBootRun {
     pub boot_plan: EjectedBootPlan,
     pub report: Option<RunReport>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EjectedBootRunSummary {
+    pub boot_plan: EjectedBootPlan,
+    pub run_status: Option<RunStatus>,
+    pub instructions_executed: Option<u32>,
+    pub open_handles: Option<u8>,
+}
+
+impl EjectedBootRun {
+    pub fn ran(self) -> bool {
+        self.report.is_some()
+    }
+
+    pub fn summary(self) -> EjectedBootRunSummary {
+        let (run_status, instructions_executed, open_handles) = match self.report {
+            Some(report) => (
+                Some(report.status),
+                Some(report.instructions_executed),
+                Some(report.open_handles),
+            ),
+            None => (None, None, None),
+        };
+
+        EjectedBootRunSummary {
+            boot_plan: self.boot_plan,
+            run_status,
+            instructions_executed,
+            open_handles,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -734,7 +766,20 @@ mod tests {
                 summary: EjectedFirmwareProgram::blink().summary(),
             }
         );
+        assert!(boot_run.ran());
         let report = boot_run.report.unwrap();
+        assert_eq!(
+            boot_run.summary(),
+            EjectedBootRunSummary {
+                boot_plan: EjectedBootPlan {
+                    action: EjectedBootAction::Run,
+                    summary: EjectedFirmwareProgram::blink().summary(),
+                },
+                run_status: Some(report.status),
+                instructions_executed: Some(report.instructions_executed),
+                open_handles: Some(report.open_handles),
+            }
+        );
         assert_eq!(report.status, RunStatus::BudgetExceeded);
         assert_eq!(report.open_handles, 1);
         assert_eq!(
@@ -777,6 +822,19 @@ mod tests {
             EjectedBootPlan {
                 action: EjectedBootAction::StoreOnly,
                 summary: program.summary(),
+            }
+        );
+        assert!(!boot_run.ran());
+        assert_eq!(
+            boot_run.summary(),
+            EjectedBootRunSummary {
+                boot_plan: EjectedBootPlan {
+                    action: EjectedBootAction::StoreOnly,
+                    summary: program.summary(),
+                },
+                run_status: None,
+                instructions_executed: None,
+                open_handles: None,
             }
         );
         assert_eq!(boot_run.report, None);


### PR DESCRIPTION
## Summary
- add `EjectedBootRunSummary` as a compact diagnostic view over checked ejected boot runs
- expose `EjectedBootRun::ran()` and `EjectedBootRun::summary()` so firmware callers can distinguish run versus store-only skip without reinterpreting artifacts
- document the summary fields beside the existing ejected runtime handoff description

## Validation
- `cargo fmt -p board-vm-uno-r4-firmware`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-ejected-boot-run-summary cargo test -p board-vm-uno-r4-firmware`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-ejected-boot-run-summary cargo test -p board-vm-protocol -p board-vm-ir -p board-vm-host -p board-vm-device -p board-vm-loopback -p board-vm-client -p board-vm-eject -p board-vm-uno-r4-firmware -p board-vm-cli`
- `git diff --check`
- `git diff --cached --check`