### PR TITLE
Track browser form hidden control descriptors

### DIFF
--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -1621,6 +1621,7 @@ pub struct BrowserForm {
     pub text_entries: Vec<BrowserFormTextEntry>,
     pub choice_controls: Vec<BrowserFormChoiceControl>,
     pub file_controls: Vec<BrowserFormFileControl>,
+    pub hidden_controls: Vec<BrowserFormHiddenControl>,
     pub controls: Vec<BrowserFormControl>,
     pub submitters: Vec<BrowserFormSubmitter>,
 }
@@ -1816,6 +1817,21 @@ pub struct BrowserFormFileControl {
     pub submission_values: Vec<String>,
     pub will_validate: bool,
     pub validation_attributes: Vec<String>,
+    pub validation_barred_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserFormHiddenControl {
+    pub id: Option<String>,
+    pub name: Option<String>,
+    pub form_owner: Option<String>,
+    pub value: Option<String>,
+    pub autocomplete: Option<String>,
+    pub autocomplete_tokens: Vec<String>,
+    pub disabled: bool,
+    pub successful: bool,
+    pub submission_values: Vec<String>,
+    pub will_validate: bool,
     pub validation_barred_reason: Option<String>,
 }
 
@@ -12886,6 +12902,7 @@ fn browser_form(
     let text_entries = browser_form_text_entries(&controls);
     let choice_controls = browser_form_choice_controls(&controls, element.attribute("id"));
     let file_controls = browser_form_file_controls(&controls);
+    let hidden_controls = browser_form_hidden_controls(&controls);
     let submitters = browser_form_submitters(
         &controls,
         action.as_deref(),
@@ -12933,6 +12950,7 @@ fn browser_form(
         text_entries,
         choice_controls,
         file_controls,
+        hidden_controls,
         controls,
         submitters,
     }
@@ -13559,6 +13577,26 @@ fn browser_form_file_controls(controls: &[BrowserFormControl]) -> Vec<BrowserFor
             submission_values: control.submission_values.clone(),
             will_validate: control.will_validate,
             validation_attributes: control.validation_attributes.clone(),
+            validation_barred_reason: control.validation_barred_reason.clone(),
+        })
+        .collect()
+}
+
+fn browser_form_hidden_controls(controls: &[BrowserFormControl]) -> Vec<BrowserFormHiddenControl> {
+    controls
+        .iter()
+        .filter(|control| control.control_type == "hidden")
+        .map(|control| BrowserFormHiddenControl {
+            id: control.id.clone(),
+            name: control.name.clone(),
+            form_owner: control.form_owner.clone(),
+            value: control.value.clone(),
+            autocomplete: control.autocomplete.clone(),
+            autocomplete_tokens: control.autocomplete_tokens.clone(),
+            disabled: control.disabled,
+            successful: control.successful,
+            submission_values: control.submission_values.clone(),
+            will_validate: control.will_validate,
             validation_barred_reason: control.validation_barred_reason.clone(),
         })
         .collect()

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -2,13 +2,14 @@ use coding_adventures_html_parser::{
     parse_browser_document, BrowserAnchor, BrowserComponentHydrationTarget, BrowserDataAttribute,
     BrowserDatalistOption, BrowserDocument, BrowserDocumentMetadata, BrowserEmbeddedContext,
     BrowserForm, BrowserFormButton, BrowserFormChoiceControl, BrowserFormControl,
-    BrowserFormDatalist, BrowserFormFieldset, BrowserFormFileControl, BrowserFormLabel,
-    BrowserFormOutput, BrowserFormSelect, BrowserFormSubmitter, BrowserFormSuccessfulControl,
-    BrowserFormTextEntry, BrowserFormValidationControl, BrowserHeading, BrowserHttpEquivHint,
-    BrowserImage, BrowserImageSource, BrowserInteractiveElement, BrowserLink, BrowserMedia,
-    BrowserMeta, BrowserMetadataDirective, BrowserRefresh, BrowserResource, BrowserResourceHint,
-    BrowserScript, BrowserSelectOption, BrowserStructuredItem, BrowserStructuredProperty,
-    BrowserStylesheet, BrowserTable, BrowserTemplate, BrowserThemeColor,
+    BrowserFormDatalist, BrowserFormFieldset, BrowserFormFileControl, BrowserFormHiddenControl,
+    BrowserFormLabel, BrowserFormOutput, BrowserFormSelect, BrowserFormSubmitter,
+    BrowserFormSuccessfulControl, BrowserFormTextEntry, BrowserFormValidationControl,
+    BrowserHeading, BrowserHttpEquivHint, BrowserImage, BrowserImageSource,
+    BrowserInteractiveElement, BrowserLink, BrowserMedia, BrowserMeta, BrowserMetadataDirective,
+    BrowserRefresh, BrowserResource, BrowserResourceHint, BrowserScript, BrowserSelectOption,
+    BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet, BrowserTable,
+    BrowserTemplate, BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -738,6 +739,8 @@ struct ExpectedForm {
     choice_controls: Vec<ExpectedFormChoiceControl>,
     #[serde(default)]
     file_controls: Vec<ExpectedFormFileControl>,
+    #[serde(default)]
+    hidden_controls: Vec<ExpectedFormHiddenControl>,
     controls: Vec<ExpectedFormControl>,
     #[serde(default)]
     submitters: Vec<ExpectedFormSubmitter>,
@@ -1014,6 +1017,31 @@ struct ExpectedFormFileControl {
     will_validate: bool,
     #[serde(default)]
     validation_attributes: Vec<String>,
+    #[serde(default)]
+    validation_barred_reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedFormHiddenControl {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    form_owner: Option<String>,
+    #[serde(default)]
+    value: Option<String>,
+    #[serde(default)]
+    autocomplete: Option<String>,
+    #[serde(default)]
+    autocomplete_tokens: Vec<String>,
+    disabled: bool,
+    #[serde(default)]
+    successful: bool,
+    #[serde(default)]
+    submission_values: Vec<String>,
+    #[serde(default)]
+    will_validate: bool,
     #[serde(default)]
     validation_barred_reason: Option<String>,
 }
@@ -1556,6 +1584,70 @@ fn browser_form_successful_control_descriptor_metadata_tracks_submission_entries
         form.successful_controls[5].submission_values,
         vec!["external"]
     );
+}
+
+#[test]
+fn browser_form_hidden_descriptor_metadata_tracks_hidden_entries_and_form_owners() {
+    let document = parse_browser_document(
+        "<form id=session>\
+         <input id=csrf type=hidden name=csrf value=token autocomplete=\"section-auth one-time-code\">\
+         <input id=charset type=hidden name=_charset_ value=utf-8>\
+         <input id=disabled-token type=hidden name=disabled value=no disabled>\
+         </form>\
+         <input id=external type=hidden form=session name=outside value=external>",
+    )
+    .expect("form hidden descriptor fixture should parse");
+
+    let form = document
+        .forms
+        .first()
+        .expect("session form should be summarized");
+    let ids: Vec<&str> = form
+        .hidden_controls
+        .iter()
+        .filter_map(|hidden| hidden.id.as_deref())
+        .collect();
+    assert_eq!(ids, vec!["csrf", "charset", "disabled-token", "external"]);
+
+    let csrf = &form.hidden_controls[0];
+    assert_eq!(csrf.name.as_deref(), Some("csrf"));
+    assert_eq!(csrf.value.as_deref(), Some("token"));
+    assert_eq!(
+        csrf.autocomplete.as_deref(),
+        Some("section-auth one-time-code")
+    );
+    assert_eq!(
+        csrf.autocomplete_tokens,
+        vec!["section-auth", "one-time-code"]
+    );
+    assert!(csrf.successful);
+    assert_eq!(csrf.submission_values, vec!["token"]);
+    assert!(!csrf.will_validate);
+    assert_eq!(
+        csrf.validation_barred_reason.as_deref(),
+        Some("input-type-hidden")
+    );
+
+    let charset = &form.hidden_controls[1];
+    assert_eq!(charset.name.as_deref(), Some("_charset_"));
+    assert_eq!(charset.value.as_deref(), Some("utf-8"));
+    assert!(charset.successful);
+    assert_eq!(charset.submission_values, vec!["utf-8"]);
+
+    let disabled = &form.hidden_controls[2];
+    assert_eq!(disabled.name.as_deref(), Some("disabled"));
+    assert!(disabled.disabled);
+    assert!(!disabled.successful);
+    assert!(disabled.submission_values.is_empty());
+    assert_eq!(
+        disabled.validation_barred_reason.as_deref(),
+        Some("disabled")
+    );
+
+    let external = &form.hidden_controls[3];
+    assert_eq!(external.form_owner.as_deref(), Some("session"));
+    assert_eq!(external.name.as_deref(), Some("outside"));
+    assert_eq!(external.submission_values, vec!["external"]);
 }
 
 #[test]
@@ -2856,6 +2948,11 @@ impl ExpectedForm {
                 .into_iter()
                 .map(ExpectedFormFileControl::into_browser_form_file_control)
                 .collect(),
+            hidden_controls: self
+                .hidden_controls
+                .into_iter()
+                .map(ExpectedFormHiddenControl::into_browser_form_hidden_control)
+                .collect(),
             controls: self
                 .controls
                 .into_iter()
@@ -3074,6 +3171,24 @@ impl ExpectedFormFileControl {
             submission_values: self.submission_values,
             will_validate: self.will_validate,
             validation_attributes: self.validation_attributes,
+            validation_barred_reason: self.validation_barred_reason,
+        }
+    }
+}
+
+impl ExpectedFormHiddenControl {
+    fn into_browser_form_hidden_control(self) -> BrowserFormHiddenControl {
+        BrowserFormHiddenControl {
+            id: self.id,
+            name: self.name,
+            form_owner: self.form_owner,
+            value: self.value,
+            autocomplete: self.autocomplete,
+            autocomplete_tokens: self.autocomplete_tokens,
+            disabled: self.disabled,
+            successful: self.successful,
+            submission_values: self.submission_values,
+            will_validate: self.will_validate,
             validation_barred_reason: self.validation_barred_reason,
         }
     }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -104,6 +104,9 @@
             "choice_controls": [
               { "control_type": "checkbox", "name": "in_stock", "value": "yes", "checked": true, "disabled": false, "successful": true, "submission_values": ["yes"], "will_validate": true, "group_name": "in_stock", "group_checked_values": ["yes"] }
             ],
+            "hidden_controls": [
+              { "name": "page", "value": "1", "disabled": false, "successful": true, "submission_values": ["1"], "validation_barred_reason": "input-type-hidden" }
+            ],
             "controls": [
               { "control_type": "text", "name": "q", "value": "rust html", "successful": true, "submission_values": ["rust html"], "disabled": false, "will_validate": true, "checked": false, "text": "", "options": [] },
               { "control_type": "hidden", "name": "page", "value": "1", "successful": true, "submission_values": ["1"], "disabled": false, "validation_barred_reason": "input-type-hidden", "checked": false, "text": "", "options": [] },


### PR DESCRIPTION
## Summary
- add dedicated BrowserForm hidden-control descriptors
- expose hidden input values, autocomplete tokens, form ownership, submission state, and validation barred reasons
- cover hidden controls in the browser-readiness fixture and a focused parser test

## Tests
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- cargo test -p coding-adventures-html-parser browser_form_hidden_descriptor_metadata_tracks_hidden_entries_and_form_owners
- cargo test -p coding-adventures-html-parser browser_form_
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser