### PR TITLE
feat(iir-to-intel4004): const → LDM n; ret → JUN-self — A4+ first lowering

### DIFF
--- a/code/packages/rust/iir-to-intel4004/CHANGELOG.md
+++ b/code/packages/rust/iir-to-intel4004/CHANGELOG.md
@@ -3,6 +3,83 @@
 All notable changes to this crate are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.2.0] — 2026-06-02 (A4+ — `const` → `LDM n`; `ret`/`ret_void` → `JUN 0x000`)
+
+### Added — first real instruction lowering
+
+Extends v0.1.0's HALT_LOOP-only skeleton with three IIR ops:
+
+| IIR op | 4004 lowering |
+|--------|---------------|
+| `const dest, Int(n)` (4-bit imm) | `LDM n` (`0xD0 \| n`, single byte) |
+| `ret <var>` | `JUN 0x000` (halt sentinel — real RET in A4++) |
+| `ret_void` | `JUN 0x000` |
+
+The accumulator-only first slice: every `const` goes into the
+4004's 4-bit accumulator.  Multi-register-pair allocation via the
+8 register pairs (`r0r1..r14r15`) arrives in A4++ alongside
+arithmetic.
+
+#### Why `ret` → halt sentinel for now?
+
+The 4004's real `RET` is `BBL` (Branch Back to Last, opcode
+`1100 dddd`).  But `BBL` requires a corresponding `JMS` (Jump to
+SubRoutine, opcode `0101 aaaa aaaaaaaa`) to have pushed the
+return address onto the 4004's 3-deep internal call stack first.
+Without proper call/return discipline (which lands in A4++),
+`BBL` from a fresh-start ROM would pop a garbage address from
+the stack and jump there — undefined behaviour on most 4004
+simulators.
+
+`JUN 0x000` gives the simulator a clean stopping point until A4++
+wires up the call stack.  Same pattern as iir-to-intel8008
+v0.2.0's HLT-for-ret stand-in.
+
+#### New constant in the public surface
+
+* `pub const LDM_OPCODE: u8 = 0xD0;` — Intel 4004 `LDM n` opcode
+  high nibble.  OR in the 4-bit immediate (0..=15) to form the
+  full byte (`LDM 0 = 0xD0`, `LDM 15 = 0xDF`).
+
+#### Immediate nibble range
+
+`const` accepts integers in `[-8, 15]` (signed 4-bit interval):
+* `[0, 15]` cast straight to the low nibble.
+* `[-8, -1]` reinterpreted as 4-bit two's-complement (`-1 → 0xF`).
+* Anything outside → `InvalidOperand` with a precise message
+  naming the 4-bit limit and pointing forward to A4++'s wider-
+  immediate idiom (LDM/arithmetic-op pairs).
+
+The 4004 has **no wide-immediate idiom** comparable to the 8008's
+8-bit `MVI` or RV32I's 12-bit `addi` — `LDM` is exactly 4 bits.
+Multi-nibble values require explicit decomposition.
+
+#### Tests added (16 total, was 7)
+
+* `ldm_opcode_pinned_to_0xd0` — sanity check on the constant.
+* `const_5_then_ret_lowers_to_ldm_5_then_jun_self` — pinned
+  3-byte sequence `0xD5 0x40 0x00`.
+* `const_15_then_ret_lowers_to_ldm_15_then_jun_self` — max
+  4-bit value `0xDF`.
+* `const_0_then_ret_emits_ldm_0` — minimum positive (LDM 0 = 0xD0,
+  the bare opcode).
+* `const_negative_uses_twos_complement_nibble` (`-1 → 0xF`).
+* `const_negative_minus_eight_uses_8_nibble` (`-8 → 0x8`, the
+  minimum signed 4-bit value).
+* `const_out_of_nibble_range_is_rejected` (`16` overflows).
+* `ret_void_alone_emits_just_jun_self`.
+* `unsupported_op_is_rejected_with_function_name` (`safepoint`
+  rejected with function name preserved).
+
+### What is NOT in v0.2.0 (deferred to A4++ and beyond)
+
+* Register-pair allocator over `r0r1..r14r15` (the 4004's 8 register
+  pairs — 16 4-bit registers organised as 8 pairs).
+* Arithmetic via accumulator (`ADD`, `SUB`, `IAC`, `DAC`).
+* Real `RET` via `BBL` + the 4004's 3-deep internal call stack.
+* Conditional jumps via `JCN` (Jump on Condition).
+* `lang-aot --emit=intel4004` wiring — A4+++.
+
 ## [0.1.0] — 2026-06-02 (A4 — crate skeleton)
 
 ### Added — `JUN 0x000`-only emission

--- a/code/packages/rust/iir-to-intel4004/Cargo.toml
+++ b/code/packages/rust/iir-to-intel4004/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iir-to-intel4004"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
-description = "IIR → Intel 4004 machine code backend — lowers IIRModule to a Vec<u8> of encoded 4-bit-data, 8-bit-instruction Intel 4004 opcodes.  v0.1.0 (A4): crate skeleton that lowers any module to a single `JUN 0x000` (0x40 0x00) infinite-loop halt sentinel — the canonical 4004-ROM halt idiom (the chip has no formal HLT instruction).  Real lowering (LDM/ADD/SUB/conditional jumps) lands in A4+ through A4++.  The 4004 (1971) is the world's first commercial microprocessor — the most constrained target in the LANG VM architecture-backend lane, primarily a Brainfuck fit per MULTILANG-ARCHITECTURE-BACKENDS.md §A4."
+description = "IIR → Intel 4004 machine code backend — lowers IIRModule to a Vec<u8> of encoded 4-bit-data, 8-bit-instruction Intel 4004 opcodes.  v0.2.0 (A4+): first real instruction lowering — `const dest, Int(n)` → `LDM n` (load immediate to accumulator, 0xD0|n where n is 4 bits, range [-8, 15]) and `ret <var>`/`ret_void` → JUN 0x000 (halt sentinel until A4++ adds real BBL/JMS call discipline).  Accumulator-only first slice: every const goes into the 4-bit accumulator.  Multi-register-pair allocation + arithmetic lands in A4++."
 
 [lib]
 name = "iir_to_intel4004"

--- a/code/packages/rust/iir-to-intel4004/src/lib.rs
+++ b/code/packages/rust/iir-to-intel4004/src/lib.rs
@@ -70,7 +70,7 @@
 //! assert_eq!(bytes, vec![0x40, 0x00]);
 //! ```
 
-use interpreter_ir::IIRModule;
+use interpreter_ir::{IIRModule, Operand};
 use std::fmt;
 
 // ===========================================================================
@@ -80,6 +80,27 @@ use std::fmt;
 // The 4004 has no formal HLT.  The canonical "halt" idiom is `JUN
 // 0x000` — an unconditional jump back to ROM address 0, which
 // (when itself at address 0) loops forever, simulating halt.
+
+/// Intel 4004 `LDM n` opcode high nibble — `0xD0`.  Loads the 4-bit
+/// immediate `n` (low nibble) into the accumulator.
+///
+/// Bit pattern: `1101 nnnn` (immediate-load family).  Single-byte
+/// instruction — OR in the 4-bit immediate value (0..=15) to form
+/// the full opcode byte.
+///
+/// Example:
+/// ```text
+/// LDM 0  = 0xD0     (0b1101_0000)
+/// LDM 7  = 0xD7     (0b1101_0111)
+/// LDM 15 = 0xDF     (0b1101_1111)
+/// ```
+///
+/// The 4004's accumulator is exactly 4 bits wide, so `LDM` is the
+/// only "load immediate" instruction needed — there's no wider
+/// immediate idiom (no `LDM_16` etc.).  Values wider than 4 bits
+/// must be built up via multiple `LDM`/arithmetic-op pairs in
+/// future slices.
+pub const LDM_OPCODE: u8 = 0xD0;
 
 /// Canonical "halt" sentinel for the Intel 4004 — two bytes:
 /// `0x40 0x00` (= `JUN 0x000`, jump-unconditional to ROM address 0).
@@ -209,13 +230,54 @@ pub fn validate_for_intel4004(_module: &IIRModule) -> Vec<String> {
 // lower_iir_to_intel4004
 // ===========================================================================
 
+/// Supported instruction opcodes in v0.2.0 (A4+).
+///
+/// * `const dest, Int(n)` lowers to `LDM n` (every value goes
+///   into the accumulator in this accumulator-only first slice).
+/// * `ret <var>` and `ret_void` both lower to `JUN 0x000` (the
+///   halt sentinel — real `RET` via `BBL` + the 4004's 3-deep
+///   internal call stack lands in A4++).
+const SUPPORTED_OPS: &[&str] = &[
+    "const", "ret", "ret_void",
+];
+
 /// Lower an [`IIRModule`] to a `Vec<u8>` of Intel 4004 opcode bytes.
 ///
-/// **v0.1.0 scope**: emits the canonical 2-byte halt sentinel `JUN
-/// 0x000` (`0x40 0x00`) regardless of the input.  This is the
-/// smallest "valid Intel 4004 program" we can produce — enough to
-/// load into a simulator, step once, and confirm the CPU is stuck
-/// at address 0.  Real lowering arrives in v0.2.0+ (A4+).
+/// **v0.2.0 scope** (A4+ — first real lowering):
+///
+/// | IIR op | 4004 lowering |
+/// |--------|---------------|
+/// | `const dest, Int(n)` (4-bit imm) | `LDM n` (`0xD0 \| n`) |
+/// | `ret <var>` | `JUN 0x000` (halt sentinel — real RET in A4++) |
+/// | `ret_void` | `JUN 0x000` |
+///
+/// ### Accumulator-only first slice
+///
+/// Every `const` loads into the accumulator.  Multi-register
+/// allocation via the 4004's 8 register pairs (`r0r1..r14r15`)
+/// arrives in A4++ alongside arithmetic.
+///
+/// ### Why `ret` → halt sentinel for now?
+///
+/// The 4004's real `RET` is `BBL` (Branch Back to Last; opcode
+/// `1100 dddd`).  But `BBL` requires that a corresponding `JMS`
+/// (Jump to SubRoutine, opcode `0101 aaaa aaaaaaaa`) have pushed
+/// the return address onto the 4004's 3-deep internal call stack
+/// first.  Without proper call/return discipline (which lands in
+/// A4++), `BBL` from a fresh-start ROM would pop a garbage
+/// address from the stack and jump to it — undefined behaviour
+/// on most 4004 simulators.
+///
+/// `JUN 0x000` gives the simulator a clean, deterministic
+/// stopping point in the meantime.
+///
+/// ### Empty-module contract
+///
+/// Preserves v0.1.0's behaviour for the trivial "fn main() {}"
+/// case: any module with no functions emits the bare
+/// `HALT_LOOP` so the simulator halts deterministically.  Once
+/// at least one function is lowered, the halt sentinel terminates
+/// the last function's instruction stream.
 pub fn lower_iir_to_intel4004(
     module: &IIRModule,
     _cfg: &IIRIntel4004Config,
@@ -224,5 +286,117 @@ pub fn lower_iir_to_intel4004(
     if !errors.is_empty() {
         return Err(IIRIntel4004Error::ValidationFailed(errors));
     }
-    Ok(HALT_LOOP.to_vec())
+
+    // Trivial empty-module contract — preserves v0.1.0 callable
+    // behaviour for the canonical "fn main() {}" minimal case.
+    if module.functions.is_empty() {
+        return Ok(HALT_LOOP.to_vec());
+    }
+
+    let mut bytes = Vec::new();
+    for f in &module.functions {
+        for instr in &f.instructions {
+            if !SUPPORTED_OPS.contains(&instr.op.as_str()) {
+                return Err(IIRIntel4004Error::UnsupportedOp {
+                    function: f.name.clone(),
+                    op: instr.op.clone(),
+                });
+            }
+            match instr.op.as_str() {
+                // ── const dest, Int(n) → LDM n ─────────────────────────
+                //
+                // The 4004's accumulator is 4 bits wide.  Values in
+                // [0, 15] cast straight to the LDM low nibble.
+                // [-8, -1] reinterpreted via two's-complement
+                // (`-1 → 0xF`).  Anything outside surfaces as
+                // `InvalidOperand`.
+                "const" => {
+                    let _dest = require_dest(instr, "const", &f.name)?;
+                    let n = encode_immediate_nibble(instr.srcs.first(), &f.name)?;
+                    bytes.push(LDM_OPCODE | n);
+                }
+
+                // ── ret <var>: JUN 0x000 ───────────────────────────────
+                //
+                // The value is already in the accumulator (every const
+                // lowers there in v0.2.0).  Real `RET` via `BBL` + the
+                // 4004's 3-deep return stack lands in A4++.  Until then,
+                // JUN-self is the universal stopping primitive.
+                "ret" => {
+                    // Validate that srcs[0] is a Var — front-end bugs
+                    // surface as `InvalidOperand` rather than producing
+                    // surprising silence.
+                    match instr.srcs.first() {
+                        Some(Operand::Var(_)) => {}
+                        _ => return Err(IIRIntel4004Error::InvalidOperand {
+                            function: f.name.clone(),
+                            detail: "ret srcs[0] must be Var".into(),
+                        }),
+                    };
+                    bytes.extend_from_slice(&HALT_LOOP);
+                }
+
+                // ── ret_void: JUN 0x000 ────────────────────────────────
+                "ret_void" => {
+                    bytes.extend_from_slice(&HALT_LOOP);
+                }
+
+                _ => unreachable!("SUPPORTED_OPS guard above prevents this"),
+            }
+        }
+    }
+
+    // Defensive — if a function had no instructions at all, fall
+    // back to HALT_LOOP so the output is still a valid halting
+    // program.
+    if bytes.is_empty() {
+        bytes.extend_from_slice(&HALT_LOOP);
+    }
+
+    Ok(bytes)
+}
+
+// ---------------------------------------------------------------------------
+// Per-instruction helpers
+// ---------------------------------------------------------------------------
+
+fn require_dest<'a>(
+    instr: &'a interpreter_ir::IIRInstr,
+    op: &str,
+    fn_name: &str,
+) -> Result<&'a str, IIRIntel4004Error> {
+    instr.dest.as_deref().ok_or_else(|| IIRIntel4004Error::InvalidOperand {
+        function: fn_name.to_string(),
+        detail: format!("{op} requires a dest"),
+    })
+}
+
+fn encode_immediate_nibble(
+    op: Option<&Operand>,
+    fn_name: &str,
+) -> Result<u8, IIRIntel4004Error> {
+    let n = match op {
+        Some(Operand::Int(n)) => *n,
+        Some(Operand::Bool(b)) => if *b { 1 } else { 0 },
+        _ => return Err(IIRIntel4004Error::InvalidOperand {
+            function: fn_name.to_string(),
+            detail: "const srcs[0] must be Int or Bool".into(),
+        }),
+    };
+    if (0..=15).contains(&n) {
+        Ok(n as u8)
+    } else if (-8..0).contains(&n) {
+        // Two's-complement reinterpretation: -1 → 0xF, -8 → 0x8.
+        Ok((n & 0xF) as u8)
+    } else {
+        Err(IIRIntel4004Error::InvalidOperand {
+            function: fn_name.to_string(),
+            detail: format!(
+                "const {n} exceeds 4-bit nibble range ([-8, 15]); the \
+                 4004's accumulator and LDM immediate are both 4 bits \
+                 wide — wider values must be built up via multiple \
+                 LDM/arithmetic-op pairs in A4++"
+            ),
+        })
+    }
 }

--- a/code/packages/rust/iir-to-intel4004/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-intel4004/tests/test_backend.rs
@@ -3,11 +3,23 @@
 //! Smoke-level — confirms the validator stub, the emitter shape,
 //! and the exact encoded `JUN 0x000` byte pair (`0x40 0x00`).
 
-use interpreter_ir::IIRModule;
+use interpreter_ir::{IIRFunction, IIRInstr, IIRModule, Operand};
 use iir_to_intel4004::{
     lower_iir_to_intel4004, validate_for_intel4004,
-    IIRIntel4004Config, IIRIntel4004Error, HALT_LOOP,
+    IIRIntel4004Config, IIRIntel4004Error, HALT_LOOP, LDM_OPCODE,
 };
+
+fn module_with(f: IIRFunction) -> IIRModule {
+    let entry = f.name.clone();
+    IIRModule {
+        name: "test".into(),
+        functions: vec![f],
+        entry_point: Some(entry),
+        language: "test".into(),
+        exports: vec![],
+        imports: vec![],
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -107,4 +119,139 @@ fn errors_display_without_panic() {
     let _ = format!("{}", IIRIntel4004Error::InvalidOperand {
         function: "f".into(), detail: "bad".into(),
     });
+}
+
+// ===========================================================================
+// 5. A4+ (v0.2.0) — `const` lowers to `LDM n`; `ret` → JUN-self (halt)
+// ===========================================================================
+//
+// The accumulator-only first slice: every `const` goes into the
+// accumulator via `LDM`.  `ret`/`ret_void` both emit the 2-byte
+// JUN 0x000 halt sentinel because real RET (via BBL + the 4004's
+// 3-deep internal stack) needs A4++'s call/return discipline.
+
+#[test]
+fn ldm_opcode_pinned_to_0xd0() {
+    // Sanity: the LDM_OPCODE high nibble matches the canonical
+    // 4004-documented encoding (1101_xxxx).
+    assert_eq!(LDM_OPCODE, 0xD0,
+        "LDM opcode high nibble should be 0xD0 (1101_0000)");
+}
+
+#[test]
+fn const_5_then_ret_lowers_to_ldm_5_then_jun_self() {
+    // const v=5; ret v
+    //   LDM 5     = 0xD5
+    //   JUN 0x000 = 0x40 0x00
+    let f = IIRFunction::new("five", vec![], "u8", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(5)], "u8"),
+        IIRInstr::new("ret",   None,             vec![Operand::Var("v".into())], "u8"),
+    ]);
+    let bytes = lower_iir_to_intel4004(&module_with(f), &IIRIntel4004Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![0xD5, 0x40, 0x00],
+        "expected LDM 5 (0xD5) + JUN 0x000 (0x40 0x00); got: {bytes:02x?}");
+}
+
+#[test]
+fn const_15_then_ret_lowers_to_ldm_15_then_jun_self() {
+    // const v=15 (the max 4-bit value); ret v
+    //   LDM 15    = 0xDF
+    //   JUN 0x000 = 0x40 0x00
+    let f = IIRFunction::new("max", vec![], "u8", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(15)], "u8"),
+        IIRInstr::new("ret",   None,             vec![Operand::Var("v".into())], "u8"),
+    ]);
+    let bytes = lower_iir_to_intel4004(&module_with(f), &IIRIntel4004Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![0xDF, 0x40, 0x00],
+        "expected LDM 15 (0xDF) + JUN 0x000; got: {bytes:02x?}");
+}
+
+#[test]
+fn const_0_then_ret_emits_ldm_0() {
+    // const v=0; ret v
+    //   LDM 0 = 0xD0 — pinned because OR-ing with 0 should leave
+    //   the LDM opcode high nibble visibly intact.
+    let f = IIRFunction::new("zero", vec![], "u8", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(0)], "u8"),
+        IIRInstr::new("ret",   None,             vec![Operand::Var("v".into())], "u8"),
+    ]);
+    let bytes = lower_iir_to_intel4004(&module_with(f), &IIRIntel4004Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![0xD0, 0x40, 0x00],
+        "expected LDM 0 (0xD0) + JUN 0x000; got: {bytes:02x?}");
+}
+
+#[test]
+fn const_negative_uses_twos_complement_nibble() {
+    // -1 → 0xF via 4-bit two's-complement reinterpretation.
+    // LDM 0xF = 0xDF.
+    let f = IIRFunction::new("minus_one", vec![], "i8", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(-1)], "i8"),
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ]);
+    let bytes = lower_iir_to_intel4004(&module_with(f), &IIRIntel4004Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![0xDF, 0x40, 0x00],
+        "expected LDM 0xF + JUN 0x000 for `const -1`; got: {bytes:02x?}");
+}
+
+#[test]
+fn const_negative_minus_eight_uses_8_nibble() {
+    // -8 → 0x8 (the minimum signed 4-bit value).  LDM 0x8 = 0xD8.
+    let f = IIRFunction::new("minus_eight", vec![], "i8", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(-8)], "i8"),
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ]);
+    let bytes = lower_iir_to_intel4004(&module_with(f), &IIRIntel4004Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![0xD8, 0x40, 0x00],
+        "expected LDM 0x8 + JUN 0x000 for `const -8`; got: {bytes:02x?}");
+}
+
+#[test]
+fn const_out_of_nibble_range_is_rejected() {
+    let f = IIRFunction::new("oversized", vec![], "i16", vec![
+        // 16 is just past the 4-bit range.
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(16)], "i16"),
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ]);
+    let err = lower_iir_to_intel4004(&module_with(f), &IIRIntel4004Config::default())
+        .expect_err("16 should overflow the 4-bit immediate");
+    match err {
+        IIRIntel4004Error::InvalidOperand { detail, .. } => {
+            assert!(detail.contains("4-bit"),
+                "expected message naming the 4-bit limit; got: {detail}");
+        }
+        other => panic!("expected InvalidOperand, got: {other:?}"),
+    }
+}
+
+#[test]
+fn ret_void_alone_emits_just_jun_self() {
+    let f = IIRFunction::new("main", vec![], "void", vec![
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ]);
+    let bytes = lower_iir_to_intel4004(&module_with(f), &IIRIntel4004Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![0x40, 0x00],
+        "ret_void-only function should emit just JUN 0x000; got: {bytes:02x?}");
+}
+
+#[test]
+fn unsupported_op_is_rejected_with_function_name() {
+    let f = IIRFunction::new("boom", vec![], "void", vec![
+        IIRInstr::new("safepoint", None, vec![], "void"),
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ]);
+    let err = lower_iir_to_intel4004(&module_with(f), &IIRIntel4004Config::default())
+        .expect_err("`safepoint` should be UnsupportedOp");
+    match err {
+        IIRIntel4004Error::UnsupportedOp { function, op } => {
+            assert_eq!(function, "boom");
+            assert_eq!(op, "safepoint");
+        }
+        other => panic!("expected UnsupportedOp, got: {other:?}"),
+    }
 }

--- a/code/specs/iir-to-intel4004.md
+++ b/code/specs/iir-to-intel4004.md
@@ -66,8 +66,8 @@ IIRModule
 
 | Version | Scope | Status |
 |---------|-------|--------|
-| **v0.1.0 (A4 — this PR)** | crate skeleton: any module → single `JUN 0x000` (`0x40 0x00`) infinite-loop halt sentinel | this PR |
-| v0.2.0 (A4+) | `const dest, Int(n)` → `LDM n` (load immediate to accumulator, 4-bit n) + `ret`/`ret_void` → JUN-self | future |
+| v0.1.0 (A4) | crate skeleton: any module → single `JUN 0x000` (`0x40 0x00`) infinite-loop halt sentinel | **merged** |
+| **v0.2.0 (A4+ — this PR)** | `const dest, Int(n)` → `LDM n` (load immediate to accumulator, 4-bit n; range `[-8, 15]` via two's-complement) + `ret`/`ret_void` → JUN-self halt sentinel | this PR |
 | v0.3.0 (A4++) | Register-pair allocator over `r0r1..r14r15` + arithmetic via accumulator (`ADD`, `SUB` family) | future |
 | v0.4.0 (A4+++) | `lang-aot --emit=intel4004` wiring + Brainfuck end-to-end | future |
 


### PR DESCRIPTION
## Summary

Extends \`iir-to-intel4004\` v0.1.0 → **v0.2.0** with the first real instruction lowering.

| IIR op | 4004 lowering |
| ------ | ------------- |
| \`const dest, Int(n)\` (4-bit imm) | \`LDM n\` (\`0xD0 \| n\`, single byte) |
| \`ret <var>\` | \`JUN 0x000\` (halt sentinel) |
| \`ret_void\` | \`JUN 0x000\` (halt sentinel) |

The accumulator-only first slice: every \`const\` goes into the 4004's 4-bit accumulator via LDM.  Multi-register-pair allocation via the 8 register pairs (\`r0r1..r14r15\`) arrives in A4++.

### Why ret → halt sentinel for now?

The 4004's real \`RET\` is \`BBL\` (Branch Back to Last).  But \`BBL\` requires a corresponding \`JMS\` (Jump to SubRoutine) to have pushed the return address onto the 4004's 3-deep internal call stack first.  Without proper call/return discipline (which lands in A4++), \`BBL\` from a fresh-start ROM would pop a garbage address from the stack and jump there — undefined behaviour on most 4004 simulators.

\`JUN 0x000\` gives the simulator a clean stopping point until A4++ wires up the call stack.

### Why no wide-immediate idiom?

The 4004 has NO wide-immediate instruction comparable to the 8008's 8-bit \`MVI\` or RV32I's 12-bit \`addi\` — \`LDM\` is exactly 4 bits.  Multi-nibble values require explicit decomposition via multiple LDM/arithmetic-op pairs in future slices.

### Immediate nibble range

\`[-8, 15]\` (signed 4-bit interval):
- \`[0, 15]\` cast straight to the low nibble
- \`[-8, -1]\` reinterpreted as 4-bit two's-complement (\`-1 → 0xF\`)
- Anything outside → \`InvalidOperand\` naming the 4-bit limit

## Test plan

- [x] \`cargo test -p iir-to-intel4004\` — 16/16 backend tests pass, 1/1 doctest passes
- [x] LDM_OPCODE pinned to 0xD0
- [x] \`LDM 5; JUN 0x000\` byte sequence pinned (\`D5 40 00\`)
- [x] LDM 15 (max 4-bit) and LDM 0 (bare opcode) both pinned
- [x] Two's-complement negative consts (\`-1 → 0xF\`, \`-8 → 0x8\`)
- [x] Out-of-nibble-range rejection with 4-bit-limit error message
- [x] ret_void emits JUN 0x000 alone
- [x] Unsupported op rejection preserves function name
- [x] Security review passed (no vulnerabilities found)
- [ ] CI green
- [ ] No merge conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)