### PR TITLE
feat(iir-to-intel4004): ACC-first allocator + mov + ret staging — A4++

### DIFF
--- a/code/packages/rust/iir-to-intel4004/CHANGELOG.md
+++ b/code/packages/rust/iir-to-intel4004/CHANGELOG.md
@@ -3,6 +3,77 @@
 All notable changes to this crate are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.3.0] — 2026-06-02 (A4++ — ACC-first allocator + `mov` + ret-value staging)
+
+### Added — ACC-first linear allocator over r0..r15
+
+Extends v0.2.0's accumulator-only `const` to a real allocator over
+the 4004's 16 4-bit general-purpose registers (`r0..r15`).  The
+allocator pool is conceptually `[ACC, r0, r1, ..., r15]` — ACC
+comes first so the trivial `const v; ret v` case stays at the
+3-byte shape `LDM v; JUN 0x000` (no XCH/LD round-trip).
+
+When a second `const` arrives, the previous ACC owner is evicted
+to its next-free GP register via `XCH r` before `LDM` clobbers
+ACC with the new value.  Mirrors iir-to-intel8008 v0.3.0 (A2++)'s
+A-first pool ordering and trivial-case preservation pattern.
+
+| IIR op | 4004 lowering |
+|--------|---------------|
+| `const dest, Int(n)` (1st) | `LDM n` (`dest` owns ACC) |
+| `const dest, Int(n)` (Nth) | (`XCH r_prev` to evict prev ACC owner) + `LDM n` |
+| `mov dest, src` | (`XCH r_src` if src in ACC) + `LD r_src` + `XCH r_dest` |
+| `ret <var>` | (`LD r_var` if var not in ACC) + `JUN 0x000` |
+| `ret_void` | `JUN 0x000` |
+
+### Why ACC-first?
+
+The 4004 has no `ST r` (store accumulator to register) — `XCH r`
+(Exchange ACC with r) is the only way to materialise an ACC value
+into a register.  Every `XCH` after `LDM` costs 1 byte; every
+`LD` to re-stage costs another 1 byte.  Keeping the first var in
+ACC saves 2 bytes for the trivial case.
+
+### New constants
+
+* `pub const LD_OPCODE: u8 = 0xA0;` — `LD r` (load register to
+  accumulator, single-byte `1010 rrrr`).
+* `pub const XCH_OPCODE: u8 = 0xB0;` — `XCH r` (exchange
+  accumulator with register, single-byte `1011 rrrr`).
+
+### New error variants
+
+* `IIRIntel4004Error::UndefinedVariable` — `mov` or `ret`
+  referenced a name that was never bound.
+* `IIRIntel4004Error::OutOfRegisters` — 18th local exhausted the
+  17-slot pool (ACC + r0..r15).  Stack spilling via the 4004's
+  data-RAM (`SRC`/`WRM`/`RDM` family) lands in a future increment.
+
+### Tests added (25 total, was 16)
+
+* `ld_opcode_pinned_to_0xa0` / `xch_opcode_pinned_to_0xb0`.
+* `ret_of_first_const_omits_xch_and_ld` — regression for v0.2.0's
+  3-byte trivial-case shape (ACC-first allocator preserves it).
+* `two_consts_use_acc_then_xch_to_r0_for_eviction` — pinned 5-byte
+  `LDM 5; XCH r0; LDM 7; JUN 0x000`.
+* `ret_of_evicted_var_emits_ld_before_jun` — pinned 6-byte
+  sequence for `const v; const w; ret v` showing the `LD r0`
+  re-staging.
+* `mov_lowers_to_ld_then_xch` — pinned `LDM 3; XCH r0; LD r0;
+  XCH r1; LD r1; JUN 0x000`.
+* `allocator_exhaustion_yields_out_of_registers` — 18 consts →
+  fails on v16's eviction with `OutOfRegisters`.
+* `undefined_variable_in_mov_is_rejected`.
+* `errors_for_new_variants_display_without_panic`.
+
+### What is NOT in v0.3.0 (deferred to v0.4.0+)
+
+* Arithmetic via the accumulator (`ADD`, `SUB`, `IAC`, `DAC`).
+* Real `RET` via `BBL` + the 4004's 3-deep internal call stack.
+* Conditional jumps via `JCN` (Jump on Condition).
+* `lang-aot --emit=intel4004` wiring — A4+++.
+* Stack spilling once the 17-slot pool exhausts.
+
 ## [0.2.0] — 2026-06-02 (A4+ — `const` → `LDM n`; `ret`/`ret_void` → `JUN 0x000`)
 
 ### Added — first real instruction lowering

--- a/code/packages/rust/iir-to-intel4004/Cargo.toml
+++ b/code/packages/rust/iir-to-intel4004/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iir-to-intel4004"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
-description = "IIR → Intel 4004 machine code backend — lowers IIRModule to a Vec<u8> of encoded 4-bit-data, 8-bit-instruction Intel 4004 opcodes.  v0.2.0 (A4+): first real instruction lowering — `const dest, Int(n)` → `LDM n` (load immediate to accumulator, 0xD0|n where n is 4 bits, range [-8, 15]) and `ret <var>`/`ret_void` → JUN 0x000 (halt sentinel until A4++ adds real BBL/JMS call discipline).  Accumulator-only first slice: every const goes into the 4-bit accumulator.  Multi-register-pair allocation + arithmetic lands in A4++."
+description = "IIR → Intel 4004 machine code backend — lowers IIRModule to a Vec<u8> of encoded 4-bit-data, 8-bit-instruction Intel 4004 opcodes.  v0.3.0 (A4++): ACC-first linear allocator over the 4004's 16 4-bit GP registers (r0..r15) + multi-register `const` + `mov` (via LD+XCH pairs) + ret-value staging.  ACC comes first in the pool to preserve v0.2.0's 3-byte shape for the trivial `const v; ret v` case (no XCH/LD when v is the sole var).  Subsequent consts evict the previous ACC owner via XCH r before clobbering ACC with LDM.  Mirrors iir-to-intel8008 v0.3.0 (A2++)'s A-first pool ordering.  Stack spilling via the 4004's data-RAM lands later."
 
 [lib]
 name = "iir_to_intel4004"

--- a/code/packages/rust/iir-to-intel4004/src/lib.rs
+++ b/code/packages/rust/iir-to-intel4004/src/lib.rs
@@ -71,6 +71,7 @@
 //! ```
 
 use interpreter_ir::{IIRModule, Operand};
+use std::collections::HashMap;
 use std::fmt;
 
 // ===========================================================================
@@ -80,6 +81,31 @@ use std::fmt;
 // The 4004 has no formal HLT.  The canonical "halt" idiom is `JUN
 // 0x000` — an unconditional jump back to ROM address 0, which
 // (when itself at address 0) loops forever, simulating halt.
+
+/// Intel 4004 `LD r` opcode high nibble — `0xA0`.  Loads register
+/// `r` (bottom nibble) into the accumulator.
+///
+/// Bit pattern: `1010 rrrr`.  Single-byte instruction — OR in the
+/// 4-bit register selector (0..=15) to form the full opcode byte.
+///
+/// Example: `LD r3 = 0xA3 = 0b1010_0011`.
+///
+/// Does NOT modify the source register `r` — it's a copy, not a swap.
+pub const LD_OPCODE: u8 = 0xA0;
+
+/// Intel 4004 `XCH r` opcode high nibble — `0xB0`.  Exchanges the
+/// accumulator with register `r`.
+///
+/// Bit pattern: `1011 rrrr`.  Single-byte instruction.  After
+/// execution, `ACC` holds what was in `r`, and `r` holds what was
+/// in `ACC`.
+///
+/// XCH is the only way on the 4004 to STORE the accumulator into
+/// a register — there's no `ST r` instruction.  The exchange
+/// destroys the previous contents of the destination register,
+/// which is fine for fresh allocation but means we must be careful
+/// not to overwrite a still-live value.
+pub const XCH_OPCODE: u8 = 0xB0;
 
 /// Intel 4004 `LDM n` opcode high nibble — `0xD0`.  Loads the 4-bit
 /// immediate `n` (low nibble) into the accumulator.
@@ -184,6 +210,14 @@ pub enum IIRIntel4004Error {
     UnsupportedType { function: String, type_hint: String },
     /// An operand has an unexpected shape.
     InvalidOperand { function: String, detail: String },
+    /// A variable name was used (via `mov` or `ret`) before it was
+    /// bound by `const` or `mov`.
+    UndefinedVariable { function: String, name: String },
+    /// The function tried to bind more locals than the 4004's 16
+    /// 4-bit general-purpose registers can hold.  Stack spilling
+    /// via the 4004's data-RAM (`SRC`/`WRM`/`RDM` family) lands in
+    /// a future increment.
+    OutOfRegisters { function: String, name: String },
 }
 
 impl fmt::Display for IIRIntel4004Error {
@@ -200,6 +234,12 @@ impl fmt::Display for IIRIntel4004Error {
             }
             Self::InvalidOperand { function, detail } => {
                 write!(f, "invalid operand in function {function:?}: {detail}")
+            }
+            Self::UndefinedVariable { function, name } => {
+                write!(f, "undefined variable {name:?} in function {function:?}")
+            }
+            Self::OutOfRegisters { function, name } => {
+                write!(f, "out of 4004 registers (r0..r15) while binding {name:?} in function {function:?}; data-RAM spilling not yet supported")
             }
         }
     }
@@ -230,15 +270,23 @@ pub fn validate_for_intel4004(_module: &IIRModule) -> Vec<String> {
 // lower_iir_to_intel4004
 // ===========================================================================
 
-/// Supported instruction opcodes in v0.2.0 (A4+).
+/// Sentinel `env` value meaning "this var currently lives in the
+/// accumulator (ACC)", not in any of the 16 GP registers.  Distinct
+/// from the 4-bit register indices `0..=15`.
+const ACC_MARKER: u8 = 16;
+
+/// Supported instruction opcodes in v0.3.0 (A4++).
 ///
-/// * `const dest, Int(n)` lowers to `LDM n` (every value goes
-///   into the accumulator in this accumulator-only first slice).
-/// * `ret <var>` and `ret_void` both lower to `JUN 0x000` (the
-///   halt sentinel — real `RET` via `BBL` + the 4004's 3-deep
-///   internal call stack lands in A4++).
+/// * `const dest, Int(n)` lowers to `LDM n` with `dest` taking
+///   over the accumulator (evicting the previous ACC owner to a
+///   real register via XCH if needed).
+/// * `mov dest, src` lowers to `LD src_reg; XCH dest_reg` —
+///   copies src's value into dest's freshly-allocated register.
+/// * `ret <var>` stages var into ACC (eliding LD when var is
+///   already there) and emits the JUN 0x000 halt sentinel.
+/// * `ret_void` just emits the halt sentinel.
 const SUPPORTED_OPS: &[&str] = &[
-    "const", "ret", "ret_void",
+    "const", "mov", "ret", "ret_void",
 ];
 
 /// Lower an [`IIRModule`] to a `Vec<u8>` of Intel 4004 opcode bytes.
@@ -295,6 +343,33 @@ pub fn lower_iir_to_intel4004(
 
     let mut bytes = Vec::new();
     for f in &module.functions {
+        // ── Per-function allocator state ──────────────────────────────
+        //
+        // The 4004's ALU is accumulator-anchored: every value flows
+        // through the 4-bit ACC.  We maintain three pieces of state:
+        //
+        //   env: HashMap<String, u8>
+        //     var name → physical location.  Values in `0..=15` are
+        //     register indices for the 16 GP registers; `ACC_MARKER`
+        //     (= 16) means "currently lives in ACC".
+        //
+        //   next_reg: usize
+        //     Next free GP register index.  Bumps from 0 upward as
+        //     we spill names from ACC into r0, r1, ...
+        //
+        //   acc_owner: Option<String>
+        //     Which var (if any) currently owns ACC.  When a new const
+        //     or LD-based op arrives that needs to clobber ACC, we
+        //     first evict the current owner via XCH.
+        //
+        // The ACC-first model preserves v0.2.0's 3-byte shape for
+        // `const v; ret v` (LDM v; JUN 0x000 — no XCH/LD needed when
+        // v is the sole var).  Mirrors iir-to-intel8008 v0.3.0's
+        // A-first pool ordering.
+        let mut env: HashMap<String, u8> = HashMap::new();
+        let mut next_reg: usize = 0;
+        let mut acc_owner: Option<String> = None;
+
         for instr in &f.instructions {
             if !SUPPORTED_OPS.contains(&instr.op.as_str()) {
                 return Err(IIRIntel4004Error::UnsupportedOp {
@@ -303,36 +378,75 @@ pub fn lower_iir_to_intel4004(
                 });
             }
             match instr.op.as_str() {
-                // ── const dest, Int(n) → LDM n ─────────────────────────
+                // ── const dest, Int(n) → (XCH r_evict)? + LDM n ────────
                 //
-                // The 4004's accumulator is 4 bits wide.  Values in
-                // [0, 15] cast straight to the LDM low nibble.
-                // [-8, -1] reinterpreted via two's-complement
-                // (`-1 → 0xF`).  Anything outside surfaces as
-                // `InvalidOperand`.
+                // If ACC is currently owned by a different var, we
+                // evict that var to its next-free real register via XCH
+                // BEFORE the LDM (which would otherwise clobber ACC).
+                // Then LDM n loads the new value into ACC, and dest
+                // becomes the new ACC owner.
                 "const" => {
-                    let _dest = require_dest(instr, "const", &f.name)?;
+                    let dest = require_dest(instr, "const", &f.name)?;
                     let n = encode_immediate_nibble(instr.srcs.first(), &f.name)?;
+                    evict_acc(&mut bytes, &mut env, &mut acc_owner, &mut next_reg, &f.name)?;
                     bytes.push(LDM_OPCODE | n);
+                    env.insert(dest.to_string(), ACC_MARKER);
+                    acc_owner = Some(dest.to_string());
                 }
 
-                // ── ret <var>: JUN 0x000 ───────────────────────────────
+                // ── mov dest, src → LD src_reg; XCH dest_reg ───────────
                 //
-                // The value is already in the accumulator (every const
-                // lowers there in v0.2.0).  Real `RET` via `BBL` + the
-                // 4004's 3-deep return stack lands in A4++.  Until then,
-                // JUN-self is the universal stopping primitive.
+                // `mov` copies src's value into a freshly-allocated
+                // dest register.  Lowering shape:
+                //
+                //   [optional] if src is in ACC: evict src to a real
+                //     register first (so LD/XCH below have a stable
+                //     source).
+                //   LD r_src             ; ACC ← src's value
+                //   alloc r_dest
+                //   XCH r_dest           ; r_dest = src's value,
+                //                        ; ACC = old r_dest (junk)
+                "mov" => {
+                    let dest = require_dest(instr, "mov", &f.name)?;
+                    let src_name = match instr.srcs.first() {
+                        Some(Operand::Var(s)) => s.clone(),
+                        _ => return Err(IIRIntel4004Error::InvalidOperand {
+                            function: f.name.clone(),
+                            detail: "mov srcs[0] must be Var".into(),
+                        }),
+                    };
+                    // If src lives in ACC, evict so the LD below has
+                    // a stable register source.
+                    if matches!(env.get(&src_name), Some(&ACC_MARKER)) {
+                        evict_acc(&mut bytes, &mut env, &mut acc_owner, &mut next_reg, &f.name)?;
+                    }
+                    let src_reg = lookup_register(&env, &src_name, &f.name)?;
+                    debug_assert!(src_reg <= 15, "src_reg should be a real GP register after eviction");
+                    bytes.push(LD_OPCODE | src_reg);
+                    let r_dest = alloc_register(&mut next_reg, dest, &f.name)?;
+                    bytes.push(XCH_OPCODE | r_dest);
+                    env.insert(dest.to_string(), r_dest);
+                    // After XCH, ACC holds the (junk) old r_dest contents.
+                    acc_owner = None;
+                }
+
+                // ── ret <var>: stage var into ACC, then JUN 0x000 ──────
+                //
+                // If var is already the ACC owner, no LD is needed —
+                // ACC already holds its value.  Otherwise emit
+                // `LD r_var` to stage it.
                 "ret" => {
-                    // Validate that srcs[0] is a Var — front-end bugs
-                    // surface as `InvalidOperand` rather than producing
-                    // surprising silence.
-                    match instr.srcs.first() {
-                        Some(Operand::Var(_)) => {}
+                    let src_name = match instr.srcs.first() {
+                        Some(Operand::Var(s)) => s.clone(),
                         _ => return Err(IIRIntel4004Error::InvalidOperand {
                             function: f.name.clone(),
                             detail: "ret srcs[0] must be Var".into(),
                         }),
                     };
+                    let src_reg = lookup_register(&env, &src_name, &f.name)?;
+                    if src_reg != ACC_MARKER {
+                        bytes.push(LD_OPCODE | src_reg);
+                    }
                     bytes.extend_from_slice(&HALT_LOOP);
                 }
 
@@ -368,6 +482,63 @@ fn require_dest<'a>(
     instr.dest.as_deref().ok_or_else(|| IIRIntel4004Error::InvalidOperand {
         function: fn_name.to_string(),
         detail: format!("{op} requires a dest"),
+    })
+}
+
+/// Evict the current ACC owner (if any) to its next-free GP register
+/// via `XCH r_evict`.  Updates the `env` mapping and clears
+/// `acc_owner`.  No-op when ACC is unowned.
+///
+/// Returns `OutOfRegisters` if all 16 GP registers are already
+/// allocated.
+fn evict_acc(
+    bytes: &mut Vec<u8>,
+    env: &mut HashMap<String, u8>,
+    acc_owner: &mut Option<String>,
+    next_reg: &mut usize,
+    fn_name: &str,
+) -> Result<(), IIRIntel4004Error> {
+    if let Some(name) = acc_owner.take() {
+        if *next_reg >= 16 {
+            return Err(IIRIntel4004Error::OutOfRegisters {
+                function: fn_name.to_string(),
+                name,
+            });
+        }
+        let r = *next_reg as u8;
+        *next_reg += 1;
+        bytes.push(XCH_OPCODE | r);
+        env.insert(name, r);
+    }
+    Ok(())
+}
+
+/// Allocate a fresh GP register for `dest`.  Returns the 4-bit
+/// register index, or `OutOfRegisters` if all 16 are taken.
+fn alloc_register(
+    next_reg: &mut usize,
+    dest: &str,
+    fn_name: &str,
+) -> Result<u8, IIRIntel4004Error> {
+    if *next_reg >= 16 {
+        return Err(IIRIntel4004Error::OutOfRegisters {
+            function: fn_name.to_string(),
+            name: dest.to_string(),
+        });
+    }
+    let r = *next_reg as u8;
+    *next_reg += 1;
+    Ok(r)
+}
+
+fn lookup_register(
+    env: &HashMap<String, u8>,
+    name: &str,
+    fn_name: &str,
+) -> Result<u8, IIRIntel4004Error> {
+    env.get(name).copied().ok_or_else(|| IIRIntel4004Error::UndefinedVariable {
+        function: fn_name.to_string(),
+        name: name.to_string(),
     })
 }
 

--- a/code/packages/rust/iir-to-intel4004/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-intel4004/tests/test_backend.rs
@@ -6,7 +6,8 @@
 use interpreter_ir::{IIRFunction, IIRInstr, IIRModule, Operand};
 use iir_to_intel4004::{
     lower_iir_to_intel4004, validate_for_intel4004,
-    IIRIntel4004Config, IIRIntel4004Error, HALT_LOOP, LDM_OPCODE,
+    IIRIntel4004Config, IIRIntel4004Error,
+    HALT_LOOP, LDM_OPCODE, LD_OPCODE, XCH_OPCODE,
 };
 
 fn module_with(f: IIRFunction) -> IIRModule {
@@ -254,4 +255,172 @@ fn unsupported_op_is_rejected_with_function_name() {
         }
         other => panic!("expected UnsupportedOp, got: {other:?}"),
     }
+}
+
+// ===========================================================================
+// 6. A4++ (v0.3.0) — ACC-first allocator + `mov` + ret-value staging
+// ===========================================================================
+//
+// The 4004's ALU is accumulator-anchored.  The ACC-first allocator
+// keeps the first var in the accumulator, only spilling to r0..r15
+// on contention.  This preserves v0.2.0's 3-byte shape for the
+// trivial `const v; ret v` case.
+
+#[test]
+fn ld_opcode_pinned_to_0xa0() {
+    assert_eq!(LD_OPCODE, 0xA0,
+        "LD r opcode high nibble should be 0xA0 (1010_0000)");
+}
+
+#[test]
+fn xch_opcode_pinned_to_0xb0() {
+    assert_eq!(XCH_OPCODE, 0xB0,
+        "XCH r opcode high nibble should be 0xB0 (1011_0000)");
+}
+
+#[test]
+fn ret_of_first_const_omits_xch_and_ld() {
+    // Regression for v0.2.0's 3-byte shape: when v is the sole var,
+    // it stays in ACC and ret v needs no staging LD.
+    let f = IIRFunction::new("trivial", vec![], "u8", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(7)], "u8"),
+        IIRInstr::new("ret",   None,             vec![Operand::Var("v".into())], "u8"),
+    ]);
+    let bytes = lower_iir_to_intel4004(&module_with(f), &IIRIntel4004Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![0xD7, 0x40, 0x00],
+        "ACC-first allocator should keep the trivial case at 3 bytes; got: {bytes:02x?}");
+}
+
+#[test]
+fn two_consts_use_acc_then_xch_to_r0_for_eviction() {
+    // const v=5; const w=7; ret w
+    //   LDM 5    = 0xD5     (v → ACC)
+    //   XCH r0   = 0xB0     (evict v to r0; ACC ← junk)
+    //   LDM 7    = 0xD7     (w → ACC)
+    //   JUN 0x000           (w is in ACC, no LD before JUN)
+    let f = IIRFunction::new("two", vec![], "u8", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(5)], "u8"),
+        IIRInstr::new("const", Some("w".into()), vec![Operand::Int(7)], "u8"),
+        IIRInstr::new("ret",   None,             vec![Operand::Var("w".into())], "u8"),
+    ]);
+    let bytes = lower_iir_to_intel4004(&module_with(f), &IIRIntel4004Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![
+        0xD5,           // LDM 5 (v → ACC)
+        0xB0,           // XCH r0 (evict v to r0)
+        0xD7,           // LDM 7 (w → ACC)
+        0x40, 0x00,     // JUN 0x000 (w already in ACC)
+    ], "expected LDM 5 + XCH r0 + LDM 7 + JUN; got: {bytes:02x?}");
+}
+
+#[test]
+fn ret_of_evicted_var_emits_ld_before_jun() {
+    // const v=5; const w=7; ret v
+    // v gets evicted to r0 when w arrives.  Then ret v needs LD r0.
+    let f = IIRFunction::new("ret_v", vec![], "u8", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(5)], "u8"),
+        IIRInstr::new("const", Some("w".into()), vec![Operand::Int(7)], "u8"),
+        IIRInstr::new("ret",   None,             vec![Operand::Var("v".into())], "u8"),
+    ]);
+    let bytes = lower_iir_to_intel4004(&module_with(f), &IIRIntel4004Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![
+        0xD5,           // LDM 5 (v → ACC)
+        0xB0,           // XCH r0 (evict v to r0)
+        0xD7,           // LDM 7 (w → ACC)
+        0xA0,           // LD r0 (stage v back into ACC for ret)
+        0x40, 0x00,     // JUN 0x000
+    ], "expected LDM 5 + XCH r0 + LDM 7 + LD r0 + JUN; got: {bytes:02x?}");
+}
+
+#[test]
+fn mov_lowers_to_ld_then_xch() {
+    // const v=3; mov w=v; ret w
+    //
+    // v → ACC.  mov w=v: v is in ACC, evict v to r0 first (LDM
+    // already happened, just need XCH); then LD r0 stages src
+    // value into ACC; XCH r1 puts it into r1 (= w).  After: w in
+    // r1, ACC has junk.
+    //
+    // For ret w: LD r1.
+    //
+    //   LDM 3    = 0xD3   (v → ACC)
+    //   XCH r0   = 0xB0   (evict v from ACC to r0)
+    //   LD  r0   = 0xA0   (ACC ← v's value)
+    //   XCH r1   = 0xB1   (r1 = v's value = w; ACC = junk)
+    //   LD  r1   = 0xA1   (ACC ← w's value for ret)
+    //   JUN 0x000
+    let f = IIRFunction::new("mov_fn", vec![], "u8", vec![
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(3)], "u8"),
+        IIRInstr::new("mov",   Some("w".into()), vec![Operand::Var("v".into())], "u8"),
+        IIRInstr::new("ret",   None,             vec![Operand::Var("w".into())], "u8"),
+    ]);
+    let bytes = lower_iir_to_intel4004(&module_with(f), &IIRIntel4004Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![
+        0xD3,           // LDM 3
+        0xB0,           // XCH r0 (evict v from ACC)
+        0xA0,           // LD r0  (stage v's value back to ACC for mov)
+        0xB1,           // XCH r1 (w = v's value)
+        0xA1,           // LD r1  (stage w into ACC for ret)
+        0x40, 0x00,     // JUN 0x000
+    ], "mov expected; got: {bytes:02x?}");
+}
+
+#[test]
+fn allocator_exhaustion_yields_out_of_registers() {
+    // Capacity: 1 var in ACC + 16 vars in r0..r15 = 17 total.  The
+    // 18th const tries to evict v16 (currently in ACC) to a real
+    // register, but next_reg is already at 16 — OutOfRegisters fires
+    // on v16's eviction.
+    let mut body = Vec::new();
+    for i in 0..18 {
+        body.push(IIRInstr::new(
+            "const",
+            Some(format!("v{i}")),
+            vec![Operand::Int((i % 16) as i64)],
+            "u8",
+        ));
+    }
+    body.push(IIRInstr::new("ret_void", None, vec![], "void"));
+    let f = IIRFunction::new("greedy", vec![], "void", body);
+    let err = lower_iir_to_intel4004(&module_with(f), &IIRIntel4004Config::default())
+        .expect_err("18 consts should exhaust the 17-slot pool (ACC + 16 GP)");
+    match err {
+        IIRIntel4004Error::OutOfRegisters { function, name } => {
+            assert_eq!(function, "greedy");
+            // v16 currently lives in ACC; the 18th const (v17) tries
+            // to evict it and runs out of GP registers.
+            assert_eq!(name, "v16");
+        }
+        other => panic!("expected OutOfRegisters, got: {other:?}"),
+    }
+}
+
+#[test]
+fn undefined_variable_in_mov_is_rejected() {
+    let f = IIRFunction::new("f", vec![], "void", vec![
+        IIRInstr::new("mov", Some("w".into()),
+            vec![Operand::Var("ghost".into())], "u8"),
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ]);
+    let err = lower_iir_to_intel4004(&module_with(f), &IIRIntel4004Config::default())
+        .expect_err("mov from undefined var should fail");
+    match err {
+        IIRIntel4004Error::UndefinedVariable { name, .. } => {
+            assert_eq!(name, "ghost");
+        }
+        other => panic!("expected UndefinedVariable, got: {other:?}"),
+    }
+}
+
+#[test]
+fn errors_for_new_variants_display_without_panic() {
+    let _ = format!("{}", IIRIntel4004Error::UndefinedVariable {
+        function: "f".into(), name: "ghost".into(),
+    });
+    let _ = format!("{}", IIRIntel4004Error::OutOfRegisters {
+        function: "greedy".into(), name: "v15".into(),
+    });
 }

--- a/code/specs/iir-to-intel4004.md
+++ b/code/specs/iir-to-intel4004.md
@@ -67,8 +67,9 @@ IIRModule
 | Version | Scope | Status |
 |---------|-------|--------|
 | v0.1.0 (A4) | crate skeleton: any module → single `JUN 0x000` (`0x40 0x00`) infinite-loop halt sentinel | **merged** |
-| **v0.2.0 (A4+ — this PR)** | `const dest, Int(n)` → `LDM n` (load immediate to accumulator, 4-bit n; range `[-8, 15]` via two's-complement) + `ret`/`ret_void` → JUN-self halt sentinel | this PR |
-| v0.3.0 (A4++) | Register-pair allocator over `r0r1..r14r15` + arithmetic via accumulator (`ADD`, `SUB` family) | future |
+| v0.2.0 (A4+) | `const dest, Int(n)` → `LDM n` + `ret`/`ret_void` → JUN-self | **merged** |
+| **v0.3.0 (A4++ — this PR)** | ACC-first linear allocator over `r0..r15` (`ACC` comes first in pool to preserve v0.2.0's trivial-case shape) + `mov` (via `LD`/`XCH` pairs) + ret-value staging via `LD r_var` if not already in ACC.  Adds `LD_OPCODE = 0xA0` and `XCH_OPCODE = 0xB0` constants. | this PR |
+| v0.4.0 (A4+++) | Arithmetic via accumulator (`ADD`, `SUB`, `IAC`, `DAC`) + conditional jumps via `JCN` | future |
 | v0.4.0 (A4+++) | `lang-aot --emit=intel4004` wiring + Brainfuck end-to-end | future |
 
 ## Public surface (v0.1.0)


### PR DESCRIPTION
## Summary

Extends \`iir-to-intel4004\` v0.2.0 → **v0.3.0** with an ACC-first linear allocator over the 4004's 16 4-bit GP registers + \`mov\` (via LD+XCH pairs) + ret-value staging.

### ACC-first allocator preserves the trivial-case shape

The pool is conceptually \`[ACC, r0, r1, ..., r15]\` — ACC comes first so the trivial \`const v; ret v\` case stays at **3 bytes** (\`LDM v; JUN 0x000\`) without an XCH/LD round-trip.

When a second \`const\` arrives, the previous ACC owner is evicted to its next-free GP register via \`XCH r\` BEFORE \`LDM\` clobbers ACC with the new value.

| IIR op                  | 4004 lowering                              |
| ----------------------- | ------------------------------------------ |
| \`const dest\` (1st)     | \`LDM n\` (dest owns ACC)                  |
| \`const dest\` (Nth)     | (\`XCH r_prev\`) + \`LDM n\`               |
| \`mov dest, src\`        | (\`XCH r_src\` if in ACC) + \`LD r_src\` + \`XCH r_dest\` |
| \`ret <var>\`            | (\`LD r_var\` if not in ACC) + \`JUN 0x000\` |
| \`ret_void\`             | \`JUN 0x000\`                              |

Mirrors iir-to-intel8008 v0.3.0 (A2++)'s A-first pool ordering.

### Why ACC-first?

The 4004 has **no ST r** (store accumulator to register) — \`XCH r\` is the only way to materialise an ACC value into a register.  Every XCH after LDM costs 1 byte; every LD to re-stage costs another 1 byte.  Keeping the first var in ACC saves 2 bytes for the trivial case.

### New public constants

- \`LD_OPCODE = 0xA0\` (Load register r to accumulator, single-byte \`1010 rrrr\`)
- \`XCH_OPCODE = 0xB0\` (eXCHange accumulator with register r, single-byte \`1011 rrrr\`)

### New error variants

- \`UndefinedVariable { function, name }\`
- \`OutOfRegisters { function, name }\` — 18th local exhausts the 17-slot pool (ACC + r0..r15)

## Test plan

- [x] \`cargo test -p iir-to-intel4004\` — 25/25 backend tests pass, 1/1 doctest passes
- [x] LD_OPCODE / XCH_OPCODE pinned
- [x] v0.2.0 3-byte trivial-case shape preserved (regression test)
- [x] Two-const eviction sequence pinned (\`D5 B0 D7 40 00\`)
- [x] ret of evicted var emits LD before JUN (\`D5 B0 D7 A0 40 00\`)
- [x] mov sequence pinned (\`D3 B0 A0 B1 A1 40 00\`)
- [x] Allocator exhaustion: 18 consts → fails on v16
- [x] Undefined variable in mov rejected
- [x] Security review passed (no vulnerabilities found)
- [ ] CI green
- [ ] No merge conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)