### PR TITLE
[codex] board-vm: diagnose ejected boot failures

### DIFF
--- a/code/packages/rust/board-vm-uno-r4-firmware/README.md
+++ b/code/packages/rust/board-vm-uno-r4-firmware/README.md
@@ -72,7 +72,9 @@ returns that plan with the optional runtime report, letting diagnostics describe
 whether startup validated-and-ran or validated-and-skipped a store-only artifact.
 Its compact summary preserves the boot plan plus run status, instruction count,
 and open-handle count when execution happened, without inventing a second
-artifact interpretation path.
+artifact interpretation path. Startup diagnostics can also capture failures as
+the embedded program summary plus the firmware smoke error, so a board-specific
+entrypoint can report what failed without re-parsing the generated constants.
 
 The ejected artifact stays board-agnostic; this firmware binary is the Uno R4
 backend that decides how to validate and execute it.

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/lib.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/lib.rs
@@ -134,6 +134,28 @@ pub struct EjectedBootRunSummary {
     pub open_handles: Option<u8>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EjectedBootFailure {
+    pub program: EjectedFirmwareProgramSummary,
+    pub error: FirmwareSmokeError,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EjectedBootDiagnostic {
+    Completed(EjectedBootRunSummary),
+    Failed(EjectedBootFailure),
+}
+
+impl EjectedBootDiagnostic {
+    pub fn completed(self) -> bool {
+        matches!(self, Self::Completed(_))
+    }
+
+    pub fn failed(self) -> bool {
+        matches!(self, Self::Failed(_))
+    }
+}
+
 impl EjectedBootRun {
     pub fn ran(self) -> bool {
         self.report.is_some()
@@ -286,6 +308,24 @@ where
         boot_plan: validated.boot_plan,
         report,
     })
+}
+
+pub fn diagnose_ejected_boot_program_once<H, const MAX_STACK: usize, const MAX_HANDLES: usize>(
+    runtime: &mut Runtime<H, MAX_STACK, MAX_HANDLES>,
+    program: EjectedFirmwareProgram<'_>,
+    instruction_budget: u32,
+) -> EjectedBootDiagnostic
+where
+    H: BoardHal,
+{
+    let program_summary = program.summary();
+    match run_ejected_boot_program_checked_once(runtime, program, instruction_budget) {
+        Ok(boot_run) => EjectedBootDiagnostic::Completed(boot_run.summary()),
+        Err(error) => EjectedBootDiagnostic::Failed(EjectedBootFailure {
+            program: program_summary,
+            error,
+        }),
+    }
 }
 
 pub fn run_ejected_program_once<H, const MAX_STACK: usize, const MAX_HANDLES: usize>(
@@ -838,6 +878,59 @@ mod tests {
             }
         );
         assert_eq!(boot_run.report, None);
+        assert!(runtime.hal().events.is_empty());
+    }
+
+    #[test]
+    fn ejected_boot_diagnostic_summarizes_completed_run() {
+        let hal = FakeHal::new();
+        let mut runtime: Runtime<_, 16, 8> = Runtime::new(hal);
+
+        let diagnostic = diagnose_ejected_boot_program_once(
+            &mut runtime,
+            EjectedFirmwareProgram::blink(),
+            EJECTED_INSTRUCTION_BUDGET,
+        );
+
+        assert!(diagnostic.completed());
+        assert!(!diagnostic.failed());
+        assert_eq!(
+            diagnostic,
+            EjectedBootDiagnostic::Completed(EjectedBootRunSummary {
+                boot_plan: EjectedBootPlan {
+                    action: EjectedBootAction::Run,
+                    summary: EjectedFirmwareProgram::blink().summary(),
+                },
+                run_status: Some(RunStatus::BudgetExceeded),
+                instructions_executed: Some(EJECTED_INSTRUCTION_BUDGET),
+                open_handles: Some(1),
+            })
+        );
+        assert!(!runtime.hal().events.is_empty());
+    }
+
+    #[test]
+    fn ejected_boot_diagnostic_keeps_program_summary_on_failure() {
+        let hal = FakeHal::with_capabilities(CapabilitySet::empty());
+        let mut runtime: Runtime<_, 16, 8> = Runtime::new(hal);
+
+        let diagnostic = diagnose_ejected_boot_program_once(
+            &mut runtime,
+            EjectedFirmwareProgram::blink(),
+            EJECTED_INSTRUCTION_BUDGET,
+        );
+
+        assert!(!diagnostic.completed());
+        assert!(diagnostic.failed());
+        assert_eq!(
+            diagnostic,
+            EjectedBootDiagnostic::Failed(EjectedBootFailure {
+                program: EjectedFirmwareProgram::blink().summary(),
+                error: FirmwareSmokeError::Validate(ValidateError::UnsupportedCapability(
+                    CAP_GPIO_OPEN
+                )),
+            })
+        );
         assert!(runtime.hal().events.is_empty());
     }
 


### PR DESCRIPTION
## Summary
- add `EjectedBootDiagnostic` and `EjectedBootFailure` for firmware startup diagnostics
- expose a diagnostic helper that preserves either the completed boot-run summary or the embedded program summary plus `FirmwareSmokeError`
- document the failure diagnostic path beside the ejected boot-run summary

## Validation
- `cargo fmt -p board-vm-uno-r4-firmware`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-ejected-boot-diagnostics cargo test -p board-vm-uno-r4-firmware`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-ejected-boot-diagnostics cargo test -p board-vm-protocol -p board-vm-ir -p board-vm-host -p board-vm-device -p board-vm-loopback -p board-vm-client -p board-vm-eject -p board-vm-uno-r4-firmware -p board-vm-cli`
- `git diff --check`
- `git diff --cached --check`